### PR TITLE
Add HTTP endpoints discovery and overview dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,11 @@ export const myEndpoint = defineEndpoint("my_endpoint", {
 
 Never use raw `fetch()` calls to `/v0/sql` - always define typed endpoints for type safety and consistency.
 
+When adding a new Tinybird endpoint, register it in **three** places:
+1. Define in `packages/domain/src/tinybird/endpoints.ts`
+2. Add pipe name to `packages/domain/src/tinybird-pipes.ts`
+3. Register in `apps/api/src/services/TinybirdService.ts` pipes config + import
+
 ## Environment Variables
 
 ```

--- a/apps/api/src/services/TinybirdService.ts
+++ b/apps/api/src/services/TinybirdService.ts
@@ -25,6 +25,8 @@ import {
   errorsFacets,
   errorsSummary,
   getServiceUsage,
+  httpEndpointsOverview,
+  httpEndpointsTimeseries,
   listLogs,
   listMetrics,
   listTraces,
@@ -99,6 +101,8 @@ export class TinybirdService extends Effect.Service<TinybirdService>()("Tinybird
         span_attribute_values: spanAttributeValues,
         resource_attribute_keys: resourceAttributeKeys,
         resource_attribute_values: resourceAttributeValues,
+        http_endpoints_overview: httpEndpointsOverview,
+        http_endpoints_timeseries: httpEndpointsTimeseries,
       },
     })
 

--- a/apps/web/src/api/tinybird/custom-charts.ts
+++ b/apps/web/src/api/tinybird/custom-charts.ts
@@ -30,7 +30,7 @@ function sortByBucket<T extends { bucket: string }>(rows: T[]): T[] {
   return [...rows].sort((left, right) => left.bucket.localeCompare(right.bucket))
 }
 
-function fillServiceDetailPoints(
+export function fillServiceDetailPoints(
   points: ServiceDetailTimeSeriesPoint[],
   startTime: string | undefined,
   endTime: string | undefined,

--- a/apps/web/src/api/tinybird/endpoint-detail.ts
+++ b/apps/web/src/api/tinybird/endpoint-detail.ts
@@ -1,0 +1,136 @@
+import { Effect, Schema } from "effect"
+import { getTinybird } from "@/lib/tinybird"
+import {
+  computeBucketSeconds,
+  toIsoBucket,
+} from "@/api/tinybird/timeseries-utils"
+import {
+  TinybirdDateTimeString,
+  decodeInput,
+  runTinybirdQuery,
+} from "@/api/tinybird/effect-utils"
+import { fillServiceDetailPoints } from "@/api/tinybird/custom-charts"
+import type { ServiceDetailTimeSeriesPoint } from "@/api/tinybird/services"
+
+const GetEndpointDetailTimeSeriesInputSchema = Schema.Struct({
+  serviceName: Schema.String,
+  spanName: Schema.String,
+  startTime: Schema.optional(TinybirdDateTimeString),
+  endTime: Schema.optional(TinybirdDateTimeString),
+})
+
+export type GetEndpointDetailTimeSeriesInput = Schema.Schema.Type<
+  typeof GetEndpointDetailTimeSeriesInputSchema
+>
+
+export function getEndpointDetailTimeSeries({
+  data,
+}: {
+  data: GetEndpointDetailTimeSeriesInput
+}) {
+  return getEndpointDetailTimeSeriesEffect({ data })
+}
+
+const getEndpointDetailTimeSeriesEffect = Effect.fn(
+  "Tinybird.getEndpointDetailTimeSeries",
+)(function* ({
+  data,
+}: {
+  data: GetEndpointDetailTimeSeriesInput
+}) {
+  const input = yield* decodeInput(
+    GetEndpointDetailTimeSeriesInputSchema,
+    data,
+    "getEndpointDetailTimeSeries",
+  )
+
+  const tinybird = getTinybird()
+  const bucketSeconds = computeBucketSeconds(input.startTime, input.endTime)
+  const result = yield* runTinybirdQuery("custom_traces_timeseries", () =>
+    tinybird.query.custom_traces_timeseries({
+      start_time: input.startTime,
+      end_time: input.endTime,
+      bucket_seconds: bucketSeconds,
+      service_name: input.serviceName,
+      span_name: input.spanName,
+    }),
+  )
+
+  const points = result.data.map(
+    (row): ServiceDetailTimeSeriesPoint => ({
+      bucket: toIsoBucket(row.bucket),
+      throughput: Number(row.count),
+      errorRate: Number(row.errorRate),
+      p50LatencyMs: Number(row.p50Duration),
+      p95LatencyMs: Number(row.p95Duration),
+      p99LatencyMs: Number(row.p99Duration),
+    }),
+  )
+
+  return {
+    data: fillServiceDetailPoints(
+      points,
+      input.startTime,
+      input.endTime,
+      bucketSeconds,
+    ),
+  }
+})
+
+const GetEndpointStatusCodeBreakdownInputSchema = Schema.Struct({
+  serviceName: Schema.String,
+  spanName: Schema.String,
+  startTime: Schema.optional(TinybirdDateTimeString),
+  endTime: Schema.optional(TinybirdDateTimeString),
+})
+
+export type GetEndpointStatusCodeBreakdownInput = Schema.Schema.Type<
+  typeof GetEndpointStatusCodeBreakdownInputSchema
+>
+
+export interface StatusCodeBreakdownItem {
+  statusCode: string
+  count: number
+}
+
+export function getEndpointStatusCodeBreakdown({
+  data,
+}: {
+  data: GetEndpointStatusCodeBreakdownInput
+}) {
+  return getEndpointStatusCodeBreakdownEffect({ data })
+}
+
+const getEndpointStatusCodeBreakdownEffect = Effect.fn(
+  "Tinybird.getEndpointStatusCodeBreakdown",
+)(function* ({
+  data,
+}: {
+  data: GetEndpointStatusCodeBreakdownInput
+}) {
+  const input = yield* decodeInput(
+    GetEndpointStatusCodeBreakdownInputSchema,
+    data,
+    "getEndpointStatusCodeBreakdown",
+  )
+
+  const tinybird = getTinybird()
+  const result = yield* runTinybirdQuery("custom_traces_breakdown", () =>
+    tinybird.query.custom_traces_breakdown({
+      start_time: input.startTime,
+      end_time: input.endTime,
+      service_name: input.serviceName,
+      span_name: input.spanName,
+      group_by_attribute: "http.status_code",
+    }),
+  )
+
+  return {
+    data: result.data.map(
+      (row): StatusCodeBreakdownItem => ({
+        statusCode: String(row.name),
+        count: Number(row.count),
+      }),
+    ),
+  }
+})

--- a/apps/web/src/api/tinybird/endpoints-overview.ts
+++ b/apps/web/src/api/tinybird/endpoints-overview.ts
@@ -5,6 +5,11 @@ import {
   decodeInput,
   runTinybirdQuery,
 } from "@/api/tinybird/effect-utils"
+import {
+  buildBucketTimeline,
+  computeBucketSeconds,
+  toIsoBucket,
+} from "@/api/tinybird/timeseries-utils"
 
 const dateTimeString = TinybirdDateTimeString
 
@@ -80,5 +85,100 @@ const getHttpEndpointsOverviewEffect = Effect.fn("Tinybird.getHttpEndpointsOverv
     return {
       data: result.data.map(coerceRow),
     }
+  },
+)
+
+// Sparkline types
+export interface EndpointSparklinePoint {
+  bucket: string
+  throughput: number
+  errorRate: number
+}
+
+const GetHttpEndpointsSparklinesInput = Schema.Struct({
+  startTime: Schema.optional(dateTimeString),
+  endTime: Schema.optional(dateTimeString),
+  serviceName: Schema.optional(Schema.String),
+  environments: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+})
+
+export type GetHttpEndpointsSparklinesInput = Schema.Schema.Type<typeof GetHttpEndpointsSparklinesInput>
+
+function fillSparklinePoints(
+  points: EndpointSparklinePoint[],
+  timeline: string[],
+): EndpointSparklinePoint[] {
+  if (timeline.length === 0) {
+    return [...points].sort((a, b) => a.bucket.localeCompare(b.bucket))
+  }
+
+  const byBucket = new Map<string, EndpointSparklinePoint>()
+  for (const point of points) {
+    byBucket.set(toIsoBucket(point.bucket), point)
+  }
+
+  return timeline.map((bucket) => {
+    const existing = byBucket.get(bucket)
+    if (existing) return existing
+    return { bucket, throughput: 0, errorRate: 0 }
+  })
+}
+
+export function getHttpEndpointsSparklines({
+  data,
+}: {
+  data: GetHttpEndpointsSparklinesInput
+}) {
+  return getHttpEndpointsSparklinesEffect({ data })
+}
+
+const getHttpEndpointsSparklinesEffect = Effect.fn("Tinybird.getHttpEndpointsSparklines")(
+  function* ({
+    data,
+  }: {
+    data: GetHttpEndpointsSparklinesInput
+  }) {
+    const input = yield* decodeInput(
+      GetHttpEndpointsSparklinesInput,
+      data ?? {},
+      "getHttpEndpointsSparklines",
+    )
+
+    const tinybird = getTinybird()
+    const bucketSeconds = computeBucketSeconds(input.startTime, input.endTime)
+    const result = yield* runTinybirdQuery("http_endpoints_timeseries", () =>
+      tinybird.query.http_endpoints_timeseries({
+        start_time: input.startTime,
+        end_time: input.endTime,
+        bucket_seconds: bucketSeconds,
+        service_name: input.serviceName,
+        environments: input.environments?.join(","),
+      }),
+    )
+
+    const timeline = buildBucketTimeline(input.startTime, input.endTime, bucketSeconds)
+    // endpointKey format: "serviceName::endpointName::httpMethod"
+    const grouped: Record<string, EndpointSparklinePoint[]> = {}
+    for (const row of result.data) {
+      const bucket = toIsoBucket(row.bucket)
+      const point: EndpointSparklinePoint = {
+        bucket,
+        throughput: Number(row.count),
+        errorRate: Number(row.errorRate),
+      }
+      if (!grouped[row.endpointKey]) {
+        grouped[row.endpointKey] = []
+      }
+      grouped[row.endpointKey].push(point)
+    }
+
+    const filledGrouped = Object.fromEntries(
+      Object.entries(grouped).map(([key, points]) => [
+        key,
+        fillSparklinePoints(points, timeline),
+      ]),
+    )
+
+    return { data: filledGrouped }
   },
 )

--- a/apps/web/src/api/tinybird/endpoints-overview.ts
+++ b/apps/web/src/api/tinybird/endpoints-overview.ts
@@ -32,7 +32,8 @@ export interface HttpEndpointsOverviewResponse {
 const GetHttpEndpointsOverviewInput = Schema.Struct({
   startTime: dateTimeString,
   endTime: dateTimeString,
-  serviceName: Schema.optional(Schema.String),
+  services: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+  httpMethods: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
   environments: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
 })
 
@@ -77,7 +78,8 @@ const getHttpEndpointsOverviewEffect = Effect.fn("Tinybird.getHttpEndpointsOverv
       tinybird.query.http_endpoints_overview({
         start_time: input.startTime,
         end_time: input.endTime,
-        service_name: input.serviceName,
+        services: input.services?.join(","),
+        http_methods: input.httpMethods?.join(","),
         environments: input.environments?.join(","),
       }),
     )
@@ -98,7 +100,8 @@ export interface EndpointSparklinePoint {
 const GetHttpEndpointsSparklinesInput = Schema.Struct({
   startTime: Schema.optional(dateTimeString),
   endTime: Schema.optional(dateTimeString),
-  serviceName: Schema.optional(Schema.String),
+  services: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+  httpMethods: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
   environments: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
 })
 
@@ -151,7 +154,8 @@ const getHttpEndpointsSparklinesEffect = Effect.fn("Tinybird.getHttpEndpointsSpa
         start_time: input.startTime,
         end_time: input.endTime,
         bucket_seconds: bucketSeconds,
-        service_name: input.serviceName,
+        services: input.services?.join(","),
+        http_methods: input.httpMethods?.join(","),
         environments: input.environments?.join(","),
       }),
     )

--- a/apps/web/src/api/tinybird/endpoints-overview.ts
+++ b/apps/web/src/api/tinybird/endpoints-overview.ts
@@ -1,0 +1,84 @@
+import { Effect, Schema } from "effect"
+import { getTinybird, type HttpEndpointsOverviewOutput } from "@/lib/tinybird"
+import {
+  TinybirdDateTimeString,
+  decodeInput,
+  runTinybirdQuery,
+} from "@/api/tinybird/effect-utils"
+
+const dateTimeString = TinybirdDateTimeString
+
+export interface HttpEndpointOverview {
+  serviceName: string
+  endpointName: string
+  httpMethod: string
+  count: number
+  avgDuration: number
+  p50Duration: number
+  p95Duration: number
+  p99Duration: number
+  errorRate: number
+}
+
+export interface HttpEndpointsOverviewResponse {
+  data: HttpEndpointOverview[]
+}
+
+const GetHttpEndpointsOverviewInput = Schema.Struct({
+  startTime: dateTimeString,
+  endTime: dateTimeString,
+  serviceName: Schema.optional(Schema.String),
+  environments: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+})
+
+export type GetHttpEndpointsOverviewInput = Schema.Schema.Type<typeof GetHttpEndpointsOverviewInput>
+
+function coerceRow(raw: HttpEndpointsOverviewOutput): HttpEndpointOverview {
+  return {
+    serviceName: raw.serviceName,
+    endpointName: raw.endpointName,
+    httpMethod: raw.httpMethod || "UNKNOWN",
+    count: Number(raw.count),
+    avgDuration: Number(raw.avgDuration),
+    p50Duration: Number(raw.p50Duration),
+    p95Duration: Number(raw.p95Duration),
+    p99Duration: Number(raw.p99Duration),
+    errorRate: Number(raw.errorRate),
+  }
+}
+
+export function getHttpEndpointsOverview({
+  data,
+}: {
+  data: GetHttpEndpointsOverviewInput
+}) {
+  return getHttpEndpointsOverviewEffect({ data })
+}
+
+const getHttpEndpointsOverviewEffect = Effect.fn("Tinybird.getHttpEndpointsOverview")(
+  function* ({
+    data,
+  }: {
+    data: GetHttpEndpointsOverviewInput
+  }) {
+    const input = yield* decodeInput(
+      GetHttpEndpointsOverviewInput,
+      data,
+      "getHttpEndpointsOverview",
+    )
+
+    const tinybird = getTinybird()
+    const result = yield* runTinybirdQuery("http_endpoints_overview", () =>
+      tinybird.query.http_endpoints_overview({
+        start_time: input.startTime,
+        end_time: input.endTime,
+        service_name: input.serviceName,
+        environments: input.environments?.join(","),
+      }),
+    )
+
+    return {
+      data: result.data.map(coerceRow),
+    }
+  },
+)

--- a/apps/web/src/components/dashboard/app-sidebar.tsx
+++ b/apps/web/src/components/dashboard/app-sidebar.tsx
@@ -4,6 +4,7 @@ import {
   HouseIcon,
   FileIcon,
   PulseIcon,
+  ChartBarIcon,
   ChartLineIcon,
   ServerIcon,
   CircleWarningIcon,
@@ -69,6 +70,11 @@ const servicesNavItems = [
 ]
 
 const telemetryNavItems = [
+  {
+    title: "Endpoints",
+    href: "/endpoints",
+    icon: ChartBarIcon,
+  },
   {
     title: "Errors",
     href: "/errors",

--- a/apps/web/src/components/endpoints/endpoint-recent-traces.tsx
+++ b/apps/web/src/components/endpoints/endpoint-recent-traces.tsx
@@ -1,0 +1,152 @@
+import { Link, useNavigate } from "@tanstack/react-router"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@maple/ui/components/ui/table"
+import { Badge } from "@maple/ui/components/ui/badge"
+import type { Trace } from "@/api/tinybird/traces"
+
+function formatDuration(ms: number): string {
+  if (ms < 1) return `${(ms * 1000).toFixed(0)}us`
+  if (ms < 1000) return `${ms.toFixed(1)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+function formatTimestamp(timestamp: string): string {
+  const date = new Date(timestamp)
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  })
+}
+
+function truncateId(id: string, length = 8): string {
+  if (id.length <= length) return id
+  return id.slice(0, length)
+}
+
+function StatusBadge({ hasError }: { hasError: boolean }) {
+  if (hasError) {
+    return (
+      <Badge
+        variant="secondary"
+        className="bg-red-500/10 text-red-600 dark:bg-red-400/10 dark:text-red-400"
+      >
+        Error
+      </Badge>
+    )
+  }
+  return (
+    <Badge
+      variant="secondary"
+      className="bg-green-500/10 text-green-600 dark:bg-green-400/10 dark:text-green-400"
+    >
+      OK
+    </Badge>
+  )
+}
+
+interface EndpointRecentTracesProps {
+  traces: Trace[]
+  service: string
+  endpoint: string
+  startTime?: string
+  endTime?: string
+}
+
+export function EndpointRecentTraces({
+  traces,
+  service,
+  endpoint,
+  startTime,
+  endTime,
+}: EndpointRecentTracesProps) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[100px]">Trace ID</TableHead>
+              <TableHead className="w-[180px]">Time</TableHead>
+              <TableHead className="w-[100px]">Duration</TableHead>
+              <TableHead className="w-[80px]">Spans</TableHead>
+              <TableHead className="w-[80px]">Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {traces.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="h-24 text-center">
+                  No traces found for this endpoint
+                </TableCell>
+              </TableRow>
+            ) : (
+              traces.map((trace) => (
+                <TableRow
+                  key={trace.traceId}
+                  className="cursor-pointer"
+                  onClick={() =>
+                    navigate({
+                      to: "/traces/$traceId",
+                      params: { traceId: trace.traceId },
+                    })
+                  }
+                >
+                  <TableCell>
+                    <Link
+                      to="/traces/$traceId"
+                      params={{ traceId: trace.traceId }}
+                      className="font-mono text-xs text-primary underline decoration-primary/30 underline-offset-2 hover:decoration-primary"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {truncateId(trace.traceId)}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {formatTimestamp(trace.startTime)}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {formatDuration(trace.durationMs)}
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {trace.spanCount}
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge hasError={trace.hasError} />
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {traces.length > 0 && (
+        <div className="text-sm">
+          <Link
+            to="/traces"
+            search={{
+              services: [service],
+              spanNames: [endpoint],
+              startTime,
+              endTime,
+            }}
+            className="text-primary hover:underline"
+          >
+            View all traces for this endpoint →
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/endpoints/endpoint-recent-traces.tsx
+++ b/apps/web/src/components/endpoints/endpoint-recent-traces.tsx
@@ -57,6 +57,7 @@ interface EndpointRecentTracesProps {
   traces: Trace[]
   service: string
   endpoint: string
+  method: string
   startTime?: string
   endTime?: string
 }
@@ -65,6 +66,7 @@ export function EndpointRecentTraces({
   traces,
   service,
   endpoint,
+  method,
   startTime,
   endTime,
 }: EndpointRecentTracesProps) {
@@ -137,7 +139,9 @@ export function EndpointRecentTraces({
             to="/traces"
             search={{
               services: [service],
-              spanNames: [endpoint],
+              httpMethods: [method],
+              attributeKey: "http.route",
+              attributeValue: endpoint,
               startTime,
               endTime,
             }}

--- a/apps/web/src/components/endpoints/endpoint-status-breakdown.tsx
+++ b/apps/web/src/components/endpoints/endpoint-status-breakdown.tsx
@@ -1,0 +1,73 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@maple/ui/components/ui/table"
+import { Badge } from "@maple/ui/components/ui/badge"
+import type { StatusCodeBreakdownItem } from "@/api/tinybird/endpoint-detail"
+
+function getStatusColorClass(code: string): string {
+  const num = Number.parseInt(code, 10)
+  if (num >= 500) return "bg-red-500/10 text-red-600 dark:bg-red-400/10 dark:text-red-400"
+  if (num >= 400) return "bg-amber-500/10 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400"
+  if (num >= 300) return "bg-blue-500/10 text-blue-600 dark:bg-blue-400/10 dark:text-blue-400"
+  if (num >= 200) return "bg-green-500/10 text-green-600 dark:bg-green-400/10 dark:text-green-400"
+  return ""
+}
+
+interface EndpointStatusBreakdownProps {
+  data: StatusCodeBreakdownItem[]
+}
+
+export function EndpointStatusBreakdown({ data }: EndpointStatusBreakdownProps) {
+  const total = data.reduce((sum, item) => sum + item.count, 0)
+  const sorted = [...data]
+    .filter((item) => item.statusCode && item.statusCode !== "")
+    .sort((a, b) => b.count - a.count)
+
+  if (sorted.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        No status code data available
+      </div>
+    )
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Status Code</TableHead>
+          <TableHead className="text-right">Count</TableHead>
+          <TableHead className="text-right">Percentage</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {sorted.map((item) => {
+          const pct = total > 0 ? (item.count / total) * 100 : 0
+          return (
+            <TableRow key={item.statusCode}>
+              <TableCell>
+                <Badge
+                  variant="secondary"
+                  className={`font-mono text-xs ${getStatusColorClass(item.statusCode)}`}
+                >
+                  {item.statusCode}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-right font-mono text-sm">
+                {item.count.toLocaleString()}
+              </TableCell>
+              <TableCell className="text-right font-mono text-sm text-muted-foreground">
+                {pct.toFixed(1)}%
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}

--- a/apps/web/src/components/endpoints/endpoint-summary-stats.tsx
+++ b/apps/web/src/components/endpoints/endpoint-summary-stats.tsx
@@ -1,0 +1,74 @@
+import type { HttpEndpointOverview } from "@/api/tinybird/endpoints-overview"
+
+function formatLatency(ms: number): string {
+  if (ms == null || Number.isNaN(ms)) return "-"
+  if (ms < 1) return `${(ms * 1000).toFixed(0)}us`
+  if (ms < 1000) return `${ms.toFixed(1)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return n.toLocaleString()
+}
+
+function formatRate(rate: number): string {
+  if (rate < 0.01) return "0%"
+  if (rate < 1) return `${rate.toFixed(2)}%`
+  return `${rate.toFixed(1)}%`
+}
+
+function formatThroughput(count: number, durationSeconds: number): string {
+  if (durationSeconds <= 0) return `${count}`
+  const rate = count / durationSeconds
+  if (rate >= 1000) return `${(rate / 1000).toFixed(1)}k/s`
+  if (rate >= 1) return `${rate.toFixed(1)}/s`
+  if (rate >= 0.01) return `${rate.toFixed(2)}/s`
+  return `${rate.toFixed(3)}/s`
+}
+
+interface StatCardProps {
+  label: string
+  value: string
+}
+
+function StatCard({ label, value }: StatCardProps) {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-semibold tracking-tight font-mono">{value}</p>
+    </div>
+  )
+}
+
+interface EndpointSummaryStatsProps {
+  endpoint: HttpEndpointOverview | undefined
+  durationSeconds: number
+}
+
+export function EndpointSummaryStats({ endpoint, durationSeconds }: EndpointSummaryStatsProps) {
+  if (!endpoint) {
+    return (
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="rounded-lg border bg-card p-4">
+            <div className="h-4 w-16 rounded bg-muted animate-pulse" />
+            <div className="mt-2 h-7 w-20 rounded bg-muted animate-pulse" />
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+      <StatCard label="Total Requests" value={formatNumber(endpoint.count)} />
+      <StatCard label="Avg Latency" value={formatLatency(endpoint.avgDuration)} />
+      <StatCard label="P95 Latency" value={formatLatency(endpoint.p95Duration)} />
+      <StatCard label="P99 Latency" value={formatLatency(endpoint.p99Duration)} />
+      <StatCard label="Error Rate" value={formatRate(endpoint.errorRate)} />
+      <StatCard label="Throughput" value={formatThroughput(endpoint.count, durationSeconds)} />
+    </div>
+  )
+}

--- a/apps/web/src/components/endpoints/endpoints-filter-sidebar.tsx
+++ b/apps/web/src/components/endpoints/endpoints-filter-sidebar.tsx
@@ -1,0 +1,92 @@
+import { useNavigate } from "@tanstack/react-router"
+
+import {
+  FilterSection,
+  SearchableFilterSection,
+} from "@/components/filters/filter-section"
+import type { FilterOption } from "@/components/filters/filter-section"
+import { Separator } from "@maple/ui/components/ui/separator"
+import {
+  FilterSidebarBody,
+  FilterSidebarFrame,
+  FilterSidebarHeader,
+  FilterSidebarLoading,
+} from "@/components/filters/filter-sidebar"
+import { Route } from "@/routes/endpoints"
+
+function LoadingState() {
+  return <FilterSidebarLoading sectionCount={2} sticky />
+}
+
+export interface EndpointsFacets {
+  services: FilterOption[]
+  httpMethods: FilterOption[]
+}
+
+interface EndpointsFilterSidebarProps {
+  facets: EndpointsFacets | undefined
+  isLoading: boolean
+}
+
+export function EndpointsFilterSidebar({ facets, isLoading }: EndpointsFilterSidebarProps) {
+  const navigate = useNavigate({ from: Route.fullPath })
+  const search = Route.useSearch()
+
+  const updateFilter = <K extends keyof typeof search>(
+    key: K,
+    value: (typeof search)[K],
+  ) => {
+    navigate({
+      search: (prev) => ({
+        ...prev,
+        [key]:
+          value === undefined || (Array.isArray(value) && value.length === 0)
+            ? undefined
+            : value,
+      }),
+    })
+  }
+
+  const clearAllFilters = () => {
+    navigate({
+      search: {
+        startTime: search.startTime,
+        endTime: search.endTime,
+      },
+    })
+  }
+
+  const hasActiveFilters =
+    (search.services?.length ?? 0) > 0 ||
+    (search.httpMethods?.length ?? 0) > 0
+
+  if (isLoading || !facets) {
+    return <LoadingState />
+  }
+
+  return (
+    <FilterSidebarFrame sticky>
+      <FilterSidebarHeader canClear={hasActiveFilters} onClear={clearAllFilters} />
+      <FilterSidebarBody>
+        <SearchableFilterSection
+          title="Service"
+          options={facets.services}
+          selected={search.services ?? []}
+          onChange={(val) => updateFilter("services", val)}
+        />
+
+        {facets.httpMethods.length > 0 && (
+          <>
+            <Separator className="my-2" />
+            <FilterSection
+              title="HTTP Method"
+              options={facets.httpMethods}
+              selected={search.httpMethods ?? []}
+              onChange={(val) => updateFilter("httpMethods", val)}
+            />
+          </>
+        )}
+      </FilterSidebarBody>
+    </FilterSidebarFrame>
+  )
+}

--- a/apps/web/src/components/endpoints/endpoints-table.tsx
+++ b/apps/web/src/components/endpoints/endpoints-table.tsx
@@ -1,0 +1,222 @@
+import { Result, useAtomValue } from "@effect-atom/atom-react"
+import { Link } from "@tanstack/react-router"
+
+import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@maple/ui/components/ui/table"
+import { Badge } from "@maple/ui/components/ui/badge"
+import { Skeleton } from "@maple/ui/components/ui/skeleton"
+import type { HttpEndpointOverview } from "@/api/tinybird/endpoints-overview"
+import { getHttpEndpointsOverviewResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
+
+function formatLatency(ms: number): string {
+  if (ms == null || Number.isNaN(ms)) return "-"
+  if (ms < 1) return `${(ms * 1000).toFixed(0)}μs`
+  if (ms < 1000) return `${ms.toFixed(1)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+function formatCount(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`
+  return count.toLocaleString()
+}
+
+function formatErrorRate(rate: number): string {
+  if (rate < 0.01) return "0%"
+  if (rate < 1) return `${rate.toFixed(2)}%`
+  return `${rate.toFixed(1)}%`
+}
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: "bg-emerald-500/10 text-emerald-600 dark:bg-emerald-400/10 dark:text-emerald-400",
+  POST: "bg-blue-500/10 text-blue-600 dark:bg-blue-400/10 dark:text-blue-400",
+  PUT: "bg-amber-500/10 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400",
+  PATCH: "bg-orange-500/10 text-orange-600 dark:bg-orange-400/10 dark:text-orange-400",
+  DELETE: "bg-red-500/10 text-red-600 dark:bg-red-400/10 dark:text-red-400",
+}
+
+function MethodBadge({ method }: { method: string }) {
+  const colorClass = METHOD_COLORS[method.toUpperCase()] ?? ""
+  return (
+    <Badge variant="secondary" className={`font-mono text-[11px] ${colorClass}`}>
+      {method}
+    </Badge>
+  )
+}
+
+export interface EndpointsTableProps {
+  filters?: {
+    startTime?: string
+    endTime?: string
+    service?: string
+    environments?: string[]
+  }
+}
+
+function LoadingState() {
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[80px]">Method</TableHead>
+            <TableHead>Endpoint</TableHead>
+            <TableHead className="w-[140px]">Service</TableHead>
+            <TableHead className="w-[90px] text-right">Requests</TableHead>
+            <TableHead className="w-[80px] text-right">P50</TableHead>
+            <TableHead className="w-[80px] text-right">P95</TableHead>
+            <TableHead className="w-[80px] text-right">P99</TableHead>
+            <TableHead className="w-[90px] text-right">Error Rate</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <TableRow key={i}>
+              <TableCell><Skeleton className="h-5 w-12" /></TableCell>
+              <TableCell><Skeleton className="h-4 w-48" /></TableCell>
+              <TableCell><Skeleton className="h-4 w-24" /></TableCell>
+              <TableCell><Skeleton className="h-4 w-14 ml-auto" /></TableCell>
+              <TableCell><Skeleton className="h-4 w-14 ml-auto" /></TableCell>
+              <TableCell><Skeleton className="h-4 w-14 ml-auto" /></TableCell>
+              <TableCell><Skeleton className="h-4 w-14 ml-auto" /></TableCell>
+              <TableCell><Skeleton className="h-4 w-14 ml-auto" /></TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+export function EndpointsTable({ filters }: EndpointsTableProps) {
+  const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
+    useEffectiveTimeRange(filters?.startTime, filters?.endTime)
+
+  const result = useAtomValue(
+    getHttpEndpointsOverviewResultAtom({
+      data: {
+        startTime: effectiveStartTime,
+        endTime: effectiveEndTime,
+        serviceName: filters?.service,
+        environments: filters?.environments,
+      },
+    }),
+  )
+
+  return Result.builder(result)
+    .onInitial(() => <LoadingState />)
+    .onError((error) => (
+      <div className="rounded-md border border-red-500/50 bg-red-500/10 p-8">
+        <p className="font-medium text-red-600">Failed to load endpoints</p>
+        <pre className="mt-2 text-xs text-red-500 whitespace-pre-wrap">{error.message}</pre>
+      </div>
+    ))
+    .onSuccess((response, resultState) => {
+      const endpoints = response.data
+
+      return (
+        <div className={`space-y-4 transition-opacity ${resultState.waiting ? "opacity-60" : ""}`}>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[80px]">Method</TableHead>
+                  <TableHead>Endpoint</TableHead>
+                  <TableHead className="w-[140px]">Service</TableHead>
+                  <TableHead className="w-[90px] text-right">Requests</TableHead>
+                  <TableHead className="w-[80px] text-right">P50</TableHead>
+                  <TableHead className="w-[80px] text-right">P95</TableHead>
+                  <TableHead className="w-[80px] text-right">P99</TableHead>
+                  <TableHead className="w-[90px] text-right">Error Rate</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {endpoints.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={8} className="h-24 text-center">
+                      No HTTP endpoints found in traces
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  endpoints.map((endpoint: HttpEndpointOverview) => (
+                    <TableRow
+                      key={`${endpoint.serviceName}-${endpoint.httpMethod}-${endpoint.endpointName}`}
+                      className="hover:bg-muted/50"
+                    >
+                      <TableCell>
+                        <MethodBadge method={endpoint.httpMethod} />
+                      </TableCell>
+                      <TableCell>
+                        <Link
+                          to="/traces"
+                          search={{
+                            spanNames: [endpoint.endpointName],
+                            services: [endpoint.serviceName],
+                            startTime: filters?.startTime,
+                            endTime: filters?.endTime,
+                          }}
+                          className="font-mono text-sm text-primary hover:underline"
+                        >
+                          {endpoint.endpointName}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <Link
+                          to="/services/$serviceName"
+                          params={{ serviceName: endpoint.serviceName }}
+                          search={{
+                            startTime: filters?.startTime,
+                            endTime: filters?.endTime,
+                          }}
+                          className="text-sm text-muted-foreground hover:text-primary hover:underline"
+                        >
+                          {endpoint.serviceName}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-right font-mono text-xs">
+                        {formatCount(endpoint.count)}
+                      </TableCell>
+                      <TableCell className="text-right font-mono text-xs">
+                        {formatLatency(endpoint.p50Duration)}
+                      </TableCell>
+                      <TableCell className="text-right font-mono text-xs">
+                        {formatLatency(endpoint.p95Duration)}
+                      </TableCell>
+                      <TableCell className="text-right font-mono text-xs">
+                        {formatLatency(endpoint.p99Duration)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <span
+                          className={`font-mono text-xs ${
+                            endpoint.errorRate > 5
+                              ? "text-red-600 dark:text-red-400 font-semibold"
+                              : endpoint.errorRate > 1
+                                ? "text-amber-600 dark:text-amber-400"
+                                : "text-muted-foreground"
+                          }`}
+                        >
+                          {formatErrorRate(endpoint.errorRate)}
+                        </span>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="text-sm text-muted-foreground">
+            Showing {endpoints.length} endpoint{endpoints.length !== 1 ? "s" : ""}
+          </div>
+        </div>
+      )
+    })
+    .render()
+}

--- a/apps/web/src/components/endpoints/endpoints-table.tsx
+++ b/apps/web/src/components/endpoints/endpoints-table.tsx
@@ -10,10 +10,10 @@ import {
   TableHeader,
   TableRow,
 } from "@maple/ui/components/ui/table"
-import { Badge } from "@maple/ui/components/ui/badge"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { Sparkline } from "@maple/ui/components/ui/gradient-chart"
 import type { HttpEndpointOverview } from "@/api/tinybird/endpoints-overview"
+import { MethodBadge } from "@/components/endpoints/method-badge"
 import {
   getHttpEndpointsOverviewResultAtom,
   getHttpEndpointsSparklinesResultAtom,
@@ -42,23 +42,6 @@ function formatErrorRate(rate: number): string {
   if (rate < 0.01) return "0%"
   if (rate < 1) return `${rate.toFixed(2)}%`
   return `${rate.toFixed(1)}%`
-}
-
-const METHOD_COLORS: Record<string, string> = {
-  GET: "bg-emerald-500/10 text-emerald-600 dark:bg-emerald-400/10 dark:text-emerald-400",
-  POST: "bg-blue-500/10 text-blue-600 dark:bg-blue-400/10 dark:text-blue-400",
-  PUT: "bg-amber-500/10 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400",
-  PATCH: "bg-orange-500/10 text-orange-600 dark:bg-orange-400/10 dark:text-orange-400",
-  DELETE: "bg-red-500/10 text-red-600 dark:bg-red-400/10 dark:text-red-400",
-}
-
-function MethodBadge({ method }: { method: string }) {
-  const colorClass = METHOD_COLORS[method.toUpperCase()] ?? ""
-  return (
-    <Badge variant="secondary" className={`font-mono text-[11px] ${colorClass}`}>
-      {method}
-    </Badge>
-  )
 }
 
 export interface EndpointsTableProps {
@@ -195,10 +178,11 @@ export function EndpointsTable({ filters }: EndpointsTableProps) {
                         </TableCell>
                         <TableCell className="truncate max-w-0">
                           <Link
-                            to="/traces"
+                            to="/endpoints/detail"
                             search={{
-                              spanNames: [endpoint.endpointName],
-                              services: [endpoint.serviceName],
+                              service: endpoint.serviceName,
+                              endpoint: endpoint.endpointName,
+                              method: endpoint.httpMethod,
                               startTime: filters?.startTime,
                               endTime: filters?.endTime,
                             }}

--- a/apps/web/src/components/endpoints/method-badge.tsx
+++ b/apps/web/src/components/endpoints/method-badge.tsx
@@ -1,0 +1,18 @@
+import { Badge } from "@maple/ui/components/ui/badge"
+
+export const METHOD_COLORS: Record<string, string> = {
+  GET: "bg-emerald-500/10 text-emerald-600 dark:bg-emerald-400/10 dark:text-emerald-400",
+  POST: "bg-blue-500/10 text-blue-600 dark:bg-blue-400/10 dark:text-blue-400",
+  PUT: "bg-amber-500/10 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400",
+  PATCH: "bg-orange-500/10 text-orange-600 dark:bg-orange-400/10 dark:text-orange-400",
+  DELETE: "bg-red-500/10 text-red-600 dark:bg-red-400/10 dark:text-red-400",
+}
+
+export function MethodBadge({ method, className }: { method: string; className?: string }) {
+  const colorClass = METHOD_COLORS[method.toUpperCase()] ?? ""
+  return (
+    <Badge variant="secondary" className={`font-mono text-[11px] ${colorClass} ${className ?? ""}`}>
+      {method}
+    </Badge>
+  )
+}

--- a/apps/web/src/lib/services/atoms/tinybird-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/tinybird-query-atoms.ts
@@ -6,6 +6,7 @@ import {
   getCustomChartTimeSeries,
   getOverviewTimeSeries,
 } from "@/api/tinybird/custom-charts"
+import { getEndpointDetailTimeSeries, getEndpointStatusCodeBreakdown } from "@/api/tinybird/endpoint-detail"
 import { getHttpEndpointsOverview, getHttpEndpointsSparklines } from "@/api/tinybird/endpoints-overview"
 import {
   getErrorDetailTraces,
@@ -218,6 +219,20 @@ export const getResourceAttributeKeysResultAtom = makeQueryAtomFamily(getResourc
 export const getResourceAttributeValuesResultAtom = makeQueryAtomFamily(getResourceAttributeValues, {
   staleTime: 30_000,
 })
+
+export const getEndpointDetailTimeSeriesResultAtom = makeQueryAtomFamily(
+  getEndpointDetailTimeSeries,
+  {
+    staleTime: 30_000,
+  },
+)
+
+export const getEndpointStatusCodeBreakdownResultAtom = makeQueryAtomFamily(
+  getEndpointStatusCodeBreakdown,
+  {
+    staleTime: 30_000,
+  },
+)
 
 export const getHttpEndpointsOverviewResultAtom = makeQueryAtomFamily(
   getHttpEndpointsOverview,

--- a/apps/web/src/lib/services/atoms/tinybird-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/tinybird-query-atoms.ts
@@ -6,6 +6,7 @@ import {
   getCustomChartTimeSeries,
   getOverviewTimeSeries,
 } from "@/api/tinybird/custom-charts"
+import { getHttpEndpointsOverview } from "@/api/tinybird/endpoints-overview"
 import {
   getErrorDetailTraces,
   getErrorsByType,
@@ -217,3 +218,10 @@ export const getResourceAttributeKeysResultAtom = makeQueryAtomFamily(getResourc
 export const getResourceAttributeValuesResultAtom = makeQueryAtomFamily(getResourceAttributeValues, {
   staleTime: 30_000,
 })
+
+export const getHttpEndpointsOverviewResultAtom = makeQueryAtomFamily(
+  getHttpEndpointsOverview,
+  {
+    staleTime: 30_000,
+  },
+)

--- a/apps/web/src/lib/services/atoms/tinybird-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/tinybird-query-atoms.ts
@@ -6,7 +6,7 @@ import {
   getCustomChartTimeSeries,
   getOverviewTimeSeries,
 } from "@/api/tinybird/custom-charts"
-import { getHttpEndpointsOverview } from "@/api/tinybird/endpoints-overview"
+import { getHttpEndpointsOverview, getHttpEndpointsSparklines } from "@/api/tinybird/endpoints-overview"
 import {
   getErrorDetailTraces,
   getErrorsByType,
@@ -221,6 +221,13 @@ export const getResourceAttributeValuesResultAtom = makeQueryAtomFamily(getResou
 
 export const getHttpEndpointsOverviewResultAtom = makeQueryAtomFamily(
   getHttpEndpointsOverview,
+  {
+    staleTime: 30_000,
+  },
+)
+
+export const getHttpEndpointsSparklinesResultAtom = makeQueryAtomFamily(
+  getHttpEndpointsSparklines,
   {
     staleTime: 30_000,
   },

--- a/apps/web/src/lib/tinybird.ts
+++ b/apps/web/src/lib/tinybird.ts
@@ -29,6 +29,7 @@ import type {
   ServiceDependenciesOutput,
   ServiceOverviewOutput,
   ServicesFacetsOutput,
+  HttpEndpointsOverviewOutput,
   ResourceAttributeKeysOutput,
   ResourceAttributeValuesOutput,
   SpanAttributeKeysOutput,
@@ -89,6 +90,8 @@ export type {
   ServiceOverviewOutput,
   ServicesFacetsParams,
   ServicesFacetsOutput,
+  HttpEndpointsOverviewParams,
+  HttpEndpointsOverviewOutput,
   ResourceAttributeKeysParams,
   ResourceAttributeKeysOutput,
   ResourceAttributeValuesParams,
@@ -192,6 +195,8 @@ const query = {
     queryTinybird<ResourceAttributeKeysOutput>("resource_attribute_keys", params),
   resource_attribute_values: (params?: Record<string, unknown>) =>
     queryTinybird<ResourceAttributeValuesOutput>("resource_attribute_values", params),
+  http_endpoints_overview: (params?: Record<string, unknown>) =>
+    queryTinybird<HttpEndpointsOverviewOutput>("http_endpoints_overview", params),
 }
 
 export function createTinybird() {

--- a/apps/web/src/lib/tinybird.ts
+++ b/apps/web/src/lib/tinybird.ts
@@ -30,6 +30,7 @@ import type {
   ServiceOverviewOutput,
   ServicesFacetsOutput,
   HttpEndpointsOverviewOutput,
+  HttpEndpointsTimeseriesOutput,
   ResourceAttributeKeysOutput,
   ResourceAttributeValuesOutput,
   SpanAttributeKeysOutput,
@@ -92,6 +93,8 @@ export type {
   ServicesFacetsOutput,
   HttpEndpointsOverviewParams,
   HttpEndpointsOverviewOutput,
+  HttpEndpointsTimeseriesParams,
+  HttpEndpointsTimeseriesOutput,
   ResourceAttributeKeysParams,
   ResourceAttributeKeysOutput,
   ResourceAttributeValuesParams,
@@ -197,6 +200,8 @@ const query = {
     queryTinybird<ResourceAttributeValuesOutput>("resource_attribute_values", params),
   http_endpoints_overview: (params?: Record<string, unknown>) =>
     queryTinybird<HttpEndpointsOverviewOutput>("http_endpoints_overview", params),
+  http_endpoints_timeseries: (params?: Record<string, unknown>) =>
+    queryTinybird<HttpEndpointsTimeseriesOutput>("http_endpoints_timeseries", params),
 }
 
 export function createTinybird() {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as MetricsRouteImport } from './routes/metrics'
 import { Route as McpRouteImport } from './routes/mcp'
 import { Route as LogsRouteImport } from './routes/logs'
 import { Route as ErrorsRouteImport } from './routes/errors'
+import { Route as EndpointsRouteImport } from './routes/endpoints'
 import { Route as DeveloperRouteImport } from './routes/developer'
 import { Route as DashboardsRouteImport } from './routes/dashboards'
 import { Route as ConnectorsRouteImport } from './routes/connectors'
@@ -90,6 +91,11 @@ const ErrorsRoute = ErrorsRouteImport.update({
   path: '/errors',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EndpointsRoute = EndpointsRouteImport.update({
+  id: '/endpoints',
+  path: '/endpoints',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DeveloperRoute = DeveloperRouteImport.update({
   id: '/developer',
   path: '/developer',
@@ -136,6 +142,7 @@ export interface FileRoutesByFullPath {
   '/connectors': typeof ConnectorsRoute
   '/dashboards': typeof DashboardsRoute
   '/developer': typeof DeveloperRoute
+  '/endpoints': typeof EndpointsRoute
   '/errors': typeof ErrorsRoute
   '/logs': typeof LogsRoute
   '/mcp': typeof McpRoute
@@ -158,6 +165,7 @@ export interface FileRoutesByTo {
   '/connectors': typeof ConnectorsRoute
   '/dashboards': typeof DashboardsRoute
   '/developer': typeof DeveloperRoute
+  '/endpoints': typeof EndpointsRoute
   '/errors': typeof ErrorsRoute
   '/logs': typeof LogsRoute
   '/mcp': typeof McpRoute
@@ -181,6 +189,7 @@ export interface FileRoutesById {
   '/connectors': typeof ConnectorsRoute
   '/dashboards': typeof DashboardsRoute
   '/developer': typeof DeveloperRoute
+  '/endpoints': typeof EndpointsRoute
   '/errors': typeof ErrorsRoute
   '/logs': typeof LogsRoute
   '/mcp': typeof McpRoute
@@ -205,6 +214,7 @@ export interface FileRouteTypes {
     | '/connectors'
     | '/dashboards'
     | '/developer'
+    | '/endpoints'
     | '/errors'
     | '/logs'
     | '/mcp'
@@ -227,6 +237,7 @@ export interface FileRouteTypes {
     | '/connectors'
     | '/dashboards'
     | '/developer'
+    | '/endpoints'
     | '/errors'
     | '/logs'
     | '/mcp'
@@ -249,6 +260,7 @@ export interface FileRouteTypes {
     | '/connectors'
     | '/dashboards'
     | '/developer'
+    | '/endpoints'
     | '/errors'
     | '/logs'
     | '/mcp'
@@ -272,6 +284,7 @@ export interface RootRouteChildren {
   ConnectorsRoute: typeof ConnectorsRoute
   DashboardsRoute: typeof DashboardsRoute
   DeveloperRoute: typeof DeveloperRoute
+  EndpointsRoute: typeof EndpointsRoute
   ErrorsRoute: typeof ErrorsRoute
   LogsRoute: typeof LogsRoute
   McpRoute: typeof McpRoute
@@ -376,6 +389,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ErrorsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/endpoints': {
+      id: '/endpoints'
+      path: '/endpoints'
+      fullPath: '/endpoints'
+      preLoaderRoute: typeof EndpointsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/developer': {
       id: '/developer'
       path: '/developer'
@@ -440,6 +460,7 @@ const rootRouteChildren: RootRouteChildren = {
   ConnectorsRoute: ConnectorsRoute,
   DashboardsRoute: DashboardsRoute,
   DeveloperRoute: DeveloperRoute,
+  EndpointsRoute: EndpointsRoute,
   ErrorsRoute: ErrorsRoute,
   LogsRoute: LogsRoute,
   McpRoute: McpRoute,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -21,15 +21,16 @@ import { Route as MetricsRouteImport } from './routes/metrics'
 import { Route as McpRouteImport } from './routes/mcp'
 import { Route as LogsRouteImport } from './routes/logs'
 import { Route as ErrorsRouteImport } from './routes/errors'
-import { Route as EndpointsRouteImport } from './routes/endpoints'
 import { Route as DeveloperRouteImport } from './routes/developer'
 import { Route as DashboardsRouteImport } from './routes/dashboards'
 import { Route as ConnectorsRouteImport } from './routes/connectors'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TracesIndexRouteImport } from './routes/traces/index'
 import { Route as ServicesIndexRouteImport } from './routes/services/index'
+import { Route as EndpointsIndexRouteImport } from './routes/endpoints/index'
 import { Route as TracesTraceIdRouteImport } from './routes/traces/$traceId'
 import { Route as ServicesServiceNameRouteImport } from './routes/services/$serviceName'
+import { Route as EndpointsDetailRouteImport } from './routes/endpoints/detail'
 
 const SignUpRoute = SignUpRouteImport.update({
   id: '/sign-up',
@@ -91,11 +92,6 @@ const ErrorsRoute = ErrorsRouteImport.update({
   path: '/errors',
   getParentRoute: () => rootRouteImport,
 } as any)
-const EndpointsRoute = EndpointsRouteImport.update({
-  id: '/endpoints',
-  path: '/endpoints',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const DeveloperRoute = DeveloperRouteImport.update({
   id: '/developer',
   path: '/developer',
@@ -126,6 +122,11 @@ const ServicesIndexRoute = ServicesIndexRouteImport.update({
   path: '/services/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EndpointsIndexRoute = EndpointsIndexRouteImport.update({
+  id: '/endpoints/',
+  path: '/endpoints/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const TracesTraceIdRoute = TracesTraceIdRouteImport.update({
   id: '/traces/$traceId',
   path: '/traces/$traceId',
@@ -136,13 +137,17 @@ const ServicesServiceNameRoute = ServicesServiceNameRouteImport.update({
   path: '/services/$serviceName',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EndpointsDetailRoute = EndpointsDetailRouteImport.update({
+  id: '/endpoints/detail',
+  path: '/endpoints/detail',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/connectors': typeof ConnectorsRoute
   '/dashboards': typeof DashboardsRoute
   '/developer': typeof DeveloperRoute
-  '/endpoints': typeof EndpointsRoute
   '/errors': typeof ErrorsRoute
   '/logs': typeof LogsRoute
   '/mcp': typeof McpRoute
@@ -155,8 +160,10 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRoute
   '/sign-in': typeof SignInRoute
   '/sign-up': typeof SignUpRoute
+  '/endpoints/detail': typeof EndpointsDetailRoute
   '/services/$serviceName': typeof ServicesServiceNameRoute
   '/traces/$traceId': typeof TracesTraceIdRoute
+  '/endpoints/': typeof EndpointsIndexRoute
   '/services/': typeof ServicesIndexRoute
   '/traces/': typeof TracesIndexRoute
 }
@@ -165,7 +172,6 @@ export interface FileRoutesByTo {
   '/connectors': typeof ConnectorsRoute
   '/dashboards': typeof DashboardsRoute
   '/developer': typeof DeveloperRoute
-  '/endpoints': typeof EndpointsRoute
   '/errors': typeof ErrorsRoute
   '/logs': typeof LogsRoute
   '/mcp': typeof McpRoute
@@ -178,8 +184,10 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsRoute
   '/sign-in': typeof SignInRoute
   '/sign-up': typeof SignUpRoute
+  '/endpoints/detail': typeof EndpointsDetailRoute
   '/services/$serviceName': typeof ServicesServiceNameRoute
   '/traces/$traceId': typeof TracesTraceIdRoute
+  '/endpoints': typeof EndpointsIndexRoute
   '/services': typeof ServicesIndexRoute
   '/traces': typeof TracesIndexRoute
 }
@@ -189,7 +197,6 @@ export interface FileRoutesById {
   '/connectors': typeof ConnectorsRoute
   '/dashboards': typeof DashboardsRoute
   '/developer': typeof DeveloperRoute
-  '/endpoints': typeof EndpointsRoute
   '/errors': typeof ErrorsRoute
   '/logs': typeof LogsRoute
   '/mcp': typeof McpRoute
@@ -202,8 +209,10 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRoute
   '/sign-in': typeof SignInRoute
   '/sign-up': typeof SignUpRoute
+  '/endpoints/detail': typeof EndpointsDetailRoute
   '/services/$serviceName': typeof ServicesServiceNameRoute
   '/traces/$traceId': typeof TracesTraceIdRoute
+  '/endpoints/': typeof EndpointsIndexRoute
   '/services/': typeof ServicesIndexRoute
   '/traces/': typeof TracesIndexRoute
 }
@@ -214,7 +223,6 @@ export interface FileRouteTypes {
     | '/connectors'
     | '/dashboards'
     | '/developer'
-    | '/endpoints'
     | '/errors'
     | '/logs'
     | '/mcp'
@@ -227,8 +235,10 @@ export interface FileRouteTypes {
     | '/settings'
     | '/sign-in'
     | '/sign-up'
+    | '/endpoints/detail'
     | '/services/$serviceName'
     | '/traces/$traceId'
+    | '/endpoints/'
     | '/services/'
     | '/traces/'
   fileRoutesByTo: FileRoutesByTo
@@ -237,7 +247,6 @@ export interface FileRouteTypes {
     | '/connectors'
     | '/dashboards'
     | '/developer'
-    | '/endpoints'
     | '/errors'
     | '/logs'
     | '/mcp'
@@ -250,8 +259,10 @@ export interface FileRouteTypes {
     | '/settings'
     | '/sign-in'
     | '/sign-up'
+    | '/endpoints/detail'
     | '/services/$serviceName'
     | '/traces/$traceId'
+    | '/endpoints'
     | '/services'
     | '/traces'
   id:
@@ -260,7 +271,6 @@ export interface FileRouteTypes {
     | '/connectors'
     | '/dashboards'
     | '/developer'
-    | '/endpoints'
     | '/errors'
     | '/logs'
     | '/mcp'
@@ -273,8 +283,10 @@ export interface FileRouteTypes {
     | '/settings'
     | '/sign-in'
     | '/sign-up'
+    | '/endpoints/detail'
     | '/services/$serviceName'
     | '/traces/$traceId'
+    | '/endpoints/'
     | '/services/'
     | '/traces/'
   fileRoutesById: FileRoutesById
@@ -284,7 +296,6 @@ export interface RootRouteChildren {
   ConnectorsRoute: typeof ConnectorsRoute
   DashboardsRoute: typeof DashboardsRoute
   DeveloperRoute: typeof DeveloperRoute
-  EndpointsRoute: typeof EndpointsRoute
   ErrorsRoute: typeof ErrorsRoute
   LogsRoute: typeof LogsRoute
   McpRoute: typeof McpRoute
@@ -297,8 +308,10 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRoute
   SignInRoute: typeof SignInRoute
   SignUpRoute: typeof SignUpRoute
+  EndpointsDetailRoute: typeof EndpointsDetailRoute
   ServicesServiceNameRoute: typeof ServicesServiceNameRoute
   TracesTraceIdRoute: typeof TracesTraceIdRoute
+  EndpointsIndexRoute: typeof EndpointsIndexRoute
   ServicesIndexRoute: typeof ServicesIndexRoute
   TracesIndexRoute: typeof TracesIndexRoute
 }
@@ -389,13 +402,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ErrorsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/endpoints': {
-      id: '/endpoints'
-      path: '/endpoints'
-      fullPath: '/endpoints'
-      preLoaderRoute: typeof EndpointsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/developer': {
       id: '/developer'
       path: '/developer'
@@ -438,6 +444,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServicesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/endpoints/': {
+      id: '/endpoints/'
+      path: '/endpoints'
+      fullPath: '/endpoints/'
+      preLoaderRoute: typeof EndpointsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/traces/$traceId': {
       id: '/traces/$traceId'
       path: '/traces/$traceId'
@@ -452,6 +465,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServicesServiceNameRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/endpoints/detail': {
+      id: '/endpoints/detail'
+      path: '/endpoints/detail'
+      fullPath: '/endpoints/detail'
+      preLoaderRoute: typeof EndpointsDetailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -460,7 +480,6 @@ const rootRouteChildren: RootRouteChildren = {
   ConnectorsRoute: ConnectorsRoute,
   DashboardsRoute: DashboardsRoute,
   DeveloperRoute: DeveloperRoute,
-  EndpointsRoute: EndpointsRoute,
   ErrorsRoute: ErrorsRoute,
   LogsRoute: LogsRoute,
   McpRoute: McpRoute,
@@ -473,8 +492,10 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRoute,
   SignInRoute: SignInRoute,
   SignUpRoute: SignUpRoute,
+  EndpointsDetailRoute: EndpointsDetailRoute,
   ServicesServiceNameRoute: ServicesServiceNameRoute,
   TracesTraceIdRoute: TracesTraceIdRoute,
+  EndpointsIndexRoute: EndpointsIndexRoute,
   ServicesIndexRoute: ServicesIndexRoute,
   TracesIndexRoute: TracesIndexRoute,
 }

--- a/apps/web/src/routes/endpoints.tsx
+++ b/apps/web/src/routes/endpoints.tsx
@@ -1,0 +1,51 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { Schema } from "effect"
+
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { EndpointsTable } from "@/components/endpoints/endpoints-table"
+import { TimeRangePicker } from "@/components/time-range-picker"
+
+const endpointsSearchSchema = Schema.Struct({
+  startTime: Schema.optional(Schema.String),
+  endTime: Schema.optional(Schema.String),
+  service: Schema.optional(Schema.String),
+})
+
+export const Route = createFileRoute("/endpoints")({
+  component: EndpointsPage,
+  validateSearch: Schema.standardSchemaV1(endpointsSearchSchema),
+})
+
+function EndpointsPage() {
+  const search = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  const handleTimeChange = ({
+    startTime,
+    endTime,
+  }: {
+    startTime?: string
+    endTime?: string
+  }) => {
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, startTime, endTime }),
+    })
+  }
+
+  return (
+    <DashboardLayout
+      breadcrumbs={[{ label: "Endpoints" }]}
+      title="Endpoints"
+      description="HTTP endpoints discovered from your traces."
+      headerActions={
+        <TimeRangePicker
+          startTime={search.startTime}
+          endTime={search.endTime}
+          onChange={handleTimeChange}
+        />
+      }
+    >
+      <EndpointsTable filters={search} />
+    </DashboardLayout>
+  )
+}

--- a/apps/web/src/routes/endpoints.tsx
+++ b/apps/web/src/routes/endpoints.tsx
@@ -1,14 +1,21 @@
+import { useMemo } from "react"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { Result, useAtomValue } from "@effect-atom/atom-react"
 import { Schema } from "effect"
 
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { EndpointsTable } from "@/components/endpoints/endpoints-table"
+import { EndpointsFilterSidebar, type EndpointsFacets } from "@/components/endpoints/endpoints-filter-sidebar"
+import type { FilterOption } from "@/components/filters/filter-section"
 import { TimeRangePicker } from "@/components/time-range-picker"
+import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { getHttpEndpointsOverviewResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
 
 const endpointsSearchSchema = Schema.Struct({
   startTime: Schema.optional(Schema.String),
   endTime: Schema.optional(Schema.String),
-  service: Schema.optional(Schema.String),
+  services: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+  httpMethods: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
 })
 
 export const Route = createFileRoute("/endpoints")({
@@ -19,6 +26,9 @@ export const Route = createFileRoute("/endpoints")({
 function EndpointsPage() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
+
+  const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
+    useEffectiveTimeRange(search.startTime, search.endTime)
 
   const handleTimeChange = ({
     startTime,
@@ -32,6 +42,42 @@ function EndpointsPage() {
     })
   }
 
+  // Unfiltered overview for deriving facet counts
+  const unfilteredResult = useAtomValue(
+    getHttpEndpointsOverviewResultAtom({
+      data: {
+        startTime: effectiveStartTime,
+        endTime: effectiveEndTime,
+      },
+    }),
+  )
+
+  const facets = useMemo((): EndpointsFacets | undefined => {
+    if (!Result.isSuccess(unfilteredResult)) return undefined
+    const data = unfilteredResult.value.data
+
+    const serviceMap = new Map<string, number>()
+    const methodMap = new Map<string, number>()
+    for (const row of data) {
+      serviceMap.set(row.serviceName, (serviceMap.get(row.serviceName) ?? 0) + row.count)
+      if (row.httpMethod && row.httpMethod !== "UNKNOWN") {
+        methodMap.set(row.httpMethod, (methodMap.get(row.httpMethod) ?? 0) + row.count)
+      }
+    }
+
+    const toSorted = (map: Map<string, number>): FilterOption[] =>
+      Array.from(map.entries())
+        .map(([name, count]) => ({ name, count }))
+        .sort((a, b) => b.count - a.count)
+
+    return {
+      services: toSorted(serviceMap),
+      httpMethods: toSorted(methodMap),
+    }
+  }, [unfilteredResult])
+
+  const isLoading = Result.isInitial(unfilteredResult)
+
   return (
     <DashboardLayout
       breadcrumbs={[{ label: "Endpoints" }]}
@@ -43,6 +89,9 @@ function EndpointsPage() {
           endTime={search.endTime}
           onChange={handleTimeChange}
         />
+      }
+      filterSidebar={
+        <EndpointsFilterSidebar facets={facets} isLoading={isLoading} />
       }
     >
       <EndpointsTable filters={search} />

--- a/apps/web/src/routes/endpoints/detail.tsx
+++ b/apps/web/src/routes/endpoints/detail.tsx
@@ -114,12 +114,15 @@ function EndpointDetailPage() {
     }),
   )
 
-  // Recent traces
+  // Recent traces — filter by http.route attribute since endpointName
+  // comes from http.route (not rootSpanName which list_traces filters on)
   const tracesResult = useAtomValue(
     listTracesResultAtom({
       data: {
         service: search.service,
-        spanName: search.endpoint,
+        httpMethod: search.method,
+        attributeKey: "http.route",
+        attributeValue: search.endpoint,
         startTime: effectiveStartTime,
         endTime: effectiveEndTime,
         limit: 20,
@@ -226,6 +229,7 @@ function EndpointDetailPage() {
             traces={traces}
             service={search.service}
             endpoint={search.endpoint}
+            method={search.method}
             startTime={search.startTime}
             endTime={search.endTime}
           />

--- a/apps/web/src/routes/endpoints/detail.tsx
+++ b/apps/web/src/routes/endpoints/detail.tsx
@@ -1,0 +1,236 @@
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { Result, useAtomValue } from "@effect-atom/atom-react"
+import { Schema } from "effect"
+
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { TimeRangePicker } from "@/components/time-range-picker"
+import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { MetricsGrid } from "@/components/dashboard/metrics-grid"
+import { MethodBadge } from "@/components/endpoints/method-badge"
+import { EndpointSummaryStats } from "@/components/endpoints/endpoint-summary-stats"
+import { EndpointStatusBreakdown } from "@/components/endpoints/endpoint-status-breakdown"
+import { EndpointRecentTraces } from "@/components/endpoints/endpoint-recent-traces"
+import { ReadonlyWidgetShell } from "@/components/dashboard-builder/widgets/widget-shell"
+import {
+  getEndpointDetailTimeSeriesResultAtom,
+  getEndpointStatusCodeBreakdownResultAtom,
+  getHttpEndpointsOverviewResultAtom,
+  listTracesResultAtom,
+} from "@/lib/services/atoms/tinybird-query-atoms"
+import type { ChartLegendMode, ChartTooltipMode } from "@maple/ui/components/charts/_shared/chart-types"
+
+const endpointDetailSearchSchema = Schema.Struct({
+  service: Schema.String,
+  endpoint: Schema.String,
+  method: Schema.String,
+  startTime: Schema.optional(Schema.String),
+  endTime: Schema.optional(Schema.String),
+  timePreset: Schema.optional(Schema.String),
+})
+
+export const Route = createFileRoute("/endpoints/detail")({
+  component: EndpointDetailPage,
+  validateSearch: Schema.standardSchemaV1(endpointDetailSearchSchema),
+})
+
+interface EndpointChartConfig {
+  id: string
+  chartId: string
+  title: string
+  layout: { x: number; y: number; w: number; h: number }
+  legend?: ChartLegendMode
+  tooltip?: ChartTooltipMode
+}
+
+const ENDPOINT_CHARTS: EndpointChartConfig[] = [
+  { id: "latency", chartId: "latency-line", title: "Latency", layout: { x: 0, y: 0, w: 6, h: 4 }, legend: "visible", tooltip: "visible" },
+  { id: "throughput", chartId: "throughput-area", title: "Throughput", layout: { x: 6, y: 0, w: 6, h: 4 }, tooltip: "visible" },
+  { id: "error-rate", chartId: "error-rate-area", title: "Error Rate", layout: { x: 0, y: 4, w: 6, h: 4 }, tooltip: "visible" },
+]
+
+function EndpointDetailPage() {
+  const search = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
+    useEffectiveTimeRange(search.startTime, search.endTime)
+
+  const durationSeconds = Math.max(
+    (new Date(effectiveEndTime).getTime() - new Date(effectiveStartTime).getTime()) / 1000,
+    1,
+  )
+
+  const handleTimeChange = ({
+    startTime,
+    endTime,
+    presetValue,
+  }: {
+    startTime?: string
+    endTime?: string
+    presetValue?: string
+  }) => {
+    navigate({
+      search: {
+        ...search,
+        startTime,
+        endTime,
+        timePreset: presetValue,
+      },
+    })
+  }
+
+  // Time series data for charts
+  const timeSeriesResult = useAtomValue(
+    getEndpointDetailTimeSeriesResultAtom({
+      data: {
+        serviceName: search.service,
+        spanName: search.endpoint,
+        startTime: effectiveStartTime,
+        endTime: effectiveEndTime,
+      },
+    }),
+  )
+
+  // Status code breakdown
+  const statusCodeResult = useAtomValue(
+    getEndpointStatusCodeBreakdownResultAtom({
+      data: {
+        serviceName: search.service,
+        spanName: search.endpoint,
+        startTime: effectiveStartTime,
+        endTime: effectiveEndTime,
+      },
+    }),
+  )
+
+  // Overview stats (reuse existing endpoint, filter client-side)
+  const overviewResult = useAtomValue(
+    getHttpEndpointsOverviewResultAtom({
+      data: {
+        startTime: effectiveStartTime,
+        endTime: effectiveEndTime,
+        services: [search.service],
+      },
+    }),
+  )
+
+  // Recent traces
+  const tracesResult = useAtomValue(
+    listTracesResultAtom({
+      data: {
+        service: search.service,
+        spanName: search.endpoint,
+        startTime: effectiveStartTime,
+        endTime: effectiveEndTime,
+        limit: 20,
+      },
+    }),
+  )
+
+  // Extract matching endpoint from overview
+  const matchingEndpoint = Result.builder(overviewResult)
+    .onSuccess((response) =>
+      response.data.find(
+        (ep) =>
+          ep.serviceName === search.service &&
+          ep.endpointName === search.endpoint &&
+          ep.httpMethod === search.method,
+      ),
+    )
+    .orElse(() => undefined)
+
+  // Chart data
+  const detailPoints = Result.builder(timeSeriesResult)
+    .onSuccess((response) => response.data as unknown as Record<string, unknown>[])
+    .orElse(() => [])
+
+  const metrics = ENDPOINT_CHARTS.map((chart) => ({
+    id: chart.id,
+    chartId: chart.chartId,
+    title: chart.title,
+    layout: chart.layout,
+    data: detailPoints,
+    legend: chart.legend,
+    tooltip: chart.tooltip,
+  }))
+
+  // Status code data
+  const statusCodeData = Result.builder(statusCodeResult)
+    .onSuccess((response) => response.data)
+    .orElse(() => [])
+
+  // Traces data
+  const traces = Result.builder(tracesResult)
+    .onSuccess((response) => response.data)
+    .orElse(() => [])
+
+  return (
+    <DashboardLayout
+      breadcrumbs={[
+        { label: "Endpoints", href: "/endpoints" },
+        { label: `${search.method} ${search.endpoint}` },
+      ]}
+      titleContent={
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <MethodBadge method={search.method} />
+            <h1 className="text-2xl font-bold tracking-tight font-mono truncate" title={search.endpoint}>
+              {search.endpoint}
+            </h1>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Service:{" "}
+            <Link
+              to="/services/$serviceName"
+              params={{ serviceName: search.service }}
+              search={{ startTime: search.startTime, endTime: search.endTime }}
+              className="text-primary hover:underline"
+            >
+              {search.service}
+            </Link>
+          </p>
+        </div>
+      }
+      headerActions={
+        <TimeRangePicker
+          startTime={search.startTime}
+          endTime={search.endTime}
+          presetValue={search.timePreset ?? "12h"}
+          onChange={handleTimeChange}
+        />
+      }
+    >
+      <div className="space-y-6">
+        {/* Summary Stats */}
+        <EndpointSummaryStats endpoint={matchingEndpoint} durationSeconds={durationSeconds} />
+
+        {/* Charts */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {/* Latency, Throughput, Error Rate charts */}
+          <div className="md:col-span-2">
+            <MetricsGrid items={metrics} />
+          </div>
+
+          {/* Status Code Breakdown */}
+          <div className="md:col-span-2 lg:col-span-1">
+            <ReadonlyWidgetShell title="Status Code Distribution">
+              <EndpointStatusBreakdown data={statusCodeData} />
+            </ReadonlyWidgetShell>
+          </div>
+        </div>
+
+        {/* Recent Traces */}
+        <div>
+          <h2 className="mb-3 text-lg font-semibold">Recent Traces</h2>
+          <EndpointRecentTraces
+            traces={traces}
+            service={search.service}
+            endpoint={search.endpoint}
+            startTime={search.startTime}
+            endTime={search.endTime}
+          />
+        </div>
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/apps/web/src/routes/endpoints/index.tsx
+++ b/apps/web/src/routes/endpoints/index.tsx
@@ -18,7 +18,7 @@ const endpointsSearchSchema = Schema.Struct({
   httpMethods: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
 })
 
-export const Route = createFileRoute("/endpoints")({
+export const Route = createFileRoute("/endpoints/")({
   component: EndpointsPage,
   validateSearch: Schema.standardSchemaV1(endpointsSearchSchema),
 })

--- a/packages/domain/src/tinybird-pipes.ts
+++ b/packages/domain/src/tinybird-pipes.ts
@@ -32,6 +32,7 @@ export const tinybirdPipes = [
   "resource_attribute_keys",
   "resource_attribute_values",
   "http_endpoints_overview",
+  "http_endpoints_timeseries",
 ] as const
 
 export type TinybirdPipe = (typeof tinybirdPipes)[number]

--- a/packages/domain/src/tinybird-pipes.ts
+++ b/packages/domain/src/tinybird-pipes.ts
@@ -31,6 +31,7 @@ export const tinybirdPipes = [
   "span_attribute_values",
   "resource_attribute_keys",
   "resource_attribute_values",
+  "http_endpoints_overview",
 ] as const
 
 export type TinybirdPipe = (typeof tinybirdPipes)[number]


### PR DESCRIPTION
## Summary
This PR adds a new Endpoints page that displays HTTP server endpoints discovered from traces, with aggregated metrics including latency percentiles, throughput, and error rates.

## Key Changes

- **New Endpoints Page** (`/endpoints`): Displays a table of HTTP endpoints with filtering by time range and service
- **Tinybird Queries**: Added two new endpoints to the domain:
  - `http_endpoints_overview`: Aggregates metrics (count, latency percentiles, error rate) for HTTP server spans grouped by service, method, and route
  - `http_endpoints_timeseries`: Provides time-bucketed throughput and error rate data for sparkline visualizations
- **EndpointsTable Component**: Renders a comprehensive table with:
  - HTTP method badges with color coding (GET, POST, PUT, PATCH, DELETE)
  - Endpoint names and service links to related pages
  - Latency metrics (P50, P95, P99) with human-readable formatting
  - Sparkline charts for throughput and error rate trends
  - Formatted count and error rate displays
- **Navigation**: Added "Endpoints" link to the sidebar under telemetry section with chart bar icon
- **Atom Integration**: Created query atoms for both endpoints overview and sparklines data with 30-second stale time
- **Loading & Error States**: Includes skeleton loading state and error boundary handling

## Implementation Details

- HTTP endpoints are identified from server spans with `SpanKind = 'Server'`, extracting the route from `http.route` attribute
- Latency values are converted from nanoseconds to milliseconds for display
- Error rate is calculated as percentage of error status codes
- Sparkline data is filled with zeros for missing time buckets to ensure continuous visualization
- The table supports filtering by service name and time range, with links to drill down into traces and service details

https://claude.ai/code/session_01TvkFU6mqAgG7UFcFf6DMTk