### PR TITLE
Add orgId parameter to query atoms for multi-tenant support

### DIFF
--- a/apps/web/src/components/dashboard-builder/config/widget-query-builder-page.tsx
+++ b/apps/web/src/components/dashboard-builder/config/widget-query-builder-page.tsx
@@ -35,6 +35,7 @@ import {
   getTracesFacetsResultAtom,
   listMetricsResultAtom,
 } from "@/lib/services/atoms/tinybird-query-atoms"
+import { useOrgId } from "@/hooks/use-org-id"
 
 type StatAggregate = "sum" | "first" | "count" | "avg" | "max" | "min"
 
@@ -310,6 +311,7 @@ export function WidgetQueryBuilderPage({
   onApply,
   onCancel,
 }: WidgetQueryBuilderPageProps) {
+  const orgId = useOrgId()
   const [state, setState] = React.useState<QueryBuilderWidgetState>(() => toInitialState(widget))
   const [stagedState, setStagedState] = React.useState<QueryBuilderWidgetState>(() =>
     cloneWidgetState(toInitialState(widget))
@@ -318,15 +320,15 @@ export function WidgetQueryBuilderPage({
   const [collapsedQueries, setCollapsedQueries] = React.useState<Set<string>>(new Set())
 
   const metricsResult = useAtomValue(
-    listMetricsResultAtom({ data: { limit: 300 } }),
+    listMetricsResultAtom({ data: { limit: 300 } }, orgId),
   )
 
   const tracesFacetsResult = useAtomValue(
-    getTracesFacetsResultAtom({ data: {} }),
+    getTracesFacetsResultAtom({ data: {} }, orgId),
   )
 
   const logsFacetsResult = useAtomValue(
-    getLogsFacetsResultAtom({ data: {} }),
+    getLogsFacetsResultAtom({ data: {} }, orgId),
   )
 
   const metricRows = React.useMemo(

--- a/apps/web/src/components/dashboard/service-usage-cards.tsx
+++ b/apps/web/src/components/dashboard/service-usage-cards.tsx
@@ -9,6 +9,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@maple/ui/components/ui/card"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { getServiceUsageResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function formatNumber(num: number): string {
   if (num >= 1_000_000) {
@@ -66,8 +67,9 @@ interface ServiceUsageCardsProps {
 }
 
 export function ServiceUsageCards({ startTime, endTime }: ServiceUsageCardsProps = {}) {
+  const orgId = useOrgId()
   const responseResult = useAtomValue(
-    getServiceUsageResultAtom({ data: { startTime, endTime } }),
+    getServiceUsageResultAtom({ data: { startTime, endTime } }, orgId),
   )
 
   return Result.builder(responseResult)

--- a/apps/web/src/components/errors/errors-by-type-table.tsx
+++ b/apps/web/src/components/errors/errors-by-type-table.tsx
@@ -20,6 +20,7 @@ import {
   getErrorDetailTracesResultAtom,
   getErrorsByTypeResultAtom,
 } from "@/lib/services/atoms/tinybird-query-atoms"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function formatNumber(num: number): string {
   if (num >= 1_000_000) {
@@ -45,6 +46,7 @@ interface ErrorsByTypeTableProps {
 }
 
 function ErrorDetailPanel({ errorRow, filters }: { errorRow: ErrorByType; filters: GetErrorsByTypeInput }) {
+  const orgId = useOrgId()
   const detailResult = useAtomValue(
     getErrorDetailTracesResultAtom({
       data: {
@@ -54,7 +56,7 @@ function ErrorDetailPanel({ errorRow, filters }: { errorRow: ErrorByType; filter
         services: filters.services,
         limit: 5,
       },
-    }),
+    }, orgId),
   )
 
   return (
@@ -197,9 +199,10 @@ function LoadingState() {
 }
 
 export function ErrorsByTypeTable({ filters }: ErrorsByTypeTableProps) {
+  const orgId = useOrgId()
   const [expandedError, setExpandedError] = useState<string | null>(null)
 
-  const errorsResult = useAtomValue(getErrorsByTypeResultAtom({ data: filters }))
+  const errorsResult = useAtomValue(getErrorsByTypeResultAtom({ data: filters }, orgId))
 
   return Result.builder(errorsResult)
     .onInitial(() => <LoadingState />)

--- a/apps/web/src/components/errors/errors-filter-sidebar.tsx
+++ b/apps/web/src/components/errors/errors-filter-sidebar.tsx
@@ -13,12 +13,14 @@ import {
   FilterSidebarHeader,
   FilterSidebarLoading,
 } from "@/components/filters/filter-sidebar"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function LoadingState() {
   return <FilterSidebarLoading sectionCount={3} />
 }
 
 export function ErrorsFilterSidebar() {
+  const orgId = useOrgId()
   const navigate = useNavigate({ from: Route.fullPath })
   const search = Route.useSearch()
   const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
@@ -31,7 +33,7 @@ export function ErrorsFilterSidebar() {
         endTime: effectiveEndTime,
         showSpam: search.showSpam,
       },
-    }),
+    }, orgId),
   )
 
   const updateFilter = <K extends keyof typeof search>(

--- a/apps/web/src/components/errors/errors-summary-cards.tsx
+++ b/apps/web/src/components/errors/errors-summary-cards.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@maple/ui/components/u
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { type GetErrorsSummaryInput } from "@/api/tinybird/errors"
 import { getErrorsSummaryResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function formatNumber(num: number): string {
   if (num >= 1_000_000) {
@@ -36,7 +37,8 @@ interface ErrorsSummaryCardsProps {
 }
 
 export function ErrorsSummaryCards({ filters }: ErrorsSummaryCardsProps) {
-  const summaryResult = useAtomValue(getErrorsSummaryResultAtom({ data: filters }))
+  const orgId = useOrgId()
+  const summaryResult = useAtomValue(getErrorsSummaryResultAtom({ data: filters }, orgId))
 
   return Result.builder(summaryResult)
     .onInitial(() => (

--- a/apps/web/src/components/logs/logs-filter-sidebar.tsx
+++ b/apps/web/src/components/logs/logs-filter-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   FilterSidebarLoading,
 } from "@/components/filters/filter-sidebar"
 import { SEVERITY_COLORS } from "@/lib/severity"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function LoadingState() {
   return <FilterSidebarLoading sectionCount={3} sticky />
@@ -27,6 +28,7 @@ function LoadingState() {
 export function LogsFilterSidebar() {
   const navigate = useNavigate({ from: Route.fullPath })
   const search = Route.useSearch()
+  const orgId = useOrgId()
   const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
     useEffectiveTimeRange(search.startTime, search.endTime)
 
@@ -54,7 +56,7 @@ export function LogsFilterSidebar() {
         startTime: effectiveStartTime,
         endTime: effectiveEndTime,
       },
-    }),
+    }, orgId),
   )
 
   const updateFilter = <K extends keyof typeof search>(

--- a/apps/web/src/components/logs/logs-table.tsx
+++ b/apps/web/src/components/logs/logs-table.tsx
@@ -18,6 +18,7 @@ import type { LogsSearchParams } from "@/routes/logs"
 import { listLogsResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { formatTimestampInTimezone } from "@/lib/timezone-format"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function truncateBody(body: string, maxLength = 100): string {
   if (body.length <= maxLength) return body
@@ -61,6 +62,7 @@ export function LogsTable({ filters }: LogsTableProps) {
   const [selectedLog, setSelectedLog] = useState<Log | null>(null)
   const [sheetOpen, setSheetOpen] = useState(false)
   const { effectiveTimezone } = useTimezonePreference()
+  const orgId = useOrgId()
 
   const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
     useEffectiveTimeRange(filters?.startTime, filters?.endTime)
@@ -74,7 +76,7 @@ export function LogsTable({ filters }: LogsTableProps) {
         severity: filters?.severities?.[0],
         search: filters?.search,
       },
-    }),
+    }, orgId),
   )
 
   const handleRowClick = (log: Log) => {

--- a/apps/web/src/components/logs/logs-volume-chart.tsx
+++ b/apps/web/src/components/logs/logs-volume-chart.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/format"
 import type { LogsSearchParams } from "@/routes/logs"
 import { SEVERITY_COLORS, SEVERITY_ORDER } from "@/lib/severity"
+import { useOrgId } from "@/hooks/use-org-id"
 
 /** More bars than the default 40-point target for a denser histogram. */
 const HISTOGRAM_TARGET_POINTS = 150
@@ -41,6 +42,7 @@ interface LogsVolumeChartProps {
 }
 
 export function LogsVolumeChart({ filters }: LogsVolumeChartProps) {
+  const orgId = useOrgId()
   const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
     useEffectiveTimeRange(filters?.startTime, filters?.endTime)
 
@@ -63,7 +65,7 @@ export function LogsVolumeChart({ filters }: LogsVolumeChartProps) {
           severity: filters?.severities?.[0],
         },
       },
-    }),
+    }, orgId),
   )
 
   return Result.builder(timeSeriesResult)

--- a/apps/web/src/components/metrics/metrics-summary-cards.tsx
+++ b/apps/web/src/components/metrics/metrics-summary-cards.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@maple/ui/components/u
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { type ListMetricsInput } from "@/api/tinybird/metrics"
 import { getMetricsSummaryResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
+import { useOrgId } from "@/hooks/use-org-id"
 
 export type MetricType = ListMetricsInput["metricType"]
 
@@ -52,7 +53,8 @@ interface MetricsSummaryCardsProps {
 }
 
 export function MetricsSummaryCards({ selectedType, onSelectType }: MetricsSummaryCardsProps) {
-  const summaryResult = useAtomValue(getMetricsSummaryResultAtom({ data: {} }))
+  const orgId = useOrgId()
+  const summaryResult = useAtomValue(getMetricsSummaryResultAtom({ data: {} }, orgId))
 
   return Result.builder(summaryResult)
     .onInitial(() => (

--- a/apps/web/src/components/metrics/metrics-table.tsx
+++ b/apps/web/src/components/metrics/metrics-table.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@maple/ui/components/ui/badge"
 import { MetricTypeBadge } from "./metric-type-badge"
 import { type Metric, type ListMetricsInput } from "@/api/tinybird/metrics"
 import { listMetricsResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function formatNumber(num: number): string {
   if (num >= 1_000_000) {
@@ -81,6 +82,7 @@ export function MetricsTable({
   selectedMetric,
   onSelectMetric,
 }: MetricsTableProps) {
+  const orgId = useOrgId()
   const metricsResult = useAtomValue(
     listMetricsResultAtom({
       data: {
@@ -88,7 +90,7 @@ export function MetricsTable({
         metricType: metricType || undefined,
         limit: 100,
       },
-    }),
+    }, orgId),
   )
 
   return Result.builder(metricsResult)

--- a/apps/web/src/components/metrics/metrics-volume-chart.tsx
+++ b/apps/web/src/components/metrics/metrics-volume-chart.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { type GetMetricTimeSeriesInput, type MetricTimeSeriesResponse } from "@/api/tinybird/metrics"
 import { disabledResultAtom } from "@/lib/services/atoms/disabled-result-atom"
 import { getMetricTimeSeriesResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
+import { useOrgId } from "@/hooks/use-org-id"
 
 const chartConfig = {
   avgValue: {
@@ -30,6 +31,7 @@ interface MetricsVolumeChartProps {
 }
 
 export function MetricsVolumeChart({ metricName, metricType }: MetricsVolumeChartProps) {
+  const orgId = useOrgId()
   const chartResult = useAtomValue(
     metricName && metricType
       ? getMetricTimeSeriesResultAtom({
@@ -38,7 +40,7 @@ export function MetricsVolumeChart({ metricName, metricType }: MetricsVolumeChar
           metricType,
           bucketSeconds: 60,
         },
-      })
+      }, orgId)
       : disabledResultAtom<MetricTimeSeriesResponse>(),
   )
 

--- a/apps/web/src/components/query-builder/query-builder-lab.tsx
+++ b/apps/web/src/components/query-builder/query-builder-lab.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Result, useAtomValue } from "@effect-atom/atom-react"
 import { PulseIcon, XmarkIcon, PlusIcon, MagnifierIcon } from "@/components/icons"
+import { useOrgId } from "@/hooks/use-org-id"
 
 import { Badge } from "@maple/ui/components/ui/badge"
 import { Button } from "@maple/ui/components/ui/button"
@@ -331,8 +332,9 @@ function QueryBuilderAtomResults({
 }: {
   input: QueryBuilderTimeseriesInput
 }) {
+  const orgId = useOrgId()
   const result = useAtomValue(
-    getQueryBuilderTimeseriesResultAtom({ data: input }),
+    getQueryBuilderTimeseriesResultAtom({ data: input }, orgId),
   )
 
   return (
@@ -421,6 +423,7 @@ export function QueryBuilderLab({
   startTime,
   endTime,
 }: QueryBuilderLabProps) {
+  const orgId = useOrgId()
   const [queries, setQueries] = React.useState<QueryDraft[]>([
     createQuery(0),
     createQuery(1),
@@ -442,7 +445,7 @@ export function QueryBuilderLab({
       data: {
         limit: 300,
       },
-    }),
+    }, orgId),
   )
 
   const tracesFacetsResult = useAtomValue(
@@ -451,7 +454,7 @@ export function QueryBuilderLab({
         startTime,
         endTime,
       },
-    }),
+    }, orgId),
   )
 
   const logsFacetsResult = useAtomValue(
@@ -460,7 +463,7 @@ export function QueryBuilderLab({
         startTime,
         endTime,
       },
-    }),
+    }, orgId),
   )
 
   const spanAttributeKeysResult = useAtomValue(
@@ -469,7 +472,7 @@ export function QueryBuilderLab({
         startTime,
         endTime,
       },
-    }),
+    }, orgId),
   )
 
   const [activeAttributeKey, setActiveAttributeKey] = React.useState<string | null>(null)
@@ -482,7 +485,7 @@ export function QueryBuilderLab({
         endTime,
         attributeKey: activeAttributeKey ?? "",
       },
-    }),
+    }, orgId),
   )
 
   const resourceAttributeKeysResult = useAtomValue(
@@ -491,7 +494,7 @@ export function QueryBuilderLab({
         startTime,
         endTime,
       },
-    }),
+    }, orgId),
   )
 
   const resourceAttributeValuesResult = useAtomValue(
@@ -501,7 +504,7 @@ export function QueryBuilderLab({
         endTime,
         attributeKey: activeResourceAttributeKey ?? "",
       },
-    }),
+    }, orgId),
   )
 
   const attributeKeys = React.useMemo(

--- a/apps/web/src/components/service-map/service-map-view.tsx
+++ b/apps/web/src/components/service-map/service-map-view.tsx
@@ -16,6 +16,7 @@ import { Result, useAtomValue } from "@effect-atom/atom-react"
 
 import { getServiceLegendColor } from "@maple/ui/colors"
 import { getServiceMapResultAtom, getServiceOverviewResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
+import { useOrgId } from "@/hooks/use-org-id"
 import type { GetServiceMapInput, ServiceEdge } from "@/api/tinybird/service-map"
 import type { GetServiceOverviewInput, ServiceOverview } from "@/api/tinybird/services"
 import { ServiceMapNode } from "./service-map-node"
@@ -169,6 +170,7 @@ function ServiceMapCanvas({
 }
 
 export function ServiceMapView({ startTime, endTime }: ServiceMapViewProps) {
+  const orgId = useOrgId()
   const durationSeconds = useMemo(() => {
     const ms = new Date(endTime).getTime() - new Date(startTime).getTime()
     return Math.max(1, ms / 1000)
@@ -184,8 +186,8 @@ export function ServiceMapView({ startTime, endTime }: ServiceMapViewProps) {
     [startTime, endTime],
   )
 
-  const mapResult = useAtomValue(getServiceMapResultAtom(mapInput))
-  const overviewResult = useAtomValue(getServiceOverviewResultAtom(overviewInput))
+  const mapResult = useAtomValue(getServiceMapResultAtom(mapInput, orgId))
+  const overviewResult = useAtomValue(getServiceOverviewResultAtom(overviewInput, orgId))
 
   // Both need to be loaded for the view
   return Result.builder(mapResult)

--- a/apps/web/src/components/services/services-filter-sidebar.tsx
+++ b/apps/web/src/components/services/services-filter-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   FilterSidebarHeader,
   FilterSidebarLoading,
 } from "@/components/filters/filter-sidebar"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function LoadingState() {
   return <FilterSidebarLoading sectionCount={2} />
@@ -21,6 +22,7 @@ function LoadingState() {
 export function ServicesFilterSidebar() {
   const navigate = useNavigate({ from: Route.fullPath })
   const search = Route.useSearch()
+  const orgId = useOrgId()
   const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
     useEffectiveTimeRange(search.startTime, search.endTime)
 
@@ -30,7 +32,7 @@ export function ServicesFilterSidebar() {
         startTime: effectiveStartTime,
         endTime: effectiveEndTime,
       },
-    }),
+    }, orgId),
   )
 
   const updateFilter = <K extends keyof typeof search>(

--- a/apps/web/src/components/services/services-table.tsx
+++ b/apps/web/src/components/services/services-table.tsx
@@ -27,6 +27,7 @@ import {
   getServiceOverviewResultAtom,
 } from "@/lib/services/atoms/tinybird-query-atoms"
 import type { ServicesSearchParams } from "@/routes/services/index"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function formatLatency(ms: number): string {
   if (ms == null || Number.isNaN(ms)) {
@@ -193,6 +194,7 @@ function LoadingState() {
 }
 
 export function ServicesTable({ filters }: ServicesTableProps) {
+  const orgId = useOrgId()
   const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
     useEffectiveTimeRange(filters?.startTime, filters?.endTime)
 
@@ -204,7 +206,7 @@ export function ServicesTable({ filters }: ServicesTableProps) {
         environments: filters?.environments,
         commitShas: filters?.commitShas,
       },
-    }),
+    }, orgId),
   )
 
   const timeSeriesResult = useAtomValue(
@@ -215,7 +217,7 @@ export function ServicesTable({ filters }: ServicesTableProps) {
         environments: filters?.environments,
         commitShas: filters?.commitShas,
       },
-    }),
+    }, orgId),
   )
 
   return Result.builder(Result.all([overviewResult, timeSeriesResult]))

--- a/apps/web/src/components/traces/span-detail-panel.tsx
+++ b/apps/web/src/components/traces/span-detail-panel.tsx
@@ -20,6 +20,7 @@ import { listLogsResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
 import { CopyableValue, AttributesTable, ResourceAttributesSection } from "@/components/attributes"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { formatTimestampInTimezone } from "@/lib/timezone-format"
+import { useOrgId } from "@/hooks/use-org-id"
 
 interface SpanDetailPanelProps {
   span: SpanNode
@@ -171,9 +172,10 @@ function SpanLogs({
   spanId: string
   timeZone: string
 }) {
+  const orgId = useOrgId()
   const logsResult = useAtomValue(
     traceId && spanId
-      ? listLogsResultAtom({ data: { traceId, spanId, limit: 100 } })
+      ? listLogsResultAtom({ data: { traceId, spanId, limit: 100 } }, orgId)
       : disabledResultAtom<LogsResponse>(),
   )
 
@@ -217,12 +219,13 @@ function SpanLogs({
 
 export function SpanDetailPanel({ span, onClose }: SpanDetailPanelProps) {
   const { effectiveTimezone } = useTimezonePreference()
+  const orgId = useOrgId()
   const cacheInfo = getCacheInfo(span.spanAttributes)
   const statusStyle = statusStyles[span.statusCode] ?? statusStyles.Unset
   const kindLabel = kindLabels[span.spanKind] ?? span.spanKind?.replace("SPAN_KIND_", "") ?? "Unknown"
   const logsResult = useAtomValue(
     span.traceId && span.spanId
-      ? listLogsResultAtom({ data: { traceId: span.traceId, spanId: span.spanId, limit: 100 } })
+      ? listLogsResultAtom({ data: { traceId: span.traceId, spanId: span.spanId, limit: 100 } }, orgId)
       : disabledResultAtom<LogsResponse>(),
   )
   const logCount = Result.isSuccess(logsResult) ? logsResult.value.data.length : null

--- a/apps/web/src/components/traces/traces-table.tsx
+++ b/apps/web/src/components/traces/traces-table.tsx
@@ -17,6 +17,7 @@ import { listTracesResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
 import type { TracesSearchParams } from "@/routes/traces"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { formatTimestampInTimezone } from "@/lib/timezone-format"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function formatDuration(ms: number): string {
   if (ms < 1) {
@@ -94,6 +95,7 @@ function LoadingState() {
 export function TracesTable({ filters }: TracesTableProps) {
   const navigate = useNavigate()
   const { effectiveTimezone } = useTimezonePreference()
+  const orgId = useOrgId()
   const { startTime: effectiveStartTime, endTime: effectiveEndTime } = useEffectiveTimeRange(
     filters?.startTime,
     filters?.endTime,
@@ -123,7 +125,7 @@ export function TracesTable({ filters }: TracesTableProps) {
         attributeValueMatchMode: filters?.attributeValueMatchMode,
         resourceAttributeValueMatchMode: filters?.resourceAttributeValueMatchMode,
       },
-    }),
+    }, orgId),
   )
 
   return Result.builder(tracesResult)

--- a/apps/web/src/hooks/use-org-id.ts
+++ b/apps/web/src/hooks/use-org-id.ts
@@ -1,0 +1,8 @@
+import { getRouteApi } from "@tanstack/react-router"
+
+const rootApi = getRouteApi("__root__")
+
+export function useOrgId(): string {
+  const context = rootApi.useRouteContext()
+  return context.auth?.orgId ?? ""
+}

--- a/apps/web/src/hooks/use-widget-data.ts
+++ b/apps/web/src/hooks/use-widget-data.ts
@@ -8,6 +8,7 @@ import { relativeToAbsolute } from "@/lib/time-utils"
 import type { TimeRange } from "@/components/dashboard-builder/types"
 import { disabledResultAtom } from "@/lib/services/atoms/disabled-result-atom"
 import type { WidgetDataState } from "@/components/dashboard-builder/types"
+import { useOrgId } from "@/hooks/use-org-id"
 
 function resolveTimeRange(timeRange: TimeRange): {
   startTime: string
@@ -224,11 +225,14 @@ const widgetDataResultFamily = Atom.family((key: string) =>
   Atom.make(
     Effect.try({
       try: () =>
-        JSON.parse(key) as {
-          endpoint: DashboardWidget["dataSource"]["endpoint"]
-          params: Record<string, unknown>
-          transform: WidgetDataSource["transform"]
-        },
+        (() => {
+          const { _orgId: _, ...rest } = JSON.parse(key) as { _orgId: string } & Record<string, unknown>
+          return rest as {
+            endpoint: DashboardWidget["dataSource"]["endpoint"]
+            params: Record<string, unknown>
+            transform: WidgetDataSource["transform"]
+          }
+        })(),
       catch: toWidgetDataAtomError,
     }).pipe(
       Effect.flatMap(({ endpoint, params, transform }) => {
@@ -258,9 +262,10 @@ const widgetDataResultAtom = (input: {
   endpoint: DashboardWidget["dataSource"]["endpoint"]
   params: Record<string, unknown>
   transform: WidgetDataSource["transform"]
-}) => widgetDataResultFamily(encodeKey(input))
+}, orgId: string) => widgetDataResultFamily(encodeKey({ _orgId: orgId, ...input }))
 
 export function useWidgetData(widget: DashboardWidget) {
+  const orgId = useOrgId()
   const dashboardTimeRange = useDashboardTimeRange()
 
   const resolvedTime = resolveTimeRange(dashboardTimeRange.state.timeRange)
@@ -284,7 +289,7 @@ export function useWidgetData(widget: DashboardWidget) {
           endpoint: widget.dataSource.endpoint,
           params: resolvedParams,
           transform: widget.dataSource.transform,
-        })
+        }, orgId)
       : disabledResultAtom(),
   )
 

--- a/apps/web/src/lib/services/atoms/tinybird-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/tinybird-query-atoms.ts
@@ -83,7 +83,10 @@ function makeQueryAtomFamily<Input, Output>(
   const family = Atom.family((key: string) => {
     let resultAtom = Atom.make(
       Effect.try({
-        try: () => JSON.parse(key) as Input,
+        try: () => {
+          const { _orgId: _, ...rest } = JSON.parse(key) as { _orgId: string } & Record<string, unknown>
+          return rest as unknown as Input
+        },
         catch: toQueryAtomError,
       }).pipe(
         Effect.flatMap((input) => query(input)),
@@ -98,7 +101,8 @@ function makeQueryAtomFamily<Input, Output>(
     return resultAtom
   })
 
-  return (input: Input) => family(encodeKey(input))
+  return (input: Input, orgId: string) =>
+    family(encodeKey({ _orgId: orgId, ...(input as Record<string, unknown>) }))
 }
 
 export const getServiceUsageResultAtom = makeQueryAtomFamily(getServiceUsage, {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from "@maple/ui/components/ui/select"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { useOrgId } from "@/hooks/use-org-id"
 import { ServiceUsageCards } from "@/components/dashboard/service-usage-cards"
 import { MetricsGrid } from "@/components/dashboard/metrics-grid"
 import type {
@@ -61,6 +62,7 @@ const OVERVIEW_CHARTS: OverviewChartConfig[] = [
 function DashboardPage() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
+  const orgId = useOrgId()
 
   const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
     useEffectiveTimeRange(search.startTime, search.endTime, "24h")
@@ -99,7 +101,7 @@ function DashboardPage() {
         startTime: effectiveStartTime,
         endTime: effectiveEndTime,
       },
-    }),
+    }, orgId),
   )
 
   const environments = Result.builder(facetsResult)
@@ -129,7 +131,7 @@ function DashboardPage() {
             endTime: effectiveEndTime,
             environments: environmentFilter,
           },
-        })
+        }, orgId)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       : disabledResultAtom<{ data: ServiceDetailTimeSeriesPoint[] }, any>(),
   )
@@ -148,7 +150,7 @@ function DashboardPage() {
               environments: environmentFilter,
             },
           },
-        })
+        }, orgId)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       : disabledResultAtom<CustomChartTimeSeriesResponse, any>(),
   )

--- a/apps/web/src/routes/quick-start.tsx
+++ b/apps/web/src/routes/quick-start.tsx
@@ -36,6 +36,7 @@ import { useQuickStart, type StepId } from "@/hooks/use-quick-start"
 import { ingestUrl } from "@/lib/services/common/ingest-url"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { useOrgId } from "@/hooks/use-org-id"
 import { getServiceOverviewResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
 import { cn } from "@maple/ui/utils"
 
@@ -286,6 +287,7 @@ function StepVerifyData({
   isComplete: boolean
   onComplete: () => void
 }) {
+  const orgId = useOrgId()
   const [pollCount, setPollCount] = useState(0)
   const { startTime, endTime } = useEffectiveTimeRange(undefined, undefined, "1h")
 
@@ -306,7 +308,7 @@ function StepVerifyData({
         endTime,
       },
       _poll: pollCount,
-    } as any),
+    } as any, orgId),
   )
 
   useEffect(() => {
@@ -601,7 +603,8 @@ const STEPS: {
 ]
 
 function QuickStartPage() {
-  const { orgId } = useAuth()
+  const { orgId: clerkOrgId } = useAuth()
+  const orgId = useOrgId()
   const {
     activeStep,
     setActiveStep,
@@ -613,7 +616,7 @@ function QuickStartPage() {
     reset,
     selectedFramework,
     setSelectedFramework,
-  } = useQuickStart(orgId)
+  } = useQuickStart(clerkOrgId)
 
   // --- Page-level auto-completion (runs regardless of active step) ---
   const { customer } = useCustomer()
@@ -622,7 +625,7 @@ function QuickStartPage() {
   const overviewResult = useAtomValue(
     getServiceOverviewResultAtom({
       data: { startTime, endTime },
-    } as any),
+    } as any, orgId),
   )
 
   // Auto-complete "verify-data" if data already exists

--- a/apps/web/src/routes/services/$serviceName.tsx
+++ b/apps/web/src/routes/services/$serviceName.tsx
@@ -5,6 +5,7 @@ import { Schema } from "effect"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { TimeRangePicker } from "@/components/time-range-picker"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { useOrgId } from "@/hooks/use-org-id"
 import { MetricsGrid } from "@/components/dashboard/metrics-grid"
 import type {
   ChartLegendMode,
@@ -46,6 +47,7 @@ function ServiceDetailPage() {
   const { serviceName } = Route.useParams()
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
+  const orgId = useOrgId()
 
   const { startTime: effectiveStartTime, endTime: effectiveEndTime } =
     useEffectiveTimeRange(search.startTime, search.endTime)
@@ -76,7 +78,7 @@ function ServiceDetailPage() {
         startTime: effectiveStartTime,
         endTime: effectiveEndTime,
       },
-    }),
+    }, orgId),
   )
 
   const apdexResult = useAtomValue(
@@ -86,7 +88,7 @@ function ServiceDetailPage() {
         startTime: effectiveStartTime,
         endTime: effectiveEndTime,
       },
-    }),
+    }, orgId),
   )
 
   const detailPoints = Result.builder(detailResult)

--- a/apps/web/src/routes/traces/$traceId.tsx
+++ b/apps/web/src/routes/traces/$traceId.tsx
@@ -16,6 +16,7 @@ import {
 import { formatDuration } from "@/lib/format"
 import { type Span, type SpanNode } from "@/api/tinybird/traces"
 import { getSpanHierarchyResultAtom } from "@/lib/services/atoms/tinybird-query-atoms"
+import { useOrgId } from "@/hooks/use-org-id"
 import { findSpanById } from "@/components/traces/flow-utils"
 
 const TraceDetailSearchSchema = Schema.Struct({
@@ -40,7 +41,8 @@ function TraceDetailPage() {
   const searchStr = useRouterState({ select: (state) => state.location.searchStr })
   const backToTracesHref = buildBackToTracesHref(searchStr)
   const navigate = useNavigate({ from: Route.fullPath })
-  const result = useAtomValue(getSpanHierarchyResultAtom({ data: { traceId } }))
+  const orgId = useOrgId()
+  const result = useAtomValue(getSpanHierarchyResultAtom({ data: { traceId } }, orgId))
 
   return Result.builder(result)
     .onInitial(() => (

--- a/apps/web/src/routes/traces/index.tsx
+++ b/apps/web/src/routes/traces/index.tsx
@@ -11,6 +11,7 @@ import { AdvancedFilterDialog } from "@/components/traces/advanced-filter-dialog
 import { MagnifierIcon, XmarkIcon } from "@/components/icons"
 import { Button } from "@maple/ui/components/ui/button"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { useOrgId } from "@/hooks/use-org-id"
 import { applyWhereClause } from "@/lib/traces/advanced-filter-sync"
 import {
   getTracesFacetsResultAtom,
@@ -56,6 +57,7 @@ export const Route = createFileRoute("/traces/")({
 function TracesPage() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
+  const orgId = useOrgId()
   const [activeAttributeKey, setActiveAttributeKey] = React.useState<string | null>(null)
   const [activeResourceAttributeKey, setActiveResourceAttributeKey] = React.useState<string | null>(null)
 
@@ -77,7 +79,7 @@ function TracesPage() {
         startTime: effectiveStartTime,
         endTime: effectiveEndTime,
       },
-    }),
+    }, orgId),
   )
 
   const spanAttributeKeysResult = useAtomValue(
@@ -86,7 +88,7 @@ function TracesPage() {
         startTime: effectiveStartTime,
         endTime: effectiveEndTime,
       },
-    }),
+    }, orgId),
   )
 
   const spanAttributeValuesResult = useAtomValue(
@@ -96,7 +98,7 @@ function TracesPage() {
         endTime: effectiveEndTime,
         attributeKey: activeAttributeKey ?? "",
       },
-    }),
+    }, orgId),
   )
 
   const resourceAttributeKeysResult = useAtomValue(
@@ -105,7 +107,7 @@ function TracesPage() {
         startTime: effectiveStartTime,
         endTime: effectiveEndTime,
       },
-    }),
+    }, orgId),
   )
 
   const resourceAttributeValuesResult = useAtomValue(
@@ -115,7 +117,7 @@ function TracesPage() {
         endTime: effectiveEndTime,
         attributeKey: activeResourceAttributeKey ?? "",
       },
-    }),
+    }, orgId),
   )
 
   const attributeKeys = React.useMemo(


### PR DESCRIPTION
## Summary
This PR adds organization ID (orgId) as a parameter to all query atom functions throughout the application to support multi-tenant data isolation. The orgId is now extracted from the route context and passed to every data fetching operation.

## Key Changes

- **New hook**: Created `useOrgId()` hook that retrieves the orgId from route context via `useAuth()`, providing a centralized way to access the current organization ID
- **Query atom updates**: Modified `makeQueryAtomFamily()` in `tinybird-query-atoms.ts` to accept and encode orgId as part of the cache key, ensuring different organizations' data is cached separately
- **Widget data atom updates**: Updated `widgetDataResultAtom()` to include orgId in the cache key for dashboard widget data
- **Component updates**: Added `useOrgId()` calls and passed orgId parameter to all atom value calls across:
  - Query builder components (lab and widget config)
  - Dashboard and service pages
  - Traces, logs, metrics, errors, and services components
  - Filter sidebars and detail panels
  - Service map and quick start pages

## Implementation Details

- The orgId is encoded into the atom family cache key using a `_orgId` prefix, which is then stripped during deserialization to maintain backward compatibility with existing input types
- All query atom factory functions now have the signature: `(input: Input, orgId: string) => Atom`
- The orgId is sourced from the authenticated user's context, ensuring it's always available in authenticated routes
- This change ensures that cached query results are properly isolated per organization, preventing data leakage between tenants

https://claude.ai/code/session_01JanCyQqgmYrKzHo2yj85ps