### PR TITLE
feat: add Hazel as an alert destination type

### DIFF
--- a/apps/api/src/services/AlertDeliveryDispatch.ts
+++ b/apps/api/src/services/AlertDeliveryDispatch.ts
@@ -27,6 +27,11 @@ type DestinationSecretConfig =
       readonly url: string
       readonly signingSecret: string | null
     }
+  | {
+      readonly type: "hazel"
+      readonly webhookUrl: string
+      readonly signingSecret: string | null
+    }
 
 export interface DispatchContext {
   readonly deliveryKey: string
@@ -371,6 +376,28 @@ export const dispatchDelivery = (
               )
             }
             return { providerMessage: "Delivered to webhook", providerReference: context.dedupeKey, responseCode: response.status } as DispatchResult
+          }),
+        hazel: (config) =>
+          Effect.gen(function* () {
+            const headers: Record<string, string> = {
+              "content-type": "application/json",
+              "x-maple-event-type": context.eventType,
+              "x-maple-delivery-key": context.deliveryKey,
+            }
+            if (config.signingSecret) {
+              headers["x-maple-signature"] = createHmac("sha256", config.signingSecret)
+                .update(payloadJson)
+                .digest("hex")
+            }
+            const response = yield* runTimedFetch("hazel", "Hazel", fetchFn, timeoutMs, () =>
+              fetchFn(config.webhookUrl, { method: "POST", headers, body: payloadJson }),
+            )
+            if (!response.ok) {
+              return yield* Effect.fail(
+                makeDeliveryError(`Hazel delivery failed with ${response.status}`, "hazel"),
+              )
+            }
+            return { providerMessage: "Delivered to Hazel", providerReference: context.dedupeKey, responseCode: response.status } as DispatchResult
           }),
       }),
     )

--- a/apps/api/src/services/AlertDestinationHydration.ts
+++ b/apps/api/src/services/AlertDestinationHydration.ts
@@ -21,6 +21,11 @@ export const DestinationSecretConfigSchema = Schema.Union([
     url: Schema.String,
     signingSecret: Schema.NullOr(Schema.String),
   }),
+  Schema.Struct({
+    type: Schema.Literal("hazel"),
+    webhookUrl: Schema.String,
+    signingSecret: Schema.NullOr(Schema.String),
+  }),
 ])
 
 export type DestinationPublicConfig = Schema.Schema.Type<

--- a/apps/api/src/services/AlertsService.ts
+++ b/apps/api/src/services/AlertsService.ts
@@ -444,6 +444,10 @@ const buildPublicConfig = (
         summary: summarizeWebhookUrl(r.url),
         channelLabel: null,
       }),
+      hazel: (r) => ({
+        summary: summarizeWebhookUrl(r.webhookUrl),
+        channelLabel: null,
+      }),
     }),
   )
 
@@ -463,6 +467,11 @@ const buildSecretConfig = (
       webhook: (r) => ({
         type: "webhook" as const,
         url: r.url.trim(),
+        signingSecret: normalizeOptionalString(r.signingSecret),
+      }),
+      hazel: (r) => ({
+        type: "hazel" as const,
+        webhookUrl: r.webhookUrl.trim(),
         signingSecret: normalizeOptionalString(r.signingSecret),
       }),
     }),
@@ -1670,6 +1679,29 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
               signingSecret:
                 request.signingSecret === undefined
                   ? hydrated.secretConfig.type === "webhook"
+                    ? hydrated.secretConfig.signingSecret
+                    : null
+                  : normalizeOptionalString(request.signingSecret),
+            }
+            break
+          case "hazel":
+            nextPublicConfig = {
+              summary:
+                request.webhookUrl != null && request.webhookUrl.trim().length > 0
+                  ? summarizeWebhookUrl(request.webhookUrl)
+                  : hydrated.publicConfig.summary,
+              channelLabel: null,
+            }
+            nextSecretConfig = {
+              type: "hazel",
+              webhookUrl:
+                normalizeOptionalString(request.webhookUrl) ??
+                (hydrated.secretConfig.type === "hazel"
+                  ? hydrated.secretConfig.webhookUrl
+                  : ""),
+              signingSecret:
+                request.signingSecret === undefined
+                  ? hydrated.secretConfig.type === "hazel"
                     ? hydrated.secretConfig.signingSecret
                     : null
                   : normalizeOptionalString(request.signingSecret),

--- a/apps/web/src/components/alerts/destination-dialog.tsx
+++ b/apps/web/src/components/alerts/destination-dialog.tsx
@@ -30,6 +30,7 @@ const typeOptions = [
   { value: "slack" as const,     label: "Slack"     },
   { value: "pagerduty" as const, label: "PagerDuty" },
   { value: "webhook" as const,   label: "Webhook"   },
+  { value: "hazel" as const,     label: "Hazel"     },
 ]
 
 function SectionHeader({ step, title, description }: { step: number; title: string; description?: string }) {
@@ -151,6 +152,36 @@ export function DestinationDialog({
                     <Label htmlFor="destination-secret">Signing secret</Label>
                     <Input
                       id="destination-secret"
+                      value={form.signingSecret}
+                      onChange={(event) => onFormChange((current) => ({ ...current, signingSecret: event.target.value }))}
+                      placeholder={isEditing ? "Leave blank to keep current secret" : "Optional HMAC secret"}
+                    />
+                  </div>
+                </>
+              )}
+
+              {form.type === "hazel" && (
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="destination-hazel-url">Hazel webhook URL</Label>
+                    <Input
+                      id="destination-hazel-url"
+                      value={form.hazelWebhookUrl}
+                      onChange={(event) => onFormChange((current) => ({ ...current, hazelWebhookUrl: event.target.value }))}
+                      placeholder={
+                        isEditing
+                          ? "Leave blank to keep current URL"
+                          : "https://api.hazel.io/webhooks/incoming/{webhookId}/{token}/maple"
+                      }
+                    />
+                    <p className="text-muted-foreground text-xs">
+                      Create a Maple webhook in Hazel under Settings → Integrations → Maple, then paste the URL here.
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="destination-hazel-secret">Signing secret</Label>
+                    <Input
+                      id="destination-hazel-secret"
                       value={form.signingSecret}
                       onChange={(event) => onFormChange((current) => ({ ...current, signingSecret: event.target.value }))}
                       placeholder={isEditing ? "Leave blank to keep current secret" : "Optional HMAC secret"}

--- a/apps/web/src/lib/alerts/form-utils.ts
+++ b/apps/web/src/lib/alerts/form-utils.ts
@@ -71,6 +71,7 @@ export const destinationTypeLabels: Record<AlertDestinationType, string> = {
   slack: "Slack",
   pagerduty: "PagerDuty",
   webhook: "Webhook",
+  hazel: "Hazel",
 }
 
 export const metricTypeLabels: Record<AlertMetricType, string> = {
@@ -335,6 +336,7 @@ export type DestinationFormState = {
   integrationKey: string
   url: string
   signingSecret: string
+  hazelWebhookUrl: string
 }
 
 export function defaultDestinationForm(type: AlertDestinationType = "slack"): DestinationFormState {
@@ -347,6 +349,7 @@ export function defaultDestinationForm(type: AlertDestinationType = "slack"): De
     integrationKey: "",
     url: "",
     signingSecret: "",
+    hazelWebhookUrl: "",
   }
 }
 
@@ -360,6 +363,7 @@ export function destinationToFormState(destination: AlertDestinationDocument): D
     integrationKey: "",
     url: "",
     signingSecret: "",
+    hazelWebhookUrl: "",
   }
 }
 
@@ -371,6 +375,8 @@ export function buildDestinationCreatePayload(form: DestinationFormState): Alert
       return { type: "pagerduty", name: form.name.trim(), enabled: form.enabled, integrationKey: form.integrationKey.trim() }
     case "webhook":
       return { type: "webhook", name: form.name.trim(), enabled: form.enabled, url: form.url.trim(), signingSecret: form.signingSecret.trim() || undefined }
+    case "hazel":
+      return { type: "hazel", name: form.name.trim(), enabled: form.enabled, webhookUrl: form.hazelWebhookUrl.trim(), signingSecret: form.signingSecret.trim() || undefined }
   }
 }
 
@@ -382,6 +388,8 @@ export function buildDestinationUpdatePayload(form: DestinationFormState): Alert
       return { type: "pagerduty", name: form.name.trim() || undefined, enabled: form.enabled, integrationKey: form.integrationKey.trim() || undefined }
     case "webhook":
       return { type: "webhook", name: form.name.trim() || undefined, enabled: form.enabled, url: form.url.trim() || undefined, signingSecret: form.signingSecret.trim() || undefined }
+    case "hazel":
+      return { type: "hazel", name: form.name.trim() || undefined, enabled: form.enabled, webhookUrl: form.hazelWebhookUrl.trim() || undefined, signingSecret: form.signingSecret.trim() || undefined }
   }
 }
 

--- a/packages/domain/src/http/alerts.ts
+++ b/packages/domain/src/http/alerts.ts
@@ -16,6 +16,7 @@ export const AlertDestinationType = Schema.Literals([
   "slack",
   "pagerduty",
   "webhook",
+  "hazel",
 ]).annotate({
   identifier: "@maple/AlertDestinationType",
   title: "Alert Destination Type",
@@ -210,6 +211,16 @@ export class WebhookAlertDestinationConfig extends Schema.Class<WebhookAlertDest
   enabled: Schema.optionalKey(Schema.Boolean),
 }) {}
 
+export class HazelAlertDestinationConfig extends Schema.Class<HazelAlertDestinationConfig>(
+  "HazelAlertDestinationConfig",
+)({
+  type: Schema.Literal("hazel"),
+  name: ChannelLabel,
+  webhookUrl: NonEmptyString,
+  signingSecret: Schema.optionalKey(Schema.String),
+  enabled: Schema.optionalKey(Schema.Boolean),
+}) {}
+
 export const AlertDestinationCreateRequest = Schema.Union([
   Schema.Struct({
     type: Schema.Literal("slack"),
@@ -228,6 +239,13 @@ export const AlertDestinationCreateRequest = Schema.Union([
     type: Schema.Literal("webhook"),
     name: ChannelLabel,
     url: NonEmptyString,
+    signingSecret: Schema.optionalKey(Schema.String),
+    enabled: Schema.optionalKey(Schema.Boolean),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("hazel"),
+    name: ChannelLabel,
+    webhookUrl: NonEmptyString,
     signingSecret: Schema.optionalKey(Schema.String),
     enabled: Schema.optionalKey(Schema.Boolean),
   }),
@@ -262,6 +280,15 @@ export class UpdateWebhookAlertDestinationConfig extends Schema.Class<UpdateWebh
   enabled: Schema.optionalKey(Schema.Boolean),
 }) {}
 
+export class UpdateHazelAlertDestinationConfig extends Schema.Class<UpdateHazelAlertDestinationConfig>(
+  "UpdateHazelAlertDestinationConfig",
+)({
+  name: OptionalNonEmptyString,
+  webhookUrl: Schema.optionalKey(Schema.String),
+  signingSecret: Schema.optionalKey(Schema.String),
+  enabled: Schema.optionalKey(Schema.Boolean),
+}) {}
+
 export const AlertDestinationUpdateRequest = Schema.Union([
   Schema.Struct({
     type: Schema.Literal("slack"),
@@ -274,6 +301,10 @@ export const AlertDestinationUpdateRequest = Schema.Union([
   Schema.Struct({
     type: Schema.Literal("webhook"),
     ...UpdateWebhookAlertDestinationConfig.fields,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("hazel"),
+    ...UpdateHazelAlertDestinationConfig.fields,
   }),
 ])
 export type AlertDestinationUpdateRequest = Schema.Schema.Type<


### PR DESCRIPTION
## Summary

- Adds a dedicated `"hazel"` destination type alongside `slack` / `pagerduty` / `webhook` so Maple alerts can be delivered into a Hazel chat channel.
- Reuses the existing `buildPayload()` JSON unchanged — Hazel parses Maple's standard webhook payload directly, so there's no parallel schema to maintain.
- Surfaces "Hazel" in the destination picker with a webhook URL field and helper text pointing at the matching Hazel setup screen.

## Changes

**Domain / contract** (`packages/domain/src/http/alerts.ts`)
- Extend `AlertDestinationType` literal with `"hazel"`.
- Add `HazelAlertDestinationConfig` and `UpdateHazelAlertDestinationConfig`.
- Add `hazel` variant to `AlertDestinationCreateRequest` and `AlertDestinationUpdateRequest` (fields: `webhookUrl`, optional `signingSecret`, optional `enabled`).

**API services**
- `AlertDestinationHydration.ts` — add `hazel` arm to `DestinationSecretConfigSchema` (mirrors `webhook` shape with a renamed URL key).
- `AlertsService.ts` — wire `hazel` through `buildPublicConfig`, `buildSecretConfig`, and the update-destination switch (preserving the existing url/secret on partial updates).
- `AlertDeliveryDispatch.ts` — add `hazel` case to the exhaustive `Match` dispatch. POSTs the existing `payloadJson` with `x-maple-event-type`, `x-maple-delivery-key`, and (when configured) an HMAC `x-maple-signature` header.

**Web**
- `destination-dialog.tsx` — `Hazel` option in the type picker plus conditional fields (Hazel webhook URL + optional signing secret) with helper copy.
- `form-utils.ts` — `hazelWebhookUrl` field on `DestinationFormState`, `Hazel` label, and create/update payload builders for the new type.

## Reviewer notes

- Existing AES-256-GCM secret encryption path is unchanged — `hazel` flows through the same encrypt/decrypt as the other types.
- The dispatch test endpoint (`POST /destinations/:id/test`) automatically works for Hazel destinations via the same code path; the synthetic test payload is just `eventType: "test"` through `buildPayload`.
- The companion Hazel-side change (the `/maple` webhook receiver, embed builder, and integration UI) is in a separate PR on the Hazel repo.
- No DB migration: the existing `alertDestinations` table holds the hazel destination just like any other type.

## Test plan

- [ ] `bun typecheck` passes (verified locally — 17/17 packages).
- [ ] In the running Maple web app, navigate to Alerts → Destinations → New destination → pick **Hazel**, paste a `…/webhooks/incoming/{id}/{token}/maple` URL from Hazel, and save.
- [ ] Hit **Test** on the destination → expect `success: true` with `responseCode: 200` and `providerMessage: "Delivered to Hazel"`.
- [ ] Trigger (or simulate) a real rule with the Hazel destination attached and confirm the rendered embed in the Hazel channel for both `trigger` and `resolve` events.
- [ ] Edit an existing Hazel destination, leave the URL field blank, and confirm the stored URL is preserved (partial-update path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)