### PR TITLE
fix: use Schema.Class members in AlertDestinationCreateRequest

### DIFF
--- a/apps/web/src/lib/alerts/form-utils.ts
+++ b/apps/web/src/lib/alerts/form-utils.ts
@@ -5,6 +5,10 @@ import {
   AlertRuleDocument,
   AlertRuleTestRequest,
   AlertRuleUpsertRequest,
+  HazelAlertDestinationConfig,
+  PagerDutyAlertDestinationConfig,
+  SlackAlertDestinationConfig,
+  WebhookAlertDestinationConfig,
   type AlertComparator,
   type AlertDestinationCreateRequest,
   type AlertDestinationId,
@@ -369,14 +373,43 @@ export function destinationToFormState(destination: AlertDestinationDocument): D
 
 export function buildDestinationCreatePayload(form: DestinationFormState): AlertDestinationCreateRequest {
   switch (form.type) {
-    case "slack":
-      return { type: "slack", name: form.name.trim(), enabled: form.enabled, webhookUrl: form.webhookUrl.trim(), channelLabel: form.channelLabel.trim() || undefined }
+    case "slack": {
+      const channelLabel = form.channelLabel.trim()
+      return new SlackAlertDestinationConfig({
+        type: "slack",
+        name: form.name.trim(),
+        enabled: form.enabled,
+        webhookUrl: form.webhookUrl.trim(),
+        ...(channelLabel ? { channelLabel } : {}),
+      })
+    }
     case "pagerduty":
-      return { type: "pagerduty", name: form.name.trim(), enabled: form.enabled, integrationKey: form.integrationKey.trim() }
-    case "webhook":
-      return { type: "webhook", name: form.name.trim(), enabled: form.enabled, url: form.url.trim(), signingSecret: form.signingSecret.trim() || undefined }
-    case "hazel":
-      return { type: "hazel", name: form.name.trim(), enabled: form.enabled, webhookUrl: form.hazelWebhookUrl.trim(), signingSecret: form.signingSecret.trim() || undefined }
+      return new PagerDutyAlertDestinationConfig({
+        type: "pagerduty",
+        name: form.name.trim(),
+        enabled: form.enabled,
+        integrationKey: form.integrationKey.trim(),
+      })
+    case "webhook": {
+      const signingSecret = form.signingSecret.trim()
+      return new WebhookAlertDestinationConfig({
+        type: "webhook",
+        name: form.name.trim(),
+        enabled: form.enabled,
+        url: form.url.trim(),
+        ...(signingSecret ? { signingSecret } : {}),
+      })
+    }
+    case "hazel": {
+      const signingSecret = form.signingSecret.trim()
+      return new HazelAlertDestinationConfig({
+        type: "hazel",
+        name: form.name.trim(),
+        enabled: form.enabled,
+        webhookUrl: form.hazelWebhookUrl.trim(),
+        ...(signingSecret ? { signingSecret } : {}),
+      })
+    }
   }
 }
 

--- a/packages/domain/src/http/alerts.ts
+++ b/packages/domain/src/http/alerts.ts
@@ -222,33 +222,10 @@ export class HazelAlertDestinationConfig extends Schema.Class<HazelAlertDestinat
 }) {}
 
 export const AlertDestinationCreateRequest = Schema.Union([
-  Schema.Struct({
-    type: Schema.Literal("slack"),
-    name: ChannelLabel,
-    webhookUrl: NonEmptyString,
-    channelLabel: OptionalNonEmptyString,
-    enabled: Schema.optionalKey(Schema.Boolean),
-  }),
-  Schema.Struct({
-    type: Schema.Literal("pagerduty"),
-    name: ChannelLabel,
-    integrationKey: NonEmptyString,
-    enabled: Schema.optionalKey(Schema.Boolean),
-  }),
-  Schema.Struct({
-    type: Schema.Literal("webhook"),
-    name: ChannelLabel,
-    url: NonEmptyString,
-    signingSecret: Schema.optionalKey(Schema.String),
-    enabled: Schema.optionalKey(Schema.Boolean),
-  }),
-  Schema.Struct({
-    type: Schema.Literal("hazel"),
-    name: ChannelLabel,
-    webhookUrl: NonEmptyString,
-    signingSecret: Schema.optionalKey(Schema.String),
-    enabled: Schema.optionalKey(Schema.Boolean),
-  }),
+  SlackAlertDestinationConfig,
+  PagerDutyAlertDestinationConfig,
+  WebhookAlertDestinationConfig,
+  HazelAlertDestinationConfig,
 ])
 export type AlertDestinationCreateRequest = Schema.Schema.Type<
   typeof AlertDestinationCreateRequest


### PR DESCRIPTION
## Problem

Saving an alert destination from the web UI failed with \"Failed to save destination\" — particularly visible after the \`hazel\` variant was added. The request payload was being built as a plain object literal whose shape diverged from the `Schema.Class`-shaped destinations defined in the domain, and the create union was a separate inline `Schema.Struct` set rather than the same classes used everywhere else.

## Fix

- **`packages/domain/src/http/alerts.ts`** — switch \`AlertDestinationCreateRequest\` from a union of inline \`Schema.Struct\` to a union of the existing \`SlackAlertDestinationConfig\` / \`PagerDutyAlertDestinationConfig\` / \`WebhookAlertDestinationConfig\` / \`HazelAlertDestinationConfig\` classes. Cuts ~30 lines of duplicated field declarations and aligns the create union with the (already class-based) update union.
- **\`apps/web/src/lib/alerts/form-utils.ts\`** — \`buildDestinationCreatePayload\` now returns \`new XxxAlertDestinationConfig({...})\` instances. Optional fields (\`channelLabel\`, \`signingSecret\`) are only spread when they have a value, so they stay absent on the wire rather than carrying \`undefined\` keys that don't match \`Schema.optionalKey\`.

## Notes

- No protocol/wire change. JSON shape over HTTP is identical to before.
- Affects all four destination types (slack/pagerduty/webhook/hazel), not just Hazel — but only because the existing types had the same latent issue if anyone hit the same Schema strictness.
- Typecheck verified clean across \`@maple/domain\`, \`@maple/web\`, \`@maple/api\`, \`@maple/alerting\`.

## Test plan

- [ ] Open Alerts → Destinations → New destination → pick **Hazel** → fill in webhook URL → Save. Expect the toast \"Destination created\" rather than \"Failed to save destination\".
- [ ] Repeat for Slack, PagerDuty, and Webhook to confirm no regression on the existing types.
- [ ] Click **Test** on the saved Hazel destination → expect \`success: true\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)