### PR TITLE
Replace Tinybird SQL client with ClickHouse HTTP client

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
 		"tinybird:deploy": "tinybird deploy"
 	},
 	"dependencies": {
+		"@clickhouse/client-web": "catalog:clickhouse",
 		"@clerk/backend": "^2.30.1",
 		"@effect/opentelemetry": "catalog:effect",
 		"@libsql/client": "0.15.15",

--- a/apps/api/src/services/Env.ts
+++ b/apps/api/src/services/Env.ts
@@ -4,6 +4,10 @@ export interface EnvShape {
 	readonly PORT: number
 	readonly TINYBIRD_HOST: string
 	readonly TINYBIRD_TOKEN: Redacted.Redacted<string>
+	readonly CLICKHOUSE_URL: Option.Option<string>
+	readonly CLICKHOUSE_USER: string
+	readonly CLICKHOUSE_PASSWORD: Option.Option<Redacted.Redacted<string>>
+	readonly CLICKHOUSE_DATABASE: string
 	readonly MAPLE_DB_URL: string
 	readonly MAPLE_DB_AUTH_TOKEN: Option.Option<Redacted.Redacted<string>>
 	readonly MAPLE_AUTH_MODE: string
@@ -54,6 +58,10 @@ const envConfig = Config.all({
 	PORT: portConfig,
 	TINYBIRD_HOST: Config.string("TINYBIRD_HOST"),
 	TINYBIRD_TOKEN: Config.redacted("TINYBIRD_TOKEN"),
+	CLICKHOUSE_URL: optionalString("CLICKHOUSE_URL"),
+	CLICKHOUSE_USER: stringWithDefault("CLICKHOUSE_USER", "default"),
+	CLICKHOUSE_PASSWORD: optionalRedacted("CLICKHOUSE_PASSWORD"),
+	CLICKHOUSE_DATABASE: stringWithDefault("CLICKHOUSE_DATABASE", "default"),
 	MAPLE_DB_URL: stringWithDefault("MAPLE_DB_URL", ""),
 	MAPLE_DB_AUTH_TOKEN: optionalRedacted("MAPLE_DB_AUTH_TOKEN"),
 	MAPLE_AUTH_MODE: stringWithDefault("MAPLE_AUTH_MODE", "self_hosted"),

--- a/apps/api/src/services/TinybirdRouting.test.ts
+++ b/apps/api/src/services/TinybirdRouting.test.ts
@@ -81,12 +81,17 @@ const tenant = {
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 describe("Tinybird routing", () => {
-	it("uses the env-backed Tinybird client by default for raw queries", async () => {
+	it("uses the env-backed ClickHouse client by default for raw queries", async () => {
 		const { url } = createTempDbUrl()
-		const calls: Array<{ baseUrl: string; token: string }> = []
+		const calls: Array<{
+			url: string
+			username: string
+			password: string
+			database: string
+		}> = []
 
-		tinybirdTestables.setClientFactory((baseUrl, token) => {
-			calls.push({ baseUrl, token })
+		tinybirdTestables.setClientFactory((config) => {
+			calls.push(config)
 			return {
 				sql: async () => ({
 					data: [{ message: "managed" }],
@@ -102,7 +107,80 @@ describe("Tinybird routing", () => {
 		)
 
 		expect(result.data).toBeDefined()
-		expect(calls).toEqual([{ baseUrl: "https://managed.tinybird.co", token: "managed-token" }])
+		expect(calls).toEqual([
+			{
+				url: "https://managed.tinybird.co",
+				username: "default",
+				password: "managed-token",
+				database: "default",
+			},
+		])
+	})
+
+	it("prefers explicit ClickHouse env settings for managed raw queries", async () => {
+		const { url } = createTempDbUrl()
+		const calls: Array<{
+			url: string
+			username: string
+			password: string
+			database: string
+		}> = []
+
+		const config = ConfigProvider.layer(
+			ConfigProvider.fromUnknown({
+				PORT: "3472",
+				TINYBIRD_HOST: "https://managed.tinybird.co",
+				TINYBIRD_TOKEN: "managed-token",
+				CLICKHOUSE_URL: "https://clickhouse.example.com:8443",
+				CLICKHOUSE_USER: "maple_reader",
+				CLICKHOUSE_PASSWORD: "clickhouse-password",
+				CLICKHOUSE_DATABASE: "observability",
+				MAPLE_DB_URL: url,
+				MAPLE_AUTH_MODE: "self_hosted",
+				MAPLE_ROOT_PASSWORD: "test-root-password",
+				MAPLE_DEFAULT_ORG_ID: "default",
+				MAPLE_INGEST_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 7).toString("base64"),
+				MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: "maple-test-lookup-secret",
+			}),
+		)
+
+		tinybirdTestables.setClientFactory((clientConfig) => {
+			calls.push(clientConfig)
+			return {
+				sql: async () => ({
+					data: [{ message: "managed-clickhouse" }],
+				}),
+			}
+		})
+
+		const layer = TinybirdService.Default.pipe(
+			Layer.provide(
+				OrgTinybirdSettingsService.Live.pipe(
+					Layer.provide(makeTestTinybirdSyncClientLayer({})),
+					Layer.provide(SelfManagedCollectorConfigService.Live),
+					Layer.provide(DatabaseLibsqlLive),
+				),
+			),
+			Layer.provide(Env.Default),
+			Layer.provide(config),
+		)
+
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const service = yield* TinybirdService
+				return yield* service.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_a'")
+			}).pipe(Effect.provide(layer)),
+		)
+
+		expect(result).toEqual([{ message: "managed-clickhouse" }])
+		expect(calls).toEqual([
+			{
+				url: "https://clickhouse.example.com:8443",
+				username: "maple_reader",
+				password: "clickhouse-password",
+				database: "observability",
+			},
+		])
 	})
 
 	it("sqlQuery rejects SQL without OrgId filter", async () => {
@@ -137,6 +215,34 @@ describe("Tinybird routing", () => {
 		)
 
 		expect(result).toEqual([{ result: 1 }])
+	})
+
+	it("strips legacy FORMAT and trailing semicolon before ClickHouse client execution", async () => {
+		const { url } = createTempDbUrl()
+		const executedSql: string[] = []
+
+		tinybirdTestables.setClientFactory(() => ({
+			sql: async (sql) => {
+				executedSql.push(sql)
+				return { data: [{ result: 1 }] }
+			},
+		}))
+
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const service = yield* TinybirdService
+				return yield* service.sqlQuery(
+					tenant,
+					"SELECT 1 FROM traces WHERE OrgId = 'org_a'\nFORMAT JSON;",
+					{ profile: "list" },
+				)
+			}).pipe(Effect.provide(makeTinybirdLayer(url))),
+		)
+
+		expect(result).toEqual([{ result: 1 }])
+		expect(executedSql).toEqual([
+			"SELECT 1 FROM traces WHERE OrgId = 'org_a' SETTINGS max_execution_time=15, max_memory_usage=1500000000",
+		])
 	})
 
 	it("uses the org-specific Tinybird client for raw queries when an override exists", async () => {
@@ -204,10 +310,16 @@ describe("Tinybird routing", () => {
 			},
 		}
 
-		const calls: Array<{ baseUrl: string; token: string; method: string }> = []
-		tinybirdTestables.setClientFactory((baseUrl, token) => ({
+		const calls: Array<{
+			url: string
+			username: string
+			password: string
+			database: string
+			method: string
+		}> = []
+		tinybirdTestables.setClientFactory((config) => ({
 			sql: async () => {
-				calls.push({ baseUrl, token, method: "sql" })
+				calls.push({ ...config, method: "sql" })
 				return { data: [{ message: "byo" }] }
 			},
 		}))
@@ -235,8 +347,10 @@ describe("Tinybird routing", () => {
 		expect(rawResult.data).toEqual([{ message: "byo" }])
 		expect(calls).toEqual([
 			{
-				baseUrl: "https://customer.tinybird.co",
-				token: "customer-token",
+				url: "https://customer.tinybird.co",
+				username: "default",
+				password: "customer-token",
+				database: "default",
 				method: "sql",
 			},
 		])

--- a/apps/api/src/services/TinybirdRouting.test.ts
+++ b/apps/api/src/services/TinybirdRouting.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest"
 import { ConfigProvider, Effect, Layer, Schema } from "effect"
-import { OrgId, RoleName, UserId } from "@maple/domain/http"
+import { OrgId, RoleName, TinybirdQueryError, TinybirdQuotaExceededError, UserId } from "@maple/domain/http"
 import { DatabaseLibsqlLive } from "./DatabaseLibsqlLive"
 import { Env } from "./Env"
 import { OrgTinybirdSettingsService } from "./OrgTinybirdSettingsService"
@@ -79,6 +79,9 @@ const tenant = {
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const makeClickHouseError = (message: string, code: string, type: string) =>
+	Object.assign(new Error(message), { code, type })
 
 describe("Tinybird routing", () => {
 	it("uses the env-backed ClickHouse client by default for raw queries", async () => {
@@ -243,6 +246,131 @@ describe("Tinybird routing", () => {
 		expect(executedSql).toEqual([
 			"SELECT 1 FROM traces WHERE OrgId = 'org_a' SETTINGS max_execution_time=15, max_memory_usage=1500000000",
 		])
+	})
+
+	it("maps ClickHouse auth errors to credential query errors", async () => {
+		const { url } = createTempDbUrl()
+
+		tinybirdTestables.setClientFactory(() => ({
+			sql: async () => {
+				throw makeClickHouseError(
+					"Authentication failed: password is incorrect",
+					"516",
+					"AUTHENTICATION_FAILED",
+				)
+			},
+		}))
+
+		const error = await Effect.runPromise(
+			Effect.gen(function* () {
+				const service = yield* TinybirdService
+				return yield* service
+					.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_a'")
+					.pipe(Effect.flip)
+			}).pipe(Effect.provide(makeTinybirdLayer(url))),
+		)
+
+		expect(error).toBeInstanceOf(TinybirdQueryError)
+		expect(error.category).toBe("auth")
+		expect(error.clickhouseCode).toBe("516")
+		expect(error.clickhouseType).toBe("AUTHENTICATION_FAILED")
+	})
+
+	it("maps ClickHouse quota errors to quota exceeded errors with ClickHouse details", async () => {
+		const { url } = createTempDbUrl()
+
+		tinybirdTestables.setClientFactory(() => ({
+			sql: async () => {
+				throw makeClickHouseError(
+					"Timeout exceeded: elapsed 15.1 seconds, maximum: 15",
+					"159",
+					"TIMEOUT_EXCEEDED",
+				)
+			},
+		}))
+
+		const error = await Effect.runPromise(
+			Effect.gen(function* () {
+				const service = yield* TinybirdService
+				return yield* service
+					.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_a'")
+					.pipe(Effect.flip)
+			}).pipe(Effect.provide(makeTinybirdLayer(url))),
+		)
+
+		expect(error).toBeInstanceOf(TinybirdQuotaExceededError)
+		expect(error.setting).toBe("max_execution_time")
+		expect(error.clickhouseCode).toBe("159")
+		expect(error.clickhouseType).toBe("TIMEOUT_EXCEEDED")
+	})
+
+	it("maps ClickHouse schema/config errors to config query errors", async () => {
+		const { url } = createTempDbUrl()
+
+		tinybirdTestables.setClientFactory(() => ({
+			sql: async () => {
+				throw makeClickHouseError("Database default does not exist", "81", "UNKNOWN_DATABASE")
+			},
+		}))
+
+		const error = await Effect.runPromise(
+			Effect.gen(function* () {
+				const service = yield* TinybirdService
+				return yield* service
+					.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_a'")
+					.pipe(Effect.flip)
+			}).pipe(Effect.provide(makeTinybirdLayer(url))),
+		)
+
+		expect(error).toBeInstanceOf(TinybirdQueryError)
+		expect(error.category).toBe("config")
+		expect(error.clickhouseCode).toBe("81")
+		expect(error.clickhouseType).toBe("UNKNOWN_DATABASE")
+	})
+
+	it("maps ClickHouse client timeout and network errors as transient upstream errors", async () => {
+		const { url } = createTempDbUrl()
+
+		tinybirdTestables.setClientFactory(() => ({
+			sql: async () => {
+				throw new Error("Timeout error.")
+			},
+		}))
+
+		const error = await Effect.runPromise(
+			Effect.gen(function* () {
+				const service = yield* TinybirdService
+				return yield* service
+					.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_a'")
+					.pipe(Effect.flip)
+			}).pipe(Effect.provide(makeTinybirdLayer(url))),
+		)
+
+		expect(error).toBeInstanceOf(TinybirdQueryError)
+		expect(error.category).toBe("upstream")
+	})
+
+	it("maps response JSON decode errors as client errors", async () => {
+		const { url } = createTempDbUrl()
+
+		tinybirdTestables.setClientFactory(() => ({
+			sql: async () => {
+				throw new SyntaxError("Unexpected token '<', \"<html>\" is not valid JSON")
+			},
+		}))
+
+		const error = await Effect.runPromise(
+			Effect.gen(function* () {
+				const service = yield* TinybirdService
+				return yield* service
+					.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_a'")
+					.pipe(Effect.flip)
+			}).pipe(Effect.provide(makeTinybirdLayer(url))),
+		)
+
+		expect(error).toBeInstanceOf(TinybirdQueryError)
+		expect(error.category).toBe("client")
+		expect(error.message).not.toContain("<html>")
 	})
 
 	it("uses the org-specific Tinybird client for raw queries when an override exists", async () => {

--- a/apps/api/src/services/TinybirdService.ts
+++ b/apps/api/src/services/TinybirdService.ts
@@ -42,6 +42,7 @@ interface SqlClientConfig {
 }
 
 export type TinybirdSqlError = TinybirdQueryError | TinybirdQuotaExceededError
+type TinybirdQueryErrorCategory = "query" | "upstream" | "auth" | "config" | "client"
 
 export interface TinybirdServiceShape {
 	readonly query: (
@@ -95,6 +96,59 @@ const normalizeSqlForClickHouseClient = (sql: string): string =>
 		.replace(/\s+FORMAT\s+(?:JSONEachRow|JSON)\s*$/i, "")
 		.replace(/;\s*$/, "")
 
+type ClickHouseErrorDetails = {
+	readonly message: string
+	readonly code?: string
+	readonly type?: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null
+
+const unknownToMessage = (error: unknown, fallback = "ClickHouse query failed"): string => {
+	if (typeof error === "string") return error
+	if (error instanceof Error) return error.message
+	if (isRecord(error) && typeof error.message === "string") return error.message
+	return fallback
+}
+
+const getClickHouseErrorDetails = (error: unknown): ClickHouseErrorDetails => {
+	const message = unknownToMessage(error)
+	if (!isRecord(error)) return { message }
+	const code =
+		typeof error.code === "string"
+			? error.code
+			: typeof error.code === "number"
+				? String(error.code)
+				: undefined
+	const type = typeof error.type === "string" ? error.type : undefined
+	return { message, code, type }
+}
+
+const authClickHouseTypes = new Set([
+	"AUTHENTICATION_FAILED",
+	"ACCESS_DENIED",
+	"USER_DOESNT_EXIST",
+	"REQUIRED_PASSWORD",
+])
+
+const configClickHouseTypes = new Set([
+	"UNKNOWN_DATABASE",
+	"UNKNOWN_TABLE",
+	"TABLE_IS_DROPPED",
+	"UNKNOWN_SETTING",
+])
+
+const transientClickHouseTypes = new Set([
+	"NETWORK_ERROR",
+	"SOCKET_TIMEOUT",
+	"TOO_MANY_SIMULTANEOUS_QUERIES",
+	"SERVER_OVERLOADED",
+	"CANNOT_SCHEDULE_TASK",
+	"KEEPER_EXCEPTION",
+	"ALL_CONNECTION_TRIES_FAILED",
+])
+
 export class TinybirdService extends Context.Service<TinybirdService, TinybirdServiceShape>()(
 	"TinybirdService",
 	{
@@ -115,41 +169,104 @@ export class TinybirdService extends Context.Service<TinybirdService, TinybirdSe
 			}
 
 			const extractUpstreamStatus = (message: string): number | undefined => {
-				const match = message.match(/status[:\s]+(\d{3})/i)
+				const match = message.match(/(?:status|HTTP status|response status code)[:\s]+(\d{3})/i)
 				if (match) return Number(match[1])
+				const titleMatch = message.match(/\b(\d{3})\s+(?:error|service temporarily unavailable)\b/i)
+				if (titleMatch) return Number(titleMatch[1])
 				return undefined
 			}
 
 			const toTinybirdQueryError = (pipe: string, error: unknown) =>
 				new TinybirdQueryError({
-					message: cleanErrorMessage(
-						error instanceof Error ? error.message : "Tinybird query failed",
-					),
+					message: cleanErrorMessage(unknownToMessage(error, "Tinybird query failed")),
 					pipe,
 				})
 
 			const mapTinybirdError = (pipe: string, error: unknown) => {
-				const rawMessage = error instanceof Error ? error.message : "Tinybird query failed"
+				const details = getClickHouseErrorDetails(error)
+				const rawMessage = details.message
 				const message = cleanErrorMessage(rawMessage)
 				const setting = detectQuotaSetting(rawMessage)
+				const clickhouseFields = {
+					clickhouseCode: details.code,
+					clickhouseType: details.type,
+				}
 				if (setting) {
-					return new TinybirdQuotaExceededError({ pipe, message, setting })
+					return new TinybirdQuotaExceededError({ pipe, message, setting, ...clickhouseFields })
 				}
 				const upstreamStatus = extractUpstreamStatus(rawMessage)
-				if (upstreamStatus === 401 || upstreamStatus === 403) {
-					return new TinybirdQueryError({ pipe, message, category: "auth", upstreamStatus })
+				const type = details.type
+				const isAuthFailure =
+					upstreamStatus === 401 ||
+					upstreamStatus === 403 ||
+					(type !== undefined && authClickHouseTypes.has(type)) ||
+					/authentication failed|access denied|not enough privileges|password is incorrect/i.test(
+						rawMessage,
+					)
+				if (isAuthFailure) {
+					return new TinybirdQueryError({
+						pipe,
+						message,
+						category: "auth",
+						upstreamStatus,
+						...clickhouseFields,
+					})
 				}
-				// Any upstream 5xx (502/503/504, Cloudflare 520-530, etc.) is treated
-				// as a transient infrastructure failure rather than a user query bug.
-				if (upstreamStatus !== undefined && upstreamStatus >= 500 && upstreamStatus < 600) {
+				const isTransientFailure =
+					(upstreamStatus !== undefined &&
+						(upstreamStatus === 408 ||
+							upstreamStatus === 429 ||
+							(upstreamStatus >= 500 && upstreamStatus < 600))) ||
+					(type !== undefined && transientClickHouseTypes.has(type)) ||
+					/^Timeout error\.?$/i.test(rawMessage) ||
+					/The user aborted a request|Failed to fetch|fetch failed|NetworkError|Load failed|ECONNREFUSED|ECONNRESET|ENOTFOUND|EAI_AGAIN|certificate/i.test(
+						rawMessage,
+					)
+				if (isTransientFailure) {
 					return new TinybirdQueryError({
 						pipe,
 						message,
 						category: "upstream",
 						upstreamStatus,
+						...clickhouseFields,
 					})
 				}
-				return new TinybirdQueryError({ pipe, message, category: "query" })
+				const isConfigFailure =
+					(upstreamStatus !== undefined && upstreamStatus === 404) ||
+					(type !== undefined && configClickHouseTypes.has(type)) ||
+					/Invalid URL|unknown database|unknown table|table .* does not exist|database .* does not exist/i.test(
+						rawMessage,
+					)
+				if (isConfigFailure) {
+					return new TinybirdQueryError({
+						pipe,
+						message,
+						category: "config",
+						upstreamStatus,
+						...clickhouseFields,
+					})
+				}
+				const isClientFailure =
+					error instanceof SyntaxError ||
+					/Cannot decode .* as JSON|Unexpected token .* JSON|Stream has been already consumed|Failed to parse ClickHouse response/i.test(
+						rawMessage,
+					)
+				if (isClientFailure) {
+					return new TinybirdQueryError({
+						pipe,
+						message,
+						category: "client",
+						upstreamStatus,
+						...clickhouseFields,
+					})
+				}
+				return new TinybirdQueryError({
+					pipe,
+					message,
+					category: "query",
+					upstreamStatus,
+					...clickhouseFields,
+				})
 			}
 
 			const getCachedOrCreateClient = (orgId: OrgId | "__managed__", config: SqlClientConfig) => {

--- a/apps/api/src/services/TinybirdService.ts
+++ b/apps/api/src/services/TinybirdService.ts
@@ -5,7 +5,7 @@ import {
 	TinybirdQuotaExceededError,
 } from "@maple/domain/http"
 import type { OrgId } from "@maple/domain"
-import { Tinybird } from "@tinybirdco/sdk"
+import { createClient as createClickHouseClient } from "@clickhouse/client-web"
 import { Effect, Layer, Option, Redacted, Context } from "effect"
 import { Env } from "./Env"
 import type { TenantContext } from "./AuthService"
@@ -27,9 +27,18 @@ export type SqlQueryOptions = {
 const CLIENT_CACHE_TTL_MS = 30_000
 interface CachedClient {
 	client: SqlClient
-	host: string
-	token: string
+	url: string
+	username: string
+	password: string
+	database: string
 	expiresAt: number
+}
+
+interface SqlClientConfig {
+	readonly url: string
+	readonly username: string
+	readonly password: string
+	readonly database: string
 }
 
 export type TinybirdSqlError = TinybirdQueryError | TinybirdQuotaExceededError
@@ -59,18 +68,32 @@ interface SqlClient {
 	readonly sql: (sql: string) => Promise<{ data: ReadonlyArray<Record<string, unknown>> }>
 }
 
-const createClient = (baseUrl: string, token: string): SqlClient => {
-	const tb = new Tinybird({
-		baseUrl,
-		token,
-		datasources: {},
-		pipes: {},
-		devMode: false,
+const createClient = (config: SqlClientConfig): SqlClient => {
+	const client = createClickHouseClient({
+		url: config.url,
+		username: config.username,
+		password: config.password,
+		database: config.database,
 	})
-	return { sql: (sql: string) => tb.sql(sql) }
+	return {
+		sql: async (sql: string) => {
+			const resultSet = await client.query({
+				query: sql,
+				format: "JSONEachRow",
+			})
+			const data = await resultSet.json<Record<string, unknown>>()
+			return { data }
+		},
+	}
 }
 
-let tinybirdClientFactory: typeof createClient = createClient
+let clickHouseClientFactory: typeof createClient = createClient
+
+const normalizeSqlForClickHouseClient = (sql: string): string =>
+	sql
+		.replace(/;\s*$/, "")
+		.replace(/\s+FORMAT\s+(?:JSONEachRow|JSON)\s*$/i, "")
+		.replace(/;\s*$/, "")
 
 export class TinybirdService extends Context.Service<TinybirdService, TinybirdServiceShape>()(
 	"TinybirdService",
@@ -83,7 +106,10 @@ export class TinybirdService extends Context.Service<TinybirdService, TinybirdSe
 				let cleaned = raw
 				const htmlIndex = cleaned.search(/<\s*(html|head|body|center|h1|hr|title)\b/i)
 				if (htmlIndex >= 0) cleaned = cleaned.slice(0, htmlIndex)
-				cleaned = cleaned.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim()
+				cleaned = cleaned
+					.replace(/<[^>]+>/g, " ")
+					.replace(/\s+/g, " ")
+					.trim()
 				if (cleaned.endsWith(":")) cleaned = cleaned.slice(0, -1).trim()
 				return cleaned || raw.slice(0, 200)
 			}
@@ -126,18 +152,25 @@ export class TinybirdService extends Context.Service<TinybirdService, TinybirdSe
 				return new TinybirdQueryError({ pipe, message, category: "query" })
 			}
 
-			const getCachedOrCreateClient = (orgId: OrgId | "__managed__", host: string, token: string) => {
+			const getCachedOrCreateClient = (orgId: OrgId | "__managed__", config: SqlClientConfig) => {
 				const now = Date.now()
 				const cached = clientCache.get(orgId)
-				if (cached && cached.host === host && cached.token === token && cached.expiresAt > now) {
+				if (
+					cached &&
+					cached.url === config.url &&
+					cached.username === config.username &&
+					cached.password === config.password &&
+					cached.database === config.database &&
+					cached.expiresAt > now
+				) {
 					return cached.client
 				}
-				const client = tinybirdClientFactory(host, token)
-				clientCache.set(orgId, { client, host, token, expiresAt: now + CLIENT_CACHE_TTL_MS })
+				const client = clickHouseClientFactory(config)
+				clientCache.set(orgId, { client, ...config, expiresAt: now + CLIENT_CACHE_TTL_MS })
 				return client
 			}
 
-			const resolveHostToken = Effect.fn("TinybirdService.resolveHostToken")(function* (
+			const resolveTinybirdHostToken = Effect.fn("TinybirdService.resolveTinybirdHostToken")(function* (
 				tenant: TenantContext,
 				label: string,
 			) {
@@ -162,6 +195,42 @@ export class TinybirdService extends Context.Service<TinybirdService, TinybirdSe
 				}
 			})
 
+			const resolveSqlConfig = Effect.fn("TinybirdService.resolveSqlConfig")(function* (
+				tenant: TenantContext,
+				label: string,
+			) {
+				const override = yield* orgTinybirdSettings
+					.resolveRuntimeConfig(tenant.orgId)
+					.pipe(Effect.mapError((error) => toTinybirdQueryError(label, error)))
+
+				if (Option.isSome(override)) {
+					yield* Effect.annotateCurrentSpan("clientSource", "org_override")
+					return {
+						config: {
+							url: override.value.host,
+							username: env.CLICKHOUSE_USER,
+							password: override.value.token,
+							database: env.CLICKHOUSE_DATABASE,
+						},
+						source: "org_override" as const,
+					}
+				}
+
+				yield* Effect.annotateCurrentSpan("clientSource", "managed")
+				return {
+					config: {
+						url: Option.getOrElse(env.CLICKHOUSE_URL, () => env.TINYBIRD_HOST),
+						username: env.CLICKHOUSE_USER,
+						password: Option.match(env.CLICKHOUSE_PASSWORD, {
+							onNone: () => Redacted.value(env.TINYBIRD_TOKEN),
+							onSome: Redacted.value,
+						}),
+						database: env.CLICKHOUSE_DATABASE,
+					},
+					source: "managed" as const,
+				}
+			})
+
 			const resolveClient = Effect.fn("TinybirdService.resolveClient")(function* (
 				tenant: TenantContext,
 				pipe: string,
@@ -169,9 +238,9 @@ export class TinybirdService extends Context.Service<TinybirdService, TinybirdSe
 				yield* Effect.annotateCurrentSpan("pipe", pipe)
 				yield* Effect.annotateCurrentSpan("orgId", tenant.orgId)
 
-				const resolved = yield* resolveHostToken(tenant, pipe)
+				const resolved = yield* resolveSqlConfig(tenant, pipe)
 				const cacheKey = resolved.source === "managed" ? "__managed__" : tenant.orgId
-				return getCachedOrCreateClient(cacheKey, resolved.host, resolved.token)
+				return getCachedOrCreateClient(cacheKey, resolved.config)
 			})
 
 			const truncateSql = (s: string, maxLen = 1000) =>
@@ -195,7 +264,8 @@ export class TinybirdService extends Context.Service<TinybirdService, TinybirdSe
 				}
 
 				const settings = resolveSettings(options)
-				const finalSql = appendSettings(sql, settings)
+				const sqlForClient = normalizeSqlForClickHouseClient(sql)
+				const finalSql = appendSettings(sqlForClient, settings)
 				yield* Effect.annotateCurrentSpan("db.statement", truncateSql(finalSql))
 				if (options?.profile) yield* Effect.annotateCurrentSpan("query.profile", options.profile)
 				if (settings) yield* Effect.annotateCurrentSpan("ch.settings", JSON.stringify(settings))
@@ -286,7 +356,7 @@ export class TinybirdService extends Context.Service<TinybirdService, TinybirdSe
 				if (rows.length === 0) return
 
 				const label = `ingest:${datasource}`
-				const resolved = yield* resolveHostToken(tenant, label)
+				const resolved = yield* resolveTinybirdHostToken(tenant, label)
 				const ndjson = rows.map((row) => JSON.stringify(row)).join("\n")
 				const url = `${resolved.host.replace(/\/$/, "")}/v0/events?name=${encodeURIComponent(datasource)}&wait=false`
 
@@ -344,11 +414,11 @@ export class TinybirdService extends Context.Service<TinybirdService, TinybirdSe
 
 export const __testables = {
 	setClientFactory: (factory: typeof createClient) => {
-		tinybirdClientFactory = factory
+		clickHouseClientFactory = factory
 		clientCache.clear()
 	},
 	reset: () => {
-		tinybirdClientFactory = createClient
+		clickHouseClientFactory = createClient
 		clientCache.clear()
 	},
 }

--- a/apps/web/src/lib/error-messages.test.ts
+++ b/apps/web/src/lib/error-messages.test.ts
@@ -73,7 +73,7 @@ describe("formatBackendError", () => {
 			category: "upstream",
 			upstreamStatus: 503,
 		})
-		expect(result.title).toBe("Tinybird is temporarily unavailable")
+		expect(result.title).toBe("Database is temporarily unavailable")
 		expect(result.description).toContain("503")
 	})
 
@@ -85,8 +85,31 @@ describe("formatBackendError", () => {
 			category: "auth",
 			upstreamStatus: 401,
 		})
-		expect(result.title).toBe("Tinybird rejected our credentials")
+		expect(result.title).toBe("Database rejected our credentials")
 		expect(result.description).toContain("invalid or expired")
+	})
+
+	it("formats TinybirdQueryError with config category as configuration issue", () => {
+		const result = formatBackendError({
+			_tag: "@maple/http/errors/TinybirdQueryError",
+			message: "Database default does not exist",
+			pipe: "sqlQuery",
+			category: "config",
+			clickhouseType: "UNKNOWN_DATABASE",
+		})
+		expect(result.title).toBe("Database is not configured correctly")
+		expect(result.description).toContain("Database default does not exist")
+	})
+
+	it("formats TinybirdQueryError with client category as decode issue", () => {
+		const result = formatBackendError({
+			_tag: "@maple/http/errors/TinybirdQueryError",
+			message: "Unexpected token '<'",
+			pipe: "sqlQuery",
+			category: "client",
+		})
+		expect(result.title).toBe("Database response could not be decoded")
+		expect(result.description).toContain("Unexpected token")
 	})
 
 	it("rewrites TinybirdQueryError when message leaks a 5xx status", () => {
@@ -95,7 +118,7 @@ describe("formatBackendError", () => {
 			message: "Request failed with status 521: error code: 521",
 			pipe: "sqlQuery",
 		})
-		expect(result.title).toBe("Tinybird is temporarily unavailable")
+		expect(result.title).toBe("Database is temporarily unavailable")
 		expect(result.description).toContain("521")
 	})
 
@@ -118,7 +141,7 @@ describe("formatBackendError", () => {
 		})
 		expect(result.description).not.toContain("<html>")
 		expect(result.description).not.toContain("<title>")
-		expect(result.title).toBe("Tinybird is temporarily unavailable")
+		expect(result.title).toBe("Database is temporarily unavailable")
 		expect(result.description).toContain("503")
 	})
 

--- a/apps/web/src/lib/error-messages.ts
+++ b/apps/web/src/lib/error-messages.ts
@@ -13,13 +13,19 @@ const QUOTA_DESCRIPTIONS: Record<string, string> = {
 }
 
 const hasTag = (value: unknown): value is { _tag: string; [key: string]: unknown } =>
-	typeof value === "object" && value !== null && "_tag" in value && typeof (value as { _tag: unknown })._tag === "string"
+	typeof value === "object" &&
+	value !== null &&
+	"_tag" in value &&
+	typeof (value as { _tag: unknown })._tag === "string"
 
 const sanitizeMessage = (raw: string): string => {
 	let cleaned = raw
 	const htmlIndex = cleaned.search(/<\s*(html|head|body|center|h1|hr|title)\b/i)
 	if (htmlIndex >= 0) cleaned = cleaned.slice(0, htmlIndex)
-	cleaned = cleaned.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim()
+	cleaned = cleaned
+		.replace(/<[^>]+>/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
 	if (cleaned.endsWith(":")) cleaned = cleaned.slice(0, -1).trim()
 	return cleaned || raw.slice(0, 200)
 }
@@ -76,7 +82,8 @@ export const formatBackendError = (input: unknown): FormattedError => {
 			case "@maple/http/errors/QueryEngineTimeoutError": {
 				return {
 					title: "Query timed out",
-					description: "The query took longer than 30 seconds. Narrow the time range or add filters.",
+					description:
+						"The query took longer than 30 seconds. Narrow the time range or add filters.",
 				}
 			}
 			case "@maple/http/errors/QueryEngineValidationError": {
@@ -103,17 +110,13 @@ export const formatBackendError = (input: unknown): FormattedError => {
 					(message.match(/status[:\s]+(\d{3})/i)?.[1]
 						? Number(message.match(/status[:\s]+(\d{3})/i)?.[1])
 						: undefined)
-				if (
-					category === "auth" ||
-					upstreamStatus === 401 ||
-					upstreamStatus === 403
-				) {
+				if (category === "auth" || upstreamStatus === 401 || upstreamStatus === 403) {
 					return {
-						title: "Tinybird rejected our credentials",
+						title: "Database rejected our credentials",
 						description:
 							upstreamStatus === 403
-								? "The configured Tinybird token is missing required permissions."
-								: "The configured Tinybird token is invalid or expired. Update it in settings.",
+								? "The configured database credentials are missing required permissions."
+								: "The configured database credentials are invalid or expired. Update them in settings.",
 					}
 				}
 				if (
@@ -121,11 +124,23 @@ export const formatBackendError = (input: unknown): FormattedError => {
 					(upstreamStatus !== undefined && upstreamStatus >= 500 && upstreamStatus < 600)
 				) {
 					return {
-						title: "Tinybird is temporarily unavailable",
+						title: "Database is temporarily unavailable",
 						description:
 							upstreamStatus !== undefined
 								? `The query backend returned ${upstreamStatus}. Retry in a few seconds.`
 								: "The query backend is unreachable. Retry in a few seconds.",
+					}
+				}
+				if (category === "config") {
+					return {
+						title: "Database is not configured correctly",
+						description: message,
+					}
+				}
+				if (category === "client") {
+					return {
+						title: "Database response could not be decoded",
+						description: message,
 					}
 				}
 				return {
@@ -136,7 +151,8 @@ export const formatBackendError = (input: unknown): FormattedError => {
 			case "@maple/http/errors/UnauthorizedError": {
 				return {
 					title: "Not authorized",
-					description: "Your session may have expired. Try refreshing the page or signing in again.",
+					description:
+						"Your session may have expired. Try refreshing the page or signing in again.",
 				}
 			}
 		}

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
       "name": "@maple/api",
       "dependencies": {
         "@clerk/backend": "^2.30.1",
+        "@clickhouse/client-web": "catalog:clickhouse",
         "@effect/opentelemetry": "catalog:effect",
         "@libsql/client": "0.15.15",
         "@maple/db": "workspace:*",
@@ -434,6 +435,9 @@
     "vitest": "^4.1.2",
   },
   "catalogs": {
+    "clickhouse": {
+      "@clickhouse/client-web": "^1.18.3",
+    },
     "effect": {
       "@effect/atom-react": "4.0.0-beta.57",
       "@effect/language-service": "^0.85.1",
@@ -802,6 +806,10 @@
     "@clerk/themes": ["@clerk/themes@2.4.57", "", { "dependencies": { "@clerk/shared": "^3.47.2", "tslib": "2.8.1" } }, "sha512-Nb3bO79rMTU/MPVTC/dde6LG27/IgOMKIYi5KSvAmO4ZUHlj0OWufu6CMvz5OYVZ0YdyMnTBU2aPGRUiRzO+2w=="],
 
     "@clerk/types": ["@clerk/types@4.101.23", "", { "dependencies": { "@clerk/shared": "^3.47.5" } }, "sha512-t5ypYYDkT5TPaNIDjLnYk9GpkJgwNTBiS7h6FuUTjoySQtf7amNDS1A1eOu7NOcVpqiSeKg+0wzGxxcre00kMA=="],
+
+    "@clickhouse/client-common": ["@clickhouse/client-common@1.18.3", "", {}, "sha512-3axzO3zvrsGT5PzDenxgWscltYCNRDbhaHWUgdsmcM9OnW/VnZn9EarOcZogr9P82Z0mQh+Jd2x+p2K4TFD2fA=="],
+
+    "@clickhouse/client-web": ["@clickhouse/client-web@1.18.3", "", { "dependencies": { "@clickhouse/client-common": "1.18.3" } }, "sha512-onqr4PJMGC3m+NiNRLqc1XxJFtKz0U2N0hHEj3SShlI++OqzE3DvyWPhRamQriKN1drSk/DAyhPeisK2FIbMzg=="],
 
     "@cloudflare/ai-chat": ["@cloudflare/ai-chat@0.3.2", "", { "peerDependencies": { "@ai-sdk/react": "^3.0.0", "agents": "^0.9.0", "ai": "^6.0.0", "react": "^19.0.0", "zod": "^4.0.0" } }, "sha512-E41BnXJ6MGG7yINhEYr3Wa6LXTIsdOVUI3sTivgF+JC9BQRk3MfNpzvlh0eLJGRp8yxd7YIBbs1N/eZFZA49bQ=="],
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
 		"vitest": "^4.1.2"
 	},
 	"catalogs": {
+		"clickhouse": {
+			"@clickhouse/client-web": "^1.18.3"
+		},
 		"effect": {
 			"@effect/atom-react": "4.0.0-beta.57",
 			"@effect/language-service": "^0.85.1",

--- a/packages/domain/src/http/tinybird.ts
+++ b/packages/domain/src/http/tinybird.ts
@@ -24,15 +24,19 @@ export class TinybirdQueryResponse extends Schema.Class<TinybirdQueryResponse>("
 // class on every endpoint costs measurable script-startup CPU on Cloudflare —
 // hit error 10021 at ~7 errors × 30 endpoints).
 //   - "query"        → ClickHouse/SQL error (default)
-//   - "upstream"     → Tinybird/CDN gateway 5xx (transient)
-//   - "auth"         → upstream 401/403 (token misconfigured)
+//   - "upstream"     → query backend/CDN/network failure (transient)
+//   - "auth"         → upstream 401/403 or database credentials failure
+//   - "config"       → backend/database configuration is wrong
+//   - "client"       → Maple's query client could not decode/consume the response
 export class TinybirdQueryError extends Schema.TaggedErrorClass<TinybirdQueryError>()(
 	"@maple/http/errors/TinybirdQueryError",
 	{
 		message: Schema.String,
 		pipe: Schema.String,
-		category: Schema.optional(Schema.Literals(["query", "upstream", "auth"])),
+		category: Schema.optional(Schema.Literals(["query", "upstream", "auth", "config", "client"])),
 		upstreamStatus: Schema.optional(Schema.Number),
+		clickhouseCode: Schema.optional(Schema.String),
+		clickhouseType: Schema.optional(Schema.String),
 	},
 	{ httpApiStatus: 502 },
 ) {}
@@ -43,6 +47,8 @@ export class TinybirdQuotaExceededError extends Schema.TaggedErrorClass<Tinybird
 		message: Schema.String,
 		pipe: Schema.String,
 		setting: Schema.Literals(["max_execution_time", "max_memory_usage", "max_threads"]),
+		clickhouseCode: Schema.optional(Schema.String),
+		clickhouseType: Schema.optional(Schema.String),
 	},
 	{ httpApiStatus: 429 },
 ) {}


### PR DESCRIPTION
## Summary
- Swap raw SQL execution from `@tinybirdco/sdk` to `@clickhouse/client-web` while keeping the `TinybirdService` facade and call sites intact
- Add ClickHouse env support with managed defaults and preserve Tinybird-backed ingest/BYO provisioning paths
- Normalize legacy SQL before execution so existing queries do not double-append `FORMAT`
- Extend routing coverage for managed config, org overrides, JSONEachRow execution, and format stripping

## Testing
- Added and updated unit tests for ClickHouse client selection, SQL routing, OrgId guards, and query normalization
- Ran the focused API service test suite for `TinybirdRouting.test.ts`