### PR TITLE
chore(ci): SHA-pin actions, gate publish/deploy with environments, fix RCE in tag input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,17 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     typescript:
         name: TypeScript
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-            - uses: oven-sh/setup-bun@v2
+            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
             - run: bun install --frozen-lockfile
 
@@ -30,11 +33,11 @@ jobs:
             run:
                 working-directory: apps/ingest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-            - uses: dtolnay/rust-toolchain@stable
+            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-            - uses: Swatinem/rust-cache@v2
+            - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
               with:
                   workspaces: apps/ingest
 

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -19,6 +19,10 @@ jobs:
     deploy-pr-preview:
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         runs-on: ubuntu-latest
+        # `pr-preview` environment must require manual approval in repo settings.
+        # This blocks PR-controlled code (install scripts, build steps) from
+        # accessing Doppler secrets until a maintainer reviews the diff.
+        environment: pr-preview
         env:
             DOPPLER_PROJECT: maple
             DOPPLER_CONFIG: pr
@@ -26,13 +30,13 @@ jobs:
             PR_BRANCH: ${{ github.head_ref }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Setup Bun
-              uses: oven-sh/setup-bun@v2
+              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
             - name: Load deployment secrets from Doppler
-              uses: dopplerhq/secrets-fetch-action@v1.3.0
+              uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
               with:
                   doppler-token: ${{ secrets.DOPPLER_TOKEN }}
                   doppler-project: ${{ env.DOPPLER_PROJECT }}

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -16,18 +16,19 @@ permissions:
 jobs:
     deploy-prd:
         runs-on: ubuntu-latest
+        environment: production
         env:
             DOPPLER_PROJECT: maple
             DOPPLER_CONFIG: prd
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Setup Bun
-              uses: oven-sh/setup-bun@v2
+              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
             - name: Load deployment secrets from Doppler
-              uses: dopplerhq/secrets-fetch-action@v1.3.0
+              uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
               with:
                   doppler-token: ${{ secrets.DOPPLER_TOKEN }}
                   doppler-project: ${{ env.DOPPLER_PROJECT }}

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -16,18 +16,19 @@ permissions:
 jobs:
     deploy-stg:
         runs-on: ubuntu-latest
+        environment: staging
         env:
             DOPPLER_PROJECT: maple
             DOPPLER_CONFIG: stg
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Setup Bun
-              uses: oven-sh/setup-bun@v2
+              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
             - name: Load deployment secrets from Doppler
-              uses: dopplerhq/secrets-fetch-action@v1.3.0
+              uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
               with:
                   doppler-token: ${{ secrets.DOPPLER_TOKEN }}
                   doppler-project: ${{ env.DOPPLER_PROJECT }}

--- a/.github/workflows/otel-collector-maple-tests.yml
+++ b/.github/workflows/otel-collector-maple-tests.yml
@@ -22,9 +22,9 @@ jobs:
             run:
                 working-directory: packages/otel-collector-maple-exporter
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
               with:
                   # Match `go 1.25.0` in packages/otel-collector-maple-exporter/go.mod.
                   go-version-file: packages/otel-collector-maple-exporter/go.mod

--- a/.github/workflows/publish-k8s-infra-chart.yml
+++ b/.github/workflows/publish-k8s-infra-chart.yml
@@ -13,10 +13,11 @@ permissions:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        environment: publish-charts
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-            - uses: azure/setup-helm@v4
+            - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
             - name: Package chart
               run: ./scripts/package-k8s-infra-chart.sh

--- a/.github/workflows/publish-maple-otel-chart.yml
+++ b/.github/workflows/publish-maple-otel-chart.yml
@@ -13,10 +13,11 @@ permissions:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        environment: publish-charts
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-            - uses: azure/setup-helm@v4
+            - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
             - name: Publish chart to GHCR
               env:

--- a/.github/workflows/publish-otel-collector-maple.yml
+++ b/.github/workflows/publish-otel-collector-maple.yml
@@ -23,20 +23,25 @@ env:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        environment: publish-images
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
             - name: Resolve image name + tag
               id: image
+              env:
+                  EVENT_NAME: ${{ github.event_name }}
+                  INPUT_TAG: ${{ inputs.tag }}
+                  OWNER: ${{ github.repository_owner }}
               run: |
+                  set -euo pipefail
                   # GHCR requires the repository part of the image to be
-                  # all-lowercase. github.repository_owner can be mixed-case
-                  # (e.g. "Makisuo"), so lowercase it here.
-                  owner_lc=$(printf '%s' "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+                  # all-lowercase. The owner can be mixed-case, so lowercase it.
+                  owner_lc=$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')
                   echo "name=ghcr.io/${owner_lc}/maple/otel-collector-maple" >> "$GITHUB_OUTPUT"
 
-                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-                    tag="${{ inputs.tag }}"
+                  if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+                    tag="$INPUT_TAG"
                   else
                     # Strip the `otel-collector-maple-v` prefix from the git tag.
                     tag="${GITHUB_REF_NAME#otel-collector-maple-v}"
@@ -45,15 +50,21 @@ jobs:
                     echo "::error::Could not resolve image tag from event"
                     exit 1
                   fi
+                  # Reject anything outside Docker tag syntax to prevent shell or
+                  # registry-path injection. Allow alphanumerics plus . _ -.
+                  if ! printf '%s' "$tag" | grep -Eq '^[A-Za-z0-9._-]{1,128}$'; then
+                    echo "::error::Tag '$tag' contains disallowed characters"
+                    exit 1
+                  fi
                   echo "tag=$tag" >> "$GITHUB_OUTPUT"
                   echo "Resolved: ghcr.io/${owner_lc}/maple/otel-collector-maple:${tag}"
 
-            - uses: docker/setup-qemu-action@v3
+            - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
-            - uses: docker/setup-buildx-action@v3
+            - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
             - name: Log in to GHCR
-              uses: docker/login-action@v3
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
               with:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.actor }}
@@ -63,7 +74,7 @@ jobs:
             # binary is statically linked, so the same Dockerfile produces a
             # working image on both amd64 and arm64.
             - name: Build + push (amd64, arm64)
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
               with:
                   context: .
                   file: deploy/k8s-infra/Dockerfile.otel-collector-maple

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -22,13 +22,18 @@ permissions:
 jobs:
     pullfrog:
         runs-on: ubuntu-latest
+        # `pullfrog-agent` environment must require manual approval in repo
+        # settings. The agent action receives a prompt that influences code
+        # execution with repo write + many provider API keys, so dispatch
+        # should be gated behind reviewer approval.
+        environment: pullfrog-agent
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 1
             - name: Run agent
-              uses: pullfrog/pullfrog@v0
+              uses: pullfrog/pullfrog@e4e93ea6d3c787a7bc6cc285d168deb0eab7ac83 # v0
               with:
                   prompt: ${{ inputs.prompt }}
               env:

--- a/.github/workflows/tinybird-cd.yml
+++ b/.github/workflows/tinybird-cd.yml
@@ -15,21 +15,27 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.event.ref }}
 
-env:
-    TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
-    TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
+permissions:
+    contents: read
 
 jobs:
     cd:
         runs-on: ubuntu-latest
+        environment: tinybird-cd
         steps:
-            - uses: actions/checkout@v3
-            - uses: oven-sh/setup-bun@v2
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
             - name: Install dependencies
-              run: bun install
+              # Run install before any secrets are scoped to the deploy step.
+              run: bun install --frozen-lockfile
             - name: Deploy project
+              env:
+                  TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
+                  TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
+                  ALLOW_DESTRUCTIVE: ${{ github.event.inputs.allow_destructive }}
               run: |
-                  if [ "${{ github.event.inputs.allow_destructive }}" = "true" ]; then
+                  set -euo pipefail
+                  if [ "$ALLOW_DESTRUCTIVE" = "true" ]; then
                     bun scripts/tinybird-deploy-destructive.ts
                   else
                     bunx tinybird deploy

--- a/.github/workflows/tinybird-ci.yml
+++ b/.github/workflows/tinybird-ci.yml
@@ -5,9 +5,8 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.event.pull_request.number }}
 
-env:
-    TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
-    TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
+permissions:
+    contents: read
 
 jobs:
     ci:
@@ -21,7 +20,7 @@ jobs:
                 ports:
                     - 7181:7181
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
             - name: Install Tinybird CLI
               run: curl https://tinybird.co | sh
             - name: Build project
@@ -29,4 +28,7 @@ jobs:
             - name: Test project
               run: tb test run
             - name: Deployment check
-              run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deploy --check
+              env:
+                  TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
+                  TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
+              run: tb --cloud --host "$TINYBIRD_HOST" --token "$TINYBIRD_TOKEN" deploy --check


### PR DESCRIPTION
## Summary
Addresses DeepSec findings under slugs `rce`, `secrets-exposure`, `other-ci-supply-chain`, `iam-permissions` (14 HIGH).

- 14 unique action refs SHA-pinned across 11 workflows (e.g. `actions/checkout@34e114876b…` with version comment).
- 11 workflows now declare explicit `permissions:` (defaults to `contents: read` where possible).
- 8 publish/deploy jobs gated on GitHub Environments: `publish-images`, `publish-charts`, `pr-preview`, `pullfrog-agent`, `production`, `staging`, `tinybird-cd`.
- **RCE fix in `publish-otel-collector-maple.yml`**: `inputs.tag` was interpolated directly into a `run:` script. Now passed via `INPUT_TAG` env var and validated against `^[A-Za-z0-9._-]{1,128}$`. Verified by simulation: 6/6 attack inputs (`\$(touch /tmp/pwn)`, `tag; rm -rf /`, etc.) rejected, 3/3 valid versions accepted.
- Tinybird tokens scoped to the deploy step instead of workflow-level `env:`, so install steps run without secrets.
- PR-preview workflow now requires Environment approval before Doppler secrets reach PR-controlled install/build code.

## ⚠️ Required repo configuration before merge
The Environments referenced above must be created in **Settings → Environments** with required-reviewer rules. Without them, jobs run as before (no regression) but without the approval gating the workflow file claims.

## Test plan
- [x] Every `uses:` line is a 40-char SHA with `# v…` comment.
- [x] All 11 workflows have `permissions:` blocks.
- [x] 8 publish/deploy jobs declare `environment:`.
- [x] Tag-validation regex blocks shell-injection attempts.
- [ ] Reviewer: confirm the named Environments exist in repo Settings before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Makisuo/codesmith/maple/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->