### PR TITLE
fix(api): require org admin to manage API keys, ingest keys, Cloudflare Logpush, error policy

### DIFF
--- a/apps/api/src/lib/auth.test.ts
+++ b/apps/api/src/lib/auth.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { Effect, Exit, Option, Schema } from "effect"
+import { RoleName } from "@maple/domain/http"
+import { isAdmin, requireAdmin } from "./auth"
+
+const role = (raw: string) => Schema.decodeUnknownSync(RoleName)(raw)
+
+class TestForbiddenError extends Error {
+	readonly _tag = "TestForbiddenError"
+}
+
+describe("isAdmin", () => {
+	it("returns true for root", () => {
+		expect(isAdmin([role("root")])).toBe(true)
+	})
+	it("returns true for org:admin", () => {
+		expect(isAdmin([role("org:admin")])).toBe(true)
+	})
+	it("returns true if any role is admin", () => {
+		expect(isAdmin([role("org:member"), role("root")])).toBe(true)
+	})
+	it("returns false for non-admin only", () => {
+		expect(isAdmin([role("org:member")])).toBe(false)
+	})
+	it("returns false for empty roles", () => {
+		expect(isAdmin([])).toBe(false)
+	})
+})
+
+describe("requireAdmin", () => {
+	it("succeeds when at least one role is admin", () => {
+		const exit = Effect.runSyncExit(
+			requireAdmin([role("root")], () => new TestForbiddenError("nope")),
+		)
+		expect(Exit.isSuccess(exit)).toBe(true)
+	})
+
+	it("fails with the supplied error for non-admin roles", () => {
+		const exit = Effect.runSyncExit(
+			requireAdmin([role("org:member")], () => new TestForbiddenError("nope")),
+		)
+		expect(Exit.isSuccess(exit)).toBe(false)
+		const err = Option.getOrUndefined(Exit.findErrorOption(exit))
+		expect(err).toBeInstanceOf(TestForbiddenError)
+	})
+})

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -1,0 +1,20 @@
+import { Effect, Schema } from "effect"
+import { RoleName } from "@maple/domain/http"
+
+const ROOT_ROLE = Schema.decodeUnknownSync(RoleName)("root")
+const ORG_ADMIN_ROLE = Schema.decodeUnknownSync(RoleName)("org:admin")
+
+const ADMIN_ROLES: ReadonlyArray<RoleName> = [ROOT_ROLE, ORG_ADMIN_ROLE]
+
+export const isAdmin = (roles: ReadonlyArray<RoleName>): boolean =>
+	roles.some((role) => ADMIN_ROLES.includes(role))
+
+/**
+ * Gate a handler on org-admin / root role membership. Threads through a
+ * caller-supplied error factory so each route group can fail with its own
+ * tagged ForbiddenError (kept domain-local for status-code mapping).
+ */
+export const requireAdmin = <E>(
+	roles: ReadonlyArray<RoleName>,
+	makeError: () => E,
+): Effect.Effect<void, E> => (isAdmin(roles) ? Effect.void : Effect.fail(makeError()))

--- a/apps/api/src/routes/api-keys.http.ts
+++ b/apps/api/src/routes/api-keys.http.ts
@@ -1,7 +1,10 @@
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { CurrentTenant, MapleApi } from "@maple/domain/http"
+import { ApiKeyForbiddenError, CurrentTenant, MapleApi } from "@maple/domain/http"
 import { Effect } from "effect"
 import { ApiKeysService } from "../services/ApiKeysService"
+import { requireAdmin } from "../lib/auth"
+
+const forbidden = (message: string) => () => new ApiKeyForbiddenError({ message })
 
 export const HttpApiKeysLive = HttpApiBuilder.group(MapleApi, "apiKeys", (handlers) =>
 	Effect.gen(function* () {
@@ -17,6 +20,7 @@ export const HttpApiKeysLive = HttpApiBuilder.group(MapleApi, "apiKeys", (handle
 			.handle("create", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(tenant.roles, forbidden("Only org admins can create API keys"))
 					return yield* apiKeysService.create(tenant.orgId, tenant.userId, {
 						name: payload.name,
 						description: payload.description,
@@ -27,6 +31,7 @@ export const HttpApiKeysLive = HttpApiBuilder.group(MapleApi, "apiKeys", (handle
 			.handle("revoke", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(tenant.roles, forbidden("Only org admins can revoke API keys"))
 					return yield* apiKeysService.revoke(tenant.orgId, params.keyId)
 				}),
 			)

--- a/apps/api/src/routes/cloudflare-logpush.http.ts
+++ b/apps/api/src/routes/cloudflare-logpush.http.ts
@@ -1,7 +1,10 @@
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { CurrentTenant, MapleApi } from "@maple/domain/http"
+import { CloudflareLogpushForbiddenError, CurrentTenant, MapleApi } from "@maple/domain/http"
 import { Effect } from "effect"
 import { CloudflareLogpushService } from "../services/CloudflareLogpushService"
+import { requireAdmin } from "../lib/auth"
+
+const forbidden = (message: string) => () => new CloudflareLogpushForbiddenError({ message })
 
 export const HttpCloudflareLogpushLive = HttpApiBuilder.group(MapleApi, "cloudflareLogpush", (handlers) =>
 	Effect.gen(function* () {
@@ -17,30 +20,50 @@ export const HttpCloudflareLogpushLive = HttpApiBuilder.group(MapleApi, "cloudfl
 			.handle("create", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(
+						tenant.roles,
+						forbidden("Only org admins can create Cloudflare Logpush connectors"),
+					)
 					return yield* service.create(tenant.orgId, tenant.userId, payload)
 				}),
 			)
 			.handle("update", ({ params, payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(
+						tenant.roles,
+						forbidden("Only org admins can update Cloudflare Logpush connectors"),
+					)
 					return yield* service.update(tenant.orgId, params.connectorId, tenant.userId, payload)
 				}),
 			)
 			.handle("delete", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(
+						tenant.roles,
+						forbidden("Only org admins can delete Cloudflare Logpush connectors"),
+					)
 					return yield* service.delete(tenant.orgId, params.connectorId)
 				}),
 			)
 			.handle("getSetup", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(
+						tenant.roles,
+						forbidden("Only org admins can view Cloudflare Logpush setup details"),
+					)
 					return yield* service.getSetup(tenant.orgId, params.connectorId)
 				}),
 			)
 			.handle("rotateSecret", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(
+						tenant.roles,
+						forbidden("Only org admins can rotate Cloudflare Logpush secrets"),
+					)
 					return yield* service.rotateSecret(tenant.orgId, params.connectorId, tenant.userId)
 				}),
 			)

--- a/apps/api/src/routes/errors.http.ts
+++ b/apps/api/src/routes/errors.http.ts
@@ -1,7 +1,8 @@
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { CurrentTenant, MapleApi } from "@maple/domain/http"
+import { CurrentTenant, ErrorForbiddenError, MapleApi } from "@maple/domain/http"
 import { Effect } from "effect"
 import { ErrorsService } from "../services/ErrorsService"
+import { requireAdmin } from "../lib/auth"
 
 export const HttpErrorsLive = HttpApiBuilder.group(MapleApi, "errors", (handlers) =>
 	Effect.gen(function* () {
@@ -200,6 +201,13 @@ export const HttpErrorsLive = HttpApiBuilder.group(MapleApi, "errors", (handlers
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
 					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
+					yield* requireAdmin(
+						tenant.roles,
+						() =>
+							new ErrorForbiddenError({
+								message: "Only org admins can manage error notification policy",
+							}),
+					)
 					return yield* errors.upsertNotificationPolicy(tenant.orgId, tenant.userId, payload)
 				}).pipe(Effect.withSpan("HttpErrors.upsertNotificationPolicy")),
 			)

--- a/apps/api/src/routes/ingest-keys.http.ts
+++ b/apps/api/src/routes/ingest-keys.http.ts
@@ -1,7 +1,10 @@
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { CurrentTenant, MapleApi } from "@maple/domain/http"
+import { CurrentTenant, IngestKeyForbiddenError, MapleApi } from "@maple/domain/http"
 import { Effect } from "effect"
 import { OrgIngestKeysService } from "../services/OrgIngestKeysService"
+import { requireAdmin } from "../lib/auth"
+
+const forbidden = (message: string) => () => new IngestKeyForbiddenError({ message })
 
 export const HttpIngestKeysLive = HttpApiBuilder.group(MapleApi, "ingestKeys", (handlers) =>
 	Effect.gen(function* () {
@@ -11,18 +14,30 @@ export const HttpIngestKeysLive = HttpApiBuilder.group(MapleApi, "ingestKeys", (
 			.handle("get", () =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(
+						tenant.roles,
+						forbidden("Only org admins can view ingest keys"),
+					)
 					return yield* ingestKeys.getOrCreate(tenant.orgId, tenant.userId)
 				}),
 			)
 			.handle("rerollPublic", () =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(
+						tenant.roles,
+						forbidden("Only org admins can rotate the public ingest key"),
+					)
 					return yield* ingestKeys.rerollPublic(tenant.orgId, tenant.userId)
 				}),
 			)
 			.handle("rerollPrivate", () =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(
+						tenant.roles,
+						forbidden("Only org admins can rotate the private ingest key"),
+					)
 					return yield* ingestKeys.rerollPrivate(tenant.orgId, tenant.userId)
 				}),
 			)

--- a/packages/domain/src/http/api-keys.ts
+++ b/packages/domain/src/http/api-keys.ts
@@ -48,6 +48,14 @@ export class ApiKeyPersistenceError extends Schema.TaggedErrorClass<ApiKeyPersis
 	{ httpApiStatus: 503 },
 ) {}
 
+export class ApiKeyForbiddenError extends Schema.TaggedErrorClass<ApiKeyForbiddenError>()(
+	"@maple/http/errors/ApiKeyForbiddenError",
+	{
+		message: Schema.String,
+	},
+	{ httpApiStatus: 403 },
+) {}
+
 export class ApiKeyNotFoundError extends Schema.TaggedErrorClass<ApiKeyNotFoundError>()(
 	"@maple/http/errors/ApiKeyNotFoundError",
 	{
@@ -68,7 +76,7 @@ export class ApiKeysApiGroup extends HttpApiGroup.make("apiKeys")
 		HttpApiEndpoint.post("create", "/", {
 			payload: CreateApiKeyRequest,
 			success: ApiKeyCreatedResponse,
-			error: ApiKeyPersistenceError,
+			error: [ApiKeyForbiddenError, ApiKeyPersistenceError],
 		}),
 	)
 	.add(
@@ -77,7 +85,7 @@ export class ApiKeysApiGroup extends HttpApiGroup.make("apiKeys")
 				keyId: ApiKeyId,
 			},
 			success: ApiKeyResponse,
-			error: [ApiKeyNotFoundError, ApiKeyPersistenceError],
+			error: [ApiKeyForbiddenError, ApiKeyNotFoundError, ApiKeyPersistenceError],
 		}),
 	)
 	.prefix("/api/api-keys")

--- a/packages/domain/src/http/cloudflare-logpush.ts
+++ b/packages/domain/src/http/cloudflare-logpush.ts
@@ -102,6 +102,14 @@ export class CloudflareLogpushEncryptionError extends Schema.TaggedErrorClass<Cl
 	{ httpApiStatus: 500 },
 ) {}
 
+export class CloudflareLogpushForbiddenError extends Schema.TaggedErrorClass<CloudflareLogpushForbiddenError>()(
+	"@maple/http/errors/CloudflareLogpushForbiddenError",
+	{
+		message: Schema.String,
+	},
+	{ httpApiStatus: 403 },
+) {}
+
 export class CloudflareLogpushApiGroup extends HttpApiGroup.make("cloudflareLogpush")
 	.add(
 		HttpApiEndpoint.get("list", "/connectors", {
@@ -114,6 +122,7 @@ export class CloudflareLogpushApiGroup extends HttpApiGroup.make("cloudflareLogp
 			payload: CreateCloudflareLogpushConnectorRequest,
 			success: CloudflareLogpushCreateResponse,
 			error: [
+				CloudflareLogpushForbiddenError,
 				CloudflareLogpushValidationError,
 				CloudflareLogpushPersistenceError,
 				CloudflareLogpushEncryptionError,
@@ -128,6 +137,7 @@ export class CloudflareLogpushApiGroup extends HttpApiGroup.make("cloudflareLogp
 			payload: UpdateCloudflareLogpushConnectorRequest,
 			success: CloudflareLogpushConnectorResponse,
 			error: [
+				CloudflareLogpushForbiddenError,
 				CloudflareLogpushNotFoundError,
 				CloudflareLogpushValidationError,
 				CloudflareLogpushPersistenceError,
@@ -140,7 +150,7 @@ export class CloudflareLogpushApiGroup extends HttpApiGroup.make("cloudflareLogp
 				connectorId: CloudflareLogpushConnectorId,
 			},
 			success: CloudflareLogpushDeleteResponse,
-			error: [CloudflareLogpushNotFoundError, CloudflareLogpushPersistenceError],
+			error: [CloudflareLogpushForbiddenError, CloudflareLogpushNotFoundError, CloudflareLogpushPersistenceError],
 		}),
 	)
 	.add(
@@ -150,6 +160,7 @@ export class CloudflareLogpushApiGroup extends HttpApiGroup.make("cloudflareLogp
 			},
 			success: CloudflareLogpushSetupResponse,
 			error: [
+				CloudflareLogpushForbiddenError,
 				CloudflareLogpushNotFoundError,
 				CloudflareLogpushPersistenceError,
 				CloudflareLogpushEncryptionError,
@@ -163,6 +174,7 @@ export class CloudflareLogpushApiGroup extends HttpApiGroup.make("cloudflareLogp
 			},
 			success: CloudflareLogpushSetupResponse,
 			error: [
+				CloudflareLogpushForbiddenError,
 				CloudflareLogpushNotFoundError,
 				CloudflareLogpushPersistenceError,
 				CloudflareLogpushEncryptionError,

--- a/packages/domain/src/http/errors.ts
+++ b/packages/domain/src/http/errors.ts
@@ -328,6 +328,14 @@ export class ErrorValidationError extends Schema.TaggedErrorClass<ErrorValidatio
 	{ httpApiStatus: 400 },
 ) {}
 
+export class ErrorForbiddenError extends Schema.TaggedErrorClass<ErrorForbiddenError>()(
+	"@maple/http/errors/ErrorForbiddenError",
+	{
+		message: Schema.String,
+	},
+	{ httpApiStatus: 403 },
+) {}
+
 export class ErrorIssueNotFoundError extends Schema.TaggedErrorClass<ErrorIssueNotFoundError>()(
 	"@maple/http/errors/ErrorIssueNotFoundError",
 	{
@@ -511,7 +519,7 @@ export class ErrorsApiGroup extends HttpApiGroup.make("errors")
 		HttpApiEndpoint.put("upsertNotificationPolicy", "/policy", {
 			payload: ErrorNotificationPolicyUpsertRequest,
 			success: ErrorNotificationPolicyDocument,
-			error: [ErrorPersistenceError, ErrorValidationError],
+			error: [ErrorForbiddenError, ErrorPersistenceError, ErrorValidationError],
 		}),
 	)
 	.prefix("/api/errors")

--- a/packages/domain/src/http/ingest-keys.ts
+++ b/packages/domain/src/http/ingest-keys.ts
@@ -26,23 +26,31 @@ export class IngestKeyEncryptionError extends Schema.TaggedErrorClass<IngestKeyE
 	{ httpApiStatus: 500 },
 ) {}
 
+export class IngestKeyForbiddenError extends Schema.TaggedErrorClass<IngestKeyForbiddenError>()(
+	"@maple/http/errors/IngestKeyForbiddenError",
+	{
+		message: Schema.String,
+	},
+	{ httpApiStatus: 403 },
+) {}
+
 export class IngestKeysApiGroup extends HttpApiGroup.make("ingestKeys")
 	.add(
 		HttpApiEndpoint.get("get", "/", {
 			success: IngestKeysResponse,
-			error: [IngestKeyPersistenceError, IngestKeyEncryptionError],
+			error: [IngestKeyForbiddenError, IngestKeyPersistenceError, IngestKeyEncryptionError],
 		}),
 	)
 	.add(
 		HttpApiEndpoint.post("rerollPublic", "/public/reroll", {
 			success: IngestKeysResponse,
-			error: [IngestKeyPersistenceError, IngestKeyEncryptionError],
+			error: [IngestKeyForbiddenError, IngestKeyPersistenceError, IngestKeyEncryptionError],
 		}),
 	)
 	.add(
 		HttpApiEndpoint.post("rerollPrivate", "/private/reroll", {
 			success: IngestKeysResponse,
-			error: [IngestKeyPersistenceError, IngestKeyEncryptionError],
+			error: [IngestKeyForbiddenError, IngestKeyPersistenceError, IngestKeyEncryptionError],
 		}),
 	)
 	.prefix("/api/ingest-keys")


### PR DESCRIPTION
## Summary
Addresses HIGH `acl-check` and `privilege-escalation` findings on key/secret management endpoints. Previously any authenticated org member could mint API keys (which the MCP path force-promoted to root), rotate ingest keys, manage Cloudflare Logpush connectors, and set the org-wide error notification policy.

- **New `apps/api/src/lib/auth.ts`**: shared `isAdmin` / `requireAdmin` helpers (extracted from the existing pattern in AlertsService and OrgClickHouseSettingsService). Admin roles: `root`, `org:admin`. `requireAdmin` takes a caller-supplied error factory so each route group fails with its own typed `*ForbiddenError`.
- Added `*ForbiddenError` (HTTP 403) types to api-keys, ingest-keys, cloudflare-logpush, and errors domain schemas, included in the relevant endpoints' error unions.
- Gated 11 handlers across 4 route groups: api-keys (create + revoke), ingest-keys (get + reroll-public + reroll-private), cloudflare-logpush (create, update, delete, getSetup, rotateSecret), errors (upsertNotificationPolicy).

The `list` endpoints stay open to org members: showing that resources exist is fine; minting / rotating / deleting them is admin-only. The api-keys + ingest-keys gate also closes the privilege-escalation finding, since the MCP variant only sees roles for keys an admin already authorized.

## Out of scope
The deepsec `acl-check` cluster also flagged autumn/billing routes, org-openrouter settings, and several web UI components — those are not in this PR. Worth a follow-up after this lands.

## Test plan
- [x] 7 new unit tests covering admin/non-admin role combinations.
- [x] All 241 existing api-package tests still pass.
- [x] Audit confirms `requireAdmin` is on every gated handler and absent on read-only endpoints (list, getIssue, etc.).
- [x] Domain error unions match: `ForbiddenError` declared on exactly the gated endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Makisuo/codesmith/maple/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->