### PR TITLE
fix(ui,web,api): escape user-controlled values in chart CSS, markdown links, OAuth callback, sign-in redirect

### DIFF
--- a/apps/api/src/routes/integrations.http.ts
+++ b/apps/api/src/routes/integrations.http.ts
@@ -136,6 +136,23 @@ const escapeHtml = (value: string) =>
 		.replace(/"/g, "&quot;")
 		.replace(/'/g, "&#39;")
 
+// JSON.stringify does not escape `<` or `>`, so a payload value of
+// `</script><script>alert(1)</script>` would terminate the inline script
+// block. Escape these characters and the U+2028 / U+2029 line separators
+// (which are valid line terminators in JS but not in JSON) before
+// interpolating into a `<script>` body.
+const LINE_SEPARATOR = String.fromCharCode(0x2028)
+const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029)
+const escapeJsonInHtml = (json: string) =>
+	json
+		.replace(/</g, "\\u003c")
+		.replace(/>/g, "\\u003e")
+		.replace(/&/g, "\\u0026")
+		.split(LINE_SEPARATOR)
+		.join("\\u2028")
+		.split(PARAGRAPH_SEPARATOR)
+		.join("\\u2029")
+
 const renderCallbackPage = (params: {
 	status: "success" | "error"
 	message: string
@@ -143,11 +160,13 @@ const renderCallbackPage = (params: {
 }) => {
 	const safeMessage = escapeHtml(params.message)
 	const safeReturn = params.returnTo ? escapeHtml(params.returnTo) : null
-	const payload = JSON.stringify({
-		type: "maple:integration:hazel",
-		status: params.status,
-		message: params.message,
-	})
+	const payload = escapeJsonInHtml(
+		JSON.stringify({
+			type: "maple:integration:hazel",
+			status: params.status,
+			message: params.message,
+		}),
+	)
 	return `<!doctype html>
 <html lang="en">
   <head>

--- a/apps/web/src/components/dashboard-builder/widgets/markdown-widget.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/markdown-widget.tsx
@@ -2,6 +2,7 @@ import { memo } from "react"
 
 import { WidgetShell } from "@/components/dashboard-builder/widgets/widget-shell"
 import type { WidgetDataState, WidgetDisplayConfig, WidgetMode } from "@/components/dashboard-builder/types"
+import { validateUrlScheme } from "@maple/ui/lib/sanitizers"
 
 interface MarkdownWidgetProps {
 	dataState?: WidgetDataState
@@ -30,17 +31,33 @@ function renderInline(text: string): React.ReactNode[] {
 		if (segment.startsWith("[")) {
 			const linkMatch = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(segment)
 			if (linkMatch) {
-				tokens.push(
-					<a
-						key={`l-${key++}`}
-						href={linkMatch[2]}
-						target="_blank"
-						rel="noreferrer"
-						className="text-primary underline decoration-primary/30 underline-offset-2 hover:decoration-primary"
-					>
-						{linkMatch[1]}
-					</a>,
-				)
+				const safeHref = validateUrlScheme(linkMatch[2])
+				if (safeHref) {
+					tokens.push(
+						<a
+							key={`l-${key++}`}
+							href={safeHref}
+							target="_blank"
+							rel="noreferrer"
+							className="text-primary underline decoration-primary/30 underline-offset-2 hover:decoration-primary"
+						>
+							{linkMatch[1]}
+						</a>,
+					)
+				} else {
+					// Reject `javascript:` / `data:` / protocol-relative — render as
+					// plain text so an attacker can't smuggle a clickable XSS link
+					// through a stored markdown widget.
+					tokens.push(
+						<span
+							key={`l-${key++}`}
+							title={`Blocked unsupported link scheme: ${linkMatch[2]}`}
+							className="text-muted-foreground"
+						>
+							{linkMatch[1]}
+						</span>,
+					)
+				}
 			}
 		} else if (segment.startsWith("**")) {
 			tokens.push(<strong key={`b-${key++}`}>{segment.slice(2, -2)}</strong>)

--- a/apps/web/src/routes/sign-in.tsx
+++ b/apps/web/src/routes/sign-in.tsx
@@ -6,6 +6,7 @@ import { effectRoute } from "@effect-router/core"
 import { Schema } from "effect"
 import { Button } from "@maple/ui/components/ui/button"
 import { Input } from "@maple/ui/components/ui/input"
+import { validateInternalRedirect } from "@maple/ui/lib/sanitizers"
 import { apiBaseUrl } from "@/lib/services/common/api-base-url"
 import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 import { setSelfHostedSessionToken } from "@/lib/services/common/self-hosted-auth"
@@ -23,7 +24,10 @@ export const Route = effectRoute(createFileRoute("/sign-in"))({
 
 export const redirectToDashboard = () => {
 	const params = new URLSearchParams(window.location.search)
-	const redirectUrl = params.get("redirect_url") || "/"
+	// Only same-origin relative paths are allowed. An absolute URL or
+	// protocol-relative `//attacker/` would let an attacker exfiltrate the
+	// just-stored session token by phishing through a sign-in link.
+	const redirectUrl = validateInternalRedirect(params.get("redirect_url")) ?? "/"
 	window.location.assign(redirectUrl)
 }
 

--- a/packages/ui/src/components/ui/chart.tsx
+++ b/packages/ui/src/components/ui/chart.tsx
@@ -5,6 +5,7 @@ import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
 import * as RechartsPrimitive from "recharts"
 
 import { cn } from "../../lib/utils"
+import { sanitizeCssIdentifier, validateCssColor } from "../../lib/sanitizers"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const
@@ -74,18 +75,27 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 		return null
 	}
 
+	// Escape the chart id and each config key so a telemetry label like
+	// `</style><script>` cannot terminate the <style> block. Validate the
+	// color via a strict allowlist; entries with a non-recognised color value
+	// are dropped rather than emitted as raw CSS.
+	const safeId = sanitizeCssIdentifier(id)
+
 	return (
 		<style
 			dangerouslySetInnerHTML={{
 				__html: Object.entries(THEMES)
 					.map(
 						([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
+${prefix} [data-chart="${safeId}"] {
 ${colorConfig
 	.map(([key, itemConfig]) => {
 		const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] || itemConfig.color
-		return color ? `  --color-${key}: ${color};` : null
+		const safeColor = validateCssColor(color)
+		if (!safeColor) return null
+		return `  --color-${sanitizeCssIdentifier(key)}: ${safeColor};`
 	})
+	.filter((line): line is string => line !== null)
 	.join("\n")}
 }
 `,

--- a/packages/ui/src/lib/__tests__/sanitizers.test.ts
+++ b/packages/ui/src/lib/__tests__/sanitizers.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+import {
+	escapeJsonInHtml,
+	sanitizeCssIdentifier,
+	validateCssColor,
+	validateInternalRedirect,
+	validateUrlScheme,
+} from "../sanitizers"
+
+describe("sanitizeCssIdentifier", () => {
+	it("escapes CSS terminators", () => {
+		const escaped = sanitizeCssIdentifier("</style><script>")
+		expect(escaped).not.toContain("<")
+		expect(escaped).not.toContain(">")
+	})
+	it("preserves safe identifiers (passes through CSS.escape)", () => {
+		expect(sanitizeCssIdentifier("series-1")).toBe("series-1")
+	})
+})
+
+describe("validateCssColor", () => {
+	it.each(["#fff", "#ffffff", "rgb(0, 0, 0)", "hsl(0 0% 0%)", "var(--color-primary)", "transparent", "currentColor"])(
+		"accepts %s",
+		(value) => {
+			expect(validateCssColor(value)).toBe(value)
+		},
+	)
+
+	it.each(["red; background:url(http://x)", "</style>", "<script>alert(1)</script>", ";"])(
+		"rejects %s",
+		(value) => {
+			expect(validateCssColor(value)).toBeNull()
+		},
+	)
+
+	it("rejects empty / null", () => {
+		expect(validateCssColor("")).toBeNull()
+		expect(validateCssColor(null)).toBeNull()
+		expect(validateCssColor(undefined)).toBeNull()
+	})
+})
+
+describe("validateUrlScheme", () => {
+	it.each([
+		"https://example.com",
+		"http://example.com/x",
+		"mailto:hi@example.com",
+		"/relative/path",
+		"/page?x=1",
+	])("accepts %s", (value) => {
+		expect(validateUrlScheme(value)).toBe(value)
+	})
+
+	it.each([
+		"javascript:alert(1)",
+		"JAVASCRIPT:alert(1)",
+		"data:text/html,<script>",
+		"vbscript:msgbox(1)",
+		"//attacker.com/",
+		"file:///etc/passwd",
+		"",
+	])("rejects %s", (value) => {
+		expect(validateUrlScheme(value)).toBeNull()
+	})
+})
+
+describe("escapeJsonInHtml", () => {
+	it("escapes script-terminator characters", () => {
+		const escaped = escapeJsonInHtml(JSON.stringify({ msg: "</script><script>alert(1)</script>" }))
+		expect(escaped).not.toContain("</script>")
+		expect(escaped).toContain("\\u003c/script\\u003e")
+	})
+	it("escapes line terminators", () => {
+		const lineSep = String.fromCharCode(0x2028)
+		const paraSep = String.fromCharCode(0x2029)
+		const escaped = escapeJsonInHtml(JSON.stringify({ msg: `a${lineSep}b${paraSep}c` }))
+		expect(escaped).toContain("\\u2028")
+		expect(escaped).toContain("\\u2029")
+	})
+})
+
+describe("validateInternalRedirect", () => {
+	it.each(["/", "/dashboard", "/path?x=1", "/a/b#c"])("accepts %s", (value) => {
+		expect(validateInternalRedirect(value)).toBe(value)
+	})
+
+	it.each([
+		"//attacker.com",
+		"https://attacker.com",
+		"javascript:alert(1)",
+		"dashboard",
+		"",
+		"/\\bad",
+	])("rejects %s", (value) => {
+		expect(validateInternalRedirect(value)).toBeNull()
+	})
+})

--- a/packages/ui/src/lib/sanitizers.ts
+++ b/packages/ui/src/lib/sanitizers.ts
@@ -1,0 +1,91 @@
+/**
+ * Sanitizers for sinks that hold user-controlled strings — CSS values, HTML
+ * hrefs, inline-script JSON, and post-login redirect targets. Each helper
+ * fails closed: the caller decides what to do with a `null` (drop the entry,
+ * fall back, etc.) rather than ever rendering an unvetted string.
+ */
+
+const CSS_COLOR_RE =
+	/^(?:#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})|rgba?\([^()]*\)|hsla?\([^()]*\)|var\(--[a-z0-9_-]+(?:,[^()]*)?\)|currentColor|transparent|inherit|initial|unset|[a-z]+)$/i
+
+const ALLOWED_HREF_SCHEMES = new Set(["http:", "https:", "mailto:"])
+
+const LINE_SEPARATOR = " "
+const PARAGRAPH_SEPARATOR = " "
+
+/**
+ * CSS.escape an identifier the way browsers do, so a value like
+ * `</style><script>alert(1)</script>` cannot break out of the surrounding
+ * `--color-…` declaration.
+ */
+export const sanitizeCssIdentifier = (key: string): string => {
+	if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+		return CSS.escape(key)
+	}
+	// Fallback for environments without CSS.escape: hex-encode anything
+	// that isn't [a-zA-Z0-9_-].
+	return key.replace(/[^a-zA-Z0-9_-]/g, (ch) => `\\${ch.charCodeAt(0).toString(16)} `)
+}
+
+/**
+ * Returns `value` only if it parses as a known-safe CSS color expression.
+ * Drops anything containing CSS structural tokens like `;`, `}`, `<` etc.
+ */
+export const validateCssColor = (value: string | undefined | null): string | null => {
+	if (typeof value !== "string") return null
+	const trimmed = value.trim()
+	if (trimmed.length === 0) return null
+	if (/[<>;{}]/.test(trimmed)) return null
+	return CSS_COLOR_RE.test(trimmed) ? trimmed : null
+}
+
+/**
+ * Allow http(s) and mailto absolute URLs, plus same-origin relative paths
+ * (single leading `/`). Reject `javascript:`, `data:`, `vbscript:`,
+ * protocol-relative (`//`), and anything malformed.
+ */
+export const validateUrlScheme = (raw: string | undefined | null): string | null => {
+	if (typeof raw !== "string") return null
+	const trimmed = raw.trim()
+	if (trimmed.length === 0) return null
+	if (trimmed.startsWith("//")) return null
+	if (trimmed.startsWith("/") && !trimmed.startsWith("//")) return trimmed
+	try {
+		const parsed = new URL(trimmed)
+		return ALLOWED_HREF_SCHEMES.has(parsed.protocol) ? trimmed : null
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Escape a JSON-stringified value before embedding it inside an inline
+ * `<script>...</script>` block. JSON.stringify alone does not escape `<`
+ * or `>`, so a string like `</script><script>alert(1)</script>` would
+ * close the script tag verbatim. U+2028/U+2029 are valid line terminators
+ * in JS but unescaped in JSON, so they must also be encoded.
+ */
+export const escapeJsonInHtml = (json: string): string =>
+	json
+		.replace(/</g, "\\u003c")
+		.replace(/>/g, "\\u003e")
+		.replace(/&/g, "\\u0026")
+		.split(LINE_SEPARATOR)
+		.join("\\u2028")
+		.split(PARAGRAPH_SEPARATOR)
+		.join("\\u2029")
+
+/**
+ * Validate a post-login `redirect_url` query value. Allows same-origin
+ * relative paths (single leading `/`, no `//`). Returns null for absolute
+ * URLs, scheme tricks, or empty input — caller should fall back to `/`.
+ */
+export const validateInternalRedirect = (raw: string | undefined | null): string | null => {
+	if (typeof raw !== "string") return null
+	const trimmed = raw.trim()
+	if (trimmed.length === 0) return null
+	if (!trimmed.startsWith("/")) return null
+	if (trimmed.startsWith("//")) return null
+	if (trimmed.startsWith("/\\")) return null
+	return trimmed
+}


### PR DESCRIPTION
## Summary
Addresses HIGH `xss` findings across charts, dashboard markdown widgets, the Hazel OAuth callback, and the post-login redirect.

- **New `packages/ui/src/lib/sanitizers.ts`** with: `sanitizeCssIdentifier` (CSS.escape with fallback), `validateCssColor` (allowlist for `#hex`, `rgb()`, `hsl()`, `var(--…)`, named keywords; rejects CSS terminators), `validateUrlScheme` (allowlist `http`/`https`/`mailto` + same-origin relative paths; rejects `javascript:`/`data:`/`//…`), `escapeJsonInHtml` (escapes `<`, `>`, `&`, U+2028/U+2029 before inline-script interpolation), `validateInternalRedirect` (same-origin relative paths only).
- **`ChartStyle`** ([chart.tsx:78](../../blob/security/xss-hardening/packages/ui/src/components/ui/chart.tsx#L78)): telemetry series names previously flowed straight into a `<style dangerouslySetInnerHTML>` block. Each `key` is now `sanitizeCssIdentifier`-escaped, `color` is validated (drop on invalid), and the chart `id` in the `[data-chart=…]` selector is quoted and escaped. The fix transitively covers 5 chart-consumer findings (alert/host/log/k8s/pie).
- **MarkdownWidget**: a stored `[click](javascript:alert(1))` previously became a clickable XSS link. URLs now go through `validateUrlScheme`; rejected URLs render as plain text with a `title` explaining the block.
- **Sign-in redirect**: `redirect_url` was passed unmodified to `window.location.assign`, letting an attacker craft a sign-in link that exfiltrates the session token. Now requires a same-origin relative path; falls back to `/`.
- **OAuth callback**: the inline `window.opener.postMessage(\${payload}, \"*\")` interpolated raw `JSON.stringify` output, which doesn't escape `</script>`. Wrapped in a local `escapeJsonInHtml` helper (apps/api doesn't depend on @maple/ui).

## Verified in browser preview
Spun up the dev server on the branch and confirmed:
- Sanitizer bundle imports correctly into the running page; all 5 helpers behave correctly on live attack payloads.
- Live dashboard charts now emit `[data-chart=\"chart-_r_1t_\"]` (quoted) instead of the previous unquoted form.
- Vite-served markdown-widget bundle confirms the `validateUrlScheme` gate and the \"Blocked unsupported link scheme\" fallback span.

## Out of scope
- Dashboard markdown URL validation at the persistence layer (`packages/domain/src/http/dashboards.ts`).
- OAuth `state` binding to the initiating session — needs a DB migration.
- Chart-consumer-side cleanup (synthetic `series_\${index}` IDs).

## Test plan
- [x] 38 sanitizer unit tests covering each helper with both attack and benign payloads.
- [x] All 234 existing api-package tests still pass.
- [x] `bun turbo typecheck` passes across all 18 packages.
- [x] Live browser verification of sanitizer bundle, ChartStyle output, and markdown-widget transformed source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Makisuo/codesmith/maple/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->