### PR TITLE
fix: detect wrong-kind ClickHouse objects, restrict Tinybird stale-deployment cleanup

### DIFF
--- a/apps/api/src/services/OrgClickHouseSettingsService.ts
+++ b/apps/api/src/services/OrgClickHouseSettingsService.ts
@@ -718,6 +718,16 @@ export class OrgClickHouseSettingsService extends Context.Service<
 			const fullyResolvedDrift = new Set<string>()
 
 			for (const entry of entries) {
+				if (entry.status === "wrong_kind") {
+					// An object with the same name exists but as a different kind
+					// (table vs materialized view). Auto-remediating would mean
+					// dropping the customer's existing object — out of scope.
+					skipped.push({
+						name: entry.name,
+						reason: `expected ${entry.kind}, found ${entry.actualKind} — resolve manually`,
+					})
+					continue
+				}
 				if (entry.status === "missing") {
 					const table = desiredByName.get(entry.name)
 					if (!table) continue

--- a/apps/web/src/components/settings/org-clickhouse-settings-section.tsx
+++ b/apps/web/src/components/settings/org-clickhouse-settings-section.tsx
@@ -135,7 +135,7 @@ export function OrgClickHouseSettingsSection({
 
 	const diffSummary = useMemo(() => {
 		if (!diff) return null
-		const counts = { up_to_date: 0, missing: 0, drifted: 0 }
+		const counts = { up_to_date: 0, missing: 0, drifted: 0, wrong_kind: 0 }
 		for (const entry of diff.entries) counts[entry.status]++
 		return counts
 	}, [diff])
@@ -428,7 +428,9 @@ export function OrgClickHouseSettingsSection({
 															? "Up to date"
 															: entry.status === "missing"
 																? "Missing — will be created"
-																: `Drift: ${entry.columnDrifts.length} mismatch${entry.columnDrifts.length === 1 ? "" : "es"}`}
+																: entry.status === "wrong_kind"
+																	? `Wrong kind: expected ${entry.kind === "materialized_view" ? "MV" : "table"}, found ${entry.actualKind === "materialized_view" ? "MV" : "table"} — resolve manually`
+																	: `Drift: ${entry.columnDrifts.length} mismatch${entry.columnDrifts.length === 1 ? "" : "es"}`}
 													</span>
 													{isDrifted ? (
 														isExpanded ? (

--- a/packages/domain/src/clickhouse/diff.test.ts
+++ b/packages/domain/src/clickhouse/diff.test.ts
@@ -223,4 +223,51 @@ describe("computeSchemaDiff", () => {
 			{ status: "missing", name: "logs_hourly", kind: "materialized_view" },
 		])
 	})
+
+	it("flags wrong_kind when an actual object exists but is the wrong kind", () => {
+		// Customer has a regular table named the same as our desired MV — the
+		// previous behavior was to silently report up_to_date, leaving the MV
+		// uncreated and aggregates unpopulated.
+		const desired: DesiredSchema = {
+			tables: [desiredMv("errors_by_service_60s_mv")],
+		}
+		const result = computeSchemaDiff(
+			desired,
+			actualMap({
+				name: "errors_by_service_60s_mv",
+				kind: "table",
+				columns: [{ name: "OrgId", type: "String" }],
+			}),
+		)
+		expect(result).toEqual([
+			{
+				status: "wrong_kind",
+				name: "errors_by_service_60s_mv",
+				kind: "materialized_view",
+				actualKind: "table",
+			},
+		])
+	})
+
+	it("flags wrong_kind in the inverse direction (MV where a table is expected)", () => {
+		const desired: DesiredSchema = {
+			tables: [desiredTable("logs", [["OrgId", "String"]])],
+		}
+		const result = computeSchemaDiff(
+			desired,
+			actualMap({
+				name: "logs",
+				kind: "materialized_view",
+				columns: [],
+			}),
+		)
+		expect(result).toEqual([
+			{
+				status: "wrong_kind",
+				name: "logs",
+				kind: "table",
+				actualKind: "materialized_view",
+			},
+		])
+	})
 })

--- a/packages/domain/src/clickhouse/diff.ts
+++ b/packages/domain/src/clickhouse/diff.ts
@@ -62,6 +62,12 @@ export type TableDiffEntry =
 			readonly kind: ClickHouseTableKind
 			readonly columnDrifts: ReadonlyArray<ColumnDrift>
 	  }
+	| {
+			readonly status: "wrong_kind"
+			readonly name: string
+			readonly kind: ClickHouseTableKind
+			readonly actualKind: ClickHouseTableKind
+	  }
 
 const normalizeType = (type: string): string =>
 	// Collapse whitespace; CH's system.columns sometimes returns the type with
@@ -118,7 +124,21 @@ export const computeSchemaDiff = (
 		if (!actualTable) {
 			return { status: "missing", name: table.name, kind: table.kind }
 		}
-		// Materialized views: presence-only check in v1.
+		// If the customer has an object of the same name but a different kind
+		// (e.g. a regular table where we expect a materialized view), the
+		// previous behavior was to fall through to the MV presence check and
+		// return `up_to_date`, leaving the MV uncreated and downstream
+		// aggregates unpopulated. Surface a `wrong_kind` drift instead so
+		// apply can skip with a clear error.
+		if (actualTable.kind !== table.kind) {
+			return {
+				status: "wrong_kind",
+				name: table.name,
+				kind: table.kind,
+				actualKind: actualTable.kind,
+			}
+		}
+		// Materialized views: presence-only check in v1 (kind already matched above).
 		if (table.kind === "materialized_view") {
 			return { status: "up_to_date", name: table.name, kind: table.kind }
 		}

--- a/packages/domain/src/http/org-clickhouse-settings.ts
+++ b/packages/domain/src/http/org-clickhouse-settings.ts
@@ -105,6 +105,17 @@ export const ClickHouseTableDiffEntry = Schema.Union([
 		kind: ClickHouseTableKind,
 		columnDrifts: Schema.Array(ClickHouseColumnDrift),
 	}),
+	// Reported when an object with the same name exists on the cluster but as
+	// the wrong kind (e.g. a regular table named `errors_by_service_60s_mv`
+	// shadowing the materialized view we expect). Apply will skip these
+	// rather than auto-remediating, since dropping a customer's existing
+	// object is destructive.
+	Schema.Struct({
+		status: Schema.Literal("wrong_kind"),
+		name: Schema.String,
+		kind: ClickHouseTableKind,
+		actualKind: ClickHouseTableKind,
+	}),
 ])
 export type ClickHouseTableDiffEntry = Schema.Schema.Type<typeof ClickHouseTableDiffEntry>
 

--- a/packages/domain/src/tinybird/project-sync.ts
+++ b/packages/domain/src/tinybird/project-sync.ts
@@ -412,7 +412,20 @@ export class TinybirdProjectSync extends Context.Service<TinybirdProjectSync, Ti
 						),
 					)
 
-					const stale = body.deployments.filter((d) => !d.live && d.status !== "live")
+					// Only delete deployments in known terminal-failed states. The
+					// previous filter (`!d.live && d.status !== "live"`) also matched
+					// in-flight states like `deploying`, `data_ready`, and any
+					// unrecognised status string from a future Tinybird release —
+					// deleting an active deployment that's still being promoted
+					// disrupts schema rollout. Restrict to `failed` / `error` and
+					// require `live === false` (or unset) as defense in depth.
+					const TERMINAL_FAILED_STATUSES = new Set(["failed", "error"])
+					const stale = body.deployments.filter(
+						(d) =>
+							d.live !== true &&
+							typeof d.status === "string" &&
+							TERMINAL_FAILED_STATUSES.has(d.status),
+					)
 					if (stale.length === 0) return
 
 					yield* Effect.forEach(
@@ -421,8 +434,20 @@ export class TinybirdProjectSync extends Context.Service<TinybirdProjectSync, Ti
 							Effect.tryPromise({
 								try: () =>
 									api.request(`/v1/deployments/${deployment.id}`, { method: "DELETE" }),
-								catch: () => null,
-							}).pipe(Effect.ignore),
+								catch: (error) =>
+									error instanceof Error ? error : new Error(String(error)),
+							}).pipe(
+								Effect.tapError((error) =>
+									Effect.logWarning("Tinybird stale-deployment cleanup failed").pipe(
+										Effect.annotateLogs({
+											deploymentId: deployment.id,
+											deploymentStatus: deployment.status ?? "unknown",
+											error: error.message,
+										}),
+									),
+								),
+								Effect.ignore,
+							),
 						{ concurrency: "unbounded", discard: true },
 					)
 				},


### PR DESCRIPTION
## Summary
Addresses two DeepSec HIGH_BUG findings.

### `other-schema-diff-kind-confusion`
`computeSchemaDiff` previously fell through to the materialized-view presence check after looking up `actual.get(table.name)` without verifying that the actual object's kind matched the desired kind. A customer with a regular table named the same as a Maple MV would be reported as `up_to_date`, the apply path would skip creating the MV, and downstream aggregate / derived tables would never get populated while sync still reported success.

Added a new `wrong_kind` status to `TableDiffEntry` (and the matching `ClickHouseTableDiffEntry` schema in the domain HTTP types). Emitted when `actualTable.kind !== table.kind`. The apply path skips these with a clear \"resolve manually\" reason rather than auto-remediating.

### `other-destructive-cleanup`
`cleanupStaleDeployments` filtered with `!d.live && d.status !== \"live\"`, which matches in-flight states like `deploying` and `data_ready` and any unrecognised status string from a future Tinybird release. Combined with `Effect.ignore` on every DELETE, this could silently delete an active rollout.

Restricted the filter to known terminal-failed states (`failed`, `error`) and require `live !== true` as defense in depth. Replaced the silent `Effect.ignore` with `Effect.tapError(Effect.logWarning)` so delete failures surface in logs.

## Out of scope (deferred)
- Two-phase organization deletion (3 HIGH_BUG findings on `OrganizationService.deleteOrganization`). The current path purges local org-scoped tables before calling Clerk and is not transactional; if Clerk fails after the purge, data is gone but the upstream org persists. The fix needs a new `deletion_pending` column + DB migration + retryable cleanup job.

## Test plan
- [x] 10 schema-diff tests pass (8 original + 2 new `wrong_kind` cases covering both directions: MV-where-table-found and table-where-MV-found).
- [x] 11/11 Tinybird cleanup-filter cases handled correctly: only `failed`/`error` (with `live !== true`) deleted; `deploying`, `data_ready`, `deleting`, unknown future statuses, and `live: true` deployments all preserved.
- [x] Web settings UI updated to render the new `wrong_kind` row (\"Wrong kind: expected MV, found table — resolve manually\").
- [x] `bun turbo typecheck` passes across all 18 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Makisuo/codesmith/maple/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->