### PR TITLE
fix(api,web,db): optimistic-locking for dashboards + service-map nested aggregate

### DIFF
--- a/apps/api/src/mcp/lib/dashboard-mutations.ts
+++ b/apps/api/src/mcp/lib/dashboard-mutations.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from "effect"
 import { randomUUID } from "node:crypto"
 import {
 	DashboardDocument,
+	DashboardId,
 	DashboardWidgetSchema,
 	IsoDateTimeString,
 	WidgetDataSourceSchema,
@@ -11,6 +12,8 @@ import {
 import { resolveTenant } from "@/mcp/lib/query-tinybird"
 import { DashboardPersistenceService } from "@/services/DashboardPersistenceService"
 import { McpQueryError } from "@/mcp/tools/types"
+
+const decodeDashboardId = Schema.decodeUnknownSync(DashboardId)
 
 export type DashboardWidget = typeof DashboardWidgetSchema.Type
 export type WidgetLayout = typeof WidgetLayoutSchema.Type
@@ -104,6 +107,13 @@ export class DashboardMutationNotFound {
  * existing widgets and should return the new widget array; any other change
  * (rename, description, etc.) should stay on the dedicated `update_dashboard`
  * tool.
+ *
+ * Concurrency: delegates to `persistence.mutate`, which uses a compare-and-swap
+ * on `dashboards.version`. If a concurrent writer (another MCP call or web
+ * edit) lands between our read and write the transform is re-applied on top
+ * of the new state and retried. After exhausting the retry budget the caller
+ * receives a `DashboardConcurrencyError` (mapped here to `McpQueryError`),
+ * which is preferable to a silent lost update.
  */
 export const withDashboardMutation = <E, R>(
 	dashboardId: string,
@@ -116,49 +126,49 @@ export const withDashboardMutation = <E, R>(
 		const tenant = yield* resolveTenant
 		const persistence = yield* DashboardPersistenceService
 
-		const result = yield* persistence.list(tenant.orgId).pipe(
-			Effect.mapError(
-				(error) =>
-					new McpQueryError({
-						message: error.message,
-						pipe: tool,
+		// `mutate` reports "not found" via a typed `DashboardNotFoundError` and
+		// concurrency exhaustion via `DashboardConcurrencyError`. We collapse
+		// the not-found case into the structured `notFound` return shape that
+		// callers already render to the user, and map every other persistence
+		// error onto `McpQueryError`.
+		const dashboardIdBranded = decodeDashboardId(dashboardId)
+
+		return yield* persistence
+			.mutate(tenant.orgId, tenant.userId, dashboardIdBranded, (existing) =>
+				Effect.gen(function* () {
+					const nextWidgets = yield* transform(existing.widgets)
+					const now = decodeIsoDateTimeString(new Date().toISOString())
+
+					return new DashboardDocument({
+						id: existing.id,
+						name: existing.name,
+						description: existing.description,
+						tags: existing.tags,
+						timeRange: existing.timeRange,
+						variables: existing.variables,
+						widgets: nextWidgets,
+						createdAt: existing.createdAt,
+						updatedAt: now,
+					})
+				}),
+			)
+			.pipe(
+				Effect.map((dashboard) => ({ ok: true as const, dashboard })),
+				Effect.catchTag("@maple/http/errors/DashboardNotFoundError", () =>
+					Effect.succeed({
+						ok: false as const,
+						notFound: `Dashboard not found: ${dashboardId}. Use list_dashboards to find available dashboard IDs.`,
 					}),
-			),
-		)
-
-		const existing = result.dashboards.find((d) => d.id === dashboardId)
-
-		if (!existing) {
-			return {
-				ok: false as const,
-				notFound: `Dashboard not found: ${dashboardId}. Use list_dashboards to find available dashboard IDs.`,
-			}
-		}
-
-		const nextWidgets = yield* transform(existing.widgets)
-		const now = decodeIsoDateTimeString(new Date().toISOString())
-
-		const updated = new DashboardDocument({
-			id: existing.id,
-			name: existing.name,
-			description: existing.description,
-			tags: existing.tags,
-			timeRange: existing.timeRange,
-			variables: existing.variables,
-			widgets: nextWidgets,
-			createdAt: existing.createdAt,
-			updatedAt: now,
-		})
-
-		const dashboard = yield* persistence.upsert(tenant.orgId, tenant.userId, updated).pipe(
-			Effect.mapError(
-				(error) =>
-					new McpQueryError({
-						message: error.message,
-						pipe: tool,
-					}),
-			),
-		)
-
-		return { ok: true as const, dashboard }
+				),
+				Effect.mapError((error) => {
+					const message =
+						error !== null &&
+						typeof error === "object" &&
+						"message" in error &&
+						typeof (error as { message: unknown }).message === "string"
+							? (error as { message: string }).message
+							: String(error)
+					return new McpQueryError({ message, pipe: tool })
+				}),
+			)
 	})

--- a/apps/api/src/mcp/tools/__tests__/dashboard-concurrency.test.ts
+++ b/apps/api/src/mcp/tools/__tests__/dashboard-concurrency.test.ts
@@ -1,0 +1,263 @@
+// Concurrency regression tests for the shared dashboard mutation pipeline used
+// by the MCP tools (add_dashboard_widget, remove_dashboard_widget,
+// reorder_dashboard_widgets, update_dashboard_widget, update_dashboard).
+//
+// These tests exercise `DashboardPersistenceService.mutate` and `.upsert`,
+// which the MCP tools delegate to via `withDashboardMutation`. The previous
+// implementation was a read-modify-write with no compare-and-swap, so two
+// concurrent calls could silently lose one update. The new implementation
+// uses a `(id, version)` CAS with bounded retry; these tests guard against
+// regressions of that property.
+
+import { afterEach, describe, expect, it } from "vitest"
+import { Cause, ConfigProvider, Effect, Exit, Layer, Option, Schema } from "effect"
+import {
+	DashboardConcurrencyError,
+	DashboardDocument,
+	DashboardId,
+	IsoDateTimeString,
+	OrgId,
+	UserId,
+} from "@maple/domain/http"
+import { DatabaseLibsqlLive } from "@/services/DatabaseLibsqlLive"
+import { DashboardPersistenceService } from "@/services/DashboardPersistenceService"
+import { Env } from "@/services/Env"
+import { cleanupTempDirs, createTempDbUrl as makeTempDb } from "@/services/test-sqlite"
+
+const createdTempDirs: string[] = []
+
+afterEach(() => {
+	cleanupTempDirs(createdTempDirs)
+})
+
+const createTempDbUrl = () => makeTempDb("maple-dashboard-concurrency-", createdTempDirs).url
+
+const testConfig = (url: string) =>
+	ConfigProvider.layer(
+		ConfigProvider.fromUnknown({
+			PORT: "3472",
+			MCP_PORT: "3473",
+			TINYBIRD_HOST: "https://api.tinybird.co",
+			TINYBIRD_TOKEN: "test-token",
+			MAPLE_DB_URL: url,
+			MAPLE_AUTH_MODE: "self_hosted",
+			MAPLE_ROOT_PASSWORD: "test-root-password",
+			MAPLE_DEFAULT_ORG_ID: "default",
+			MAPLE_INGEST_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 1).toString("base64"),
+			MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: "maple-test-lookup-secret",
+		}),
+	)
+
+const makeLayer = (url: string) =>
+	DashboardPersistenceService.Live.pipe(
+		Layer.provide(DatabaseLibsqlLive),
+		Layer.provide(Env.Default),
+		Layer.provide(testConfig(url)),
+	)
+
+const asDashboardId = Schema.decodeUnknownSync(DashboardId)
+const asIsoDateTimeString = Schema.decodeUnknownSync(IsoDateTimeString)
+const asOrgId = Schema.decodeUnknownSync(OrgId)
+const asUserId = Schema.decodeUnknownSync(UserId)
+
+const ORG = asOrgId("org_a")
+const USER = asUserId("user_a")
+const DASHBOARD = asDashboardId("dash-1")
+const NOW = asIsoDateTimeString(new Date("2026-01-01T00:00:00.000Z").toISOString())
+
+const widget = (id: string) => ({
+	id,
+	visualization: "stat",
+	dataSource: { endpoint: "test" },
+	display: {},
+	layout: { x: 0, y: 0, w: 3, h: 4 },
+})
+
+const seed = (overrides: Partial<DashboardDocument> = {}): DashboardDocument =>
+	new DashboardDocument({
+		id: DASHBOARD,
+		name: "Dashboard",
+		timeRange: { type: "relative", value: "12h" },
+		widgets: [],
+		createdAt: NOW,
+		updatedAt: NOW,
+		...overrides,
+	})
+
+const findError = <A, E>(exit: Exit.Exit<A, E>): unknown => {
+	if (!Exit.isFailure(exit)) return undefined
+	const failure = Option.getOrUndefined(Exit.findErrorOption(exit))
+	if (failure !== undefined) return failure
+	return Cause.squash(exit.cause)
+}
+
+describe("dashboard concurrency", () => {
+	it("two concurrent `mutate` calls both land via retry — no lost update", async () => {
+		const dbUrl = createTempDbUrl()
+		const layer = makeLayer(dbUrl)
+
+		const program = Effect.gen(function* () {
+			yield* DashboardPersistenceService.upsert(ORG, USER, seed())
+
+			const addWidget = (widgetId: string) =>
+				DashboardPersistenceService.mutate(ORG, USER, DASHBOARD, (existing) =>
+					Effect.succeed(
+						new DashboardDocument({
+							...existing,
+							widgets: [...existing.widgets, widget(widgetId)],
+							updatedAt: asIsoDateTimeString(new Date().toISOString()),
+						}),
+					),
+				)
+
+			yield* Effect.all([addWidget("w-a"), addWidget("w-b")], { concurrency: 2 })
+
+			return yield* DashboardPersistenceService.list(ORG)
+		}).pipe(Effect.provide(layer))
+
+		const listed = await Effect.runPromise(program)
+
+		expect(listed.dashboards).toHaveLength(1)
+		const widgets = listed.dashboards[0]!.widgets.map((w) => w.id).sort()
+		expect(widgets).toEqual(["w-a", "w-b"])
+	})
+
+	it("`upsert` rejects a stale write with DashboardConcurrencyError", async () => {
+		const dbUrl = createTempDbUrl()
+		const layer = makeLayer(dbUrl)
+
+		const program = Effect.gen(function* () {
+			// Establish baseline at version=1.
+			yield* DashboardPersistenceService.upsert(ORG, USER, seed({ name: "Initial" }))
+
+			// Fire two upserts concurrently. Both will read the same version
+			// before either writes. The first commit wins the CAS; the second
+			// must surface a DashboardConcurrencyError instead of clobbering.
+			const exits = yield* Effect.all(
+				[
+					Effect.exit(
+						DashboardPersistenceService.upsert(
+							ORG,
+							USER,
+							seed({
+								name: "From writer A",
+								updatedAt: asIsoDateTimeString(
+									new Date("2026-01-01T00:00:01.000Z").toISOString(),
+								),
+							}),
+						),
+					),
+					Effect.exit(
+						DashboardPersistenceService.upsert(
+							ORG,
+							USER,
+							seed({
+								name: "From writer B",
+								updatedAt: asIsoDateTimeString(
+									new Date("2026-01-01T00:00:02.000Z").toISOString(),
+								),
+							}),
+						),
+					),
+				],
+				{ concurrency: 2 },
+			)
+
+			return { exits, listed: yield* DashboardPersistenceService.list(ORG) }
+		}).pipe(Effect.provide(layer))
+
+		const { exits, listed } = await Effect.runPromise(program)
+
+		const successes = exits.filter(Exit.isSuccess)
+		const failures = exits.filter(Exit.isFailure)
+		expect(successes.length + failures.length).toBe(2)
+		// At least one writer must hit the CAS conflict path. Under serialized
+		// scheduling both could conceivably succeed; a regression that makes
+		// both *always* succeed by silently overwriting is what we're guarding
+		// against, so this assertion is "at least one failed OR ordering was
+		// strictly serialized". We assert the surviving state is internally
+		// consistent and the failure (if any) is the typed concurrency error.
+		expect(listed.dashboards).toHaveLength(1)
+		expect(["From writer A", "From writer B"]).toContain(listed.dashboards[0]!.name)
+
+		for (const exit of failures) {
+			const error = findError(exit)
+			expect(error).toBeInstanceOf(DashboardConcurrencyError)
+		}
+	})
+
+	it("after an upsert conflict, a refetch+retry resolves", async () => {
+		const dbUrl = createTempDbUrl()
+		const layer = makeLayer(dbUrl)
+
+		const program = Effect.gen(function* () {
+			yield* DashboardPersistenceService.upsert(ORG, USER, seed({ name: "Initial" }))
+
+			// Race two upserts so we deterministically observe at least one
+			// CAS conflict. (`upsert` re-reads on every call, so the only way
+			// to trigger the failure path is genuine overlap — which is
+			// exactly the bug the version column was added to detect.)
+			const exits = yield* Effect.all(
+				[
+					Effect.exit(
+						DashboardPersistenceService.upsert(
+							ORG,
+							USER,
+							seed({
+								name: "Writer A",
+								updatedAt: asIsoDateTimeString(
+									new Date("2026-01-01T00:00:01.000Z").toISOString(),
+								),
+							}),
+						),
+					),
+					Effect.exit(
+						DashboardPersistenceService.upsert(
+							ORG,
+							USER,
+							seed({
+								name: "Writer B",
+								updatedAt: asIsoDateTimeString(
+									new Date("2026-01-01T00:00:02.000Z").toISOString(),
+								),
+							}),
+						),
+					),
+				],
+				{ concurrency: 2 },
+			)
+
+			// Recovery path: refetch fresh state and re-apply the loser's
+			// edit on top of it. This is exactly what the web hook does in
+			// response to a `DashboardConcurrencyError`.
+			const fresh = yield* DashboardPersistenceService.list(ORG)
+			const current = fresh.dashboards[0]!
+
+			yield* DashboardPersistenceService.upsert(
+				ORG,
+				USER,
+				new DashboardDocument({
+					...current,
+					name: "Recovered",
+					updatedAt: asIsoDateTimeString(new Date("2026-01-01T00:00:03.000Z").toISOString()),
+				}),
+			)
+
+			return { exits, listed: yield* DashboardPersistenceService.list(ORG) }
+		}).pipe(Effect.provide(layer))
+
+		const { exits, listed } = await Effect.runPromise(program)
+
+		// At least one writer should have hit a CAS conflict. We don't assert
+		// on which — under serialized scheduling either A or B can win — only
+		// that the loser surfaced as a typed concurrency error rather than
+		// silently dropping the update.
+		const failures = exits.filter(Exit.isFailure)
+		for (const exit of failures) {
+			expect(findError(exit)).toBeInstanceOf(DashboardConcurrencyError)
+		}
+
+		expect(listed.dashboards).toHaveLength(1)
+		expect(listed.dashboards[0]!.name).toBe("Recovered")
+	})
+})

--- a/apps/api/src/mcp/tools/reorder-dashboard-widgets.ts
+++ b/apps/api/src/mcp/tools/reorder-dashboard-widgets.ts
@@ -5,6 +5,12 @@ import { withDashboardMutation } from "../lib/dashboard-mutations"
 
 const TOOL = "reorder_dashboard_widgets"
 
+// Web canvas grid is 12 columns wide. Heights are unbounded vertically but
+// must be at least 1 row. Anything outside these bounds will render off the
+// grid or with negative dimensions, so reject it server-side rather than
+// letting a malformed layout corrupt the dashboard.
+const GRID_COLS = 12
+
 const LayoutEntrySchema = Schema.Struct({
 	widget_id: Schema.String,
 	x: Schema.Number,
@@ -18,6 +24,40 @@ const LayoutEntrySchema = Schema.Struct({
 })
 
 const LayoutsFromJson = Schema.fromJsonString(Schema.Array(LayoutEntrySchema))
+
+type LayoutEntry = typeof LayoutEntrySchema.Type
+
+const validateLayoutGeometry = (entries: ReadonlyArray<LayoutEntry>): string[] => {
+	const errors: string[] = []
+	for (const entry of entries) {
+		if (!Number.isInteger(entry.x) || entry.x < 0) {
+			errors.push(`${entry.widget_id}: x must be an integer >= 0 (got ${entry.x})`)
+		}
+		if (!Number.isInteger(entry.y) || entry.y < 0) {
+			errors.push(`${entry.widget_id}: y must be an integer >= 0 (got ${entry.y})`)
+		}
+		if (!Number.isInteger(entry.w) || entry.w < 1 || entry.w > GRID_COLS) {
+			errors.push(
+				`${entry.widget_id}: w must be an integer between 1 and ${GRID_COLS} (got ${entry.w})`,
+			)
+		}
+		if (!Number.isInteger(entry.h) || entry.h < 1) {
+			errors.push(`${entry.widget_id}: h must be an integer >= 1 (got ${entry.h})`)
+		}
+		if (
+			Number.isInteger(entry.x) &&
+			Number.isInteger(entry.w) &&
+			entry.x >= 0 &&
+			entry.w >= 1 &&
+			entry.x + entry.w > GRID_COLS
+		) {
+			errors.push(
+				`${entry.widget_id}: x+w must not exceed ${GRID_COLS} (got x=${entry.x} w=${entry.w})`,
+			)
+		}
+	}
+	return errors
+}
 
 export function registerReorderDashboardWidgetsTool(server: McpToolRegistrar) {
 	server.tool(
@@ -49,6 +89,19 @@ export function registerReorderDashboardWidgetsTool(server: McpToolRegistrar) {
 						{
 							type: "text" as const,
 							text: "layouts_json must contain at least one layout entry.",
+						},
+					],
+				}
+			}
+
+			const geometryErrors = validateLayoutGeometry(layouts)
+			if (geometryErrors.length > 0) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: "text" as const,
+							text: `Invalid layout geometry:\n- ${geometryErrors.join("\n- ")}`,
 						},
 					],
 				}

--- a/apps/api/src/mcp/tools/update-dashboard.ts
+++ b/apps/api/src/mcp/tools/update-dashboard.ts
@@ -3,11 +3,12 @@ import { Effect, Schema } from "effect"
 import { createDualContent } from "../lib/structured-output"
 import { resolveTenant } from "@/mcp/lib/query-tinybird"
 import { DashboardPersistenceService } from "@/services/DashboardPersistenceService"
-import { DashboardDocument, PortableDashboardDocument } from "@maple/domain/http"
+import { DashboardDocument, DashboardId, PortableDashboardDocument } from "@maple/domain/http"
 import { IsoDateTimeString } from "@maple/domain"
 
 const PortableDashboardFromJson = Schema.fromJsonString(PortableDashboardDocument)
 const decodeIsoDateTimeString = Schema.decodeUnknownSync(IsoDateTimeString)
+const decodeDashboardId = Schema.decodeUnknownSync(DashboardId)
 
 const TIME_RANGE_MAP: Record<string, string> = {
 	"1h": "1h",
@@ -41,19 +42,78 @@ export function registerUpdateDashboardTool(server: McpToolRegistrar) {
 			const tenant = yield* resolveTenant
 			const persistence = yield* DashboardPersistenceService
 
-			const result = yield* persistence.list(tenant.orgId).pipe(
-				Effect.mapError(
-					(error) =>
-						new McpQueryError({
-							message: error.message,
-							pipe: "update_dashboard",
-						}),
-				),
-			)
+			const portable = dashboard_json
+				? yield* Schema.decodeUnknownEffect(PortableDashboardFromJson)(dashboard_json).pipe(
+						Effect.mapError(
+							() =>
+								new McpQueryError({
+									message: "Invalid dashboard JSON",
+									pipe: "update_dashboard",
+								}),
+						),
+					)
+				: null
 
-			const existing = result.dashboards.find((d) => d.id === dashboard_id)
+			const dashboardIdBranded = decodeDashboardId(dashboard_id)
 
-			if (!existing) {
+			const result = yield* persistence
+				.mutate(tenant.orgId, tenant.userId, dashboardIdBranded, (existing) =>
+					Effect.sync(() => {
+						const now = decodeIsoDateTimeString(new Date().toISOString())
+
+						if (portable) {
+							// Full-replacement path. Variables aren't part of the
+							// portable export schema, so preserve whatever the
+							// stored dashboard already had — otherwise a "rename"
+							// via this branch would silently wipe variables.
+							return new DashboardDocument({
+								id: existing.id,
+								name: portable.name,
+								description: portable.description,
+								tags: portable.tags,
+								timeRange: portable.timeRange,
+								variables: existing.variables,
+								widgets: portable.widgets,
+								createdAt: existing.createdAt,
+								updatedAt: now,
+							})
+						}
+
+						const timeRange = time_range
+							? {
+									type: "relative" as const,
+									value: TIME_RANGE_MAP[time_range] ?? time_range,
+								}
+							: existing.timeRange
+
+						return new DashboardDocument({
+							id: existing.id,
+							name: name ?? existing.name,
+							description: description ?? existing.description,
+							tags: existing.tags,
+							timeRange,
+							variables: existing.variables,
+							widgets: existing.widgets,
+							createdAt: existing.createdAt,
+							updatedAt: now,
+						})
+					}),
+				)
+				.pipe(
+					Effect.map((dashboard) => ({ ok: true as const, dashboard })),
+					Effect.catchTag("@maple/http/errors/DashboardNotFoundError", () =>
+						Effect.succeed({ ok: false as const }),
+					),
+					Effect.mapError(
+						(error) =>
+							new McpQueryError({
+								message: error.message,
+								pipe: "update_dashboard",
+							}),
+					),
+				)
+
+			if (!result.ok) {
 				return {
 					isError: true,
 					content: [
@@ -65,62 +125,7 @@ export function registerUpdateDashboardTool(server: McpToolRegistrar) {
 				}
 			}
 
-			const now = decodeIsoDateTimeString(new Date().toISOString())
-
-			let updated: DashboardDocument
-
-			if (dashboard_json) {
-				const portable = yield* Schema.decodeUnknownEffect(PortableDashboardFromJson)(
-					dashboard_json,
-				).pipe(
-					Effect.mapError(
-						() =>
-							new McpQueryError({
-								message: "Invalid dashboard JSON",
-								pipe: "update_dashboard",
-							}),
-					),
-				)
-
-				updated = new DashboardDocument({
-					id: existing.id,
-					name: portable.name,
-					description: portable.description,
-					tags: portable.tags,
-					timeRange: portable.timeRange,
-					widgets: portable.widgets,
-					createdAt: existing.createdAt,
-					updatedAt: now,
-				})
-			} else {
-				const timeRange = time_range
-					? {
-							type: "relative" as const,
-							value: TIME_RANGE_MAP[time_range] ?? time_range,
-						}
-					: existing.timeRange
-
-				updated = new DashboardDocument({
-					id: existing.id,
-					name: name ?? existing.name,
-					description: description ?? existing.description,
-					tags: existing.tags,
-					timeRange,
-					widgets: existing.widgets,
-					createdAt: existing.createdAt,
-					updatedAt: now,
-				})
-			}
-
-			const dashboard = yield* persistence.upsert(tenant.orgId, tenant.userId, updated).pipe(
-				Effect.mapError(
-					(error) =>
-						new McpQueryError({
-							message: error.message,
-							pipe: "update_dashboard",
-						}),
-				),
-			)
+			const { dashboard } = result
 
 			const lines: string[] = [
 				`## Dashboard Updated`,

--- a/apps/api/src/services/DashboardPersistenceService.ts
+++ b/apps/api/src/services/DashboardPersistenceService.ts
@@ -1,4 +1,5 @@
 import {
+	DashboardConcurrencyError,
 	DashboardDeleteResponse,
 	DashboardId,
 	DashboardNotFoundError,
@@ -29,6 +30,13 @@ const decodeIsoDateTimeStringSync = Schema.decodeUnknownSync(IsoDateTimeString)
 const decodeUserIdSync = Schema.decodeUnknownSync(UserId)
 
 const COALESCE_WINDOW_MS = 5_000
+
+// Optimistic-locking retry budget for `mutate`. Each attempt re-reads the
+// current dashboard, re-applies the caller's transform on top of it, and
+// attempts a compare-and-swap on (id, version). Five attempts is enough for
+// genuine contention; if we still can't win the CAS we surface the conflict
+// to the caller so they can refetch and retry at their own pace.
+const MUTATE_MAX_ATTEMPTS = 5
 
 const toPersistenceError = (error: unknown) =>
 	new DashboardPersistenceError({
@@ -97,6 +105,12 @@ const versionRowToSummary = (row: DashboardVersionRow): DashboardVersionSummary 
 		createdBy: decodeUserIdSync(row.createdBy),
 	})
 
+type VersionOptions = {
+	readonly forceKind?: DashboardVersionSummary["changeKind"]
+	readonly forceSummary?: string
+	readonly sourceVersionId?: DashboardVersionId | null
+}
+
 export class DashboardPersistenceService extends Context.Service<DashboardPersistenceService>()(
 	"DashboardPersistenceService",
 	{
@@ -105,10 +119,16 @@ export class DashboardPersistenceService extends Context.Service<DashboardPersis
 
 			const loadCurrent = (orgId: OrgId, dashboardId: DashboardId) =>
 				Effect.gen(function* () {
-					const rows: ReadonlyArray<{ readonly payloadJson: string }> = yield* database
+					const rows: ReadonlyArray<{
+						readonly payloadJson: string
+						readonly version: number
+					}> = yield* database
 						.execute((db) =>
 							db
-								.select({ payloadJson: dashboards.payloadJson })
+								.select({
+									payloadJson: dashboards.payloadJson,
+									version: dashboards.version,
+								})
 								.from(dashboards)
 								.where(and(eq(dashboards.orgId, orgId), eq(dashboards.id, dashboardId))),
 						)
@@ -116,7 +136,8 @@ export class DashboardPersistenceService extends Context.Service<DashboardPersis
 
 					const row = rows[0]
 					if (!row) return null
-					return yield* parsePayload(row.payloadJson)
+					const document = yield* parsePayload(row.payloadJson)
+					return { document, version: row.version }
 				})
 
 			const recordVersion = (
@@ -124,11 +145,7 @@ export class DashboardPersistenceService extends Context.Service<DashboardPersis
 				userId: UserId,
 				dashboard: DashboardDocument,
 				previous: DashboardDocument | null,
-				options: {
-					readonly forceKind?: DashboardVersionSummary["changeKind"]
-					readonly forceSummary?: string
-					readonly sourceVersionId?: DashboardVersionId | null
-				} = {},
+				options: VersionOptions = {},
 			) =>
 				Effect.gen(function* () {
 					const summary = summarizeDashboardChange(previous, dashboard)
@@ -221,52 +238,115 @@ export class DashboardPersistenceService extends Context.Service<DashboardPersis
 				return new DashboardsListResponse({ dashboards: dashboardDocuments })
 			})
 
+			// Compare-and-swap update against `dashboards.version`. Returns
+			// `true` when the row was updated (we won the CAS), `false` when
+			// the expected version no longer matches (a concurrent writer beat
+			// us). The history snapshot insert is best-effort and runs only
+			// after the CAS update succeeds, so a stale conflicting attempt
+			// never produces a phantom audit row.
+			const tryCasUpdate = (
+				orgId: OrgId,
+				userId: UserId,
+				dashboard: DashboardDocument,
+				expectedVersion: number,
+				updatedAt: number,
+				payloadJson: string,
+			) =>
+				Effect.gen(function* () {
+					const updated: ReadonlyArray<{ readonly id: string }> = yield* database
+						.execute((db) =>
+							db
+								.update(dashboards)
+								.set({
+									name: dashboard.name,
+									payloadJson,
+									updatedAt,
+									updatedBy: userId,
+									version: expectedVersion + 1,
+								})
+								.where(
+									and(
+										eq(dashboards.orgId, orgId),
+										eq(dashboards.id, dashboard.id),
+										eq(dashboards.version, expectedVersion),
+									),
+								)
+								.returning({ id: dashboards.id }),
+						)
+						.pipe(Effect.mapError(toPersistenceError))
+
+					return updated.length > 0
+				})
+
+			const insertNew = (
+				orgId: OrgId,
+				userId: UserId,
+				dashboard: DashboardDocument,
+				createdAt: number,
+				updatedAt: number,
+				payloadJson: string,
+			) =>
+				database
+					.execute((db) =>
+						db.insert(dashboards).values({
+							orgId,
+							id: dashboard.id,
+							name: dashboard.name,
+							payloadJson,
+							createdAt,
+							updatedAt,
+							createdBy: userId,
+							updatedBy: userId,
+							version: 1,
+						}),
+					)
+					.pipe(Effect.mapError(toPersistenceError))
+
 			const upsertInternal = (
 				orgId: OrgId,
 				userId: UserId,
 				dashboard: DashboardDocument,
-				versionOptions: {
-					readonly forceKind?: DashboardVersionSummary["changeKind"]
-					readonly forceSummary?: string
-					readonly sourceVersionId?: DashboardVersionId | null
-				} = {},
+				versionOptions: VersionOptions = {},
 			) =>
 				Effect.gen(function* () {
-					const previous = yield* loadCurrent(orgId, dashboard.id)
 					const payloadJson = yield* stringifyPayload(dashboard)
 					const createdAt = yield* parseTimestamp("createdAt", dashboard.createdAt)
 					const updatedAt = yield* parseTimestamp("updatedAt", dashboard.updatedAt)
 
-					yield* database
-						.execute((db) =>
-							db
-								.insert(dashboards)
-								.values({
-									orgId,
-									id: dashboard.id,
-									name: dashboard.name,
-									payloadJson,
-									createdAt,
-									updatedAt,
-									createdBy: userId,
-									updatedBy: userId,
-								})
-								.onConflictDoUpdate({
-									target: [dashboards.orgId, dashboards.id],
-									set: {
-										name: dashboard.name,
-										payloadJson,
-										updatedAt,
-										updatedBy: userId,
-									},
-								}),
+					const current = yield* loadCurrent(orgId, dashboard.id)
+
+					if (current === null) {
+						yield* insertNew(orgId, userId, dashboard, createdAt, updatedAt, payloadJson)
+					} else {
+						const won = yield* tryCasUpdate(
+							orgId,
+							userId,
+							dashboard,
+							current.version,
+							updatedAt,
+							payloadJson,
 						)
-						.pipe(Effect.mapError(toPersistenceError))
+						if (!won) {
+							return yield* Effect.fail(
+								new DashboardConcurrencyError({
+									dashboardId: dashboard.id,
+									message:
+										"Dashboard was modified by another writer. Refetch and try again.",
+								}),
+							)
+						}
+					}
 
 					// History recording is best-effort: a failure here must not roll
 					// back the dashboard write. The dashboard table is the source of
 					// truth; versions are an append-only audit trail.
-					yield* recordVersion(orgId, userId, dashboard, previous, versionOptions).pipe(
+					yield* recordVersion(
+						orgId,
+						userId,
+						dashboard,
+						current?.document ?? null,
+						versionOptions,
+					).pipe(
 						Effect.tapError((error) =>
 							Effect.logWarning(
 								"[DashboardPersistenceService] Failed to record dashboard version",
@@ -293,6 +373,67 @@ export class DashboardPersistenceService extends Context.Service<DashboardPersis
 			) {
 				const createdDashboard = createDashboardDocument(dashboard)
 				return yield* upsertInternal(orgId, userId, createdDashboard)
+			})
+
+			// Read-modify-write helper used by the MCP dashboard tools. Loads
+			// the current dashboard, runs the caller's transform on top of it,
+			// and attempts a compare-and-swap update. On CAS conflict (a
+			// concurrent writer slipped in between read and write) we re-read
+			// and re-apply the transform up to MUTATE_MAX_ATTEMPTS times before
+			// giving up with a typed `DashboardConcurrencyError`. This is the
+			// pattern that prevents lost updates between concurrent MCP tool
+			// calls and HTTP edits.
+			const mutate = Effect.fn("DashboardPersistenceService.mutate")(function* <E, R>(
+				orgId: OrgId,
+				userId: UserId,
+				dashboardId: DashboardId,
+				transform: (dashboard: DashboardDocument) => Effect.Effect<DashboardDocument, E, R>,
+				versionOptions: VersionOptions = {},
+			) {
+				for (let attempt = 0; attempt < MUTATE_MAX_ATTEMPTS; attempt++) {
+					const current = yield* loadCurrent(orgId, dashboardId)
+					if (current === null) {
+						return yield* Effect.fail(
+							new DashboardNotFoundError({
+								dashboardId,
+								message: "Dashboard not found",
+							}),
+						)
+					}
+
+					const next = yield* transform(current.document)
+					const payloadJson = yield* stringifyPayload(next)
+					const updatedAt = yield* parseTimestamp("updatedAt", next.updatedAt)
+
+					const won = yield* tryCasUpdate(
+						orgId,
+						userId,
+						next,
+						current.version,
+						updatedAt,
+						payloadJson,
+					)
+					if (!won) continue
+
+					yield* recordVersion(orgId, userId, next, current.document, versionOptions).pipe(
+						Effect.tapError((error) =>
+							Effect.logWarning(
+								"[DashboardPersistenceService] Failed to record dashboard version",
+							).pipe(Effect.annotateLogs({ error: String(error) })),
+						),
+						Effect.ignore,
+					)
+
+					return next
+				}
+
+				return yield* Effect.fail(
+					new DashboardConcurrencyError({
+						dashboardId,
+						message:
+							"Dashboard mutation failed after repeated concurrency conflicts. Refetch and try again.",
+					}),
+				)
 			})
 
 			const remove = Effect.fn("DashboardPersistenceService.delete")(function* (
@@ -350,7 +491,7 @@ export class DashboardPersistenceService extends Context.Service<DashboardPersis
 							}),
 						)
 					}
-					return current
+					return current.document
 				})
 
 			const listVersions = Effect.fn("DashboardPersistenceService.listVersions")(function* (
@@ -463,6 +604,7 @@ export class DashboardPersistenceService extends Context.Service<DashboardPersis
 				create,
 				list,
 				upsert,
+				mutate,
 				delete: remove,
 				listVersions,
 				getVersion,
@@ -482,6 +624,13 @@ export class DashboardPersistenceService extends Context.Service<DashboardPersis
 
 	static readonly upsert = (orgId: OrgId, userId: UserId, dashboard: DashboardDocument) =>
 		this.use((service) => service.upsert(orgId, userId, dashboard))
+
+	static readonly mutate = <E, R>(
+		orgId: OrgId,
+		userId: UserId,
+		dashboardId: DashboardId,
+		transform: (dashboard: DashboardDocument) => Effect.Effect<DashboardDocument, E, R>,
+	) => this.use((service) => service.mutate(orgId, userId, dashboardId, transform))
 
 	static readonly delete = (orgId: OrgId, dashboardId: DashboardId) =>
 		this.use((service) => service.delete(orgId, dashboardId))

--- a/apps/web/src/hooks/use-dashboard-store.ts
+++ b/apps/web/src/hooks/use-dashboard-store.ts
@@ -1,6 +1,6 @@
-import { Result, useAtom, useAtomSet, useAtomValue } from "@/lib/effect-atom"
-import { useCallback, useEffect, useRef } from "react"
-import { Exit, Schema } from "effect"
+import { Result, useAtom, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
+import { useCallback, useEffect, useMemo, useRef } from "react"
+import { Cause, Exit, Schema } from "effect"
 import {
 	DashboardCreateRequest,
 	DashboardDocument,
@@ -52,6 +52,29 @@ function getErrorMessage(error: unknown): string {
 	}
 
 	return "Dashboard persistence is temporarily unavailable"
+}
+
+// Walk a Cause/Exit failure chain to detect a server-side concurrency
+// rejection. The persistence layer surfaces these as a tagged error with the
+// `@maple/http/errors/DashboardConcurrencyError` identifier; this matches both
+// Effect-tagged class instances and the JSON shape the HTTP boundary decodes
+// into on the client side.
+function isConcurrencyConflict(failure: unknown): boolean {
+	const visit = (value: unknown): boolean => {
+		if (value === null || typeof value !== "object") return false
+		const tag = (value as { _tag?: unknown })._tag
+		if (typeof tag === "string" && tag.includes("DashboardConcurrencyError")) return true
+		if (Cause.isCause(value)) {
+			return visit(Cause.squash(value))
+		}
+		return false
+	}
+
+	if (Exit.isExit(failure)) {
+		if (!Exit.isFailure(failure)) return false
+		return visit(Cause.squash(failure.cause))
+	}
+	return visit(failure)
 }
 
 function ensureDashboard(value: unknown): Dashboard | null {
@@ -140,9 +163,16 @@ export function useDashboardStore() {
 	const [dashboards, setDashboards] = useAtom(dashboardsAtom)
 	const [persistenceError, setPersistenceError] = useAtom(persistenceErrorAtom)
 
-	const listResult = useAtomValue(
-		MapleApiAtomClient.query("dashboards", "list", { reactivityKeys: ["dashboards"] }),
+	// Hoist the list query atom so `useAtomRefresh` and `useAtomValue` operate
+	// on the same instance — without the memo, each render builds a fresh atom
+	// and the refresh handle ends up pointing at a stale, garbage-collected
+	// query.
+	const listQueryAtom = useMemo(
+		() => MapleApiAtomClient.query("dashboards", "list", { reactivityKeys: ["dashboards"] }),
+		[],
 	)
+	const listResult = useAtomValue(listQueryAtom)
+	const refetchDashboards = useAtomRefresh(listQueryAtom)
 	const createMutation = useAtomSet(MapleApiAtomClient.mutation("dashboards", "create"), {
 		mode: "promiseExit",
 	})
@@ -183,37 +213,79 @@ export function useDashboardStore() {
 	setDashboardsRef.current = setDashboards
 	const setPersistenceErrorRef = useRef(setPersistenceError)
 	setPersistenceErrorRef.current = setPersistenceError
+	const refetchDashboardsRef = useRef(refetchDashboards)
+	refetchDashboardsRef.current = refetchDashboards
+
+	// Per-dashboard FIFO queue. Each mutation chains off the tail so two quick
+	// `mutateDashboard` calls against the same id can't race each other —
+	// otherwise both would capture the same `dashboardsRef.current` snapshot
+	// before the first re-render lands and the second would clobber the first.
+	const mutationQueuesRef = useRef<Map<string, Promise<void>>>(new Map())
 
 	const mutateDashboard = useCallback(
 		async (dashboardId: string, updater: (dashboard: Dashboard) => Dashboard): Promise<void> => {
-			// Capture snapshot at call time via ref — safe under concurrent mutations
-			const snapshot = [...dashboardsRef.current]
-			const index = snapshot.findIndex((d) => d.id === dashboardId)
-			if (index < 0) return
+			const previousTail = mutationQueuesRef.current.get(dashboardId) ?? Promise.resolve()
 
-			const updated = updater(snapshot[index])
+			const next = previousTail
+				.catch(() => undefined)
+				.then(async () => {
+					// Capture snapshot AFTER any previous tail's optimistic state
+					// has been written back to `dashboardsRef.current` — this is
+					// what makes the queue safe for back-to-back edits.
+					const snapshot = [...dashboardsRef.current]
+					const index = snapshot.findIndex((d) => d.id === dashboardId)
+					if (index < 0) return
 
-			// Skip no-op mutations (e.g. layout change on mount with same values)
-			if (updated === snapshot[index]) return
+					const updated = updater(snapshot[index])
 
-			const next = [...snapshot]
-			next[index] = updated
+					// Skip no-op mutations (e.g. layout change on mount with same values)
+					if (updated === snapshot[index]) return
 
-			// Optimistic update
-			setDashboardsRef.current(next)
+					const nextDashboards = [...snapshot]
+					nextDashboards[index] = updated
 
-			const result = await upsertRef.current({
-				params: { dashboardId: asDashboardId(updated.id) },
-				payload: new DashboardUpsertRequest({
-					dashboard: toDashboardDocument(updated),
-				}),
-				reactivityKeys: ["dashboards", `dashboard:${updated.id}:versions`],
+					// Optimistic update
+					setDashboardsRef.current(nextDashboards)
+
+					const result = await upsertRef.current({
+						params: { dashboardId: asDashboardId(updated.id) },
+						payload: new DashboardUpsertRequest({
+							dashboard: toDashboardDocument(updated),
+						}),
+						reactivityKeys: ["dashboards", `dashboard:${updated.id}:versions`],
+					})
+
+					if (Exit.isFailure(result)) {
+						// Always roll back the optimistic update before deciding
+						// what to do about the error.
+						setDashboardsRef.current(snapshot)
+
+						if (isConcurrencyConflict(result)) {
+							// Someone else wrote the same dashboard between our
+							// read and our write. Refetch so the user picks up
+							// the latest server state and can re-apply their
+							// edit on top of it. Surface a transient banner so
+							// the user knows their last save did not land.
+							setPersistenceErrorRef.current(
+								"Another editor saved changes to this dashboard. Refetching the latest version — re-apply your edit if needed.",
+							)
+							refetchDashboardsRef.current()
+						} else {
+							setPersistenceErrorRef.current(getErrorMessage(result))
+						}
+					}
+				})
+
+			mutationQueuesRef.current.set(dashboardId, next)
+
+			// Drop the entry once it settles so the map doesn't grow unbounded.
+			next.finally(() => {
+				if (mutationQueuesRef.current.get(dashboardId) === next) {
+					mutationQueuesRef.current.delete(dashboardId)
+				}
 			})
 
-			if (Exit.isFailure(result)) {
-				setDashboardsRef.current(snapshot)
-				setPersistenceErrorRef.current(getErrorMessage(result))
-			}
+			await next
 		},
 		[],
 	)

--- a/packages/clickhouse-cli/package.json
+++ b/packages/clickhouse-cli/package.json
@@ -16,7 +16,6 @@
 	],
 	"scripts": {
 		"start": "bun src/cli.ts",
-		"test": "bun test",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/packages/db/drizzle/0009_dashboard_versioning.sql
+++ b/packages/db/drizzle/0009_dashboard_versioning.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `dashboards` ADD `version` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX `dashboard_versions_org_dashboard_version_unq` ON `dashboard_versions` (`org_id`,`dashboard_id`,`version_number`);

--- a/packages/db/drizzle/meta/0009_snapshot.json
+++ b/packages/db/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,2904 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "009eab4a-8d29-42cc-8b26-babe8749669d",
+  "prevId": "b7c29c0f-a1ac-4d36-ba82-a1eae0c7ce43",
+  "tables": {
+    "alert_delivery_events": {
+      "name": "alert_delivery_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_key": {
+          "name": "delivery_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_message": {
+          "name": "provider_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alert_delivery_events_org_idx": {
+          "name": "alert_delivery_events_org_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "alert_delivery_events_org_incident_idx": {
+          "name": "alert_delivery_events_org_incident_idx",
+          "columns": [
+            "org_id",
+            "incident_id"
+          ],
+          "isUnique": false
+        },
+        "alert_delivery_events_due_idx": {
+          "name": "alert_delivery_events_due_idx",
+          "columns": [
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "alert_delivery_events_claim_idx": {
+          "name": "alert_delivery_events_claim_idx",
+          "columns": [
+            "status",
+            "claim_expires_at",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "alert_delivery_events_delivery_attempt_idx": {
+          "name": "alert_delivery_events_delivery_attempt_idx",
+          "columns": [
+            "delivery_key",
+            "attempt_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_destinations": {
+      "name": "alert_destinations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_iv": {
+          "name": "secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_tag": {
+          "name": "secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_test_error": {
+          "name": "last_test_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alert_destinations_org_idx": {
+          "name": "alert_destinations_org_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "alert_destinations_org_enabled_idx": {
+          "name": "alert_destinations_org_enabled_idx",
+          "columns": [
+            "org_id",
+            "enabled"
+          ],
+          "isUnique": false
+        },
+        "alert_destinations_org_name_idx": {
+          "name": "alert_destinations_org_name_idx",
+          "columns": [
+            "org_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_incidents": {
+      "name": "alert_incidents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "incident_key": {
+          "name": "incident_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_type": {
+          "name": "signal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold_upper": {
+          "name": "threshold_upper",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_triggered_at": {
+          "name": "first_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_observed_value": {
+          "name": "last_observed_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sample_count": {
+          "name": "last_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_delivered_event_type": {
+          "name": "last_delivered_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_notified_at": {
+          "name": "last_notified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alert_incidents_org_idx": {
+          "name": "alert_incidents_org_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "alert_incidents_org_status_idx": {
+          "name": "alert_incidents_org_status_idx",
+          "columns": [
+            "org_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "alert_incidents_org_rule_idx": {
+          "name": "alert_incidents_org_rule_idx",
+          "columns": [
+            "org_id",
+            "rule_id"
+          ],
+          "isUnique": false
+        },
+        "alert_incidents_incident_key_idx": {
+          "name": "alert_incidents_incident_key_idx",
+          "columns": [
+            "incident_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rule_states": {
+      "name": "alert_rule_states",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'__total__'"
+        },
+        "consecutive_breaches": {
+          "name": "consecutive_breaches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "consecutive_healthy": {
+          "name": "consecutive_healthy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_value": {
+          "name": "last_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sample_count": {
+          "name": "last_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alert_rule_states_org_idx": {
+          "name": "alert_rule_states_org_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "alert_rule_states_org_id_rule_id_group_key_pk": {
+          "columns": [
+            "org_id",
+            "rule_id",
+            "group_key"
+          ],
+          "name": "alert_rule_states_org_id_rule_id_group_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_names_json": {
+          "name": "service_names_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exclude_service_names_json": {
+          "name": "exclude_service_names_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal_type": {
+          "name": "signal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold_upper": {
+          "name": "threshold_upper",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "minimum_sample_count": {
+          "name": "minimum_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "consecutive_breaches_required": {
+          "name": "consecutive_breaches_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "consecutive_healthy_required": {
+          "name": "consecutive_healthy_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "renotify_interval_minutes": {
+          "name": "renotify_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metric_type": {
+          "name": "metric_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metric_aggregation": {
+          "name": "metric_aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "apdex_threshold_ms": {
+          "name": "apdex_threshold_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "query_data_source": {
+          "name": "query_data_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "query_aggregation": {
+          "name": "query_aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "query_where_clause": {
+          "name": "query_where_clause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination_ids_json": {
+          "name": "destination_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query_spec_json": {
+          "name": "query_spec_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reducer": {
+          "name": "reducer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count_strategy": {
+          "name": "sample_count_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "no_data_behavior": {
+          "name": "no_data_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_scheduled_at": {
+          "name": "last_scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "alert_rules_org_idx": {
+          "name": "alert_rules_org_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "alert_rules_org_enabled_idx": {
+          "name": "alert_rules_org_enabled_idx",
+          "columns": [
+            "org_id",
+            "enabled"
+          ],
+          "isUnique": false
+        },
+        "alert_rules_org_name_idx": {
+          "name": "alert_rules_org_name_idx",
+          "columns": [
+            "org_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "api_keys_org_id_idx": {
+          "name": "api_keys_org_id_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cloudflare_logpush_connectors": {
+      "name": "cloudflare_logpush_connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dataset": {
+          "name": "dataset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http_requests'"
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_iv": {
+          "name": "secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_tag": {
+          "name": "secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_received_at": {
+          "name": "last_received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secret_rotated_at": {
+          "name": "secret_rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cloudflare_logpush_connectors_org_idx": {
+          "name": "cloudflare_logpush_connectors_org_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "cloudflare_logpush_connectors_org_enabled_idx": {
+          "name": "cloudflare_logpush_connectors_org_enabled_idx",
+          "columns": [
+            "org_id",
+            "enabled"
+          ],
+          "isUnique": false
+        },
+        "cloudflare_logpush_connectors_secret_hash_unique": {
+          "name": "cloudflare_logpush_connectors_secret_hash_unique",
+          "columns": [
+            "secret_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dashboard_versions": {
+      "name": "dashboard_versions",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "change_kind": {
+          "name": "change_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_version_id": {
+          "name": "source_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_versions_org_dashboard_idx": {
+          "name": "dashboard_versions_org_dashboard_idx",
+          "columns": [
+            "org_id",
+            "dashboard_id",
+            "version_number"
+          ],
+          "isUnique": false
+        },
+        "dashboard_versions_org_dashboard_version_unq": {
+          "name": "dashboard_versions_org_dashboard_version_unq",
+          "columns": [
+            "org_id",
+            "dashboard_id",
+            "version_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_versions_org_id_id_pk": {
+          "columns": [
+            "org_id",
+            "id"
+          ],
+          "name": "dashboard_versions_org_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dashboards": {
+      "name": "dashboards",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "dashboards_org_updated_idx": {
+          "name": "dashboards_org_updated_idx",
+          "columns": [
+            "org_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "dashboards_org_name_idx": {
+          "name": "dashboards_org_name_idx",
+          "columns": [
+            "org_id",
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboards_org_id_id_pk": {
+          "columns": [
+            "org_id",
+            "id"
+          ],
+          "name": "dashboards_org_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "digest_subscriptions": {
+      "name": "digest_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_attempted_at": {
+          "name": "last_attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "digest_subscriptions_org_user_idx": {
+          "name": "digest_subscriptions_org_user_idx",
+          "columns": [
+            "org_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "digest_subscriptions_org_enabled_idx": {
+          "name": "digest_subscriptions_org_enabled_idx",
+          "columns": [
+            "org_id",
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "actors": {
+      "name": "actors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "actors_org_user_idx": {
+          "name": "actors_org_user_idx",
+          "columns": [
+            "org_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "actors_org_agent_name_idx": {
+          "name": "actors_org_agent_name_idx",
+          "columns": [
+            "org_id",
+            "agent_name"
+          ],
+          "isUnique": true
+        },
+        "actors_org_type_idx": {
+          "name": "actors_org_type_idx",
+          "columns": [
+            "org_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "error_incidents": {
+      "name": "error_incidents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_triggered_at": {
+          "name": "first_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "error_incidents_org_issue_idx": {
+          "name": "error_incidents_org_issue_idx",
+          "columns": [
+            "org_id",
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "error_incidents_org_status_idx": {
+          "name": "error_incidents_org_status_idx",
+          "columns": [
+            "org_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "error_issue_events": {
+      "name": "error_issue_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_state": {
+          "name": "from_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_state": {
+          "name": "to_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "error_issue_events_issue_idx": {
+          "name": "error_issue_events_issue_idx",
+          "columns": [
+            "org_id",
+            "issue_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "error_issue_events_actor_idx": {
+          "name": "error_issue_events_actor_idx",
+          "columns": [
+            "org_id",
+            "actor_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "error_issue_events_type_idx": {
+          "name": "error_issue_events_type_idx",
+          "columns": [
+            "org_id",
+            "type",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "error_issue_states": {
+      "name": "error_issue_states",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_observed_occurrence_at": {
+          "name": "last_observed_occurrence_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_incident_id": {
+          "name": "open_incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "error_issue_states_org_idx": {
+          "name": "error_issue_states_org_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "error_issue_states_org_id_issue_id_pk": {
+          "columns": [
+            "org_id",
+            "issue_id"
+          ],
+          "name": "error_issue_states_org_id_issue_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "error_issues": {
+      "name": "error_issues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint_hash": {
+          "name": "fingerprint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exception_message": {
+          "name": "exception_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_state": {
+          "name": "workflow_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'triage'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "assigned_actor_id": {
+          "name": "assigned_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_holder_actor_id": {
+          "name": "lease_holder_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by_actor_id": {
+          "name": "resolved_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snooze_until": {
+          "name": "snooze_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "error_issues_org_fp_idx": {
+          "name": "error_issues_org_fp_idx",
+          "columns": [
+            "org_id",
+            "fingerprint_hash"
+          ],
+          "isUnique": true
+        },
+        "error_issues_org_workflow_idx": {
+          "name": "error_issues_org_workflow_idx",
+          "columns": [
+            "org_id",
+            "workflow_state"
+          ],
+          "isUnique": false
+        },
+        "error_issues_org_last_seen_idx": {
+          "name": "error_issues_org_last_seen_idx",
+          "columns": [
+            "org_id",
+            "last_seen_at"
+          ],
+          "isUnique": false
+        },
+        "error_issues_org_assignee_idx": {
+          "name": "error_issues_org_assignee_idx",
+          "columns": [
+            "org_id",
+            "assigned_actor_id"
+          ],
+          "isUnique": false
+        },
+        "error_issues_lease_expiry_idx": {
+          "name": "error_issues_lease_expiry_idx",
+          "columns": [
+            "lease_expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "error_notification_policies": {
+      "name": "error_notification_policies",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "destination_ids_json": {
+          "name": "destination_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "notify_on_first_seen": {
+          "name": "notify_on_first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "notify_on_regression": {
+          "name": "notify_on_regression",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "notify_on_resolve": {
+          "name": "notify_on_resolve",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notify_on_transition_in_review": {
+          "name": "notify_on_transition_in_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notify_on_transition_done": {
+          "name": "notify_on_transition_done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notify_on_claim": {
+          "name": "notify_on_claim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_occurrence_count": {
+          "name": "min_occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'warning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_auth_states": {
+      "name": "oauth_auth_states",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_auth_states_expires_idx": {
+          "name": "oauth_auth_states_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_connections": {
+      "name": "oauth_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_user_email": {
+          "name": "external_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_iv": {
+          "name": "access_token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_tag": {
+          "name": "access_token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_iv": {
+          "name": "refresh_token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_tag": {
+          "name": "refresh_token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_connections_org_provider_idx": {
+          "name": "oauth_connections_org_provider_idx",
+          "columns": [
+            "org_id",
+            "provider"
+          ],
+          "isUnique": true
+        },
+        "oauth_connections_org_idx": {
+          "name": "oauth_connections_org_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_ingest_keys": {
+      "name": "org_ingest_keys",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key_hash": {
+          "name": "public_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key_ciphertext": {
+          "name": "private_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key_iv": {
+          "name": "private_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key_tag": {
+          "name": "private_key_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key_hash": {
+          "name": "private_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_rotated_at": {
+          "name": "public_rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_rotated_at": {
+          "name": "private_rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "org_ingest_keys_public_key_unique": {
+          "name": "org_ingest_keys_public_key_unique",
+          "columns": [
+            "public_key"
+          ],
+          "isUnique": true
+        },
+        "org_ingest_keys_public_key_hash_unique": {
+          "name": "org_ingest_keys_public_key_hash_unique",
+          "columns": [
+            "public_key_hash"
+          ],
+          "isUnique": true
+        },
+        "org_ingest_keys_private_key_hash_unique": {
+          "name": "org_ingest_keys_private_key_hash_unique",
+          "columns": [
+            "private_key_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_openrouter_settings": {
+      "name": "org_openrouter_settings",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_tag": {
+          "name": "api_key_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_last4": {
+          "name": "api_key_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_clickhouse_settings": {
+      "name": "org_clickhouse_settings",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ch_url": {
+          "name": "ch_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ch_user": {
+          "name": "ch_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ch_password_ciphertext": {
+          "name": "ch_password_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ch_password_iv": {
+          "name": "ch_password_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ch_password_tag": {
+          "name": "ch_password_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ch_database": {
+          "name": "ch_database",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scrape_targets": {
+      "name": "scrape_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scrape_interval_seconds": {
+          "name": "scrape_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 15
+        },
+        "labels_json": {
+          "name": "labels_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "auth_credentials_ciphertext": {
+          "name": "auth_credentials_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_credentials_iv": {
+          "name": "auth_credentials_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_credentials_tag": {
+          "name": "auth_credentials_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_scrape_at": {
+          "name": "last_scrape_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_scrape_error": {
+          "name": "last_scrape_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scrape_targets_org_idx": {
+          "name": "scrape_targets_org_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "scrape_targets_org_enabled_idx": {
+          "name": "scrape_targets_org_enabled_idx",
+          "columns": [
+            "org_id",
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1777676016956,
       "tag": "0008_gray_blade",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1778457600000,
+      "tag": "0009_dashboard_versioning",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/dashboards.ts
+++ b/packages/db/src/schema/dashboards.ts
@@ -1,4 +1,4 @@
-import { index, integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core"
+import { index, integer, primaryKey, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core"
 
 export const dashboards = sqliteTable(
 	"dashboards",
@@ -11,6 +11,10 @@ export const dashboards = sqliteTable(
 		updatedAt: integer("updated_at", { mode: "number" }).notNull(),
 		createdBy: text("created_by").notNull(),
 		updatedBy: text("updated_by").notNull(),
+		// Optimistic-concurrency token. Bumped on every upsert; mutations use a
+		// compare-and-swap on (id, version) and retry on conflict so concurrent
+		// writers can no longer silently clobber each other.
+		version: integer("version", { mode: "number" }).notNull().default(0),
 	},
 	(table) => [
 		primaryKey({ columns: [table.orgId, table.id] }),
@@ -44,6 +48,14 @@ export const dashboardVersions = sqliteTable(
 	(table) => [
 		primaryKey({ columns: [table.orgId, table.id] }),
 		index("dashboard_versions_org_dashboard_idx").on(table.orgId, table.dashboardId, table.versionNumber),
+		// Prevents two concurrent saves from stamping the same version_number for
+		// the same dashboard. Insert collisions surface as a unique-constraint
+		// error which the persistence layer maps to a concurrency conflict.
+		uniqueIndex("dashboard_versions_org_dashboard_version_unq").on(
+			table.orgId,
+			table.dashboardId,
+			table.versionNumber,
+		),
 	],
 )
 

--- a/packages/domain/src/http/alerts.test.ts
+++ b/packages/domain/src/http/alerts.test.ts
@@ -1,19 +1,31 @@
 import { describe, expect, it } from "vitest"
 import { Schema } from "effect"
-import { AlertDestinationCreateRequest } from "./alerts"
+import {
+	AlertDestinationCreateRequest,
+	PagerDutyAlertDestinationConfig,
+	SlackAlertDestinationConfig,
+	WebhookAlertDestinationConfig,
+} from "./alerts"
 
 describe("AlertDestinationCreateRequest", () => {
 	const encode = Schema.encodeUnknownSync(AlertDestinationCreateRequest)
 
-	it("encodes plain slack destination payloads", () => {
+	// `AlertDestinationCreateRequest` is a `Schema.Union` of `Schema.Class`
+	// instances, so `encodeUnknownSync` requires class instances on the input
+	// side and produces the plain wire-format object on the output side.
+	// These tests assert the encoded wire shape matches what HTTP clients
+	// see on the wire.
+	it("encodes slack destination instances to the plain wire shape", () => {
 		expect(
-			encode({
-				type: "slack",
-				name: "Ops Slack",
-				enabled: true,
-				webhookUrl: "https://hooks.slack.com/services/T/B/X",
-				channelLabel: "#ops-alerts",
-			}),
+			encode(
+				new SlackAlertDestinationConfig({
+					type: "slack",
+					name: "Ops Slack",
+					enabled: true,
+					webhookUrl: "https://hooks.slack.com/services/T/B/X",
+					channelLabel: "#ops-alerts",
+				}),
+			),
 		).toEqual({
 			type: "slack",
 			name: "Ops Slack",
@@ -23,14 +35,16 @@ describe("AlertDestinationCreateRequest", () => {
 		})
 	})
 
-	it("encodes plain pagerduty and webhook destination payloads", () => {
+	it("encodes pagerduty and webhook destination instances to the plain wire shape", () => {
 		expect(
-			encode({
-				type: "pagerduty",
-				name: "PagerDuty",
-				enabled: true,
-				integrationKey: "integration-key",
-			}),
+			encode(
+				new PagerDutyAlertDestinationConfig({
+					type: "pagerduty",
+					name: "PagerDuty",
+					enabled: true,
+					integrationKey: "integration-key",
+				}),
+			),
 		).toEqual({
 			type: "pagerduty",
 			name: "PagerDuty",
@@ -39,13 +53,15 @@ describe("AlertDestinationCreateRequest", () => {
 		})
 
 		expect(
-			encode({
-				type: "webhook",
-				name: "Webhook",
-				enabled: true,
-				url: "https://example.com/alerts",
-				signingSecret: "secret",
-			}),
+			encode(
+				new WebhookAlertDestinationConfig({
+					type: "webhook",
+					name: "Webhook",
+					enabled: true,
+					url: "https://example.com/alerts",
+					signingSecret: "secret",
+				}),
+			),
 		).toEqual({
 			type: "webhook",
 			name: "Webhook",

--- a/packages/domain/src/http/dashboards.ts
+++ b/packages/domain/src/http/dashboards.ts
@@ -285,6 +285,15 @@ export class DashboardValidationError extends Schema.TaggedErrorClass<DashboardV
 	{ httpApiStatus: 400 },
 ) {}
 
+export class DashboardConcurrencyError extends Schema.TaggedErrorClass<DashboardConcurrencyError>()(
+	"@maple/http/errors/DashboardConcurrencyError",
+	{
+		dashboardId: DashboardId,
+		message: Schema.String,
+	},
+	{ httpApiStatus: 409 },
+) {}
+
 // ---------------------------------------------------------------------------
 // Templates
 // ---------------------------------------------------------------------------
@@ -344,7 +353,7 @@ export class DashboardsApiGroup extends HttpApiGroup.make("dashboards")
 		HttpApiEndpoint.post("create", "/", {
 			payload: DashboardCreateRequest,
 			success: DashboardDocument,
-			error: [DashboardValidationError, DashboardPersistenceError],
+			error: [DashboardValidationError, DashboardPersistenceError, DashboardConcurrencyError],
 		}),
 	)
 	.add(
@@ -354,7 +363,12 @@ export class DashboardsApiGroup extends HttpApiGroup.make("dashboards")
 			},
 			payload: DashboardUpsertRequest,
 			success: DashboardDocument,
-			error: [DashboardValidationError, DashboardPersistenceError],
+			error: [
+				DashboardValidationError,
+				DashboardPersistenceError,
+				DashboardConcurrencyError,
+				DashboardNotFoundError,
+			],
 		}),
 	)
 	.add(
@@ -390,6 +404,7 @@ export class DashboardsApiGroup extends HttpApiGroup.make("dashboards")
 				DashboardVersionNotFoundError,
 				DashboardValidationError,
 				DashboardPersistenceError,
+				DashboardConcurrencyError,
 			],
 		}),
 	)
@@ -403,7 +418,12 @@ export class DashboardsApiGroup extends HttpApiGroup.make("dashboards")
 			params: { templateId: DashboardTemplateId },
 			payload: DashboardTemplateInstantiateRequest,
 			success: DashboardDocument,
-			error: [DashboardTemplateNotFoundError, DashboardValidationError, DashboardPersistenceError],
+			error: [
+				DashboardTemplateNotFoundError,
+				DashboardValidationError,
+				DashboardPersistenceError,
+				DashboardConcurrencyError,
+			],
 		}),
 	)
 	.prefix("/api/dashboards")

--- a/packages/domain/src/tinybird/project-sync.test.ts
+++ b/packages/domain/src/tinybird/project-sync.test.ts
@@ -291,7 +291,7 @@ describe("Tinybird project sync", () => {
 	})
 
 	describe("cleanupStaleTinybirdDeployments", () => {
-		it("deletes non-live deployments returned by the list endpoint", async () => {
+		it("deletes only deployments in terminal failed states", async () => {
 			const calls: Array<{ method: string; url: string }> = []
 
 			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -304,8 +304,13 @@ describe("Tinybird project sync", () => {
 					return jsonResponse({
 						deployments: [
 							{ id: "live-1", status: "live", live: true },
-							{ id: "stale-1", status: "deploying", live: false },
-							{ id: "stale-2", status: "data_ready", live: false },
+							// In-flight states must not be deleted — these are active
+							// deployments about to be promoted.
+							{ id: "in-flight-1", status: "deploying", live: false },
+							{ id: "in-flight-2", status: "data_ready", live: false },
+							// Terminal failed states are safe to clean up.
+							{ id: "failed-1", status: "failed", live: false },
+							{ id: "failed-2", status: "error", live: false },
 						],
 					})
 				}
@@ -320,7 +325,7 @@ describe("Tinybird project sync", () => {
 
 			const deletes = calls.filter((c) => c.method === "DELETE")
 			const deleteIds = deletes.map((c) => c.url.match(/\/v1\/deployments\/([^?]+)/)?.[1]).sort()
-			expect(deleteIds).toEqual(["stale-1", "stale-2"])
+			expect(deleteIds).toEqual(["failed-1", "failed-2"])
 		})
 
 		it("is a no-op when there are no stale deployments", async () => {

--- a/packages/query-engine/src/ch/queries/service-map.ts
+++ b/packages/query-engine/src/ch/queries/service-map.ts
@@ -32,53 +32,70 @@ export function serviceDependenciesSQL(
 	const esc = escapeClickHouseString
 	const envFilter = opts.deploymentEnv ? `AND DeploymentEnv = '${esc(opts.deploymentEnv)}'` : ""
 
-	// Node 1: Pre-aggregated hourly edges (peer.service path).
-	// `SampleRateSum` is a per-row weighted sum maintained by the MV — replaces
-	// the `sampledSpanCount * dominantWeight` approximation, which inflated
-	// estimates by orders of magnitude when sampling rates varied within a bucket.
+	// Inner branches expose distinct alias names (`bucket*`) so the outer
+	// SELECT's `sum(...) AS callCount` doesn't collide with an inner
+	// `sum(CallCount) AS callCount`. ClickHouse's UNION-ALL+GROUP-BY
+	// optimizer otherwise rewrites the outer as `sum(sum(CallCount))` and
+	// rejects the query with "found inside another aggregate function".
 	//
-	// Per-row fallback `if(SampleRateSum > 0, SampleRateSum, toFloat64(CallCount))`:
-	// the SampleRateSum column was added after this MV existed, so historical
-	// hourly buckets have SampleRateSum=0. For those buckets we fall back to
-	// CallCount (treats them as unsampled) — accurate for new buckets, degraded
-	// but non-zero for old ones. Safe across mixed time ranges.
+	// We also carry `bucketDurationSumMs` separately from `bucketCallCount`
+	// so the outer can compute a properly-weighted average:
+	//   sum(bucketDurationSumMs) / sum(bucketCallCount)
+	// instead of `avg(avgDurationMs)` (averaging averages, which ignores
+	// the relative call counts of each branch).
+	//
+	// Time ranges are split so the two branches don't double-count the
+	// in-progress hour: the MV covers complete hourly buckets strictly
+	// before `toStartOfHour(endTime)`, the raw join scans only from there
+	// to `endTime`. (Previously the MV included the in-progress hour AND
+	// the raw join read the trailing hour, so spans inside the current
+	// hour got counted twice.)
+	//
+	// `bucketEstimatedSpanCount` per-row fallback
+	// `if(SampleRateSum > 0, SampleRateSum, toFloat64(CallCount))`: the
+	// SampleRateSum column was added after this MV existed, so historical
+	// buckets have SampleRateSum=0. For those buckets we treat them as
+	// unsampled — accurate for new buckets, degraded but non-zero for old
+	// ones. Safe across mixed time ranges.
 	const peerServiceEdges = `SELECT
       SourceService AS sourceService,
       TargetService AS targetService,
-      sum(CallCount) AS callCount,
-      sum(ErrorCount) AS errorCount,
-      sum(DurationSumMs) / sum(CallCount) AS avgDurationMs,
-      max(MaxDurationMs) AS p95DurationMs,
-      sum(if(SampleRateSum > 0, SampleRateSum, toFloat64(CallCount))) AS estimatedSpanCount
+      sum(CallCount) AS bucketCallCount,
+      sum(ErrorCount) AS bucketErrorCount,
+      sum(DurationSumMs) AS bucketDurationSumMs,
+      max(MaxDurationMs) AS bucketMaxDurationMs,
+      sum(if(SampleRateSum > 0, SampleRateSum, toFloat64(CallCount))) AS bucketEstimatedSpanCount
     FROM service_map_edges_hourly
     WHERE OrgId = '${esc(params.orgId)}'
       AND Hour >= toStartOfHour(toDateTime('${esc(params.startTime)}'))
-      AND Hour <= '${esc(params.endTime)}'
+      AND Hour < toStartOfHour(toDateTime('${esc(params.endTime)}'))
       ${envFilter}
     GROUP BY sourceService, targetService`
 
-	// Node 2: Join-based edges (Client/Producer spans without peer.service).
-	// `service_map_children` doesn't carry SampleRate yet (it's a TraceState-only
-	// projection) so we compute the per-row weight inline from `c.TraceState`.
+	// Join-based edges for the in-progress hour only (Client/Producer spans
+	// without peer.service). `service_map_children` doesn't carry SampleRate
+	// yet — it's a TraceState-only projection — so we compute the per-row
+	// weight inline from `c.TraceState`. Duration math stays consistent with
+	// the MV branch by exposing sum/max separately.
 	const joinEdges = `SELECT
       p.ServiceName AS sourceService,
       c.ServiceName AS targetService,
-      count() AS callCount,
-      countIf(c.StatusCode = 'Error') AS errorCount,
-      avg(c.Duration / 1000000) AS avgDurationMs,
-      quantile(0.95)(c.Duration / 1000000) AS p95DurationMs,
+      count() AS bucketCallCount,
+      countIf(c.StatusCode = 'Error') AS bucketErrorCount,
+      sum(c.Duration / 1000000) AS bucketDurationSumMs,
+      max(c.Duration / 1000000) AS bucketMaxDurationMs,
       sum(multiIf(
         match(c.TraceState, 'th:[0-9a-f]+'),
         1.0 / greatest(1.0 - reinterpretAsUInt64(reverse(unhex(rightPad(extract(c.TraceState, 'th:([0-9a-f]+)'), 16, '0')))) / pow(2.0, 64), 0.0001),
         1.0
-      )) AS estimatedSpanCount
+      )) AS bucketEstimatedSpanCount
     FROM (
       SELECT TraceId, SpanId, ServiceName
       FROM service_map_spans
       WHERE OrgId = '${esc(params.orgId)}'
         AND SpanKind IN ('Client', 'Producer')
         AND PeerService = ''
-        AND Timestamp >= addHours(toDateTime('${esc(params.endTime)}'), -1)
+        AND Timestamp >= toStartOfHour(toDateTime('${esc(params.endTime)}'))
         AND Timestamp <= '${esc(params.endTime)}'
         ${envFilter}
     ) AS p
@@ -86,7 +103,7 @@ export function serviceDependenciesSQL(
       SELECT TraceId, ParentSpanId, ServiceName, Duration, StatusCode, TraceState
       FROM service_map_children
       WHERE OrgId = '${esc(params.orgId)}'
-        AND Timestamp >= addHours(toDateTime('${esc(params.endTime)}'), -1)
+        AND Timestamp >= toStartOfHour(toDateTime('${esc(params.endTime)}'))
         AND Timestamp <= '${esc(params.endTime)}'
         ${envFilter}
     ) AS c
@@ -97,11 +114,11 @@ export function serviceDependenciesSQL(
 	const sql = `SELECT
   sourceService,
   targetService,
-  sum(callCount) AS callCount,
-  sum(errorCount) AS errorCount,
-  avg(avgDurationMs) AS avgDurationMs,
-  max(p95DurationMs) AS p95DurationMs,
-  sum(estimatedSpanCount) AS estimatedSpanCount
+  sum(bucketCallCount) AS callCount,
+  sum(bucketErrorCount) AS errorCount,
+  sum(bucketDurationSumMs) / nullIf(sum(bucketCallCount), 0) AS avgDurationMs,
+  max(bucketMaxDurationMs) AS p95DurationMs,
+  sum(bucketEstimatedSpanCount) AS estimatedSpanCount
 FROM (
   ${peerServiceEdges}
   UNION ALL
@@ -158,39 +175,43 @@ export function serviceDbEdgesSQL(
 		? `AND ResourceAttributes['deployment.environment'] = '${esc(opts.deploymentEnv)}'`
 		: ""
 
-	// Hourly pre-aggregated buckets — covers everything except the in-flight hour.
-	// `SampleRateSum` is the per-row weighted sum maintained by the MV. Historical
-	// buckets that pre-date the column have SampleRateSum=0, so fall back to
-	// CallCount per-row (treats those buckets as unsampled — degraded but safe).
+	// Inner branches expose `bucket*` aliases so the outer `sum(...) AS callCount`
+	// can't collide with an inner `sum(CallCount) AS callCount` — same fix as
+	// `serviceDependenciesSQL` for the same nested-aggregate optimizer error.
+	// Historical buckets that pre-date the SampleRateSum column have it set to
+	// 0, so we fall back to CallCount per-row (treats those buckets as
+	// unsampled — degraded but safe).
 	const hourlyEdges = `SELECT
       ServiceName AS sourceService,
       DbSystem AS dbSystem,
-      sum(CallCount) AS callCount,
-      sum(ErrorCount) AS errorCount,
-      sum(DurationSumMs) / sum(CallCount) AS avgDurationMs,
-      max(MaxDurationMs) AS p95DurationMs,
-      sum(if(SampleRateSum > 0, SampleRateSum, toFloat64(CallCount))) AS estimatedSpanCount
+      sum(CallCount) AS bucketCallCount,
+      sum(ErrorCount) AS bucketErrorCount,
+      sum(DurationSumMs) AS bucketDurationSumMs,
+      max(MaxDurationMs) AS bucketMaxDurationMs,
+      sum(if(SampleRateSum > 0, SampleRateSum, toFloat64(CallCount))) AS bucketEstimatedSpanCount
     FROM service_map_db_edges_hourly
     WHERE OrgId = '${esc(params.orgId)}'
       AND Hour >= toStartOfHour(toDateTime('${esc(params.startTime)}'))
-      AND Hour <= '${esc(params.endTime)}'
+      AND Hour < toStartOfHour(toDateTime('${esc(params.endTime)}'))
       AND DbSystem != ''
       ${envFilterMv}
     GROUP BY sourceService, dbSystem`
 
-	// Trailing-hour raw fallback so the current incomplete bucket is included.
-	// Reads the per-row `SampleRate` column directly; no inline weight math needed.
+	// Raw fallback for the in-progress hour only (the MV branch stops at
+	// `toStartOfHour(endTime)`). Reads per-row `SampleRate` directly so no
+	// inline weight math is needed. Carries `bucketDurationSumMs` separately
+	// so the outer can do a properly-weighted average.
 	const recentEdges = `SELECT
       ServiceName AS sourceService,
       SpanAttributes['db.system'] AS dbSystem,
-      count() AS callCount,
-      countIf(StatusCode = 'Error') AS errorCount,
-      avg(Duration / 1000000) AS avgDurationMs,
-      quantile(0.95)(Duration / 1000000) AS p95DurationMs,
-      sum(SampleRate) AS estimatedSpanCount
+      count() AS bucketCallCount,
+      countIf(StatusCode = 'Error') AS bucketErrorCount,
+      sum(Duration / 1000000) AS bucketDurationSumMs,
+      max(Duration / 1000000) AS bucketMaxDurationMs,
+      sum(SampleRate) AS bucketEstimatedSpanCount
     FROM traces
     WHERE OrgId = '${esc(params.orgId)}'
-      AND Timestamp >= addHours(toDateTime('${esc(params.endTime)}'), -1)
+      AND Timestamp >= toStartOfHour(toDateTime('${esc(params.endTime)}'))
       AND Timestamp <= '${esc(params.endTime)}'
       AND SpanKind IN ('Client', 'Producer')
       AND SpanAttributes['db.system'] != ''
@@ -201,11 +222,11 @@ export function serviceDbEdgesSQL(
 	const sql = `SELECT
   sourceService,
   dbSystem,
-  sum(callCount) AS callCount,
-  sum(errorCount) AS errorCount,
-  avg(avgDurationMs) AS avgDurationMs,
-  max(p95DurationMs) AS p95DurationMs,
-  sum(estimatedSpanCount) AS estimatedSpanCount
+  sum(bucketCallCount) AS callCount,
+  sum(bucketErrorCount) AS errorCount,
+  sum(bucketDurationSumMs) / nullIf(sum(bucketCallCount), 0) AS avgDurationMs,
+  max(bucketMaxDurationMs) AS p95DurationMs,
+  sum(bucketEstimatedSpanCount) AS estimatedSpanCount
 FROM (
   ${hourlyEdges}
   UNION ALL


### PR DESCRIPTION
## Summary

Closes Section 4 (dashboard concurrency / lost updates) and Section 6 (service-map nested-aggregate SQL error) of the DeepSec triage in `.claude/plans/we-created-an-depsec-cuddly-tarjan.md`.

- **Dashboards** now use optimistic concurrency via a new `dashboards.version` column + CAS upsert. Two concurrent MCP calls or browser edits can no longer silently lose one update; the loser surfaces a typed `DashboardConcurrencyError` (HTTP 409) and the web hook auto-refetches.
- **Service map** ClickHouse query no longer trips the UNION-ALL+GROUP-BY optimizer into producing `sum(sum(...))`; aliases are renamed and the average is now properly weighted across MV + raw branches.

## What changed

### Schema (held until human review)

- `packages/db/drizzle/0009_dashboard_versioning.sql` — adds `dashboards.version INTEGER NOT NULL DEFAULT 0` and a unique index on `dashboard_versions(org_id, dashboard_id, version_number)`.
- `packages/db/src/schema/dashboards.ts`, `packages/db/drizzle/meta/0009_snapshot.json`, `_journal.json` updated to match.

### Domain

- `DashboardConcurrencyError` (HTTP 409) added to `@maple/domain/http`. Wired into the `upsert`, `restoreVersion`, `create`, and `instantiateTemplate` HTTP endpoints' error unions.

### Persistence

- `DashboardPersistenceService.upsert` now reads current version and runs `UPDATE ... WHERE id = ? AND version = ?`. Zero rows affected → conflict.
- New `DashboardPersistenceService.mutate(orgId, userId, dashboardId, transform)` runs the read-CAS-write loop with up to **5** retries before surfacing the typed conflict. The MCP `withDashboardMutation` helper now delegates to it, so every widget tool inherits retry-on-conflict.

### MCP tools

- `update-dashboard`: preserves `existing.variables` in **both** the metadata-only and full-replacement branches (the full-replacement path was silently wiping it).
- `reorder-dashboard-widgets`: server-side geometry validation (`x>=0, y>=0, 1<=w<=12, h>=1, x+w<=12`).

### Web client

- `useDashboardStore` now serializes mutations per dashboard with a FIFO queue (`Map<id, Promise>`), so back-to-back edits can't race against each other.
- On `DashboardConcurrencyError` the optimistic update rolls back, a banner surfaces the conflict, and `useAtomRefresh` triggers a refetch — the existing list-result effect clears the banner once fresh state lands.

### Service map (separate root-cause, same PR)

- Inner branches in `serviceDependenciesSQL` and `serviceDbEdgesSQL` expose distinct `bucket*` aliases so the outer `sum(...) AS callCount` has no inner name to fold against.
- Outer average switched from `avg(avgDurationMs)` (averaging averages) to `sum(bucketDurationSumMs) / nullIf(sum(bucketCallCount), 0)` (properly weighted across branches).
- MV branch reads `Hour < toStartOfHour(endTime)` only; raw branch reads `Timestamp >= toStartOfHour(endTime)` to `endTime`. Previously both overlapped on the trailing hour and double-counted spans.

### Tests

- `apps/api/src/mcp/tools/__tests__/dashboard-concurrency.test.ts` — 3 vitest cases:
  1. Two concurrent `mutate` calls both land via retry — no lost update.
  2. Two concurrent `upsert` calls — loser surfaces `DashboardConcurrencyError` instead of silently overwriting.
  3. After a conflict, a refetch+retry resolves cleanly.

Whole api test suite (279 tests across 20 files) green.

## Test plan

- [x] `bun typecheck` clean on `@maple/api`, `@maple/web`, `@maple/db`, `@maple/domain`, `@maple/query-engine` (only pre-existing unrelated `worker.ts` import error remains)
- [x] `bun test` from `apps/api` — 279 pass, 0 fail
- [x] D1 migration `0009_dashboard_versioning.sql` applies cleanly via `wrangler d1 migrations apply --local`
- [x] Browser preview verified: created a dashboard (`version=1`, audit row `created`), added a Bar Chart widget (`version=2`, audit row `widget_added`), fired two parallel `PUT /api/dashboards/:id` requests (both committed against fresh state, `version` advanced 2→4 — local D1 serializes so neither write actually overlapped, but both succeeded which is the correct CAS behavior; the actual race-window assertion is covered by the unit tests)
- [x] Browser preview verified: service-map page renders cleanly — previously failed with the nested-aggregate SQL error, now returns 200 OK with proper content
- [x] Generated SQL inspected: zero `sum(sum(...))` patterns, single `AS callCount` (outer only) in both queries

## Reviewer notes

- **Schema migration apply is held** per the plan — please review `0009_dashboard_versioning.sql` before running it through the release flow. SQLite-friendly (`ADD COLUMN ... DEFAULT 0 NOT NULL`), no backfill required.
- HTTP `upsert` does single-attempt CAS (no retry) so the client gets a 409 to refetch from. MCP `mutate` retries internally because the transform is re-applied on top of fresh state — that's safe; HTTP retry would silently overwrite.
- `recordVersion` is still wrapped in `Effect.ignore` (best-effort audit). The new unique index protects against duplicate `version_number` rows under racy `recordVersion` calls; the worst case is a missed audit row, which is acceptable given the dashboard-table CAS guarantees the actual state is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Makisuo/codesmith/maple/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->