### PR TITLE
fix(dev): patch portless 0.13 for worktree prefix + recursion guard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -465,6 +465,7 @@
   },
   "patchedDependencies": {
     "effect@4.0.0-beta.64": "patches/effect@4.0.0-beta.64.patch",
+    "portless@0.13.0": "patches/portless@0.13.0.patch",
   },
   "catalog": {
     "vite": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		}
 	},
 	"patchedDependencies": {
-		"effect@4.0.0-beta.64": "patches/effect@4.0.0-beta.64.patch"
+		"effect@4.0.0-beta.64": "patches/effect@4.0.0-beta.64.patch",
+		"portless@0.13.0": "patches/portless@0.13.0.patch"
 	}
 }

--- a/patches/portless@0.13.0.patch
+++ b/patches/portless@0.13.0.patch
@@ -1,0 +1,46 @@
+diff --git a/dist/cli.js b/dist/cli.js
+index 35e52b60a6458732786677d15d2a8dcb5f1ee476..741a56940980180ce5fcb2db008de0883fbb2a9a 100755
+--- a/dist/cli.js
++++ b/dist/cli.js
+@@ -2166,6 +2166,17 @@ function hasScript(scriptName, dir) {
+     return false;
+   }
+ }
++function readScriptValue(dir, scriptName) {
++  const pkgPath = path5.join(dir, "package.json");
++  try {
++    const raw = fs5.readFileSync(pkgPath, "utf-8");
++    const pkg = JSON.parse(raw);
++    const value = pkg?.scripts?.[scriptName];
++    return typeof value === "string" ? value : null;
++  } catch {
++    return null;
++  }
++}
+ var LOCK_FILES = [
+   ["pnpm-lock.yaml", "pnpm"],
+   ["yarn.lock", "yarn"],
+@@ -5415,6 +5426,12 @@ async function handleDefaultMulti(wsRoot, globalScript, extraArgs = []) {
+     console.error(colors_default.yellow(`No workspace packages have a "${scriptName}" script.`));
+     process.exit(1);
+   }
++  const worktree = detectWorktreePrefix(wsRoot);
++  if (worktree) {
++    for (const app of apps) {
++      app.name = `${worktree.prefix}.${app.name}`;
++    }
++  }
+   apps.sort((a, b) => a.label.localeCompare(b.label));
+   const proxiedApps = apps.filter((a) => a.proxied);
+   const taskApps = apps.filter((a) => !a.proxied);
+@@ -5495,7 +5512,9 @@ async function runWithTurbo(wsRoot, stateDir, proxyPort, tls2, tld, scriptName,
+   }
+   console.log("");
+   const pm = detectPackageManager(wsRoot);
+-  const useRootScript = hasScript(scriptName, wsRoot);
++  const rootScriptValue = readScriptValue(wsRoot, scriptName);
++  const rootScriptIsPortless = typeof rootScriptValue === "string" && /^portless(\s|$)/.test(rootScriptValue.trim());
++  const useRootScript = hasScript(scriptName, wsRoot) && !rootScriptIsPortless;
+   const turboArgs = useRootScript ? [pm, "run", scriptName, ...extraArgs] : pm === "npm" ? ["npx", "turbo", "run", scriptName, ...extraArgs] : pm === "bun" ? ["bunx", "turbo", "run", scriptName, ...extraArgs] : [pm, "exec", "turbo", "run", scriptName, ...extraArgs];
+   const turboChild = spawn3(turboArgs[0], turboArgs.slice(1), {
+     stdio: "inherit",

--- a/turbo.json
+++ b/turbo.json
@@ -15,8 +15,7 @@
 		},
 		"dev": {
 			"cache": false,
-			"persistent": true,
-			"interactive": true
+			"persistent": true
 		},
 		"tinybird:dev": {
 			"cache": false


### PR DESCRIPTION
## Summary

Fixes `bun dev` crashing with `Error: "alerting.localhost" is already registered by a running process (PID …)` after #39. Two upstream portless 0.13 bugs piled on, plus stale turbo config that blocked the new flow.

## Why this happened

1. **Worktree prefix never applied in multi-mode.** Portless 0.13's `detectWorktreePrefix()` runs in `handleDefaultSingle`, `handleAutoMode`, and `handleNamedMode`, but **not** in `handleDefaultMulti` — the path `bun dev` takes from the workspace root. So every worktree (and the main checkout) tried to bind the same bare hostnames (`alerting.localhost`, `api.localhost`, …), guaranteeing a collision the moment two `bun dev`s overlapped.
2. **Self-recursion via `useRootScript`.** `runWithTurbo` does `useRootScript = hasScript("dev", wsRoot)` and, when true, spawns `bun run dev` instead of turbo directly. Our root \`dev\` script *is* \`portless\`, so the outer portless registered the routes, then the inner \`bun run dev\` reinvoked portless and conflicted with itself. The "running process PID" in the error message was the outer parent.
3. **\`"interactive": true\` on the \`dev\` turbo task.** Leftover from the pre-#39 `turbo dev --ui=tui` root script. With portless spawning turbo non-interactively, every workspace package failed with *"Cannot run interactive task without Terminal UI"* once the route conflict was fixed.

## What changed

- **\`patches/portless@0.13.0.patch\`** (registered via \`bun patch\`):
  - In \`handleDefaultMulti\`, call \`detectWorktreePrefix(wsRoot)\` and prepend \`worktree.prefix\` to every \`app.name\`. Mirrors what single-app modes already do.
  - Add a \`readScriptValue\` helper and skip the \`useRootScript\` shortcut when the root's script value is literally \`portless\` (or \`portless …\`). Portless now invokes \`bunx turbo run dev\` directly when called from a root whose own \`dev\` is just \`portless\`, instead of recursing into itself.
- **\`turbo.json\`** — removed \`"interactive": true\` from the \`dev\` task.

Both portless fixes are general — worth pushing upstream once we've lived with the patch for a bit.

## Verification

From this worktree, \`bun dev\` now boots cleanly with worktree-prefixed URLs:

\`\`\`
alerting    https://affectionate-wiles-1fb8df.alerting.localhost
api         https://affectionate-wiles-1fb8df.api.localhost
chat-agent  https://affectionate-wiles-1fb8df.chat-agent.localhost
ingest      https://affectionate-wiles-1fb8df.ingest.localhost
landing     https://affectionate-wiles-1fb8df.landing.localhost
web         https://affectionate-wiles-1fb8df.web.localhost
\`\`\`

Turbo proceeds to run each app's \`dev\` script (vite / wrangler / astro / cargo). Two concurrent \`bun dev\`s from different worktrees no longer collide because their hostnames are now disjoint (\`<worktree>.<app>.localhost\`).

## Test plan

- [ ] \`bun install\` applies the patch cleanly on a fresh clone.
- [ ] \`bun dev\` from \`main\` boots without route conflict; URLs are bare (no worktree prefix, since branch is \`main\`).
- [ ] \`bun dev\` from any worktree boots with worktree-prefixed URLs (\`<worktree>.<app>.localhost\`).
- [ ] \`bun dev\` from two worktrees concurrently both start, both visible in \`~/.portless/routes.json\` (or \`/tmp/portless/routes.json\` when using the system proxy on :443).
- [ ] Ctrl+C on either \`bun dev\` clears its entries from \`routes.json\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)