### PR TITLE
feat: optimize traces list queries to avoid OOM

### DIFF
--- a/packages/query-engine/src/ch/queries/traces.test.ts
+++ b/packages/query-engine/src/ch/queries/traces.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest"
+import { compileCH } from "../compile"
+import { tracesListQuery, tracesRootListQuery } from "./traces"
+
+const baseParams = {
+	orgId: "org_1",
+	startTime: "2024-01-01 00:00:00",
+	endTime: "2024-01-02 00:00:00",
+	bucketSeconds: 3600,
+}
+
+// ---------------------------------------------------------------------------
+// tracesListQuery
+// ---------------------------------------------------------------------------
+
+describe("tracesListQuery", () => {
+	it("compiles basic list with all columns", () => {
+		const q = tracesListQuery({})
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("FROM traces")
+		expect(sql).toContain("TraceId AS traceId")
+		expect(sql).toContain("Timestamp AS timestamp")
+		expect(sql).toContain("SpanId AS spanId")
+		expect(sql).toContain("ServiceName AS serviceName")
+		expect(sql).toContain("SpanName AS spanName")
+		expect(sql).toContain("Duration / 1000000 AS durationMs")
+		expect(sql).toContain("StatusCode AS statusCode")
+		expect(sql).toContain("SpanKind AS spanKind")
+		expect(sql).toContain("AS hasError")
+		expect(sql).toContain("SpanAttributes AS spanAttributes")
+		expect(sql).toContain("ResourceAttributes AS resourceAttributes")
+		expect(sql).toContain("ORDER BY timestamp DESC")
+		expect(sql).toContain("LIMIT 25")
+		expect(sql).toContain("FORMAT JSON")
+	})
+
+	it("applies cursor pagination", () => {
+		const q = tracesListQuery({ cursor: "2024-01-01T12:00:00" })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("Timestamp < '2024-01-01T12:00:00'")
+	})
+
+	it("applies custom limit", () => {
+		const q = tracesListQuery({ limit: 100 })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("LIMIT 100")
+	})
+
+	it("applies offset", () => {
+		const q = tracesListQuery({ limit: 50, offset: 20 })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("LIMIT 50")
+		expect(sql).toContain("OFFSET 20")
+	})
+
+	it("applies all filters simultaneously", () => {
+		const q = tracesListQuery({
+			serviceName: "api",
+			spanName: "GET /users",
+			errorsOnly: true,
+		})
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("ServiceName = 'api'")
+		expect(sql).toContain("SpanName = 'GET /users'")
+		expect(sql).toContain("StatusCode = 'Error'")
+	})
+
+	it("projects only requested attribute keys when columns are specified", () => {
+		const q = tracesListQuery({
+			columns: ["spanAttributes.http.method", "resourceAttributes.service.version"],
+		})
+		const { sql } = compileCH(q, baseParams)
+		// Projected map literal uses map(...) instead of the bare column.
+		expect(sql).toContain("'http.method'")
+		expect(sql).toContain("'service.version'")
+	})
+
+	it("gates the heavy column scan on a cheap cutoff subquery", () => {
+		const q = tracesListQuery({ limit: 100 })
+		const { sql } = compileCH(q, baseParams)
+
+		// Outer query keeps the heavy Map columns.
+		expect(sql).toContain("SpanAttributes AS spanAttributes")
+		expect(sql).toContain("ResourceAttributes AS resourceAttributes")
+
+		// Cutoff subquery reads only Timestamp — no Map columns, no Duration math.
+		const cutoffMatch = sql.match(/SELECT min\(ts\) FROM \(([\s\S]*?)\)\)/)
+		expect(cutoffMatch).not.toBeNull()
+		const inner = cutoffMatch![1]!
+		expect(inner).toContain("Timestamp AS ts")
+		expect(inner).not.toContain("SpanAttributes")
+		expect(inner).not.toContain("ResourceAttributes")
+		expect(inner).not.toContain("Duration")
+		expect(inner).toContain("ORDER BY ts DESC")
+		expect(inner).toContain("LIMIT 100")
+
+		// Outer query gates on the cutoff.
+		expect(sql).toContain("Timestamp >= (SELECT min(ts) FROM (")
+	})
+
+	it("extends the cutoff limit by offset so the cutoff covers all skipped rows", () => {
+		const q = tracesListQuery({ limit: 25, offset: 100 })
+		const { sql } = compileCH(q, baseParams)
+		const cutoffMatch = sql.match(/SELECT min\(ts\) FROM \(([\s\S]*?)\)\)/)
+		expect(cutoffMatch).not.toBeNull()
+		const inner = cutoffMatch![1]!
+		// Stage 1 must look at limit+offset rows so the cutoff isn't above the
+		// rows the outer OFFSET will skip past.
+		expect(inner).toContain("LIMIT 125")
+	})
+
+	it("applies the same filters to both the cutoff and outer stages", () => {
+		const q = tracesListQuery({ serviceName: "api", errorsOnly: true })
+		const { sql } = compileCH(q, baseParams)
+		// Each filter appears twice — once per stage.
+		expect(sql.match(/ServiceName = 'api'/g)).toHaveLength(2)
+		expect(sql.match(/OrgId = 'org_1'/g)).toHaveLength(2)
+		// `StatusCode = 'Error'` shows up in the WHERE of both stages (errorsOnly)
+		// plus once in the outer SELECT's `hasError` expression — 3 total.
+		expect(sql.match(/StatusCode = 'Error'/g)).toHaveLength(3)
+	})
+
+	it("includes the cursor in the cutoff subquery so pagination narrows the cheap scan too", () => {
+		const q = tracesListQuery({ cursor: "2024-01-01T12:00:00" })
+		const { sql } = compileCH(q, baseParams)
+		// Cursor predicate applies in both stages.
+		expect(sql.match(/Timestamp < '2024-01-01T12:00:00'/g)).toHaveLength(2)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// tracesRootListQuery
+// ---------------------------------------------------------------------------
+
+describe("tracesRootListQuery", () => {
+	it("compiles basic root list with all columns", () => {
+		const q = tracesRootListQuery({})
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("FROM traces")
+		expect(sql).toContain("TraceId AS traceId")
+		expect(sql).toContain("Timestamp AS startTime")
+		expect(sql).toContain("Timestamp AS endTime")
+		expect(sql).toContain("AS durationMicros")
+		expect(sql).toContain("AS spanCount")
+		expect(sql).toContain("AS services")
+		expect(sql).toContain("SpanName AS rootSpanName")
+		expect(sql).toContain("SpanKind AS rootSpanKind")
+		expect(sql).toContain("StatusCode AS rootSpanStatusCode")
+		expect(sql).toContain("'http.method'")
+		expect(sql).toContain("'http.route'")
+		expect(sql).toContain("'http.status_code'")
+		expect(sql).toContain("AS hasError")
+		expect(sql).toContain("ORDER BY startTime DESC")
+		expect(sql).toContain("LIMIT 25")
+		expect(sql).toContain("FORMAT JSON")
+	})
+
+	it("applies rootOnly filter (SpanKind in Server/Consumer OR ParentSpanId='')", () => {
+		const q = tracesRootListQuery({})
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("SpanKind IN ('Server', 'Consumer') OR ParentSpanId = ''")
+	})
+
+	it("applies cursor pagination", () => {
+		const q = tracesRootListQuery({ cursor: "2024-01-01T12:00:00" })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("Timestamp < '2024-01-01T12:00:00'")
+	})
+
+	it("applies offset", () => {
+		const q = tracesRootListQuery({ limit: 50, offset: 20 })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("LIMIT 50")
+		expect(sql).toContain("OFFSET 20")
+	})
+
+	it("gates the heavy column scan on a cheap cutoff subquery", () => {
+		const q = tracesRootListQuery({ limit: 100 })
+		const { sql } = compileCH(q, baseParams)
+
+		// Outer query keeps the heavy Map lookups.
+		expect(sql).toContain("'http.method'")
+		expect(sql).toContain("'http.route'")
+
+		// Cutoff subquery reads only Timestamp.
+		const cutoffMatch = sql.match(/SELECT min\(ts\) FROM \(([\s\S]*?)\)\)/)
+		expect(cutoffMatch).not.toBeNull()
+		const inner = cutoffMatch![1]!
+		expect(inner).toContain("Timestamp AS ts")
+		expect(inner).not.toContain("SpanAttributes")
+		expect(inner).not.toContain("Duration")
+		expect(inner).toContain("ORDER BY ts DESC")
+		expect(inner).toContain("LIMIT 100")
+
+		// The rootOnly predicate still applies inside the cheap scan so
+		// the cutoff matches the same population as the outer query.
+		expect(inner).toContain("SpanKind IN ('Server', 'Consumer') OR ParentSpanId = ''")
+
+		// Outer query gates on the cutoff.
+		expect(sql).toContain("Timestamp >= (SELECT min(ts) FROM (")
+	})
+
+	it("extends the cutoff limit by offset", () => {
+		const q = tracesRootListQuery({ limit: 25, offset: 75 })
+		const { sql } = compileCH(q, baseParams)
+		const cutoffMatch = sql.match(/SELECT min\(ts\) FROM \(([\s\S]*?)\)\)/)
+		expect(cutoffMatch).not.toBeNull()
+		const inner = cutoffMatch![1]!
+		expect(inner).toContain("LIMIT 100")
+	})
+
+	it("applies the same filters to both stages", () => {
+		const q = tracesRootListQuery({ serviceName: "api", errorsOnly: true })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql.match(/ServiceName = 'api'/g)).toHaveLength(2)
+		expect(sql.match(/OrgId = 'org_1'/g)).toHaveLength(2)
+		// `StatusCode = 'Error'` shows up in the WHERE of both stages (errorsOnly)
+		// plus once in the outer SELECT's `hasError` expression — 3 total.
+		expect(sql.match(/StatusCode = 'Error'/g)).toHaveLength(3)
+	})
+})

--- a/packages/query-engine/src/ch/queries/traces.ts
+++ b/packages/query-engine/src/ch/queries/traces.ts
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------
 
 import type { TracesMetric } from "../../query-engine"
+import { compileCH } from "../compile"
 import * as CH from "../expr"
 import { param } from "../param"
 import { from, type CHQuery, type ColumnAccessor } from "../query"
@@ -361,6 +362,20 @@ export interface TracesListOutput {
 	readonly resourceAttributes: Record<string, string>
 }
 
+/**
+ * Two-stage list query. The `traces` sort key is
+ * `(OrgId, ServiceName, SpanName, toDateTime(Timestamp))` — `ServiceName` and
+ * `SpanName` sit between `OrgId` and the timestamp, so `ORDER BY Timestamp DESC`
+ * is not a sort-key prefix and ClickHouse cannot read-in-order. A single-stage
+ * query therefore scans the whole window and materializes the heavy
+ * `SpanAttributes` / `ResourceAttributes` Map columns for every matching row
+ * *before* `LIMIT` discards all but N, which OOMs on busy orgs.
+ *
+ * Stage 1 reads only `Timestamp` to find the cutoff (the (limit+offset)-th
+ * newest matching timestamp). Stage 2 gates on `Timestamp >= cutoff`, so the
+ * heavy columns are materialized only for the small slice of rows at/after the
+ * cutoff. The outer `LIMIT` / `OFFSET` trims any ties at the cutoff timestamp.
+ */
 export function tracesListQuery(opts: TracesListOpts) {
 	const limit = opts.limit ?? 25
 	const offset = opts.offset ?? 0
@@ -389,6 +404,26 @@ export function tracesListQuery(opts: TracesListOpts) {
 
 	const cursor = opts.cursor
 
+	const baseWhere = (
+		$: ColumnAccessor<typeof Traces.columns>,
+	): Array<CH.Condition | undefined> => [
+		...buildWhereConditions($, opts),
+		CH.when(cursor, (v: string) => $.Timestamp.lt(v)),
+	]
+
+	// Stage 1: cheap scan — only `Timestamp` is read. Compiled with placeholders
+	// intact ({} params) so the outer `CH.compile()` substitutes them once.
+	// Limit is `limit + offset` so the cutoff covers every row the outer query
+	// might examine, not just the slice it returns.
+	const cutoffInner = from(Traces)
+		.select(($) => ({ ts: $.Timestamp }))
+		.where(baseWhere)
+		.orderBy(["ts", "desc"])
+		.limit(limit + offset)
+	const cutoffSql = compileCH(cutoffInner, {}, { skipFormat: true }).sql
+	const cutoff = CH.rawExpr<string>(`(SELECT min(ts) FROM (${cutoffSql}))`)
+
+	// Stage 2: heavy columns read only for rows at/after the cutoff timestamp.
 	let q = from(Traces)
 		.select(($) => ({
 			traceId: $.TraceId,
@@ -403,7 +438,7 @@ export function tracesListQuery(opts: TracesListOpts) {
 			spanAttributes: spanAttrExpr ?? $.SpanAttributes,
 			resourceAttributes: resourceAttrExpr ?? $.ResourceAttributes,
 		}))
-		.where(($) => [...buildWhereConditions($, opts), CH.when(cursor, (v: string) => $.Timestamp.lt(v))])
+		.where(($) => [...baseWhere($), $.Timestamp.gte(cutoff)])
 		.orderBy(["timestamp", "desc"])
 		.limit(limit)
 		.format("JSON")
@@ -445,12 +480,42 @@ export interface TracesRootListOutput {
 	readonly hasError: number
 }
 
+/**
+ * Two-stage root-trace list query. Same OOM avoidance as `tracesListQuery`:
+ * the `traces` sort key is `(OrgId, ServiceName, SpanName, toDateTime(Timestamp))`,
+ * so `ORDER BY Timestamp DESC` can't read-in-order. The single-stage form
+ * materializes `SpanAttributes['http.method']` / `['http.route']` /
+ * `['http.status_code']` Map lookups for every matching span before `LIMIT`
+ * discards them.
+ *
+ * Stage 1 scans only `Timestamp` under the same WHERE (including `rootOnly`)
+ * to find the (limit+offset)-th newest cutoff. Stage 2 reads the heavy
+ * Map-lookup columns only for rows at/after the cutoff.
+ */
 export function tracesRootListQuery(opts: TracesRootListOpts) {
 	const limit = opts.limit ?? 25
 	const offset = opts.offset ?? 0
 
 	const cursor = opts.cursor
 
+	const baseWhere = (
+		$: ColumnAccessor<typeof Traces.columns>,
+	): Array<CH.Condition | undefined> => [
+		...buildWhereConditions($, { ...opts, rootOnly: true }),
+		CH.when(cursor, (v: string) => $.Timestamp.lt(v)),
+	]
+
+	// Stage 1: cheap scan — only `Timestamp` is read, sharing the same WHERE
+	// (rootOnly included) as the outer heavy query.
+	const cutoffInner = from(Traces)
+		.select(($) => ({ ts: $.Timestamp }))
+		.where(baseWhere)
+		.orderBy(["ts", "desc"])
+		.limit(limit + offset)
+	const cutoffSql = compileCH(cutoffInner, {}, { skipFormat: true }).sql
+	const cutoff = CH.rawExpr<string>(`(SELECT min(ts) FROM (${cutoffSql}))`)
+
+	// Stage 2: heavy SpanAttributes lookups read only for rows at/after the cutoff.
 	let q = from(Traces)
 		.select(($) => ({
 			traceId: $.TraceId,
@@ -467,10 +532,7 @@ export function tracesRootListQuery(opts: TracesRootListOpts) {
 			rootHttpStatusCode: $.SpanAttributes.get("http.status_code"),
 			hasError: CH.if_($.StatusCode.eq("Error"), CH.lit(1), CH.lit(0)),
 		}))
-		.where(($) => [
-			...buildWhereConditions($, { ...opts, rootOnly: true }),
-			CH.when(cursor, (v: string) => $.Timestamp.lt(v)),
-		])
+		.where(($) => [...baseWhere($), $.Timestamp.gte(cutoff)])
 		.orderBy(["startTime", "desc"])
 		.limit(limit)
 		.format("JSON")


### PR DESCRIPTION
## What & Why

`tracesListQuery` and `tracesRootListQuery` had the same ClickHouse OOM anti-pattern that was just fixed in `logsListQuery` ([fc4761f75](https://github.com/Makisuo/maple/commit/fc4761f75)).

The `traces` sort key is `(OrgId, ServiceName, SpanName, toDateTime(Timestamp))` ([datasources.ts:213](https://github.com/Makisuo/maple/blob/main/packages/domain/src/tinybird/datasources.ts#L213)). Because `ServiceName` and `SpanName` sit between `OrgId` and `Timestamp`, `ORDER BY Timestamp DESC` is **not** a sort-key prefix — ClickHouse cannot read-in-order, so it scans the whole org+time window and materializes the heavy `SpanAttributes` / `ResourceAttributes` `Map(LowCardinality(String), String)` columns for **every** matching span before `LIMIT` discards all but N. Busy orgs hit the memory limit and the query OOMs.

## Fix

Two-stage query, mirroring [`logsListQuery`](packages/query-engine/src/ch/queries/logs.ts):

1. **Extract `baseWhere`** so stage 1 and stage 2 filter identically (including `cursor` and, for the root variant, `rootOnly`).
2. **Stage 1** — cheap scan: `SELECT Timestamp AS ts FROM traces WHERE … ORDER BY ts DESC LIMIT (limit + offset)`, compiled via `compileCH(inner, {}, { skipFormat: true })` so the outer compile substitutes params once.
   - **Only delta from `logsListQuery`:** `LIMIT (limit + offset)`, not just `LIMIT limit`. Traces support `OFFSET` for paging; the cutoff must cover every row the outer `OFFSET` will skip past, not just the slice returned.
3. **Stage 2** — heavy projection retained but gated on `Timestamp >= (SELECT min(ts) FROM (<cutoffSql>))`, so the Map columns / `SpanAttributes.get('http.method' …)` lookups in the root variant materialize only for rows at/after the cutoff.

## Tests

New file [packages/query-engine/src/ch/queries/traces.test.ts](packages/query-engine/src/ch/queries/traces.test.ts) — 17 tests mirroring the new `logsListQuery` tests:

- Basic SELECT shape and `FORMAT JSON`
- Cursor pagination, offset, custom limit
- Filter composition (serviceName, spanName, errorsOnly)
- Attribute-key projection (`columns: ["spanAttributes.http.method", …]`)
- **Cutoff subquery shape** — `Timestamp`-only SELECT, `ORDER BY ts DESC`, `LIMIT = limit + offset`, no `SpanAttributes` / `Duration` materialization
- **`rootOnly` predicate inside the cutoff** for the root variant (so the cheap scan matches the same population as the outer query)
- Filters applied identically across both stages (including the cursor predicate, so paginated queries narrow the cheap scan too)

## Verification

- `bun run test` in `packages/query-engine` — **15 files, 350 tests, all pass**
- `bun typecheck` — all touched packages type-check cleanly (the unrelated `@maple/api` `@maple-dev/effect-sdk/cloudflare` error reproduces on a clean `main`)

## Reviewer notes

- No behavior change for callers — same return shape, same filter semantics, same pagination contract.
- The cutoff subquery uses `CH.rawExpr` because the DSL has no first-class subquery helper for `(SELECT min(ts) FROM (…))`. Same approach as `logsListQuery`.
- This change touches only `tracesListQuery` and `tracesRootListQuery`. `tracesTimeseriesQuery` / `tracesBreakdownQuery` aggregate up front so they don't carry heavy per-row projections — no fix needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)