### PR TITLE
feat: use ChartSkeleton on main dashboard

### DIFF
--- a/apps/web/src/components/dashboard/metrics-grid.tsx
+++ b/apps/web/src/components/dashboard/metrics-grid.tsx
@@ -1,8 +1,8 @@
 import { Suspense, type ReactNode } from "react"
 
 import { cn } from "@maple/ui/utils"
-import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { getChartById } from "@maple/ui/components/charts/registry"
+import { ChartSkeleton } from "@maple/ui/components/charts/_shared/chart-skeleton"
 import type {
 	ChartLegendMode,
 	ChartReferenceLine,
@@ -64,9 +64,9 @@ export function MetricsGrid({ items, className, waiting, syncId }: MetricsGridPr
 							footer={item.footer}
 						>
 							{item.isLoading ? (
-								<Skeleton className="h-full w-full" />
+								<ChartSkeleton variant={entry.category} />
 							) : (
-								<Suspense fallback={<Skeleton className="h-full w-full" />}>
+								<Suspense fallback={<ChartSkeleton variant={entry.category} />}>
 									<ChartComponent
 										data={item.data}
 										className="h-full w-full aspect-auto"


### PR DESCRIPTION
Swap the generic `Skeleton` placeholders in `MetricsGrid` for the category-aware `ChartSkeleton` already used by the dashboard-builder widgets, so the main dashboard's loading state matches what saved dashboards show.

## Change

Only one file touched: [`apps/web/src/components/dashboard/metrics-grid.tsx`](../blob/feat/dashboard-chart-skeleton/apps/web/src/components/dashboard/metrics-grid.tsx).

- Drop the `Skeleton` import.
- Import `ChartSkeleton` from `@maple/ui/components/charts/_shared/chart-skeleton`.
- Replace both `<Skeleton className="h-full w-full" />` usages (the `item.isLoading` branch + the `<Suspense>` fallback) with `<ChartSkeleton variant={entry.category} />`. `entry` was already in scope from the existing `getChartById(item.chartId)` call.

This mirrors the pattern `ChartWidget` already uses in the dashboard-builder.

## Result per card

| Card           | `chartId`         | Variant |
| -------------- | ----------------- | ------- |
| Request Volume | `throughput-area` | `area`  |
| Error Rate     | `error-rate-area` | `area`  |
| Latency        | `latency-line`    | `line`  |
| Log Volume     | `throughput-area` | `area`  |

## Verified

- All four cards render `[data-slot="chart-skeleton"]` during the initial load, with correct path counts (area = 2 paths + 1 filled + animated trend; line = 1 path + 0 filled + animated trend).
- Real charts still fade in via the existing `<Suspense>` boundary once data resolves.
- No related console errors. `syncId="home-overview"` cross-hover behavior is unchanged.

## Not in scope

`ServiceUsageCards` still uses the small `Skeleton` typography placeholders for the stat-card title/icon/number/delta — those aren't chart loading states and `ChartSkeleton` has no matching variant. Leaving for a future card-stat skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)