### PR TITLE
fix(web): scope vitest include to src/, exclude Playwright perf suite

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import path from "node:path"
 import { defineConfig, loadEnv } from "vite"
 import { devtools } from "@tanstack/devtools-vite"
@@ -51,6 +52,11 @@ export default defineConfig(({ mode }) => {
 
 	return {
 		envDir,
+		// Keep the Playwright perf suite (perf/*.perf.spec.ts) out of the Vitest
+		// run — it's executed separately via `bun run test:perf`.
+		test: {
+			include: ["src/**/*.test.{ts,tsx}"],
+		},
 		resolve: {
 			tsconfigPaths: true,
 		},


### PR DESCRIPTION
## Problem

CI has been red on `main` (and the prior two commits). The failing job is `@maple/web#test`:

```
FAIL  perf/service-map.perf.spec.ts
Error: Playwright Test did not expect test() to be called here.
 Test Files  1 failed | 42 passed (43)
```

`apps/web`'s `test` script runs `vitest run`, but the config had no `test.include`. Vitest's default globs (`**/*.{test,spec}.?(c|m)[jt]s?(x)`) therefore collected the new Playwright perf spec `perf/service-map.perf.spec.ts` (added alongside the canvas service-map work), whose `@playwright/test` `test()` blows up under the Vitest runner.

## Fix

Scope Vitest's `include` to `src/**/*.test.{ts,tsx}` — matching the `apps/api/vitest.config.ts` convention. All 42 real web test files live under `src/`; the only test-shaped file outside it is the Playwright perf suite, which still runs separately via `bun run test:perf` (and `playwright.config.ts`'s `testDir: "./perf"`).

## Verification

- `bun run test` in `apps/web` → **42 files / 343 tests passed** (perf spec no longer collected)
- `bun run typecheck` in `apps/web` → clean