### PR TITLE
fix(docker): build workspace deps before web bundle + bump bun to 1.3.11

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,5 @@
 # Build context: monorepo root (.)
-FROM oven/bun:1.3.8 AS base
+FROM oven/bun:1.3.11 AS base
 WORKDIR /app
 
 FROM base AS pruner
@@ -16,7 +16,7 @@ RUN bun install
 COPY --from=pruner /app/out/full/ ./
 RUN bunx turbo typecheck
 
-FROM oven/bun:1.3.8-slim AS runner
+FROM oven/bun:1.3.11-slim AS runner
 WORKDIR /app
 
 COPY --from=installer --chown=bun:bun /app /app

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 # Build context: monorepo root (.)
-FROM oven/bun:1.3.8 AS base
+FROM oven/bun:1.3.11 AS base
 WORKDIR /app
 
 FROM base AS pruner
@@ -14,6 +14,10 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 RUN bun install
 COPY --from=pruner /app/out/full/ ./
+
+# Build workspace dependencies that publish from dist/
+RUN bun run --cwd packages/browser build && \
+    bun run --cwd lib/effect-sdk build
 
 # Build-time env vars (baked into the SPA bundle)
 ARG VITE_API_BASE_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,6 @@ services:
         env_file: .env
         environment:
             PORT: 3472
-        depends_on:
-            otel-collector:
-                condition: service_started
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:3472/health"]
             interval: 10s

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
 	"scripts": {
 		"build": "turbo build",
 		"dev": "turbo dev --ui=tui",
+		"docker:build": "COMPOSE_PARALLEL_LIMIT=1 docker compose build",
+		"docker:up": "COMPOSE_PARALLEL_LIMIT=1 docker compose up --build",
 		"dev:alerting": "bun --filter=@maple/alerting dev",
 		"format": "oxfmt && oxlint --ignore-pattern '.context/**' --fix",
 		"alchemy:build-deps": "turbo build --filter=@maple-dev/effect-sdk --filter=@maple-dev/browser",


### PR DESCRIPTION
## Summary

- `@maple-dev/browser` and `@maple-dev/effect-sdk` both export from `dist/` which is gitignored. Without an explicit build step, Rolldown can't resolve their imports and `docker compose up --build` fails for the web service with:
  ```
  Error: [vite]: Rolldown failed to resolve import "@maple-dev/browser" from "main.tsx"
  ```
- Bumps the bun base image from `1.3.8` to `1.3.11` across `api` and `web` Dockerfiles
- Removes the `otel-collector` `depends_on` from the `api` service (causes a circular startup problem)
- Adds `docker:build` and `docker:up` convenience scripts to root `package.json`

## Test plan

- [ ] `docker compose build` completes without error
- [ ] `docker compose up` starts all services
- [ ] `curl http://localhost:3471` returns `200 OK` from the web service