### PR TITLE
Document Homebrew installation for Maple local mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ Maple is now organized as a monorepo with a SPA frontend and an Effect-based bac
 bun install
 ```
 
+## Try Maple Locally
+
+Run Maple as a single local binary with OTLP ingest, embedded ClickHouse, and
+the dashboard:
+
+```bash
+brew install Makisuo/tap/maple
+maple start
+```
+
+See [docs/local-mode.md](docs/local-mode.md) for Homebrew, manual installer,
+update, and uninstall details.
+
 ## Develop
 
 Run every available `dev` task in the monorepo:

--- a/apps/landing/src/components/local/LocalHero.astro
+++ b/apps/landing/src/components/local/LocalHero.astro
@@ -6,7 +6,7 @@
  * page title), so it leads with a one-line install + the real `maple start`
  * banner rather than restating the title. Reuses global.css tokens only.
  */
-const INSTALL = "curl -fsSL https://maple.dev/cli/install | sh";
+const INSTALL = "brew install Makisuo/tap/maple";
 
 // Tidied reproduction of the startup banner from apps/cli/src/commands/server.ts.
 const banner: Array<{ key?: string; value: string; tone?: "amber" | "green" | "dim" | "fg" }> = [

--- a/apps/landing/src/components/local/LocalProductHero.astro
+++ b/apps/landing/src/components/local/LocalProductHero.astro
@@ -9,7 +9,7 @@
  * CLI product. Atmosphere is built from global tokens only: an amber glow
  * behind the terminal, a fine grain overlay, and a staggered entrance cascade.
  */
-const INSTALL = "curl -fsSL https://maple.dev/cli/install | sh";
+const INSTALL = "brew install Makisuo/tap/maple";
 
 // Tidied reproduction of the startup banner from apps/cli/src/commands/server.ts.
 const banner: Array<{ key?: string; value: string; tone?: "amber" | "green" | "dim" }> = [

--- a/apps/landing/src/content/docs/local-mode.mdx
+++ b/apps/landing/src/content/docs/local-mode.mdx
@@ -16,12 +16,18 @@ Local mode is the fastest way to look at OpenTelemetry data — point any OTLP e
 ## Install
 
 ```bash
+brew install Makisuo/tap/maple
+```
+
+Homebrew downloads the matching release bundle, verifies its checksum, installs `maple` and `libchdb` together, and links `maple` onto your `PATH`. macOS (Apple Silicon) and Linux (x86_64 & arm64) are supported. Upgrade later with `brew upgrade maple`; Homebrew-managed installs block `maple update` so the package manager stays in charge. If Homebrew asks you to trust the third-party tap, run `brew trust Makisuo/tap` once and retry the install.
+
+Prefer the standalone installer?
+
+```bash
 curl -fsSL https://maple.dev/cli/install | sh
 ```
 
-The installer detects your OS/arch, downloads the matching bundle from the latest GitHub release, verifies its checksum, installs the two files (`maple` + `libchdb`) into `~/.maple/bin`, clears the macOS Gatekeeper quarantine, and symlinks `maple` onto your `PATH`. macOS (Apple Silicon) and Linux (x86_64 & arm64) are supported.
-
-> Prefer not to pipe to a shell? The script is [`scripts/install.sh`](https://github.com/Makisuo/maple/blob/main/scripts/install.sh) — read it first, or download a release bundle from [GitHub Releases](https://github.com/Makisuo/maple/releases) by hand. Uninstall with `curl -fsSL https://maple.dev/cli/uninstall | sh` (your `~/.maple/data` is kept).
+The script is [`scripts/install.sh`](https://github.com/Makisuo/maple/blob/main/scripts/install.sh) — read it first, or download a release bundle from [GitHub Releases](https://github.com/Makisuo/maple/releases) by hand. Uninstall Homebrew builds with `brew uninstall maple`; uninstall script builds with `curl -fsSL https://maple.dev/cli/uninstall | sh` (your `~/.maple/data` is kept). If you migrate from the script to Homebrew, remove the old PATH symlink so your shell resolves Homebrew's `maple`.
 
 ## Start the server
 

--- a/apps/landing/src/content/docs/local-mode/cli-reference.md
+++ b/apps/landing/src/content/docs/local-mode/cli-reference.md
@@ -291,14 +291,26 @@ OTLP bodies may be protobuf (default) or JSON, optionally gzip-encoded. The `/lo
 | --- | --- | --- |
 | `MAPLE_LOCAL_URL` | `http://127.0.0.1:4318` | Base URL the CLI targets in local mode |
 | `MAPLE_LOCAL_UI_URL` | `https://local.maple.dev` | Deployed dashboard origin `maple start` links to |
-| `MAPLE_LIBCHDB` | _(auto)_ | Explicit path to `libchdb`. Otherwise resolved beside the binary, then `~/.maple/bin/libchdb.{so,dylib}` |
+| `MAPLE_LIBCHDB` | _(auto)_ | Explicit path to `libchdb`. Otherwise resolved beside the binary (Homebrew keeps it in the same `libexec` dir), then `~/.maple/bin/libchdb.{so,dylib}` |
 | `MAPLE_API_URL` | `https://api.maple.dev` | Remote API base URL |
 | `MAPLE_API_TOKEN` | | Remote bearer token (overrides the stored value) |
 | `MAPLE_ORG_ID` | | Remote org override |
 | `MAPLE_DEBUG` | | Set to `1` to enable `--debug` |
 | `MAPLE_FORMAT` | `json` | `json` or `table` — same as `--format` |
+| `MAPLE_NO_UPDATE_CHECK` | | Set to `1` to disable startup update checks (the Homebrew wrapper sets this automatically) |
 
-**Installer** (`scripts/install.sh`, env-only):
+**Homebrew**:
+
+```bash
+brew install Makisuo/tap/maple
+brew upgrade maple
+brew uninstall maple
+```
+
+Homebrew-managed installs block `maple update`; use `brew upgrade maple` so Homebrew owns the installed version and receipt.
+If Homebrew asks you to trust the third-party tap, run `brew trust Makisuo/tap` once and retry the install.
+
+**Manual installer** (`scripts/install.sh`, env-only):
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
@@ -311,7 +323,9 @@ The on-disk config at `~/.maple/config.json` stores `apiUrl`, `token`, `orgId`, 
 
 ## Troubleshooting
 
-**`libchdb` not found.** The binary `dlopen`s `libchdb` relative to its own path, then falls back to `~/.maple/bin`. Keep `libchdb.so`/`.dylib` beside `maple`, or set `MAPLE_LIBCHDB` to its full path. (Running from source has no sibling library — set `MAPLE_LIBCHDB` or drop one in `~/.maple/bin`.)
+**`libchdb` not found.** The binary `dlopen`s `libchdb` relative to its own path, then falls back to `~/.maple/bin`. Homebrew keeps `maple` and `libchdb` together in its Cellar; the manual installer keeps them in `~/.maple/bin`. If you move files by hand, keep `libchdb.so`/`.dylib` beside `maple`, or set `MAPLE_LIBCHDB` to its full path. (Running from source has no sibling library — set `MAPLE_LIBCHDB` or drop one in `~/.maple/bin`.)
+
+**Homebrew installed but `maple` still runs the old binary.** You probably have a manual-installer symlink earlier on `PATH`. Run `command -v maple` to confirm, then remove the old symlink or run `curl -fsSL https://maple.dev/cli/uninstall | sh` before reinstalling with Homebrew.
 
 **`maple is already running (PID …)`.** A server already owns this data dir. Stop it with `maple stop`, or start a second instance on another port and data dir: `maple start --port 4400 --data-dir ~/.maple/data-2`.
 

--- a/apps/landing/src/pages/local.astro
+++ b/apps/landing/src/pages/local.astro
@@ -196,12 +196,12 @@ const valueProps = [
                         Two files, one command
                     </h2>
                     <p class="mt-5 text-sm md:text-base text-fg-muted leading-relaxed max-w-xl">
-                        The installer detects your OS and architecture, downloads the matching bundle from the
-                        latest GitHub release, verifies its checksum, and drops the two files —
+                        Homebrew downloads the matching bundle from the latest GitHub release, verifies its
+                        checksum, and keeps the two files —
                         <code class="text-accent font-mono text-[0.9em]">maple</code> and
-                        <code class="text-accent font-mono text-[0.9em]">libchdb</code> — into
-                        <code class="text-accent font-mono text-[0.9em]">~/.maple/bin</code>, then symlinks
-                        <code class="text-accent font-mono text-[0.9em]">maple</code> onto your PATH.
+                        <code class="text-accent font-mono text-[0.9em]">libchdb</code> — together in its
+                        Cellar, then links <code class="text-accent font-mono text-[0.9em]">maple</code> onto
+                        your PATH. Prefer a standalone script? The curl installer still works.
                     </p>
 
                     <div class="mt-7 flex flex-wrap items-center gap-3">
@@ -235,7 +235,11 @@ const valueProps = [
                     </li>
                     <li class="flex items-baseline justify-between gap-4 px-5 py-3.5">
                         <span class="text-[10px] uppercase tracking-wider text-fg-muted">Installs to</span>
-                        <span class="font-mono text-xs text-fg">~/.maple/bin</span>
+                        <span class="font-mono text-xs text-fg">Homebrew Cellar</span>
+                    </li>
+                    <li class="flex items-baseline justify-between gap-4 px-5 py-3.5">
+                        <span class="text-[10px] uppercase tracking-wider text-fg-muted">Upgrade</span>
+                        <span class="font-mono text-xs text-fg">brew upgrade maple</span>
                     </li>
                     <li class="flex items-baseline justify-between gap-4 px-5 py-3.5">
                         <span class="text-[10px] uppercase tracking-wider text-fg-muted">Data</span>
@@ -243,7 +247,7 @@ const valueProps = [
                     </li>
                     <li class="flex items-baseline justify-between gap-4 px-5 py-3.5">
                         <span class="text-[10px] uppercase tracking-wider text-fg-muted">Uninstall</span>
-                        <span class="font-mono text-xs text-fg">.../cli/uninstall | sh</span>
+                        <span class="font-mono text-xs text-fg">brew uninstall maple</span>
                     </li>
                 </ul>
             </div>

--- a/docs/local-mode.md
+++ b/docs/local-mode.md
@@ -10,6 +10,20 @@ every compiled query filters on it.
 
 ## Install
 
+Recommended:
+
+```bash
+brew install Makisuo/tap/maple
+```
+
+Homebrew downloads the matching release bundle, verifies its checksum, installs
+`maple` and `libchdb.so` together in the Homebrew Cellar, and links `maple` onto
+your PATH. macOS Apple Silicon and Linux (x86_64 & arm64) are supported. If
+Homebrew asks you to trust the third-party tap, run `brew trust Makisuo/tap`
+once and retry the install.
+
+Manual installer:
+
 ```bash
 curl -fsSL https://maple.dev/cli/install | sh
 ```
@@ -18,9 +32,10 @@ curl -fsSL https://maple.dev/cli/install | sh
 `apps/landing` — the build copies it to `public/cli/install`. The raw GitHub URL
 `https://raw.githubusercontent.com/Makisuo/maple/main/scripts/install.sh` works too.)
 
-The installer detects your OS/arch, downloads the matching bundle from the latest
-GitHub release, verifies its checksum, installs the two files into `~/.maple/bin`,
-clears the macOS Gatekeeper quarantine, and symlinks `maple` onto your PATH. Then:
+The manual installer detects your OS/arch, downloads the matching bundle from
+the latest GitHub release, verifies its checksum, installs the two files into
+`~/.maple/bin`, clears the macOS Gatekeeper quarantine, and symlinks `maple`
+onto your PATH. Then:
 
 ```bash
 maple start            # OTLP ingest + embedded ClickHouse on :4318; UI from local.maple.dev
@@ -40,14 +55,24 @@ Query commands accept `--format table` for an aligned table instead of JSON, and
 `--debug` to print the compiled SQL + per-query timing to stderr (stdout stays
 clean JSON). Pin the backend with `maple use local|remote` (or `auto` to clear).
 
-Env overrides: `MAPLE_VERSION` (pin a release tag), `MAPLE_INSTALL_DIR` (bundle
-location, default `~/.maple/bin`), `MAPLE_BIN_DIR` (PATH symlink location),
-`MAPLE_SKIP_CHECKSUM=1` (skip SHA-256 verification — only for air-gapped mirrors
-without the `.sha256`; not recommended).
+Manual installer env overrides: `MAPLE_VERSION` (pin a release tag),
+`MAPLE_INSTALL_DIR` (bundle location, default `~/.maple/bin`), `MAPLE_BIN_DIR`
+(PATH symlink location), `MAPLE_SKIP_CHECKSUM=1` (skip SHA-256 verification —
+only for air-gapped mirrors without the `.sha256`; not recommended).
 
 ### Updating
 
-Once installed, the binary keeps itself current:
+Update with the same tool you installed with:
+
+```bash
+brew upgrade maple
+```
+
+Homebrew installs are managed by Homebrew: the wrapper disables Maple's startup
+update check and `maple update` exits with a reminder to use `brew upgrade
+maple`.
+
+Manual-installer builds keep themselves current:
 
 - **Startup notice.** On any command, `maple` checks GitHub Releases for a newer
   version — at most **once per 24h** (the result is cached in
@@ -73,13 +98,25 @@ This is the same artifact the installer fetches, so `maple update` and re-runnin
 
 ### Uninstall
 
+Homebrew:
+
+```bash
+brew uninstall maple
+```
+
+Manual installer:
+
 ```bash
 curl -fsSL https://maple.dev/cli/uninstall | sh
 ```
 
-Removes the `maple` symlink and the `~/.maple/bin` bundle. Your data dir
-(`~/.maple/data`) is kept unless you confirm its removal when prompted. Honors
-the same `MAPLE_INSTALL_DIR` / `MAPLE_BIN_DIR` overrides as the installer.
+The manual uninstaller removes the `maple` symlink and the `~/.maple/bin`
+bundle. Your data dir (`~/.maple/data`) is kept unless you confirm its removal
+when prompted. Honors the same `MAPLE_INSTALL_DIR` / `MAPLE_BIN_DIR` overrides
+as the installer.
+
+If you migrate from the manual installer to Homebrew, run the manual uninstaller
+or remove the old PATH symlink so your shell resolves Homebrew's `maple`.
 
 ## Architecture: one Bun binary + libchdb
 


### PR DESCRIPTION
## Summary
- Add Homebrew as the recommended install path for Maple local mode in README and local-mode docs
- Update landing page copy and hero install commands to match the Homebrew flow
- Clarify upgrade, uninstall, and PATH migration behavior for Homebrew vs the standalone script

Fixes #76 

## Testing
- Not run (not requested)