### PR TITLE
fix(api): pin warehouse ingest to Tinybird (demo-seed onboarding outage)

### DIFF
--- a/apps/api/src/lib/WarehouseQueryService.test.ts
+++ b/apps/api/src/lib/WarehouseQueryService.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 
 const createTempDbUrl = () => makeTempDb("maple-warehouse-", createdTempDirs)
 
-const makeConfig = (url: string) =>
+const makeConfig = (url: string, extra: Record<string, string> = {}) =>
 	ConfigProvider.layer(
 		ConfigProvider.fromUnknown({
 			PORT: "3472",
@@ -39,11 +39,12 @@ const makeConfig = (url: string) =>
 			MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: "lookup-key",
 			MAPLE_INGEST_PUBLIC_URL: "http://127.0.0.1:3474",
 			MAPLE_APP_BASE_URL: "http://127.0.0.1:3471",
+			...extra,
 		}),
 	)
 
-const buildLayer = (url: string) => {
-	const configLive = makeConfig(url)
+const buildLayer = (url: string, extra: Record<string, string> = {}) => {
+	const configLive = makeConfig(url, extra)
 	const envLive = Env.layer.pipe(Layer.provide(configLive))
 	const databaseLive = DatabaseLibsqlLive.pipe(Layer.provide(envLive))
 	const orgSettingsLive = OrgClickHouseSettingsService.layer.pipe(
@@ -390,12 +391,10 @@ describe("WarehouseQueryService.ingest writes through the SQL client", () => {
 	})
 })
 
-describe("createClickHouseSqlClient.insert wire framing", () => {
-	// Regression guard for the demo-seed onboarding outage: the official
-	// client.insert() puts `INSERT … FORMAT JSONEachRow` in the `?query=` URL
-	// param, which proxied ClickHouse endpoints drop — the NDJSON body is then
-	// parsed as SQL ("Syntax error at position 1 ({)"). The insert must frame the
-	// whole statement in the request BODY, like the (working) read path.
+describe("createClickHouseSqlClient.insert is disabled (ClickHouse is read-only)", () => {
+	// ClickHouse only serves reads for Maple; ingest goes to Tinybird. The CH
+	// client's insert must fail loudly so it can never silently 500 against the
+	// read-only query gateway ("Only SELECT or DESCRIBE … Got: InsertQuery").
 	const chConfig = {
 		_tag: "clickhouse" as const,
 		url: "https://ch.example.com",
@@ -404,52 +403,27 @@ describe("createClickHouseSqlClient.insert wire framing", () => {
 		database: "default",
 	}
 
-	it("sends INSERT … FORMAT JSONEachRow + rows in the body, not the ?query= param", async () => {
-		const captured: Array<{ url: string; body: string }> = []
-		const realFetch = globalThis.fetch
-		globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-			captured.push({
-				url: String(input),
-				body: typeof init?.body === "string" ? init.body : String(init?.body ?? ""),
-			})
-			return new Response("", { status: 200 })
-		}) as typeof fetch
-
-		try {
-			const client = __testables.createClickHouseSqlClient(chConfig)
-			await client.insert("traces", [{ trace_id: "a" }, { trace_id: "b" }])
-		} finally {
-			globalThis.fetch = realFetch
-		}
-
-		assert.strictEqual(captured.length, 1)
-		const req = captured[0]!
-		// The statement + data ride in the body…
-		assert.strictEqual(
-			req.body,
-			'INSERT INTO traces FORMAT JSONEachRow\n{"trace_id":"a"}\n{"trace_id":"b"}',
-		)
-		// …and NOT in the URL query string (the param the proxy drops).
-		assert.isFalse(req.url.includes("query=INSERT"))
-		assert.isFalse(req.url.toUpperCase().includes("INSERT+INTO"))
-	})
-
-	it("no-ops on an empty row set (no request issued)", async () => {
-		let calls = 0
+	it("throws — ingest must use Tinybird, never ClickHouse — and issues no request", async () => {
+		let fetched = 0
 		const realFetch = globalThis.fetch
 		globalThis.fetch = (async () => {
-			calls++
+			fetched++
 			return new Response("", { status: 200 })
 		}) as typeof fetch
 
+		let thrown: unknown
 		try {
 			const client = __testables.createClickHouseSqlClient(chConfig)
-			await client.insert("traces", [])
+			await client.insert("traces", [{ trace_id: "a" }])
+		} catch (error) {
+			thrown = error
 		} finally {
 			globalThis.fetch = realFetch
 		}
 
-		assert.strictEqual(calls, 0)
+		assert.instanceOf(thrown, Error)
+		assert.match((thrown as Error).message, /read-only|Tinybird/)
+		assert.strictEqual(fetched, 0)
 	})
 })
 
@@ -577,6 +551,48 @@ describe("ingest routes writes to the managed pipeline, not a per-org read overr
 			yield* executor.ingest(tenant, "traces", [{ trace_id: "a" }])
 			assert.deepStrictEqual(used, [{ op: "insert", tag: "tinybird" }])
 		})
+	})
+})
+
+describe("ingest pins writes to Tinybird even when CLICKHOUSE_URL makes managed reads ClickHouse", () => {
+	// Reproduces the prod incident: CLICKHOUSE_URL is set, so the managed READ
+	// backend is a read-only ClickHouse query gateway. Inserts there are rejected
+	// ("Only SELECT or DESCRIBE queries are supported. Got: InsertQuery"). Writes
+	// MUST resolve to Tinybird regardless. Routing ingest through the managed
+	// resolver (which prefers ClickHouse) is what kept demo-seed onboarding broken.
+	it.effect("reads resolve to managed ClickHouse, but ingest resolves to Tinybird", () => {
+		const used: Array<{ op: "sql" | "insert"; tag: string }> = []
+		__testables.setClientFactory((config) => ({
+			sql: async () => {
+				used.push({ op: "sql", tag: config._tag })
+				return { data: [] }
+			},
+			insert: async () => {
+				used.push({ op: "insert", tag: config._tag })
+			},
+		}))
+
+		const { url } = createTempDbUrl()
+		const layer = buildLayer(url, {
+			CLICKHOUSE_URL: "https://readonly-ch.example.com",
+			CLICKHOUSE_USER: "reader",
+			CLICKHOUSE_DATABASE: "default",
+		})
+		const tenant = makeTenant()
+
+		return Effect.gen(function* () {
+			yield* WarehouseQueryService.use((service) =>
+				service.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_test'"),
+			)
+			yield* WarehouseQueryService.use((service) =>
+				service.ingest(tenant, "traces", [{ trace_id: "a" }]),
+			)
+
+			assert.deepStrictEqual(used, [
+				{ op: "sql", tag: "clickhouse" },
+				{ op: "insert", tag: "tinybird" },
+			])
+		}).pipe(Effect.provide(layer))
 	})
 })
 

--- a/apps/api/src/lib/WarehouseQueryService.ts
+++ b/apps/api/src/lib/WarehouseQueryService.ts
@@ -51,19 +51,13 @@ const createClickHouseSqlClient = (config: ClickHouseConfig): WarehouseSqlClient
 			const data = await resultSet.json<Record<string, unknown>>()
 			return { data }
 		},
-		insert: async (datasource, rows) => {
-			if (rows.length === 0) return
-			// ClickHouse inserts must frame the statement in the request BODY, not the
-			// `?query=` URL param. The official `client.insert()` puts `INSERT INTO …
-			// FORMAT JSONEachRow` in the query param (see @clickhouse/client-web
-			// web_connection: insert() adds `query` to searchParams; query()/command()
-			// send it as the body). Managed/proxied ClickHouse endpoints drop that param,
-			// so the NDJSON body gets parsed as SQL — "Syntax error at position 1 ({)" —
-			// 500-ing every write (this broke demo-seed onboarding). The read path works
-			// because `query()` already sends SQL in the body, so we mirror it: send
-			// `INSERT … FORMAT JSONEachRow\n<ndjson>` as the body via command().
-			const ndjson = rows.map((row) => JSON.stringify(row)).join("\n")
-			await client.command({ query: `INSERT INTO ${datasource} FORMAT JSONEachRow\n${ndjson}` })
+		insert: async (_datasource, _rows) => {
+			// ClickHouse is READ-ONLY for Maple: the managed CLICKHOUSE_URL endpoint is
+			// a query gateway that rejects inserts ("Only SELECT or DESCRIBE queries are
+			// supported. Got: InsertQuery"), and a BYO org override is a read concern.
+			// All ingest goes to Tinybird's Events API (see resolveIngestConfig), so this
+			// must never be reached — fail loudly instead of silently 500'ing.
+			throw new Error("ClickHouse is read-only for Maple — ingest must use Tinybird")
 		},
 	}
 }
@@ -187,20 +181,31 @@ export class WarehouseQueryService extends Context.Service<
 
 		/**
 		 * Write-path config. Inserts (demo seed, service-map rollups, alert checks)
-		 * MUST target the managed Tinybird pipeline — never a per-org BYO ClickHouse
-		 * override. The override is a READ concern: an org queries their own
-		 * warehouse, but Maple-managed ingest only writes to the managed backend.
-		 * Routing writes through the override 500'd every insert (ClickHouse parsed
-		 * the JSON body as SQL) and broke demo-seed onboarding for any org with a
-		 * BYO ClickHouse row.
+		 * ALWAYS go to the Tinybird ingest pipeline (Events API) — never ClickHouse.
+		 *
+		 * This is deliberately NOT `resolveManagedConfig()`: when `CLICKHOUSE_URL` is
+		 * set, the *managed* backend is a READ-ONLY ClickHouse query gateway that
+		 * rejects inserts ("DB::Exception: Only SELECT or DESCRIBE queries are
+		 * supported. Got: InsertQuery"). A per-org BYO ClickHouse override is also a
+		 * read concern. Tinybird is the only writable warehouse, so ingest pins to
+		 * it unconditionally (TINYBIRD_HOST/TOKEN are required env, always present).
+		 * Routing writes anywhere else broke demo-seed onboarding.
 		 */
 		const resolveIngestConfig: WarehouseExecutorDeps["resolveConfig"] = Effect.fn(
 			"WarehouseQueryService.resolveIngestConfig",
 		)(function* (tenant, _label) {
 			yield* Effect.annotateCurrentSpan("orgId", tenant.orgId)
 			yield* Effect.annotateCurrentSpan("clientSource", "managed")
-			yield* Effect.annotateCurrentSpan("ingest.routing", "managed")
-			return yield* resolveManagedConfig()
+			yield* Effect.annotateCurrentSpan("ingest.routing", "tinybird")
+			yield* Effect.annotateCurrentSpan("db.client", "tinybird-sdk")
+			return {
+				config: {
+					_tag: "tinybird" as const,
+					host: env.TINYBIRD_HOST,
+					token: Redacted.value(env.TINYBIRD_TOKEN),
+				},
+				source: "managed" as const,
+			}
 		})
 
 		return makeWarehouseExecutor({


### PR DESCRIPTION
Demo-seed onboarding (POST /api/demo/seed) was 100% failing because WarehouseQueryService.ingest resolved to ClickHouse. In prod the managed CLICKHOUSE_URL endpoint is a read-only query gateway that rejects inserts ("DB::Exception: Only SELECT or DESCRIBE queries are supported. Got: InsertQuery"). Ingest only ever needs to work on Tinybird.

- resolveIngestConfig now returns the Tinybird config directly (Events API), never resolveManagedConfig() (which prefers ClickHouse when CLICKHOUSE_URL is set). Reads are unchanged: BYO override -> managed CH -> Tinybird.
- createClickHouseSqlClient.insert now throws instead of attempting a write — ClickHouse is read-only for Maple; ingest must use Tinybird. Drops the dead command()/FORMAT JSONEachRow body-framing.
- Tests: Tinybird insert wire format (POST /v0/events); prod-scenario routing guard (CLICKHOUSE_URL set -> reads CH, ingest Tinybird); CH insert throws.