### PR TITLE
ci: bump pullfrog action to v0.1.29

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -33,7 +33,7 @@ jobs:
               with:
                   fetch-depth: 1
             - name: Run agent
-              uses: pullfrog/pullfrog@e4e93ea6d3c787a7bc6cc285d168deb0eab7ac83 # v0
+              uses: pullfrog/pullfrog@27557aef1ccff9b9ea531324824daa1f86c066c4 # v0.1.29
               with:
                   prompt: ${{ inputs.prompt }}
               env:


### PR DESCRIPTION
## What

One-line bump of the pinned `pullfrog/pullfrog` action SHA in `.github/workflows/pullfrog.yml`: `e4e93ea6` (v0.0.205) → `27557aef` (v0.1.29, the current `v0` tag target — verified via `gh api repos/pullfrog/pullfrog/git/ref/tags/v0` before pinning).

## Why

Every Pullfrog dispatch run currently fails before doing anything:

> action failed: Payload version 0.1.29 is incompatible with action version 0.0.205. Please update your workflow to use at least 0.1.0 version of the action.

Example failed run: https://github.com/Makisuo/maple/actions/runs/27352335091

The SHA-pinned style with a version comment is kept; only the action ref changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)