### PR TITLE
[codex] Route ClickHouse-ready ingest before forwarding

### DIFF
--- a/apps/api/src/services/ErrorsService.test.ts
+++ b/apps/api/src/services/ErrorsService.test.ts
@@ -600,7 +600,7 @@ describe("ErrorsService.runTick", () => {
 			assert.lengthOf(open, 1)
 			assert.strictEqual(open[0]?.reason, "regression")
 		}).pipe(Effect.provide(makeErrorsLayer(() => rows)))
-	})
+	}, 15_000)
 
 	it.effect("a wontfix issue with an indefinite snooze is skipped entirely by the scan", () => {
 		const rows = [scanRow()]

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -140,6 +140,14 @@ impl WriteMode {
     }
 }
 
+fn uses_native_pipeline_for(write_mode: WriteMode, destination: ExportDestination) -> bool {
+    write_mode.uses_tinybird() || destination == ExportDestination::ClickHouse
+}
+
+fn uses_forward_path_for(write_mode: WriteMode, destination: ExportDestination) -> bool {
+    write_mode.uses_forward() && destination != ExportDestination::ClickHouse
+}
+
 #[derive(Clone)]
 enum KeyStoreBackend {
     // No-DB local backend: every well-formed ingest key resolves to a single
@@ -1022,26 +1030,27 @@ async fn main() {
         }
     };
 
+    let direct_clickhouse_possible = matches!(config.key_store_backend, KeyStoreBackend::D1 { .. });
     let clickhouse_target_provider: Option<Arc<dyn ClickHouseTargetProvider>> =
-        if config.write_mode.uses_tinybird() {
-            let resolver = ClickHouseTargetResolver {
+        if direct_clickhouse_possible {
+            Some(Arc::new(ClickHouseTargetResolver {
                 store: Arc::clone(&store),
                 encryption_key: config.clickhouse_encryption_key,
                 cache: Cache::builder()
                     .time_to_live(Duration::from_secs(60))
                     .max_capacity(10_000)
                     .build(),
-            };
-            Some(Arc::new(resolver))
+            }) as Arc<dyn ClickHouseTargetProvider>)
         } else {
             None
         };
 
-    let telemetry_pipeline = if config.write_mode.uses_tinybird() {
-        match TelemetryPipeline::new_with_clickhouse(
+    let telemetry_pipeline = if config.write_mode.uses_tinybird() || direct_clickhouse_possible {
+        match TelemetryPipeline::new_with_clickhouse_validation(
             config.tinybird.clone(),
             http_client.clone(),
             clickhouse_target_provider,
+            config.write_mode.uses_tinybird(),
         )
         .await
         {
@@ -1565,10 +1574,11 @@ async fn handle_replay_meta_inner(
     let destination = native_destination_for(&resolved_key);
     Span::current().record("maple.ingest.destination", destination.as_str());
 
-    let pipeline = state
-        .telemetry_pipeline
-        .as_ref()
-        .ok_or_else(|| ApiError::service_unavailable("Session replay storage is not configured"))?;
+    let pipeline = native_rows_pipeline_for(
+        state,
+        destination,
+        "Session replay storage is not configured",
+    )?;
 
     // NDJSON: one session-metadata object per line. The org_id is always taken
     // from the authenticated key, never from the client-supplied body.
@@ -1687,10 +1697,11 @@ async fn handle_session_events_inner(
     let destination = native_destination_for(&resolved_key);
     Span::current().record("maple.ingest.destination", destination.as_str());
 
-    let pipeline = state
-        .telemetry_pipeline
-        .as_ref()
-        .ok_or_else(|| ApiError::service_unavailable("Session event storage is not configured"))?;
+    let pipeline = native_rows_pipeline_for(
+        state,
+        destination,
+        "Session event storage is not configured",
+    )?;
 
     // NDJSON: one distilled session-event object per line. As with replay
     // metadata, org_id is taken from the authenticated key, never the body.
@@ -1786,10 +1797,11 @@ async fn handle_replay_blob_inner(
     let destination = native_destination_for(&resolved_key);
     Span::current().record("maple.ingest.destination", destination.as_str());
 
-    let pipeline = state
-        .telemetry_pipeline
-        .as_ref()
-        .ok_or_else(|| ApiError::service_unavailable("Session replay storage is not configured"))?;
+    let pipeline = native_rows_pipeline_for(
+        state,
+        destination,
+        "Session replay storage is not configured",
+    )?;
 
     let session_id = replay_header(headers, "x-maple-session-id")
         .ok_or_else(|| ApiError::bad_request("missing x-maple-session-id header"))?;
@@ -2949,6 +2961,20 @@ fn native_destination_for(resolved_key: &ResolvedIngestKey) -> ExportDestination
     }
 }
 
+fn native_rows_pipeline_for<'a>(
+    state: &'a AppState,
+    destination: ExportDestination,
+    unavailable_message: &'static str,
+) -> Result<&'a TelemetryPipeline, ApiError> {
+    if destination == ExportDestination::Tinybird && !state.config.write_mode.uses_tinybird() {
+        return Err(ApiError::service_unavailable(unavailable_message));
+    }
+    state
+        .telemetry_pipeline
+        .as_ref()
+        .ok_or_else(|| ApiError::service_unavailable(unavailable_message))
+}
+
 async fn forward_to_collector(
     state: &AppState,
     signal: Signal,
@@ -3075,75 +3101,17 @@ async fn process_decoded_payload(
     decoded: &DecodedPayload,
     resolved_key: &ResolvedIngestKey,
 ) -> Result<Response, ApiError> {
-    if state.config.write_mode.uses_tinybird() {
-        let destination = native_destination_for(resolved_key);
-        Span::current().record("maple.ingest.destination", destination.as_str());
-        let pipeline = state
-            .telemetry_pipeline
-            .as_ref()
-            .ok_or_else(|| ApiError::service_unavailable("Telemetry pipeline is not configured"))?;
-        let native_start = Instant::now();
-        let stats = match decoded {
-            DecodedPayload::Traces(request) => {
-                let policy = state
-                    .sampling_resolver
-                    .resolve_policy(&resolved_key.org_id)
-                    .await;
-                let attribute_mappings = state
-                    .attribute_mapping_resolver
-                    .resolve_mappings(&resolved_key.org_id)
-                    .await;
-                pipeline
-                    .accept_traces_to(
-                        &resolved_key.org_id,
-                        request,
-                        &policy,
-                        attribute_mappings.as_slice(),
-                        destination,
-                    )
-                    .await
-            }
-            DecodedPayload::Logs(request) => {
-                pipeline
-                    .accept_logs_to(&resolved_key.org_id, request, destination)
-                    .await
-            }
-            DecodedPayload::Metrics(request) => {
-                pipeline
-                    .accept_metrics_to(&resolved_key.org_id, request, destination)
-                    .await
-            }
+    let destination = native_destination_for(resolved_key);
+    Span::current().record("maple.ingest.destination", destination.as_str());
+
+    if uses_native_pipeline_for(state.config.write_mode, destination) {
+        accept_native_decoded_payload(state, signal, decoded, resolved_key, destination).await?;
+        if destination == ExportDestination::ClickHouse {
+            return Ok(StatusCode::OK.into_response());
         }
-        .map_err(|error| {
-            let api_error = match &error {
-                PipelineError::Throttled(_) => {
-                    ApiError::too_many_requests("Per-org ingest queue limit exceeded")
-                }
-                PipelineError::Backpressure(_) => {
-                    ApiError::service_unavailable("Telemetry backend unavailable")
-                }
-                PipelineError::QueueUnavailable(_) | PipelineError::Encode(_) => {
-                    ApiError::service_unavailable("Telemetry backend unavailable")
-                }
-            };
-            error!(
-                error = %error,
-                signal = signal.path(),
-                org_id = %resolved_key.org_id,
-                "Native telemetry pipeline rejected payload"
-            );
-            api_error
-        })?;
-        metrics::native_accept_duration(signal.path(), native_start.elapsed().as_secs_f64());
-        metrics::native_rows(signal.path(), stats.rows as u64);
-        if stats.dropped > 0 {
-            metrics::native_sampled_dropped(signal.path(), stats.dropped as u64);
-        }
-        Span::current().record("maple.ingest.native_rows", stats.rows as u64);
-        Span::current().record("maple.ingest.sampled_dropped", stats.dropped as u64);
     }
 
-    if state.config.write_mode.uses_forward() {
+    if uses_forward_path_for(state.config.write_mode, destination) {
         let outbound_payload = decoded.encode(payload_format)?;
         let outbound_body = encode_payload(&outbound_payload, content_encoding)?;
         let outbound_bytes = outbound_body.len();
@@ -3161,6 +3129,79 @@ async fn process_decoded_payload(
     }
 
     Ok(StatusCode::OK.into_response())
+}
+
+async fn accept_native_decoded_payload(
+    state: &AppState,
+    signal: Signal,
+    decoded: &DecodedPayload,
+    resolved_key: &ResolvedIngestKey,
+    destination: ExportDestination,
+) -> Result<(), ApiError> {
+    let pipeline = state
+        .telemetry_pipeline
+        .as_ref()
+        .ok_or_else(|| ApiError::service_unavailable("Telemetry pipeline is not configured"))?;
+    let native_start = Instant::now();
+    let stats = match decoded {
+        DecodedPayload::Traces(request) => {
+            let policy = state
+                .sampling_resolver
+                .resolve_policy(&resolved_key.org_id)
+                .await;
+            let attribute_mappings = state
+                .attribute_mapping_resolver
+                .resolve_mappings(&resolved_key.org_id)
+                .await;
+            pipeline
+                .accept_traces_to(
+                    &resolved_key.org_id,
+                    request,
+                    &policy,
+                    attribute_mappings.as_slice(),
+                    destination,
+                )
+                .await
+        }
+        DecodedPayload::Logs(request) => {
+            pipeline
+                .accept_logs_to(&resolved_key.org_id, request, destination)
+                .await
+        }
+        DecodedPayload::Metrics(request) => {
+            pipeline
+                .accept_metrics_to(&resolved_key.org_id, request, destination)
+                .await
+        }
+    }
+    .map_err(|error| {
+        let api_error = match &error {
+            PipelineError::Throttled(_) => {
+                ApiError::too_many_requests("Per-org ingest queue limit exceeded")
+            }
+            PipelineError::Backpressure(_) => {
+                ApiError::service_unavailable("Telemetry backend unavailable")
+            }
+            PipelineError::QueueUnavailable(_) | PipelineError::Encode(_) => {
+                ApiError::service_unavailable("Telemetry backend unavailable")
+            }
+        };
+        error!(
+            error = %error,
+            signal = signal.path(),
+            org_id = %resolved_key.org_id,
+            "Native telemetry pipeline rejected payload"
+        );
+        api_error
+    })?;
+    metrics::native_accept_duration(signal.path(), native_start.elapsed().as_secs_f64());
+    metrics::native_rows(signal.path(), stats.rows as u64);
+    if stats.dropped > 0 {
+        metrics::native_sampled_dropped(signal.path(), stats.dropped as u64);
+    }
+    Span::current().record("maple.ingest.native_rows", stats.rows as u64);
+    Span::current().record("maple.ingest.sampled_dropped", stats.dropped as u64);
+    Ok(())
 }
 
 impl IngestKeyResolver {
@@ -4254,6 +4295,42 @@ mod tests {
         let (endpoint, pool) = select_forward_endpoint("http://shared:4318", None, true);
         assert_eq!(endpoint, "http://shared:4318");
         assert_eq!(pool, "shared");
+    }
+
+    #[test]
+    fn clickhouse_destination_uses_native_pipeline_even_in_forward_mode() {
+        assert!(uses_native_pipeline_for(
+            WriteMode::Forward,
+            ExportDestination::ClickHouse
+        ));
+        assert!(!uses_forward_path_for(
+            WriteMode::Forward,
+            ExportDestination::ClickHouse
+        ));
+    }
+
+    #[test]
+    fn tinybird_destination_keeps_forward_mode_on_forward_path() {
+        assert!(!uses_native_pipeline_for(
+            WriteMode::Forward,
+            ExportDestination::Tinybird
+        ));
+        assert!(uses_forward_path_for(
+            WriteMode::Forward,
+            ExportDestination::Tinybird
+        ));
+    }
+
+    #[test]
+    fn clickhouse_destination_is_terminal_in_dual_mode() {
+        assert!(uses_native_pipeline_for(
+            WriteMode::Dual,
+            ExportDestination::ClickHouse
+        ));
+        assert!(!uses_forward_path_for(
+            WriteMode::Dual,
+            ExportDestination::ClickHouse
+        ));
     }
 
     /// In-memory KeyStore used to exercise the resolver's behavior (caching,

--- a/apps/ingest/src/telemetry.rs
+++ b/apps/ingest/src/telemetry.rs
@@ -152,15 +152,23 @@ pub struct TinybirdConfig {
 
 impl TinybirdConfig {
     pub fn validate(&self) -> Result<(), String> {
+        self.validate_for_pipeline(true)
+    }
+
+    pub fn validate_for_pipeline(&self, require_tinybird_credentials: bool) -> Result<(), String> {
         if self.endpoint.is_empty() {
-            return Err(
-                "TINYBIRD_HOST is required when INGEST_WRITE_MODE uses tinybird".to_string(),
-            );
+            if require_tinybird_credentials {
+                return Err(
+                    "TINYBIRD_HOST is required when INGEST_WRITE_MODE uses tinybird".to_string(),
+                );
+            }
         }
         if self.token.is_empty() {
-            return Err(
-                "TINYBIRD_TOKEN is required when INGEST_WRITE_MODE uses tinybird".to_string(),
-            );
+            if require_tinybird_credentials {
+                return Err(
+                    "TINYBIRD_TOKEN is required when INGEST_WRITE_MODE uses tinybird".to_string(),
+                );
+            }
         }
         if self.wal_shards == 0 {
             return Err("INGEST_WAL_SHARDS must be greater than 0".to_string());
@@ -343,7 +351,16 @@ impl TelemetryPipeline {
         http: Client,
         clickhouse_targets: Option<Arc<dyn ClickHouseTargetProvider>>,
     ) -> Result<Self, String> {
-        cfg.validate()?;
+        Self::new_with_clickhouse_validation(cfg, http, clickhouse_targets, true).await
+    }
+
+    pub async fn new_with_clickhouse_validation(
+        cfg: TinybirdConfig,
+        http: Client,
+        clickhouse_targets: Option<Arc<dyn ClickHouseTargetProvider>>,
+        require_tinybird_credentials: bool,
+    ) -> Result<Self, String> {
+        cfg.validate_for_pipeline(require_tinybird_credentials)?;
         std::fs::create_dir_all(&cfg.queue_dir)
             .map_err(|error| format!("create ingest WAL dir: {error}"))?;
         let cfg = Arc::new(cfg);
@@ -2250,6 +2267,35 @@ mod tests {
             datasource_session_replay_events: "session_replay_events".to_string(),
             datasource_session_events: "session_events".to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn pipeline_can_start_for_clickhouse_only_without_tinybird_credentials() {
+        let queue_dir = unique_test_dir("clickhouse-only-pipeline");
+        let mut cfg = test_cfg();
+        cfg.endpoint = String::new();
+        cfg.token = String::new();
+        cfg.queue_dir = queue_dir.clone();
+
+        let provider = Arc::new(StaticClickHouseTargetProvider {
+            target: ClickHouseTarget {
+                endpoint: "http://127.0.0.1:1".to_string(),
+                user: "ingest".to_string(),
+                password: String::new(),
+                database: "maple".to_string(),
+            },
+        });
+
+        TelemetryPipeline::new_with_clickhouse_validation(
+            cfg,
+            Client::new(),
+            Some(provider),
+            false,
+        )
+        .await
+        .expect("ClickHouse-only pipeline should not require Tinybird credentials");
+
+        let _ = std::fs::remove_dir_all(queue_dir);
     }
 
     fn unique_test_dir(name: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

Fixes production ingest routing for orgs with self-managed ClickHouse fully set up.

## What changed

- Routes `clickhouse_ready` orgs to the native direct ClickHouse pipeline before any collector forwarding.
- Keeps non-ready orgs on the existing managed Tinybird path, including production `INGEST_WRITE_MODE=forward` deployments.
- Prevents `dual` mode from double-writing ClickHouse-ready org traffic to ClickHouse and then forward/Tinybird.
- Allows the native pipeline to start for ClickHouse-only routing without requiring Tinybird credentials in forward-mode deployments.

## Root cause

The previous PR made direct ClickHouse routing depend on `write_mode.uses_tinybird()`. Production uses forward/collector mode, so ready orgs could still be forwarded to the Tinybird-backed collector instead of the direct ClickHouse sink.

## Validation

- `cargo test` in `apps/ingest`
- `bun run clickhouse:schema:check`
