### PR TITLE
Fix ClickHouse-ready ingest routing cache

### DIFF
--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -108,6 +108,8 @@ struct AppConfig {
     autumn_flush_interval_secs: u64,
     autumn_enforce_limits: bool,
     autumn_check_cache_ttl_secs: u64,
+    ingest_key_cache_ttl_secs: u64,
+    org_routing_cache_ttl_secs: u64,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -366,6 +368,18 @@ impl AppConfig {
             60,
         )?;
 
+        let ingest_key_cache_ttl_secs = parse_u64(
+            "INGEST_KEY_CACHE_TTL_SECS",
+            std::env::var("INGEST_KEY_CACHE_TTL_SECS").ok(),
+            60,
+        )?;
+
+        let org_routing_cache_ttl_secs = parse_u64(
+            "INGEST_ORG_ROUTING_CACHE_TTL_SECS",
+            std::env::var("INGEST_ORG_ROUTING_CACHE_TTL_SECS").ok(),
+            1,
+        )?;
+
         Ok(Self {
             port,
             otlp_grpc_port,
@@ -385,6 +399,8 @@ impl AppConfig {
             autumn_flush_interval_secs,
             autumn_enforce_limits,
             autumn_check_cache_ttl_secs,
+            ingest_key_cache_ttl_secs,
+            org_routing_cache_ttl_secs,
         })
     }
 }
@@ -463,13 +479,20 @@ fn resolve_key_store_backend() -> Result<KeyStoreBackend, String> {
 struct IngestKeyResolver {
     store: Arc<dyn KeyStore>,
     lookup_hmac_key: String,
-    cache: Cache<String, ResolvedIngestKey>,
+    cache: Cache<String, IngestKeyIdentity>,
+    routing: Arc<OrgRoutingResolver>,
 }
 
 struct CloudflareConnectorResolver {
     store: Arc<dyn KeyStore>,
     lookup_hmac_key: String,
-    cache: Cache<String, ResolvedCloudflareConnector>,
+    cache: Cache<String, CloudflareConnectorIdentity>,
+    routing: Arc<OrgRoutingResolver>,
+}
+
+struct OrgRoutingResolver {
+    store: Arc<dyn KeyStore>,
+    cache: Cache<String, OrgRouting>,
 }
 
 struct SamplingPolicyResolver {
@@ -521,6 +544,8 @@ trait KeyStore: Send + Sync {
         org_id: &str,
     ) -> Result<Option<ClickHouseTargetRow>, String>;
 
+    async fn fetch_org_routing(&self, org_id: &str) -> Result<Option<OrgRouting>, String>;
+
     async fn record_connector_success(&self, connector_id: &str, now_ms: i64)
         -> Result<(), String>;
 
@@ -562,6 +587,72 @@ struct AttributeMappingRow {
     source_key: String,
     target_key: String,
     operation: String,
+}
+
+#[derive(Clone)]
+struct IngestKeyIdentity {
+    org_id: String,
+    key_type: IngestKeyType,
+    key_id: String,
+}
+
+impl IngestKeyIdentity {
+    fn into_resolved(self, routing: OrgRouting) -> ResolvedIngestKey {
+        ResolvedIngestKey {
+            org_id: self.org_id,
+            key_type: self.key_type,
+            key_id: self.key_id,
+            self_managed: routing.self_managed,
+            clickhouse_ready: routing.clickhouse_ready,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CloudflareConnectorIdentity {
+    connector_id: String,
+    org_id: String,
+    service_name: String,
+    zone_name: String,
+    dataset: String,
+    secret_key_id: String,
+}
+
+impl CloudflareConnectorIdentity {
+    fn into_resolved(self, routing: OrgRouting) -> ResolvedCloudflareConnector {
+        ResolvedCloudflareConnector {
+            connector_id: self.connector_id,
+            org_id: self.org_id,
+            service_name: self.service_name,
+            zone_name: self.zone_name,
+            dataset: self.dataset,
+            secret_key_id: self.secret_key_id,
+            self_managed: routing.self_managed,
+            clickhouse_ready: routing.clickhouse_ready,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct OrgRouting {
+    self_managed: bool,
+    clickhouse_ready: bool,
+}
+
+impl OrgRouting {
+    fn from_key_row(row: &KeyRow) -> Self {
+        Self {
+            self_managed: row.self_managed,
+            clickhouse_ready: row.clickhouse_ready,
+        }
+    }
+
+    fn from_connector_row(row: &ConnectorRow) -> Self {
+        Self {
+            self_managed: row.self_managed,
+            clickhouse_ready: row.clickhouse_ready,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1085,13 +1176,17 @@ async fn main() {
     };
 
     let ingest_key_cache = Cache::builder()
-        .time_to_live(Duration::from_secs(60))
+        .time_to_live(Duration::from_secs(config.ingest_key_cache_ttl_secs))
         .max_capacity(1_000)
         .build();
 
     let cloudflare_connector_cache = Cache::builder()
-        .time_to_live(Duration::from_secs(60))
+        .time_to_live(Duration::from_secs(config.ingest_key_cache_ttl_secs))
         .max_capacity(1_000)
+        .build();
+    let org_routing_cache = Cache::builder()
+        .time_to_live(Duration::from_secs(config.org_routing_cache_ttl_secs))
+        .max_capacity(10_000)
         .build();
     let sampling_policy_cache = Cache::builder()
         .time_to_live(Duration::from_secs(30))
@@ -1102,11 +1197,17 @@ async fn main() {
         .max_capacity(10_000)
         .build();
 
+    let org_routing_resolver = Arc::new(OrgRoutingResolver {
+        store: Arc::clone(&store),
+        cache: org_routing_cache,
+    });
+
     let state = Arc::new(AppState {
         resolver: IngestKeyResolver {
             store: Arc::clone(&store),
             lookup_hmac_key: config.lookup_hmac_key.clone(),
             cache: ingest_key_cache,
+            routing: Arc::clone(&org_routing_resolver),
         },
         org_inflight_limiter: OrgInFlightLimiter::new(config.org_max_in_flight),
         sampling_resolver: SamplingPolicyResolver {
@@ -1121,6 +1222,7 @@ async fn main() {
             store: Arc::clone(&store),
             lookup_hmac_key: config.lookup_hmac_key.clone(),
             cache: cloudflare_connector_cache,
+            routing: org_routing_resolver,
         },
         telemetry_pipeline,
         http_client,
@@ -2938,17 +3040,17 @@ fn upsert_string_attribute(attributes: &mut Vec<KeyValue>, key: &str, value: &st
 
 /// Pick the upstream collector endpoint + pool label for a resolved ingest key.
 ///
-/// Self-managed orgs go to the self-managed pool when it is configured; any
-/// other case (shared orgs, or self-managed-but-endpoint-unset) falls through
-/// to the shared pool. Kept as a pure function so the routing decision is unit
-/// testable without spinning up collectors or state.
+/// Direct ClickHouse is terminal before this function is called. Any frame that
+/// still needs forwarding is on the managed Tinybird path, including orgs whose
+/// ClickHouse settings exist but are not yet schema-ready.
 fn select_forward_endpoint<'a>(
     shared: &'a str,
     self_managed: Option<&'a str>,
     org_is_self_managed: bool,
+    destination: ExportDestination,
 ) -> (&'a str, &'static str) {
-    match (org_is_self_managed, self_managed) {
-        (true, Some(url)) => (url, "self_managed"),
+    match (destination, org_is_self_managed, self_managed) {
+        (ExportDestination::ClickHouse, true, Some(url)) => (url, "self_managed"),
         _ => (shared, "shared"),
     }
 }
@@ -2982,11 +3084,13 @@ async fn forward_to_collector(
     content_encoding: Option<&str>,
     body: Vec<u8>,
     resolved_key: &ResolvedIngestKey,
+    destination: ExportDestination,
 ) -> Result<Response, ApiError> {
     let (endpoint, upstream_pool) = select_forward_endpoint(
         state.config.forward_endpoint.as_str(),
         state.config.forward_self_managed_endpoint.as_deref(),
         resolved_key.self_managed,
+        destination,
     );
 
     let url = format!("{endpoint}/v1/{}", signal.path());
@@ -3123,6 +3227,7 @@ async fn process_decoded_payload(
             content_encoding,
             outbound_body,
             resolved_key,
+            destination,
         )
         .instrument(forward_span)
         .await;
@@ -3204,10 +3309,31 @@ async fn accept_native_decoded_payload(
     Ok(())
 }
 
+impl OrgRoutingResolver {
+    async fn resolve_org_routing(&self, org_id: &str) -> Result<OrgRouting, String> {
+        if let Some(cached) = self.cache.get(org_id).await {
+            return Ok(cached);
+        }
+
+        let routing = self
+            .store
+            .fetch_org_routing(org_id)
+            .await?
+            .unwrap_or_default();
+        self.cache.insert(org_id.to_string(), routing.clone()).await;
+        Ok(routing)
+    }
+
+    async fn remember_org_routing(&self, org_id: &str, routing: OrgRouting) {
+        self.cache.insert(org_id.to_string(), routing).await;
+    }
+}
+
 impl IngestKeyResolver {
     async fn resolve_ingest_key(&self, raw_key: &str) -> Result<Option<ResolvedIngestKey>, String> {
-        if let Some(cached) = self.cache.get(raw_key).await {
-            return Ok(Some(cached));
+        if let Some(identity) = self.cache.get(raw_key).await {
+            let routing = self.routing.resolve_org_routing(&identity.org_id).await?;
+            return Ok(Some(identity.into_resolved(routing)));
         }
 
         let key_type = infer_ingest_key_type(raw_key);
@@ -3222,26 +3348,29 @@ impl IngestKeyResolver {
             IngestKeyType::Connector => return Ok(None),
         };
 
-        // LEFT JOIN against org_clickhouse_settings so the "self-managed?" flag is
-        // resolved in the same roundtrip as org_id. This hits the DB only on cache
-        // miss; warm cache hits (>99% of traffic) skip this entirely.
+        // LEFT JOIN against org_clickhouse_settings so the initial routing state
+        // is resolved in the same roundtrip as org_id. Warm auth-cache hits keep
+        // the key identity cached while the separate org-routing cache refreshes
+        // ClickHouse readiness on its shorter TTL.
         let Some(row) = self.store.fetch_ingest_key(&key_hash, hash_column).await? else {
             return Ok(None);
         };
 
-        let resolved = ResolvedIngestKey {
-            org_id: row.org_id,
+        let routing = OrgRouting::from_key_row(&row);
+        let identity = IngestKeyIdentity {
+            org_id: row.org_id.clone(),
             key_type,
             key_id: key_hash.chars().take(16).collect(),
-            self_managed: row.self_managed,
-            clickhouse_ready: row.clickhouse_ready,
         };
 
         self.cache
-            .insert(raw_key.to_string(), resolved.clone())
+            .insert(raw_key.to_string(), identity.clone())
+            .await;
+        self.routing
+            .remember_org_routing(&identity.org_id, routing.clone())
             .await;
 
-        Ok(Some(resolved))
+        Ok(Some(identity.into_resolved(routing)))
     }
 }
 
@@ -3252,8 +3381,9 @@ impl CloudflareConnectorResolver {
         raw_secret: &str,
     ) -> Result<Option<ResolvedCloudflareConnector>, String> {
         let cache_key = format!("{connector_id}:{raw_secret}");
-        if let Some(cached) = self.cache.get(&cache_key).await {
-            return Ok(Some(cached));
+        if let Some(identity) = self.cache.get(&cache_key).await {
+            let routing = self.routing.resolve_org_routing(&identity.org_id).await?;
+            return Ok(Some(identity.into_resolved(routing)));
         }
 
         let secret_hash = hash_ingest_key(raw_secret, &self.lookup_hmac_key)?;
@@ -3265,20 +3395,22 @@ impl CloudflareConnectorResolver {
             return Ok(None);
         };
 
-        let resolved = ResolvedCloudflareConnector {
+        let routing = OrgRouting::from_connector_row(&row);
+        let identity = CloudflareConnectorIdentity {
             connector_id: connector_id.to_string(),
-            org_id: row.org_id,
+            org_id: row.org_id.clone(),
             service_name: row.service_name,
             zone_name: row.zone_name,
             dataset: row.dataset,
             secret_key_id: secret_hash.chars().take(16).collect(),
-            self_managed: row.self_managed,
-            clickhouse_ready: row.clickhouse_ready,
         };
 
-        self.cache.insert(cache_key, resolved.clone()).await;
+        self.cache.insert(cache_key, identity.clone()).await;
+        self.routing
+            .remember_org_routing(&identity.org_id, routing.clone())
+            .await;
 
-        Ok(Some(resolved))
+        Ok(Some(identity.into_resolved(routing)))
     }
 
     async fn record_success(&self, connector_id: &str) -> Result<(), String> {
@@ -3735,6 +3867,29 @@ impl KeyStore for D1KeyStore {
         }))
     }
 
+    async fn fetch_org_routing(&self, org_id: &str) -> Result<Option<OrgRouting>, String> {
+        let sql = "SELECT CASE WHEN sync_status = 'connected' THEN 1 ELSE 0 END AS self_managed, \
+                          CASE WHEN sync_status = 'connected' AND schema_version = ? THEN 1 ELSE 0 END AS clickhouse_ready \
+                   FROM org_clickhouse_settings \
+                   WHERE org_id = ? LIMIT 1";
+        let rows = self
+            .query(
+                sql,
+                vec![
+                    serde_json::Value::String(CLICKHOUSE_PROJECT_REVISION.to_string()),
+                    serde_json::Value::String(org_id.to_string()),
+                ],
+            )
+            .await?;
+        let Some(row) = rows.into_iter().next() else {
+            return Ok(None);
+        };
+        Ok(Some(OrgRouting {
+            self_managed: d1_truthy(&row, "self_managed"),
+            clickhouse_ready: d1_truthy(&row, "clickhouse_ready"),
+        }))
+    }
+
     async fn record_connector_success(
         &self,
         connector_id: &str,
@@ -3816,6 +3971,10 @@ impl KeyStore for StaticKeyStore {
         &self,
         _org_id: &str,
     ) -> Result<Option<ClickHouseTargetRow>, String> {
+        Ok(None)
+    }
+
+    async fn fetch_org_routing(&self, _org_id: &str) -> Result<Option<OrgRouting>, String> {
         Ok(None)
     }
 
@@ -4274,17 +4433,22 @@ mod tests {
             "http://shared:4318",
             Some("http://self-managed:4318"),
             false,
+            ExportDestination::Tinybird,
         );
         assert_eq!(endpoint, "http://shared:4318");
         assert_eq!(pool, "shared");
     }
 
     #[test]
-    fn self_managed_goes_to_self_managed_pool_when_configured() {
-        let (endpoint, pool) =
-            select_forward_endpoint("http://shared:4318", Some("http://self-managed:4318"), true);
-        assert_eq!(endpoint, "http://self-managed:4318");
-        assert_eq!(pool, "self_managed");
+    fn tinybird_fallback_uses_shared_pool_even_for_clickhouse_configured_org() {
+        let (endpoint, pool) = select_forward_endpoint(
+            "http://shared:4318",
+            Some("http://self-managed:4318"),
+            true,
+            ExportDestination::Tinybird,
+        );
+        assert_eq!(endpoint, "http://shared:4318");
+        assert_eq!(pool, "shared");
     }
 
     #[test]
@@ -4292,7 +4456,12 @@ mod tests {
         // Missing INGEST_FORWARD_SELF_MANAGED_ENDPOINT should never drop traffic
         // — self-managed orgs degrade back to the shared pool until the
         // operator wires the second collector in.
-        let (endpoint, pool) = select_forward_endpoint("http://shared:4318", None, true);
+        let (endpoint, pool) = select_forward_endpoint(
+            "http://shared:4318",
+            None,
+            true,
+            ExportDestination::ClickHouse,
+        );
         assert_eq!(endpoint, "http://shared:4318");
         assert_eq!(pool, "shared");
     }
@@ -4339,16 +4508,50 @@ mod tests {
     #[derive(Default)]
     struct FakeKeyStore {
         keys: std::sync::Mutex<std::collections::HashMap<(String, &'static str), KeyRow>>,
+        connectors: std::sync::Mutex<std::collections::HashMap<(String, String), ConnectorRow>>,
+        routings: std::sync::Mutex<std::collections::HashMap<String, OrgRouting>>,
         targets: std::sync::Mutex<std::collections::HashMap<String, ClickHouseTargetRow>>,
+        ingest_key_fetches: AtomicU64,
+        connector_fetches: AtomicU64,
+        routing_fetches: AtomicU64,
     }
 
     impl FakeKeyStore {
         fn insert_private(&self, raw_key: &str, row: KeyRow) {
             let hash = hash_ingest_key(raw_key, "test-hmac-key").unwrap();
+            self.set_org_routing(
+                &row.org_id,
+                OrgRouting {
+                    self_managed: row.self_managed,
+                    clickhouse_ready: row.clickhouse_ready,
+                },
+            );
             self.keys
                 .lock()
                 .unwrap()
                 .insert((hash, "private_key_hash"), row);
+        }
+
+        fn insert_connector(&self, connector_id: &str, raw_secret: &str, row: ConnectorRow) {
+            let hash = hash_ingest_key(raw_secret, "test-hmac-key").unwrap();
+            self.set_org_routing(
+                &row.org_id,
+                OrgRouting {
+                    self_managed: row.self_managed,
+                    clickhouse_ready: row.clickhouse_ready,
+                },
+            );
+            self.connectors
+                .lock()
+                .unwrap()
+                .insert((connector_id.to_string(), hash), row);
+        }
+
+        fn set_org_routing(&self, org_id: &str, routing: OrgRouting) {
+            self.routings
+                .lock()
+                .unwrap()
+                .insert(org_id.to_string(), routing);
         }
 
         fn insert_clickhouse_target(&self, org_id: &str, row: ClickHouseTargetRow) {
@@ -4363,6 +4566,7 @@ mod tests {
             key_hash: &str,
             hash_column: &'static str,
         ) -> Result<Option<KeyRow>, String> {
+            self.ingest_key_fetches.fetch_add(1, Ordering::Relaxed);
             Ok(self
                 .keys
                 .lock()
@@ -4372,10 +4576,16 @@ mod tests {
         }
         async fn fetch_connector(
             &self,
-            _connector_id: &str,
-            _secret_hash: &str,
+            connector_id: &str,
+            secret_hash: &str,
         ) -> Result<Option<ConnectorRow>, String> {
-            Ok(None)
+            self.connector_fetches.fetch_add(1, Ordering::Relaxed);
+            Ok(self
+                .connectors
+                .lock()
+                .unwrap()
+                .get(&(connector_id.to_string(), secret_hash.to_string()))
+                .cloned())
         }
         async fn fetch_sampling_policy(
             &self,
@@ -4395,6 +4605,10 @@ mod tests {
         ) -> Result<Option<ClickHouseTargetRow>, String> {
             Ok(self.targets.lock().unwrap().get(org_id).cloned())
         }
+        async fn fetch_org_routing(&self, org_id: &str) -> Result<Option<OrgRouting>, String> {
+            self.routing_fetches.fetch_add(1, Ordering::Relaxed);
+            Ok(self.routings.lock().unwrap().get(org_id).cloned())
+        }
         async fn record_connector_success(
             &self,
             _connector_id: &str,
@@ -4412,7 +4626,24 @@ mod tests {
         }
     }
 
+    fn make_routing_resolver(store: Arc<FakeKeyStore>, ttl: Duration) -> Arc<OrgRoutingResolver> {
+        let store: Arc<dyn KeyStore> = store;
+        Arc::new(OrgRoutingResolver {
+            store,
+            cache: Cache::builder().time_to_live(ttl).max_capacity(16).build(),
+        })
+    }
+
     fn make_resolver(store: Arc<FakeKeyStore>) -> IngestKeyResolver {
+        make_resolver_with_routing_ttl(store, Duration::from_secs(60))
+    }
+
+    fn make_resolver_with_routing_ttl(
+        store: Arc<FakeKeyStore>,
+        routing_ttl: Duration,
+    ) -> IngestKeyResolver {
+        let routing = make_routing_resolver(Arc::clone(&store), routing_ttl);
+        let store: Arc<dyn KeyStore> = store;
         IngestKeyResolver {
             store,
             lookup_hmac_key: "test-hmac-key".to_string(),
@@ -4420,6 +4651,249 @@ mod tests {
                 .time_to_live(Duration::from_secs(60))
                 .max_capacity(16)
                 .build(),
+            routing,
+        }
+    }
+
+    #[derive(Debug)]
+    struct FakeClickHouseImport {
+        query: String,
+        database: String,
+        user: String,
+        content_encoding: String,
+        body: String,
+    }
+
+    #[derive(Debug)]
+    struct FakeForwardImport {
+        content_type: String,
+        content_encoding: String,
+        body_len: usize,
+    }
+
+    async fn fake_clickhouse_import(
+        State(tx): State<tokio::sync::mpsc::UnboundedSender<FakeClickHouseImport>>,
+        Query(query): Query<std::collections::HashMap<String, String>>,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> StatusCode {
+        let mut decoded = String::new();
+        GzDecoder::new(&body[..])
+            .read_to_string(&mut decoded)
+            .expect("fake ClickHouse should receive gzip NDJSON");
+
+        let _ = tx.send(FakeClickHouseImport {
+            query: query.get("query").cloned().unwrap_or_default(),
+            database: query.get("database").cloned().unwrap_or_default(),
+            user: headers
+                .get("x-clickhouse-user")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string(),
+            content_encoding: headers
+                .get(CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string(),
+            body: decoded,
+        });
+
+        StatusCode::OK
+    }
+
+    async fn fake_forward_collector(
+        State(tx): State<tokio::sync::mpsc::UnboundedSender<FakeForwardImport>>,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> StatusCode {
+        let _ = tx.send(FakeForwardImport {
+            content_type: headers
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string(),
+            content_encoding: headers
+                .get(CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string(),
+            body_len: body.len(),
+        });
+        StatusCode::OK
+    }
+
+    fn unique_main_test_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "maple-ingest-main-{name}-{}-{}",
+            std::process::id(),
+            current_time_millis()
+        ))
+    }
+
+    fn test_tinybird_config(queue_dir: PathBuf) -> TinybirdConfig {
+        TinybirdConfig {
+            endpoint: String::new(),
+            token: String::new(),
+            queue_dir,
+            queue_max_bytes: 1024 * 1024,
+            org_queue_max_bytes: 1024 * 1024,
+            queue_channel_capacity: 10,
+            wal_shards: 1,
+            batch_max_rows: 100,
+            batch_max_bytes: 1024 * 1024,
+            batch_max_wait: Duration::from_millis(1),
+            export_concurrency_per_shard: 1,
+            export_max_attempts: 1,
+            datasources: DatasourceNames::defaults(),
+            datasource_session_replays: "session_replays".to_string(),
+            datasource_session_replay_events: "session_replay_events".to_string(),
+            datasource_session_events: "session_events".to_string(),
+        }
+    }
+
+    fn test_log_request(message: &str) -> ExportLogsServiceRequest {
+        ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                resource: Some(Resource {
+                    attributes: vec![KeyValue {
+                        key: "service.name".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(any_value::Value::StringValue("routing-test".to_string())),
+                        }),
+                    }],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_logs: vec![ScopeLogs {
+                    scope: Some(InstrumentationScope {
+                        name: "routing-logger".to_string(),
+                        version: "1.0.0".to_string(),
+                        attributes: Vec::new(),
+                        dropped_attributes_count: 0,
+                    }),
+                    log_records: vec![LogRecord {
+                        time_unix_nano: 1_700_000_002_000_000_000,
+                        observed_time_unix_nano: 1_700_000_002_000_000_000,
+                        severity_number: 9,
+                        severity_text: "INFO".to_string(),
+                        body: Some(AnyValue {
+                            value: Some(any_value::Value::StringValue(message.to_string())),
+                        }),
+                        ..Default::default()
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        }
+    }
+
+    fn test_headers(raw_key: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            format!("Bearer {raw_key}")
+                .parse()
+                .expect("valid auth header"),
+        );
+        headers.insert(CONTENT_TYPE, "application/x-protobuf".parse().unwrap());
+        headers
+    }
+
+    async fn test_app_state(
+        store: Arc<FakeKeyStore>,
+        queue_dir: PathBuf,
+        forward_endpoint: String,
+        routing_ttl: Duration,
+    ) -> AppState {
+        let tinybird = test_tinybird_config(queue_dir);
+        let key_store: Arc<dyn KeyStore> = store.clone();
+        let routing = make_routing_resolver(Arc::clone(&store), routing_ttl);
+        let clickhouse_targets = Arc::new(ClickHouseTargetResolver {
+            store: Arc::clone(&key_store),
+            encryption_key: None,
+            cache: Cache::builder()
+                .time_to_live(Duration::from_secs(60))
+                .max_capacity(16)
+                .build(),
+        });
+        let http_client = Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap();
+        let telemetry_pipeline = TelemetryPipeline::new_with_clickhouse_validation(
+            tinybird.clone(),
+            http_client.clone(),
+            Some(clickhouse_targets),
+            false,
+        )
+        .await
+        .expect("test pipeline should start without Tinybird credentials");
+
+        AppState {
+            config: AppConfig {
+                port: 0,
+                otlp_grpc_port: None,
+                forward_endpoint,
+                forward_self_managed_endpoint: None,
+                forward_timeout: Duration::from_secs(5),
+                write_mode: WriteMode::Forward,
+                tinybird,
+                max_request_body_bytes: 1024 * 1024,
+                org_max_in_flight: 100,
+                require_tls: false,
+                key_store_backend: KeyStoreBackend::D1 {
+                    cf_account_id: "test".to_string(),
+                    d1_database_id: "test".to_string(),
+                    d1_api_token: "test".to_string(),
+                },
+                clickhouse_encryption_key: None,
+                lookup_hmac_key: "test-hmac-key".to_string(),
+                autumn_secret_key: None,
+                autumn_api_url: "https://api.useautumn.com".to_string(),
+                autumn_flush_interval_secs: 1,
+                autumn_enforce_limits: false,
+                autumn_check_cache_ttl_secs: 60,
+                ingest_key_cache_ttl_secs: 60,
+                org_routing_cache_ttl_secs: 5,
+            },
+            http_client,
+            telemetry_pipeline: Some(telemetry_pipeline),
+            resolver: IngestKeyResolver {
+                store: Arc::clone(&key_store),
+                lookup_hmac_key: "test-hmac-key".to_string(),
+                cache: Cache::builder()
+                    .time_to_live(Duration::from_secs(60))
+                    .max_capacity(16)
+                    .build(),
+                routing: Arc::clone(&routing),
+            },
+            org_inflight_limiter: OrgInFlightLimiter::new(100),
+            sampling_resolver: SamplingPolicyResolver {
+                store: Arc::clone(&key_store),
+                cache: Cache::builder()
+                    .time_to_live(Duration::from_secs(30))
+                    .max_capacity(16)
+                    .build(),
+            },
+            attribute_mapping_resolver: AttributeMappingResolver {
+                store: Arc::clone(&key_store),
+                cache: Cache::builder()
+                    .time_to_live(Duration::from_secs(30))
+                    .max_capacity(16)
+                    .build(),
+            },
+            cloudflare_resolver: CloudflareConnectorResolver {
+                store: key_store,
+                lookup_hmac_key: "test-hmac-key".to_string(),
+                cache: Cache::builder()
+                    .time_to_live(Duration::from_secs(60))
+                    .max_capacity(16)
+                    .build(),
+                routing,
+            },
+            autumn_tracker: None,
+            autumn_entitlements: None,
         }
     }
 
@@ -4493,6 +4967,251 @@ mod tests {
             native_destination_for(&resolved),
             ExportDestination::Tinybird
         );
+    }
+
+    #[tokio::test]
+    async fn resolve_ingest_key_refreshes_routing_before_auth_cache_expires() {
+        let store = Arc::new(FakeKeyStore::default());
+        store.insert_private(
+            "maple_sk_test_becomes_ready",
+            KeyRow {
+                org_id: "org_transition".to_string(),
+                self_managed: false,
+                clickhouse_ready: false,
+            },
+        );
+
+        let resolver = make_resolver_with_routing_ttl(Arc::clone(&store), Duration::from_millis(5));
+        let first = resolver
+            .resolve_ingest_key("maple_sk_test_becomes_ready")
+            .await
+            .expect("resolve should succeed")
+            .expect("key should be found");
+        assert!(!first.clickhouse_ready);
+        assert_eq!(store.ingest_key_fetches.load(Ordering::Relaxed), 1);
+
+        store.set_org_routing(
+            "org_transition",
+            OrgRouting {
+                self_managed: true,
+                clickhouse_ready: true,
+            },
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let second = resolver
+            .resolve_ingest_key("maple_sk_test_becomes_ready")
+            .await
+            .expect("resolve should succeed")
+            .expect("key should be found");
+        assert!(second.self_managed);
+        assert!(second.clickhouse_ready);
+        assert_eq!(
+            native_destination_for(&second),
+            ExportDestination::ClickHouse
+        );
+        assert_eq!(
+            store.ingest_key_fetches.load(Ordering::Relaxed),
+            1,
+            "auth identity should stay cached while routing refreshes"
+        );
+        assert_eq!(store.routing_fetches.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn resolve_connector_refreshes_routing_before_auth_cache_expires() {
+        let store = Arc::new(FakeKeyStore::default());
+        store.insert_connector(
+            "connector_ready_later",
+            "secret-before-ready",
+            ConnectorRow {
+                org_id: "org_logpush_transition".to_string(),
+                service_name: "cloudflare/example.com".to_string(),
+                zone_name: "example.com".to_string(),
+                dataset: "http_requests".to_string(),
+                self_managed: false,
+                clickhouse_ready: false,
+            },
+        );
+        let routing = make_routing_resolver(Arc::clone(&store), Duration::from_millis(5));
+        let key_store: Arc<dyn KeyStore> = store.clone();
+        let resolver = CloudflareConnectorResolver {
+            store: key_store,
+            lookup_hmac_key: "test-hmac-key".to_string(),
+            cache: Cache::builder()
+                .time_to_live(Duration::from_secs(60))
+                .max_capacity(16)
+                .build(),
+            routing,
+        };
+
+        let first = resolver
+            .resolve_connector("connector_ready_later", "secret-before-ready")
+            .await
+            .expect("resolve should succeed")
+            .expect("connector should be found");
+        assert!(!first.clickhouse_ready);
+        assert_eq!(store.connector_fetches.load(Ordering::Relaxed), 1);
+
+        store.set_org_routing(
+            "org_logpush_transition",
+            OrgRouting {
+                self_managed: true,
+                clickhouse_ready: true,
+            },
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let second = resolver
+            .resolve_connector("connector_ready_later", "secret-before-ready")
+            .await
+            .expect("resolve should succeed")
+            .expect("connector should be found");
+        assert!(second.self_managed);
+        assert!(second.clickhouse_ready);
+        assert_eq!(
+            store.connector_fetches.load(Ordering::Relaxed),
+            1,
+            "connector identity should stay cached while routing refreshes"
+        );
+        assert_eq!(store.routing_fetches.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn forward_mode_switches_ready_org_to_clickhouse_without_forwarding_again() {
+        let (ch_tx, mut ch_rx) = tokio::sync::mpsc::unbounded_channel();
+        let ch_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let ch_addr = ch_listener.local_addr().unwrap();
+        let ch_app = Router::new()
+            .route("/", post(fake_clickhouse_import))
+            .with_state(ch_tx);
+        tokio::spawn(async move {
+            axum::serve(ch_listener, ch_app).await.unwrap();
+        });
+
+        let (forward_tx, mut forward_rx) = tokio::sync::mpsc::unbounded_channel();
+        let forward_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let forward_addr = forward_listener.local_addr().unwrap();
+        let forward_app = Router::new()
+            .route("/v1/logs", post(fake_forward_collector))
+            .with_state(forward_tx);
+        tokio::spawn(async move {
+            axum::serve(forward_listener, forward_app).await.unwrap();
+        });
+
+        let queue_dir = unique_main_test_dir("forward-ready-clickhouse");
+        let store = Arc::new(FakeKeyStore::default());
+        let raw_key = "maple_sk_test_forward_ready";
+        store.insert_private(
+            raw_key,
+            KeyRow {
+                org_id: "org_forward_ready".to_string(),
+                self_managed: false,
+                clickhouse_ready: false,
+            },
+        );
+        let state = test_app_state(
+            Arc::clone(&store),
+            queue_dir.clone(),
+            format!("http://{forward_addr}"),
+            Duration::from_millis(5),
+        )
+        .await;
+
+        let first_payload = test_log_request("before setup").encode_to_vec();
+        let (first_response, first_count, _, _) = handle_signal_inner(
+            &state,
+            &test_headers(raw_key),
+            Bytes::from(first_payload),
+            Signal::Logs,
+        )
+        .await
+        .expect("non-ready request should be accepted through forward path");
+        assert_eq!(first_response.status(), StatusCode::OK);
+        assert_eq!(first_count, 1);
+        let first_forward = tokio::time::timeout(Duration::from_secs(2), forward_rx.recv())
+            .await
+            .expect("non-ready org should forward")
+            .expect("forward channel should stay open");
+        assert_eq!(first_forward.content_type, "application/x-protobuf");
+        assert_eq!(first_forward.content_encoding, "");
+        assert!(first_forward.body_len > 0);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), ch_rx.recv())
+                .await
+                .is_err(),
+            "non-ready org must not write to ClickHouse"
+        );
+
+        store.set_org_routing(
+            "org_forward_ready",
+            OrgRouting {
+                self_managed: true,
+                clickhouse_ready: true,
+            },
+        );
+        store.insert_clickhouse_target(
+            "org_forward_ready",
+            ClickHouseTargetRow {
+                ch_url: format!("http://{ch_addr}"),
+                ch_user: "ingest".to_string(),
+                ch_password_ciphertext: None,
+                ch_password_iv: None,
+                ch_password_tag: None,
+                ch_database: "maple".to_string(),
+                schema_version: CLICKHOUSE_PROJECT_REVISION.to_string(),
+            },
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let second_payload = test_log_request("after setup").encode_to_vec();
+        let (second_response, second_count, _, _) = handle_signal_inner(
+            &state,
+            &test_headers(raw_key),
+            Bytes::from(second_payload),
+            Signal::Logs,
+        )
+        .await
+        .expect("ready request should be accepted through ClickHouse path");
+        assert_eq!(second_response.status(), StatusCode::OK);
+        assert_eq!(second_count, 1);
+
+        let clickhouse = tokio::time::timeout(Duration::from_secs(2), ch_rx.recv())
+            .await
+            .expect("ready org should write to ClickHouse")
+            .expect("ClickHouse channel should stay open");
+        assert!(clickhouse.query.starts_with("INSERT INTO logs"));
+        assert!(clickhouse.query.contains(" FROM input('"));
+        assert!(clickhouse.query.ends_with(" FORMAT JSONEachRow"));
+        assert_eq!(clickhouse.database, "maple");
+        assert_eq!(clickhouse.user, "ingest");
+        assert_eq!(clickhouse.content_encoding, "gzip");
+        assert!(clickhouse.body.contains("after setup"));
+        assert!(
+            !clickhouse.body.contains("before setup"),
+            "the earlier Tinybird-routed request must not be replayed into ClickHouse"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), forward_rx.recv())
+                .await
+                .is_err(),
+            "ready org must not forward to the Tinybird collector path"
+        );
+        assert_eq!(
+            store.ingest_key_fetches.load(Ordering::Relaxed),
+            1,
+            "same key should stay auth-cached across setup transition"
+        );
+        assert!(
+            store.routing_fetches.load(Ordering::Relaxed) >= 1,
+            "routing cache should refresh independently from auth cache"
+        );
+
+        let _ = std::fs::remove_dir_all(queue_dir);
     }
 
     #[test]

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -5,7 +5,7 @@ mod autumn;
 
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -93,7 +93,6 @@ struct AppConfig {
     port: u16,
     otlp_grpc_port: Option<u16>,
     forward_endpoint: String,
-    forward_self_managed_endpoint: Option<String>,
     forward_timeout: Duration,
     write_mode: WriteMode,
     tinybird: TinybirdConfig,
@@ -190,14 +189,6 @@ impl AppConfig {
         if forward_endpoint.is_empty() {
             return Err("INGEST_FORWARD_OTLP_ENDPOINT is required".to_string());
         }
-
-        // Optional: endpoint for the self-managed collector pool. When unset, self-managed
-        // orgs fall back to the shared pool so a missing env var degrades to "current
-        // behavior" rather than dropping traffic.
-        let forward_self_managed_endpoint = std::env::var("INGEST_FORWARD_SELF_MANAGED_ENDPOINT")
-            .ok()
-            .map(|value| value.trim().trim_end_matches('/').to_string())
-            .filter(|value| !value.is_empty());
 
         let forward_timeout_ms = parse_u64(
             "INGEST_FORWARD_TIMEOUT_MS",
@@ -305,17 +296,6 @@ impl AppConfig {
             );
         }
 
-        if require_tls {
-            if let Some(endpoint) = forward_self_managed_endpoint.as_ref() {
-                if !endpoint.starts_with("https://") {
-                    return Err(
-                        "INGEST_REQUIRE_TLS=true requires an https INGEST_FORWARD_SELF_MANAGED_ENDPOINT"
-                            .to_string(),
-                    );
-                }
-            }
-        }
-
         let key_store_backend = resolve_key_store_backend()?;
         let clickhouse_encryption_key = match &key_store_backend {
             KeyStoreBackend::D1 { .. } => {
@@ -384,7 +364,6 @@ impl AppConfig {
             port,
             otlp_grpc_port,
             forward_endpoint,
-            forward_self_managed_endpoint,
             forward_timeout: Duration::from_millis(forward_timeout_ms),
             write_mode,
             tinybird,
@@ -493,6 +472,7 @@ struct CloudflareConnectorResolver {
 struct OrgRoutingResolver {
     store: Arc<dyn KeyStore>,
     cache: Cache<String, OrgRouting>,
+    last_known: DashMap<String, OrgRouting>,
 }
 
 struct SamplingPolicyResolver {
@@ -1200,6 +1180,7 @@ async fn main() {
     let org_routing_resolver = Arc::new(OrgRoutingResolver {
         store: Arc::clone(&store),
         cache: org_routing_cache,
+        last_known: DashMap::new(),
     });
 
     let state = Arc::new(AppState {
@@ -1297,10 +1278,6 @@ async fn main() {
         info!(
             port = config.port,
             forward_endpoint = %config.forward_endpoint,
-            forward_self_managed_endpoint = %config
-                .forward_self_managed_endpoint
-                .as_deref()
-                .unwrap_or("<unset>"),
             require_tls = config.require_tls,
             max_body_bytes = config.max_request_body_bytes,
             hmac_fingerprint = %hmac_fingerprint,
@@ -3038,23 +3015,6 @@ fn upsert_string_attribute(attributes: &mut Vec<KeyValue>, key: &str, value: &st
     });
 }
 
-/// Pick the upstream collector endpoint + pool label for a resolved ingest key.
-///
-/// Direct ClickHouse is terminal before this function is called. Any frame that
-/// still needs forwarding is on the managed Tinybird path, including orgs whose
-/// ClickHouse settings exist but are not yet schema-ready.
-fn select_forward_endpoint<'a>(
-    shared: &'a str,
-    self_managed: Option<&'a str>,
-    org_is_self_managed: bool,
-    destination: ExportDestination,
-) -> (&'a str, &'static str) {
-    match (destination, org_is_self_managed, self_managed) {
-        (ExportDestination::ClickHouse, true, Some(url)) => (url, "self_managed"),
-        _ => (shared, "shared"),
-    }
-}
-
 fn native_destination_for(resolved_key: &ResolvedIngestKey) -> ExportDestination {
     if resolved_key.clickhouse_ready {
         ExportDestination::ClickHouse
@@ -3084,14 +3044,9 @@ async fn forward_to_collector(
     content_encoding: Option<&str>,
     body: Vec<u8>,
     resolved_key: &ResolvedIngestKey,
-    destination: ExportDestination,
 ) -> Result<Response, ApiError> {
-    let (endpoint, upstream_pool) = select_forward_endpoint(
-        state.config.forward_endpoint.as_str(),
-        state.config.forward_self_managed_endpoint.as_deref(),
-        resolved_key.self_managed,
-        destination,
-    );
+    let endpoint = state.config.forward_endpoint.as_str();
+    let upstream_pool = "shared";
 
     let url = format!("{endpoint}/v1/{}", signal.path());
     let outbound_bytes = body.len();
@@ -3227,7 +3182,6 @@ async fn process_decoded_payload(
             content_encoding,
             outbound_body,
             resolved_key,
-            destination,
         )
         .instrument(forward_span)
         .await;
@@ -3315,16 +3269,34 @@ impl OrgRoutingResolver {
             return Ok(cached);
         }
 
-        let routing = self
-            .store
-            .fetch_org_routing(org_id)
-            .await?
-            .unwrap_or_default();
-        self.cache.insert(org_id.to_string(), routing.clone()).await;
-        Ok(routing)
+        match self.store.fetch_org_routing(org_id).await {
+            Ok(row) => {
+                let routing = row.unwrap_or_default();
+                self.remember_org_routing(org_id, routing.clone()).await;
+                Ok(routing)
+            }
+            Err(error) => {
+                if let Some(stale) = self.last_known.get(org_id) {
+                    warn!(
+                        org_id,
+                        error = %error,
+                        "Org routing refresh failed; serving last-known routing"
+                    );
+                    Ok(stale.clone())
+                } else {
+                    warn!(
+                        org_id,
+                        error = %error,
+                        "Org routing refresh failed with no last-known routing; using managed Tinybird path"
+                    );
+                    Ok(OrgRouting::default())
+                }
+            }
+        }
     }
 
     async fn remember_org_routing(&self, org_id: &str, routing: OrgRouting) {
+        self.last_known.insert(org_id.to_string(), routing.clone());
         self.cache.insert(org_id.to_string(), routing).await;
     }
 }
@@ -4428,45 +4400,6 @@ mod tests {
     }
 
     #[test]
-    fn non_self_managed_goes_to_shared_pool() {
-        let (endpoint, pool) = select_forward_endpoint(
-            "http://shared:4318",
-            Some("http://self-managed:4318"),
-            false,
-            ExportDestination::Tinybird,
-        );
-        assert_eq!(endpoint, "http://shared:4318");
-        assert_eq!(pool, "shared");
-    }
-
-    #[test]
-    fn tinybird_fallback_uses_shared_pool_even_for_clickhouse_configured_org() {
-        let (endpoint, pool) = select_forward_endpoint(
-            "http://shared:4318",
-            Some("http://self-managed:4318"),
-            true,
-            ExportDestination::Tinybird,
-        );
-        assert_eq!(endpoint, "http://shared:4318");
-        assert_eq!(pool, "shared");
-    }
-
-    #[test]
-    fn self_managed_degrades_to_shared_when_endpoint_unset() {
-        // Missing INGEST_FORWARD_SELF_MANAGED_ENDPOINT should never drop traffic
-        // — self-managed orgs degrade back to the shared pool until the
-        // operator wires the second collector in.
-        let (endpoint, pool) = select_forward_endpoint(
-            "http://shared:4318",
-            None,
-            true,
-            ExportDestination::ClickHouse,
-        );
-        assert_eq!(endpoint, "http://shared:4318");
-        assert_eq!(pool, "shared");
-    }
-
-    #[test]
     fn clickhouse_destination_uses_native_pipeline_even_in_forward_mode() {
         assert!(uses_native_pipeline_for(
             WriteMode::Forward,
@@ -4514,6 +4447,7 @@ mod tests {
         ingest_key_fetches: AtomicU64,
         connector_fetches: AtomicU64,
         routing_fetches: AtomicU64,
+        routing_errors: AtomicBool,
     }
 
     impl FakeKeyStore {
@@ -4607,6 +4541,9 @@ mod tests {
         }
         async fn fetch_org_routing(&self, org_id: &str) -> Result<Option<OrgRouting>, String> {
             self.routing_fetches.fetch_add(1, Ordering::Relaxed);
+            if self.routing_errors.load(Ordering::Relaxed) {
+                return Err("simulated routing store outage".to_string());
+            }
             Ok(self.routings.lock().unwrap().get(org_id).cloned())
         }
         async fn record_connector_success(
@@ -4631,6 +4568,7 @@ mod tests {
         Arc::new(OrgRoutingResolver {
             store,
             cache: Cache::builder().time_to_live(ttl).max_capacity(16).build(),
+            last_known: DashMap::new(),
         })
     }
 
@@ -4835,7 +4773,6 @@ mod tests {
                 port: 0,
                 otlp_grpc_port: None,
                 forward_endpoint,
-                forward_self_managed_endpoint: None,
                 forward_timeout: Duration::from_secs(5),
                 write_mode: WriteMode::Forward,
                 tinybird,
@@ -5016,6 +4953,65 @@ mod tests {
             "auth identity should stay cached while routing refreshes"
         );
         assert_eq!(store.routing_fetches.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn resolve_ingest_key_serves_last_known_routing_when_refresh_fails() {
+        let store = Arc::new(FakeKeyStore::default());
+        store.insert_private(
+            "maple_sk_test_d1_blip",
+            KeyRow {
+                org_id: "org_d1_blip".to_string(),
+                self_managed: false,
+                clickhouse_ready: false,
+            },
+        );
+
+        let resolver = make_resolver_with_routing_ttl(Arc::clone(&store), Duration::from_millis(5));
+        let first = resolver
+            .resolve_ingest_key("maple_sk_test_d1_blip")
+            .await
+            .expect("initial resolve should succeed")
+            .expect("key should be found");
+        assert!(!first.clickhouse_ready);
+
+        store.set_org_routing(
+            "org_d1_blip",
+            OrgRouting {
+                self_managed: true,
+                clickhouse_ready: true,
+            },
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let ready = resolver
+            .resolve_ingest_key("maple_sk_test_d1_blip")
+            .await
+            .expect("routing refresh should succeed")
+            .expect("key should be found");
+        assert!(ready.clickhouse_ready);
+
+        store.routing_errors.store(true, Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let stale = resolver
+            .resolve_ingest_key("maple_sk_test_d1_blip")
+            .await
+            .expect("warm key should not 503 when routing refresh fails")
+            .expect("key should be found");
+        assert!(
+            stale.clickhouse_ready,
+            "last-known ready routing should be served during a routing-store outage"
+        );
+        assert_eq!(
+            store.ingest_key_fetches.load(Ordering::Relaxed),
+            1,
+            "auth identity should stay cached through the routing-store outage"
+        );
+        assert!(
+            store.routing_fetches.load(Ordering::Relaxed) >= 2,
+            "routing refresh should have been attempted before falling back to stale"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Split ingest-key/Cloudflare connector identity caching from per-org ClickHouse routing readiness caching.
- Add a short `INGEST_ORG_ROUTING_CACHE_TTL_SECS` default (1s) so setup changes stop being pinned behind the 60s auth cache.
- Keep non-ready ClickHouse orgs on the shared Tinybird forward path.
- Add a request-path regression proving a ready org in `INGEST_WRITE_MODE=forward` writes to ClickHouse without forwarding again.

## Tests
- `cargo test` in `apps/ingest`
- `cargo test forward_mode_switches_ready_org_to_clickhouse_without_forwarding_again` in `apps/ingest`
- `bun run clickhouse:schema:check`
