### PR TITLE
fix(effect-patch): anchor workerd/miniflare Clock origin on Date.now()

### DIFF
--- a/patches/effect@4.0.0-beta.70.patch
+++ b/patches/effect@4.0.0-beta.70.patch
@@ -1,6 +1,29 @@
+diff --git a/node_modules/effect/.bun-tag-1d037809e62e2eb2 b/.bun-tag-1d037809e62e2eb2
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/node_modules/effect/.bun-tag-c229b3c97d76a6b9 b/.bun-tag-c229b3c97d76a6b9
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/internal/effect.js b/dist/internal/effect.js
+index 542308a1c54b7112bfa816dafb54cd413b001ae4..241f15339399df2274345245c92e195d03369636 100644
+--- a/dist/internal/effect.js
++++ b/dist/internal/effect.js
+@@ -2524,7 +2524,14 @@ const processOrPerformanceNow = /*#__PURE__*/function () {
+   if (!processHrtime) {
+     return performanceNowNanos;
+   }
+-  const origin = /*#__PURE__*/performanceNowNanos() - /*#__PURE__*/processHrtime.bigint();
++  // maple patch (workerd/miniflare clock fix): anchor the hrtime offset on Date.now()
++  // instead of performanceNowNanos(). performanceNowNanos() is 0 at module-load scope in
++  // `wrangler dev`/miniflare while process.hrtime is already live wall-clock, which poisons
++  // this cached origin and makes Clock.currentTimeNanos (and span start times) ~1970.
++  // Date.now() is consistent with hrtime's scale at load in every runtime (both 0 in
++  // production workerd, both live in miniflare, wall-clock+monotonic in node) so origin is
++  // correct everywhere. Deployed workerd is unaffected. See workers-sdk / effect-smol issues.
++  const origin = BigInt(Date.now()) * BigInt(1_000_000) - processHrtime.bigint();
+   return () => origin + processHrtime.bigint();
+ }();
+ /** @internal */
 diff --git a/dist/unstable/ai/McpServer.d.ts b/dist/unstable/ai/McpServer.d.ts
 index 54d704a04d931c25bae1ca7f6c54877bae040317..0e5f97a8370ab0ce76a6a8e3d3495bbf29af0c7e 100644
 --- a/dist/unstable/ai/McpServer.d.ts


### PR DESCRIPTION
## What

Extends the vendored `effect@4.0.0-beta.70` patch (`patches/effect@4.0.0-beta.70.patch`) with a one-line fix to `processOrPerformanceNow` in `dist/internal/effect.js`.

## Why

Under `wrangler dev` / miniflare with `nodejs_compat`, `performance.now()` returns `0` at module-load scope while `process.hrtime.bigint()` already returns live wall-clock nanoseconds. The clock pre-computes a fixed origin as `performanceNowNanos() - hrtime`, which becomes a large negative offset — so `Clock.currentTimeNanos` (and every span start/end time) lands near **1970** and is invisible to time-windowed trace backends.

Anchoring the origin on `Date.now()` keeps hrtime's scale consistent at load in every runtime:
- production workerd: both 0
- miniflare: both live
- node: wall-clock + monotonic

so the origin is correct everywhere. **Deployed workerd is unaffected.**

This replaces the previous stopgap (manual timestamp correction in `flushable-tracer.ts`) with a fix at the source.

## Upstream

https://github.com/Effect-TS/effect-smol/issues/2416

## Scope

Patch file only — net diff is the `processOrPerformanceNow` hunk (plus a regenerated bun-tag marker). The existing McpServer `clientSessions` portion of the patch is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)