### PR TITLE
fix(api-worker): yield a macrotask before flushing telemetry

### DIFF
--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -45,6 +45,17 @@ const telemetry = MapleCloudflareSDK.make({
 	dropSpanNames: ["McpServer/Notifications."],
 })
 
+// `HttpMiddleware.tracer` ends the root server span on a deferred macrotask
+// (`scheduleTask(span.end, 0)`), but `telemetry.flush` drains synchronously.
+// Flushing immediately after the response loses the server span — its macrotask
+// hasn't fired yet. Isolated requests (e.g. a GitHub webhook) freeze the isolate
+// before a subsequent request rescues it, so the trace is silently dropped.
+// Yield one macrotask first so `span.end` runs before we drain.
+const flushTelemetry = async (env: Record<string, unknown>): Promise<void> => {
+	await new Promise<void>((resolve) => setTimeout(resolve, 0))
+	await telemetry.flush(env)
+}
+
 // POST /mcp hangs indefinitely on Cloudflare Workers when `toWebHandler` is
 // called with no middleware (1101 in prod, miniflare "worker hung" locally).
 // Suspected Effect RpcServer / HttpRouter scope-propagation bug. Providing
@@ -186,7 +197,7 @@ const handle = async (
 					` resp_sid=${response.headers.get("mcp-session-id") ?? "-"}`,
 			)
 		}
-		ctx.waitUntil(telemetry.flush(env))
+		ctx.waitUntil(flushTelemetry(env))
 		return response
 	} catch (err) {
 		console.error("[worker] handler failed:", err)
@@ -195,7 +206,7 @@ const handle = async (
 				`[mcp-err] method=${mcpFrame.method} id=${mcpFrame.id}` + ` dur=${Date.now() - startedAt}ms`,
 			)
 		}
-		ctx.waitUntil(telemetry.flush(env))
+		ctx.waitUntil(flushTelemetry(env))
 		const message = err instanceof Error ? err.message : String(err)
 		return new Response(`worker handler error: ${message}`, { status: 504 })
 	}


### PR DESCRIPTION
## What

Introduces `flushTelemetry(env)` in `apps/api/src/worker.ts` and routes both `ctx.waitUntil(...)` flush call sites in `handle` through it.

## Why

`HttpMiddleware.tracer` ends the root server span on a **deferred macrotask** (`scheduleTask(span.end, 0)`), but `telemetry.flush` drains **synchronously**. Flushing immediately after producing the response drains *before* `span.end` has fired, so the root server span is missing from the exported batch.

For isolated requests — e.g. a GitHub webhook that doesn't get followed by another request in the same isolate — the isolate freezes before a subsequent request can flush the span, and the trace is **silently dropped**.

## Fix

```ts
const flushTelemetry = async (env) => {
  await new Promise((resolve) => setTimeout(resolve, 0)) // let span.end's macrotask run
  await telemetry.flush(env)
}
```

One `setTimeout(0)` yield is enough to let the span-end macrotask run before we drain.

## Scope

`apps/api/src/worker.ts` only — the new helper plus swapping the two `telemetry.flush(env)` call sites to `flushTelemetry(env)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)