### PR TITLE
fix(query-engine): make raw-traces filters coalesce HTTP semconv like trace_list_mv

### DIFF
--- a/packages/query-engine/src/ch/ch.test.ts
+++ b/packages/query-engine/src/ch/ch.test.ts
@@ -458,7 +458,10 @@ describe("tracesTimeseriesQuery", () => {
 			attributeFilters: [{ key: "http.status_code", value: "200", mode: "equals" }],
 		})
 		const { sql } = compileCH(q, baseParams)
-		expect(sql).toContain("SpanAttributes['http.status_code'] = '200'")
+		// Coalesces the old + new OTel semconv spellings (mirrors trace_list_mv).
+		expect(sql).toContain(
+			"if(SpanAttributes['http.status_code'] != '', SpanAttributes['http.status_code'], SpanAttributes['http.response.status_code']) = '200'",
+		)
 	})
 
 	it("filters by attribute filters (exists)", () => {
@@ -488,7 +491,9 @@ describe("tracesTimeseriesQuery", () => {
 			attributeFilters: [{ key: "http.status_code", value: "400", mode: "gt" }],
 		})
 		const { sql } = compileCH(q, baseParams)
-		expect(sql).toContain("toFloat64OrZero(SpanAttributes['http.status_code']) > 400")
+		expect(sql).toContain(
+			"toFloat64OrZero(if(SpanAttributes['http.status_code'] != '', SpanAttributes['http.status_code'], SpanAttributes['http.response.status_code'])) > 400",
+		)
 	})
 
 	it("filters by resource attribute filters", () => {
@@ -510,7 +515,9 @@ describe("tracesTimeseriesQuery", () => {
 		})
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("FROM traces")
-		expect(sql).toContain("SpanAttributes['http.method'] = 'GET'")
+		expect(sql).toContain(
+			"if(SpanAttributes['http.method'] != '', SpanAttributes['http.method'], SpanAttributes['http.request.method']) = 'GET'",
+		)
 	})
 
 	it("falls back to raw traces when groupBy includes span_name", () => {
@@ -732,7 +739,10 @@ describe("tracesListQuery", () => {
 	it("emits NOT IN for excludedSpanNames", () => {
 		const q = tracesListQuery({ excludedSpanNames: ["GET /health"] })
 		const { sql } = compileCH(q, baseParams)
-		expect(sql).toContain("SpanName NOT IN ('GET /health')")
+		// Display-name aware: excludes rows whose raw OR rewritten span name
+		// matches, so excluding a "Root Span" facet value ("GET /route") works.
+		expect(sql).toMatch(/NOT \(\(SpanName IN \('GET \/health'\) OR /)
+		expect(sql).toContain("replaceOne(SpanName, 'http.server ', '')")
 	})
 
 	it("wraps a negated attribute filter in NOT (...)", () => {

--- a/packages/query-engine/src/ch/queries/errors.ts
+++ b/packages/query-engine/src/ch/queries/errors.ts
@@ -19,6 +19,7 @@ import {
 	Traces,
 } from "../tables"
 import { buildProjectedMapExpr } from "./query-helpers"
+import { httpDisplaySpanName } from "../../traces-shared"
 
 function errorEventsTableForRecentScan(opts: {
 	fingerprintHashes?: readonly string[]
@@ -199,23 +200,12 @@ export function spanHierarchyQuery(opts: SpanHierarchyOpts) {
 	return (
 		from(TraceDetailSpans)
 			.select(($) => {
-				// HTTP span name rewriting: "http.server GET" + route → "GET /api/users"
-				const route = $.SpanAttributes.get("http.route")
-				const urlPath = $.SpanAttributes.get("url.path")
-				const httpRewriteExpr = CH.if_(
-					$.SpanName.like("http.server %")
-						.or($.SpanName.in_("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"))
-						.and(route.neq("").or(urlPath.neq(""))),
-					CH.concat(
-						CH.if_(
-							$.SpanName.like("http.server %"),
-							CH.replaceOne($.SpanName, "http.server ", ""),
-							$.SpanName,
-						),
-						CH.lit(" "),
-						CH.if_(route.neq(""), route, urlPath),
-					),
+				// HTTP span name rewriting: "http.server GET" + route → "GET /api/users".
+				// Shared with the materialized view and the trace-list span-name filter.
+				const httpRewriteExpr = httpDisplaySpanName(
 					$.SpanName,
+					$.SpanAttributes.get("http.route"),
+					$.SpanAttributes.get("url.path"),
 				)
 
 				const relationshipExpr = opts.spanId

--- a/packages/query-engine/src/ch/queries/query-helpers.ts
+++ b/packages/query-engine/src/ch/queries/query-helpers.ts
@@ -11,7 +11,7 @@ import { param } from "@maple-dev/clickhouse-builder"
 import type { ColumnAccessor } from "@maple-dev/clickhouse-builder"
 import type { ServiceOverviewSpans, Traces, TracesAggregatesHourly } from "../tables"
 import { MetricsSum, MetricsGauge, MetricsHistogram, MetricsExpHistogram } from "../tables"
-import { buildAttrFilterCondition } from "../../traces-shared"
+import { buildAttrFilterCondition, httpDisplaySpanName } from "../../traces-shared"
 
 // ---------------------------------------------------------------------------
 // APDEX expressions
@@ -145,11 +145,21 @@ export function tracesBaseWhereConditions(
 				? CH.positionCaseInsensitive($.ServiceName, CH.lit(v)).gt(0)
 				: $.ServiceName.eq(v),
 		),
-		CH.when(opts.spanName, (v: string) =>
-			mm?.spanName === "contains"
-				? CH.positionCaseInsensitive($.SpanName, CH.lit(v)).gt(0)
-				: $.SpanName.eq(v),
-		),
+		CH.when(opts.spanName, (v: string) => {
+			// The "Root Span" facet and trace_list_mv expose the *display* name
+			// ("GET /api/users"); the raw traces table stores "http.server GET".
+			// Match either spelling so a facet click actually selects rows.
+			const display = httpDisplaySpanName(
+				$.SpanName,
+				$.SpanAttributes.get("http.route"),
+				$.SpanAttributes.get("url.path"),
+			)
+			return mm?.spanName === "contains"
+				? CH.positionCaseInsensitive($.SpanName, CH.lit(v))
+						.gt(0)
+						.or(CH.positionCaseInsensitive(display, CH.lit(v)).gt(0))
+				: $.SpanName.eq(v).or(display.eq(v))
+		}),
 		CH.whenTrue(!!opts.rootOnly, () => $.SpanKind.in_("Server", "Consumer").or($.ParentSpanId.eq(""))),
 		CH.whenTrue(!!opts.errorsOnly, () => $.StatusCode.eq("Error")),
 	]
@@ -202,7 +212,19 @@ export function tracesBaseWhereConditions(
 		conditions.push(CH.notInList($.ServiceName, opts.excludedServiceNames))
 	}
 	if (opts.excludedSpanNames?.length) {
-		conditions.push(CH.notInList($.SpanName, opts.excludedSpanNames))
+		// Display-name aware: exclude rows matching either the raw or rewritten span name.
+		const display = httpDisplaySpanName(
+			$.SpanName,
+			$.SpanAttributes.get("http.route"),
+			$.SpanAttributes.get("url.path"),
+		)
+		conditions.push(
+			CH.not(
+				CH.inList($.SpanName, opts.excludedSpanNames).or(
+					CH.inList(display, opts.excludedSpanNames),
+				),
+			),
+		)
 	}
 	if (opts.excludedEnvironments?.length) {
 		conditions.push(

--- a/packages/query-engine/src/traces-shared.ts
+++ b/packages/query-engine/src/traces-shared.ts
@@ -44,16 +44,90 @@ export const TRACE_LIST_MV_RESOURCE_MAP: Record<string, string> = {
 
 import * as CH from "@maple-dev/clickhouse-builder/expr"
 
+// ---------------------------------------------------------------------------
+// HTTP semconv coalescing
+//
+// OpenTelemetry renamed several HTTP span attributes in the stable semconv:
+//   http.method      → http.request.method
+//   http.status_code → http.response.status_code
+// `trace_list_mv` coalesces both spellings when it pre-extracts its columns
+// (see materializations.ts), so the quick-filter facet counts cover spans that
+// use *either* key. Filters that read the raw `traces` table must coalesce the
+// same way — otherwise a facet shows a count while applying it matches zero
+// rows (the data carries the new key, the filter looked up the old one).
+// ---------------------------------------------------------------------------
+
+const HTTP_SEMCONV_ALIASES: Record<string, readonly string[]> = {
+	"http.method": ["http.method", "http.request.method"],
+	"http.request.method": ["http.method", "http.request.method"],
+	"http.status_code": ["http.status_code", "http.response.status_code"],
+	"http.response.status_code": ["http.status_code", "http.response.status_code"],
+}
+
+/** `if(map[k0] != '', map[k0], if(map[k1] != '', …))` — first non-empty alias. */
+function coalescedMapGet(
+	mapExpr: CH.Expr<Record<string, string>>,
+	keys: readonly string[],
+): CH.Expr<string> {
+	let expr = CH.mapGet(mapExpr, keys[keys.length - 1])
+	for (let i = keys.length - 2; i >= 0; i--) {
+		const candidate = CH.mapGet(mapExpr, keys[i])
+		expr = CH.if_(candidate.neq(""), candidate, expr)
+	}
+	return expr
+}
+
+/** `mapContains(map, k0) OR mapContains(map, k1) OR …` */
+function anyMapContains(
+	mapExpr: CH.Expr<Record<string, string>>,
+	keys: readonly string[],
+): CH.Condition {
+	let cond = CH.mapContains(mapExpr, keys[0])
+	for (let i = 1; i < keys.length; i++) {
+		cond = cond.or(CH.mapContains(mapExpr, keys[i]))
+	}
+	return cond
+}
+
+/**
+ * Rewrites an HTTP server span name to the display form used by the UI and by
+ * `trace_list_mv.SpanName`: spanName `"http.server GET"` + route → `"GET /api/users"`.
+ * Centralized so the MV, span-hierarchy query, and span-name filter stay in
+ * sync — drift between them caused the "Root Span" quick filter to return zero rows.
+ */
+export function httpDisplaySpanName(
+	spanName: CH.Expr<string>,
+	route: CH.Expr<string>,
+	urlPath: CH.Expr<string>,
+): CH.Expr<string> {
+	return CH.if_(
+		spanName
+			.like("http.server %")
+			.or(spanName.in_("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"))
+			.and(route.neq("").or(urlPath.neq(""))),
+		CH.concat(
+			CH.if_(spanName.like("http.server %"), CH.replaceOne(spanName, "http.server ", ""), spanName),
+			CH.lit(" "),
+			CH.if_(route.neq(""), route, urlPath),
+		),
+		spanName,
+	)
+}
+
 export function buildAttrFilterCondition(
 	af: AttributeFilter,
 	mapName: "SpanAttributes" | "ResourceAttributes",
 ): CH.Condition {
-	const colExpr: CH.Expr<string> = CH.mapGet(CH.dynamicColumn<Record<string, string>>(mapName), af.key)
+	const mapExpr = CH.dynamicColumn<Record<string, string>>(mapName)
+	// Span attributes renamed across OTel semconv versions match either spelling,
+	// mirroring trace_list_mv. Resource attributes have no such aliases.
+	const keys = mapName === "SpanAttributes" ? (HTTP_SEMCONV_ALIASES[af.key] ?? [af.key]) : [af.key]
+	const colExpr: CH.Expr<string> = coalescedMapGet(mapExpr, keys)
 	const value = af.value ?? ""
 
 	const positive = ((): CH.Condition => {
 		if (af.mode === "exists") {
-			return CH.mapContains(CH.dynamicColumn<Record<string, string>>(mapName), af.key)
+			return anyMapContains(mapExpr, keys)
 		}
 		if (af.mode === "contains") {
 			return CH.positionCaseInsensitive(colExpr, CH.lit(value)).gt(0)


### PR DESCRIPTION
## Problem

Trace **quick-filter (facet) counts** come from `trace_list_mv`, whose materialized-view SQL coalesces both OTel HTTP semconv spellings when it pre-extracts columns:

- `http.method` ↔ `http.request.method`
- `http.status_code` ↔ `http.response.status_code`

…and rewrites HTTP server span names to their display form (`"http.server GET"` + `http.route`/`url.path` → `"GET /api/users"`).

But **applying** a facet filters the raw `traces` table, which previously matched only the single literal attribute key / raw span name. Local data (chDB / a fresh Tinybird) emits only the **new** semconv keys and stores **raw** span names — so a facet would show a non-zero count, yet selecting it matched **zero rows**. This is the documented "facets vs list-filter invariant" break, most visibly the **"Root Span"** quick filter returning nothing locally.

## Fix

Mirror the MV's normalization on the raw-traces query path, all within `packages/query-engine`:

- **`traces-shared.ts`** — add `HTTP_SEMCONV_ALIASES` plus `coalescedMapGet` (`if(map[k0] != '', map[k0], map[k1])`) and `anyMapContains`; add the shared `httpDisplaySpanName(spanName, route, urlPath)` rewrite. `buildAttrFilterCondition` now coalesces both spellings for `SpanAttributes`.
- **`query-helpers.ts`** — `tracesBaseWhereConditions`: the `spanName` include branch and the `excludedSpanNames` exclude branch are now display-name aware, matching the raw **OR** rewritten span name.
- **`errors.ts`** — `spanHierarchyQuery` uses the shared `httpDisplaySpanName` instead of its inline copy.

## Scope & verification

Self-contained to `packages/query-engine`. The `trace_list_mv` side already coalesces both spellings on `main`; no datasource/MV/route companion change required.

`ch.test.ts` updated and passing (103/103) with assertions for the coalesced `if(... != '', ...)` SQL and the display-name-aware `NOT IN`.

> Extracted out of the `feat/github-integration` branch and rebased onto current `main` (which had refactored the CH DSL into `@maple-dev/clickhouse-builder`); one cosmetic conflict in `spanHierarchyQuery` was resolved in favor of `main`'s formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)