### PR TITLE
fix(services): mark every release on deploy markers, not just non-dominant ones

### DIFF
--- a/apps/web/src/lib/services/release-markers.test.ts
+++ b/apps/web/src/lib/services/release-markers.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import { detectReleaseMarkers } from "./release-markers"
+
+const point = (bucket: string, commitSha: string, count: number) => ({ bucket, commitSha, count })
+
+describe("detectReleaseMarkers", () => {
+	it("returns nothing for an empty timeline", () => {
+		expect(detectReleaseMarkers([])).toEqual([])
+	})
+
+	it("returns nothing when only one SHA is present (no deploy to mark)", () => {
+		expect(
+			detectReleaseMarkers([point("00:00", "aaaaaaa000", 5), point("00:05", "aaaaaaa000", 8)]),
+		).toEqual([])
+	})
+
+	it("marks every distinct SHA at the bucket it first appears in", () => {
+		const markers = detectReleaseMarkers([
+			point("00:00", "aaaaaaa000", 5),
+			point("00:05", "aaaaaaa000", 4),
+			point("00:05", "bbbbbbb111", 2),
+			point("00:10", "ccccccc222", 1),
+		])
+		expect(markers.map((m) => m.commitSha)).toEqual(["aaaaaaa000", "bbbbbbb111", "ccccccc222"])
+		expect(markers.map((m) => m.bucket)).toEqual(["00:00", "00:05", "00:10"])
+		expect(markers.map((m) => m.label)).toEqual(["aaaaaaa", "bbbbbbb", "ccccccc"])
+	})
+
+	// Regression for the reported bug: a mid-sequence release that carries the most
+	// spans AND lands in the first bucket of the window must still get a marker. The
+	// old "dominant SHA / first bucket" heuristics hid exactly this one.
+	it("marks a high-traffic release that is both the densest and the first-bucket SHA", () => {
+		const dense = "4736deb564"
+		const a = "98fb39d840"
+		const b = "262ae718dd"
+		const markers = detectReleaseMarkers([
+			point("13:25", dense, 1),
+			point("13:30", dense, 4), // dense has the most spans overall (5)
+			point("13:30", a, 1),
+			point("13:30", b, 1),
+		])
+		const shas = markers.map((m) => m.commitSha)
+		expect(shas).toContain(dense)
+		expect(shas).toContain(a)
+		expect(shas).toContain(b)
+		expect(shas).toHaveLength(3)
+	})
+
+	it("orders markers by first-appearance bucket regardless of input order", () => {
+		const markers = detectReleaseMarkers([
+			point("02:00", "ccccccc222", 1),
+			point("00:00", "aaaaaaa000", 1),
+			point("01:00", "bbbbbbb111", 1),
+		])
+		expect(markers.map((m) => m.bucket)).toEqual(["00:00", "01:00", "02:00"])
+	})
+})

--- a/apps/web/src/lib/services/release-markers.ts
+++ b/apps/web/src/lib/services/release-markers.ts
@@ -4,20 +4,6 @@ export interface ReleaseMarker {
 	label: string
 }
 
-/**
- * Turn a per-bucket commit-SHA timeline into deploy markers — one per distinct
- * commit SHA, placed at the earliest bucket it appears in.
- *
- * Every version seen in the range gets a marker (including the one already active
- * at the window's start), so a release is never silently dropped. A window with a
- * single SHA has nothing to mark.
- *
- * Earlier versions keyed markers off a single "dominant" (highest-span) SHA and
- * hid it as the assumed baseline. That wrongly disappeared a real release whenever
- * it happened to carry the most traffic in the window — e.g. a mid-sequence deploy
- * that accumulated more spans than the releases on either side of it. Marking the
- * first appearance of every SHA avoids that: the count is no longer load-bearing.
- */
 export function detectReleaseMarkers(
 	timeline: Array<{ bucket: string; commitSha: string; count: number }>,
 ): ReleaseMarker[] {

--- a/apps/web/src/lib/services/release-markers.ts
+++ b/apps/web/src/lib/services/release-markers.ts
@@ -4,49 +4,42 @@ export interface ReleaseMarker {
 	label: string
 }
 
+/**
+ * Turn a per-bucket commit-SHA timeline into deploy markers — one per distinct
+ * commit SHA, placed at the earliest bucket it appears in.
+ *
+ * Every version seen in the range gets a marker (including the one already active
+ * at the window's start), so a release is never silently dropped. A window with a
+ * single SHA has nothing to mark.
+ *
+ * Earlier versions keyed markers off a single "dominant" (highest-span) SHA and
+ * hid it as the assumed baseline. That wrongly disappeared a real release whenever
+ * it happened to carry the most traffic in the window — e.g. a mid-sequence deploy
+ * that accumulated more spans than the releases on either side of it. Marking the
+ * first appearance of every SHA avoids that: the count is no longer load-bearing.
+ */
 export function detectReleaseMarkers(
 	timeline: Array<{ bucket: string; commitSha: string; count: number }>,
 ): ReleaseMarker[] {
 	if (timeline.length === 0) return []
 
+	// A single-version window has no deploy to mark (nothing changed).
+	const distinct = new Set(timeline.map((point) => point.commitSha))
+	if (distinct.size <= 1) return []
+
 	const sorted = timeline.toSorted((a, b) => a.bucket.localeCompare(b.bucket))
 
-	// Find the dominant SHA (highest total count) — this is the "established" release
-	const countBySha = new Map<string, number>()
-	for (const point of sorted) {
-		countBySha.set(point.commitSha, (countBySha.get(point.commitSha) ?? 0) + point.count)
-	}
-
-	let dominantSha = ""
-	let maxCount = 0
-	for (const [sha, count] of countBySha) {
-		if (count > maxCount) {
-			dominantSha = sha
-			maxCount = count
-		}
-	}
-
-	// Only 1 SHA in the entire range — no releases to mark
-	if (countBySha.size <= 1) return []
-
-	// Mark the first appearance of every non-dominant SHA,
-	// but only if it appears after the first bucket (otherwise the
-	// release predates the visible time range)
-	const firstBucket = sorted[0].bucket
+	// One marker per SHA, at the earliest bucket it shows up in.
 	const seen = new Set<string>()
 	const markers: ReleaseMarker[] = []
-
 	for (const point of sorted) {
-		if (!seen.has(point.commitSha)) {
-			seen.add(point.commitSha)
-			if (point.commitSha !== dominantSha && point.bucket !== firstBucket) {
-				markers.push({
-					bucket: point.bucket,
-					commitSha: point.commitSha,
-					label: point.commitSha.slice(0, 7),
-				})
-			}
-		}
+		if (seen.has(point.commitSha)) continue
+		seen.add(point.commitSha)
+		markers.push({
+			bucket: point.bucket,
+			commitSha: point.commitSha,
+			label: point.commitSha.slice(0, 7),
+		})
 	}
 
 	return markers


### PR DESCRIPTION
## Problem

`detectReleaseMarkers` decided which deploy markers to draw on the service charts by picking a single **dominant** (highest-span) commit SHA and skipping it as the assumed baseline — and it also skipped any SHA sitting in the window's **first bucket**.

A release that hit *both* conditions (the densest SHA in the window **and** the earliest bucket) was silently dropped, even though it was clearly present in the data. Observed in practice: a service deployed three SHAs in sequence where the middle one carried the most traffic — the middle deploy marker vanished, while the two flanking it showed. The dropped SHA still appeared as a trace quick-filter, making the omission look like a bug (it was).

Keying markers off span count is the core flaw: whichever release happens to carry the most traffic in a window disappears, regardless of when it was deployed.

## Fix

Mark the **first appearance of every distinct commit SHA** instead. Span count is no longer load-bearing, so a high-traffic release can't be hidden. A single-SHA window still produces no markers (nothing changed to mark).

### Trade-off
Because every version now gets a marker, a window that opens mid-deployment shows a marker at its left edge for whatever version was already running (previously that leading baseline was suppressed). This is intentional — "show every release that ran" — and is what surfaced the originally-missing deploy. Single-version windows are unaffected.

## Tests
Adds `release-markers.test.ts`, including a regression for the densest-and-first-bucket case that reproduced the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)