### PR TITLE
Try Gemini 3.5 Flash via the Workers AI binding (keyless)

### DIFF
--- a/apps/chat-flue/src/agents/maple-chat.ts
+++ b/apps/chat-flue/src/agents/maple-chat.ts
@@ -6,17 +6,17 @@ import { buildSystemPrompt, modeFromInstanceId } from "../lib/modes.ts"
 import { orgIdFromInstanceId } from "../lib/org.ts"
 
 /**
- * Default Workers AI model. `cloudflare/<model-id>` is passed verbatim to
- * `env.AI.run(...)`, billed to the Worker's account (no API key).
+ * Default chat model. EXPERIMENT: trying Google's Gemini 3.5 Flash through the
+ * Cloudflare Workers AI binding's partner-model path. `cloudflare/<model-id>` is
+ * passed verbatim to `env.AI.run(...)`, so this resolves to
+ * `env.AI.run("google/gemini-3.5-flash", …)`. Inference is billed through the
+ * Cloudflare account (Workers AI Unified Billing) — **no Gemini API key and no
+ * AI Gateway BYOK setup needed**, same keyless model as the `@cf/*` models.
  *
- * `@cf/moonshotai/kimi-k2.6` is validated working (Phase 0 live run) and is the
- * same model family the legacy agent used via OpenRouter (`moonshotai/kimi-k2.7-code`),
- * so tool-calling quality should carry over. Note the Workers AI catalog churns:
- * `@cf/meta/llama-3.1-8b-instruct` was deprecated 2026-05-30 and
- * `@cf/meta/llama-3.3-70b-instruct-fp8-fast` returned a bad stream — confirm any
- * swap against the live catalog. Override per-org via `MAPLE_CHAT_MODEL`.
+ * Previous default: `cloudflare/@cf/moonshotai/kimi-k2.6` (validated, keyless).
+ * Override per-org via `MAPLE_CHAT_MODEL`.
  */
-const DEFAULT_MODEL = "cloudflare/@cf/moonshotai/kimi-k2.6"
+const DEFAULT_MODEL = "cloudflare/google/gemini-3.5-flash"
 
 /**
  * The addressable Maple chat agent on Cloudflare Workers AI, with tools sourced


### PR DESCRIPTION
## What

Experiment: switch the Flue chat agent (`apps/chat-flue`) default model to **`cloudflare/google/gemini-3.5-flash`**.

Flue's `cloudflare/*` provider passes everything after `cloudflare/` **verbatim** to the Workers AI binding, so this runs:

```ts
env.AI.run("google/gemini-3.5-flash", …)
```

That's Cloudflare's **partner-model** path — Gemini inference is billed through the Cloudflare account (Workers AI Unified Billing), exactly like the `@cf/*` models. **No `GEMINI_API_KEY`, no AI Gateway BYOK, no provider registration** — it's keyless.

## Change
- `src/agents/maple-chat.ts` — one line: `DEFAULT_MODEL = "cloudflare/google/gemini-3.5-flash"` (+ doc comment). `MAPLE_CHAT_MODEL` still overrides per-org (e.g. back to `cloudflare/@cf/moonshotai/kimi-k2.6`).

No env/secret/Alchemy changes. Triage is unchanged (its own Workers AI default).

## Verification
- `bun --filter=@maple/chat-flue typecheck` ✅
- chat-flue vitest 40/40 ✅

Open live-run risks (need a deployed run): (1) tool-calling quality of Gemini 3.5 Flash across the Maple MCP tool set, and (2) that pi-ai's `cloudflare-ai-binding` formats requests correctly for the `google/*` partner model via the binding (the documented pattern works for `cloudflare/openai/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)