### PR TITLE
Try @cf/zai-org/glm-5.2 as the chat model

### DIFF
--- a/apps/chat-flue/src/agents/maple-chat.ts
+++ b/apps/chat-flue/src/agents/maple-chat.ts
@@ -6,17 +6,17 @@ import { buildSystemPrompt, modeFromInstanceId } from "../lib/modes.ts"
 import { orgIdFromInstanceId } from "../lib/org.ts"
 
 /**
- * Default Workers AI model. `cloudflare/<model-id>` is passed verbatim to
- * `env.AI.run(...)`, billed to the Worker's account (no API key).
+ * Default Workers AI model. EXPERIMENT: trying Z.ai's `@cf/zai-org/glm-5.2`.
+ * `cloudflare/<model-id>` is passed verbatim to `env.AI.run(...)`; an `@cf/*`
+ * model is hosted natively on Workers AI — keyless and billed as normal Workers
+ * AI usage (neurons + the daily free allocation), no partner/Unified Billing or
+ * AI Gateway BYOK.
  *
- * `@cf/moonshotai/kimi-k2.6` is validated working (Phase 0 live run) and is the
- * same model family the legacy agent used via OpenRouter (`moonshotai/kimi-k2.7-code`),
- * so tool-calling quality should carry over. Note the Workers AI catalog churns:
- * `@cf/meta/llama-3.1-8b-instruct` was deprecated 2026-05-30 and
- * `@cf/meta/llama-3.3-70b-instruct-fp8-fast` returned a bad stream — confirm any
- * swap against the live catalog. Override per-org via `MAPLE_CHAT_MODEL`.
+ * Previous default: `cloudflare/@cf/moonshotai/kimi-k2.6` (validated). The
+ * Workers AI catalog churns, so confirm the id against the live catalog if a
+ * call 404s. Override per-org via `MAPLE_CHAT_MODEL`.
  */
-const DEFAULT_MODEL = "cloudflare/@cf/moonshotai/kimi-k2.6"
+const DEFAULT_MODEL = "cloudflare/@cf/zai-org/glm-5.2"
 
 /**
  * The addressable Maple chat agent on Cloudflare Workers AI, with tools sourced


### PR DESCRIPTION
## What

Experiment: switch the Flue chat agent (`apps/chat-flue`) default model to **`cloudflare/@cf/zai-org/glm-5.2`** (Z.ai GLM-5.2).

It's a native Workers AI model (`@cf/*`), so Flue passes it straight to `env.AI.run("@cf/zai-org/glm-5.2", …)`. **Keyless**, billed as normal Workers AI usage (neurons + the daily free allocation) — no Gemini-style API key, no Unified Billing credits, no AI Gateway BYOK.

## Change
- `src/agents/maple-chat.ts` — one line: `DEFAULT_MODEL = "cloudflare/@cf/zai-org/glm-5.2"` (+ doc comment). `MAPLE_CHAT_MODEL` still overrides per-org (e.g. back to `cloudflare/@cf/moonshotai/kimi-k2.6`).

No env/secret/Alchemy changes. Triage is unchanged (its own Workers AI default).

## Verification
- `bun --filter=@maple/chat-flue typecheck` ✅
- chat-flue vitest 40/40 ✅

Live-run checks (need a deploy): the exact model id resolves on the live Workers AI catalog (the catalog churns; a wrong id 404s), and GLM-5.2's tool-calling quality across the Maple MCP tool set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)