### PR TITLE
perf(autumn): edge-cache getOrCreateCustomer to cut hot-path latency

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -146,6 +146,7 @@ const DigestServiceLive = DigestService.layer.pipe(
 export const MainLive = Layer.mergeAll(
 	CoreServicesLive,
 	WarehouseQueryServiceLive,
+	EdgeCacheServiceLive,
 	QueryEngineServiceLive,
 	AlertsServiceLive,
 	AnomalyDetectionServiceLive,

--- a/apps/api/src/lib/CacheBackendLive.ts
+++ b/apps/api/src/lib/CacheBackendLive.ts
@@ -37,6 +37,9 @@ const makeWorkersBackend = (cache: Cache): EdgeCacheBackend => ({
 		})
 		await cache.put(buildCacheUrl(bucket, hash), response)
 	},
+	delete: async (bucket, hash) => {
+		await cache.delete(buildCacheUrl(bucket, hash))
+	},
 })
 
 export const CacheBackendLive = Layer.effect(

--- a/apps/api/src/routes/autumn.http.test.ts
+++ b/apps/api/src/routes/autumn.http.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { Effect } from "effect"
+import { makeEdgeCacheService, makeMemoryBackend } from "@maple/query-engine/caching"
+import { CUSTOMER_CACHE_BUCKET, readCustomerCached } from "./autumn.http"
+
+const ORG = "org_test_123"
+
+const makeCache = () => makeEdgeCacheService(makeMemoryBackend())
+
+describe("readCustomerCached", () => {
+	it("caches a 200 response: 2nd call hits the cache, upstream runs once", async () => {
+		const cache = makeCache()
+		let calls = 0
+		const run = Effect.sync(() => {
+			calls += 1
+			return { statusCode: 200, response: { customer: ORG, calls } }
+		})
+
+		const { first, second } = await Effect.runPromise(
+			Effect.gen(function* () {
+				const first = yield* readCustomerCached(cache, ORG, run)
+				const second = yield* readCustomerCached(cache, ORG, run)
+				return { first, second }
+			}),
+		)
+
+		expect(calls).toBe(1)
+		expect(first.hit).toBe(false)
+		expect(second.hit).toBe(true)
+		expect(second.result.response).toEqual({ customer: ORG, calls: 1 })
+	})
+
+	it("does NOT cache a non-200 response — recomputes on every call", async () => {
+		const cache = makeCache()
+		let calls = 0
+		const run = Effect.sync(() => {
+			calls += 1
+			return { statusCode: 500, response: { error: "boom" } }
+		})
+
+		const { first, second } = await Effect.runPromise(
+			Effect.gen(function* () {
+				const first = yield* readCustomerCached(cache, ORG, run)
+				const second = yield* readCustomerCached(cache, ORG, run)
+				return { first, second }
+			}),
+		)
+
+		expect(calls).toBe(2)
+		expect(first.hit).toBe(false)
+		expect(second.hit).toBe(false)
+		expect(first.result.statusCode).toBe(500)
+	})
+
+	it("recomputes after the org entry is invalidated", async () => {
+		const cache = makeCache()
+		let calls = 0
+		const run = Effect.sync(() => {
+			calls += 1
+			return { statusCode: 200, response: { calls } }
+		})
+
+		const after = await Effect.runPromise(
+			Effect.gen(function* () {
+				yield* readCustomerCached(cache, ORG, run)
+				yield* readCustomerCached(cache, ORG, run) // served from cache
+				yield* cache.invalidate({ bucket: CUSTOMER_CACHE_BUCKET, key: ORG })
+				return yield* readCustomerCached(cache, ORG, run)
+			}),
+		)
+
+		expect(calls).toBe(2)
+		expect(after.hit).toBe(false)
+		expect(after.result.response).toEqual({ calls: 2 })
+	})
+
+	it("scopes the cache per org — a different orgId is a separate entry", async () => {
+		const cache = makeCache()
+		let calls = 0
+		const run = Effect.sync(() => {
+			calls += 1
+			return { statusCode: 200, response: { calls } }
+		})
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				yield* readCustomerCached(cache, "org_a", run)
+				yield* readCustomerCached(cache, "org_b", run)
+			}),
+		)
+
+		expect(calls).toBe(2)
+	})
+})

--- a/apps/api/src/routes/autumn.http.ts
+++ b/apps/api/src/routes/autumn.http.ts
@@ -1,13 +1,68 @@
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
-import { Effect, Option, Redacted } from "effect"
+import { Effect, Option, Redacted, Schema } from "effect"
 import { autumnHandler, type CustomerData } from "autumn-js/backend"
+import { EdgeCacheService, type EdgeCacheServiceShape } from "@maple/query-engine/caching"
 import { Env } from "../lib/Env"
 import { AuthService } from "../services/AuthService"
+
+type AutumnResult = Awaited<ReturnType<typeof autumnHandler>>
+
+/**
+ * Sentinel used to keep non-200 Autumn responses out of the edge cache: the
+ * compute Effect fails with this so `getOrCompute` never stores the value, and
+ * the caller immediately recovers it back into the normal response path. The
+ * struct field mirrors `AutumnHandlerResult` so `.result` stays typed without a
+ * cast (it is never serialized — caught immediately).
+ */
+class UncacheableAutumnResult extends Schema.TaggedErrorClass<UncacheableAutumnResult>()(
+	"@maple/api/autumn/UncacheableAutumnResult",
+	{
+		result: Schema.Struct({ statusCode: Schema.Number, response: Schema.Unknown }),
+	},
+) {}
+
+// getOrCreateCustomer fires on every page load (the hot path) and its latency is
+// dominated by the upstream Autumn API call. Cache its success response per org
+// for 5 minutes behind the shared edge cache (Workers Cache; single-flight dedup
+// collapses concurrent misses into one upstream call).
+export const CUSTOMER_CACHE_BUCKET = "autumn-customer"
+export const CUSTOMER_CACHE_TTL_SECONDS = 300
+
+/**
+ * Run `getOrCreateCustomer` through the per-org edge cache. Only 200 responses
+ * are cached — anything else (Autumn error / transient) fails the compute via a
+ * sentinel so `getOrCompute` never stores it, and is then recovered so the
+ * caller still gets the real response. Returns the resolved result plus whether
+ * it came from the cache (for span annotation). Exported for unit tests.
+ */
+export const readCustomerCached = (
+	edgeCache: Pick<EdgeCacheServiceShape, "getOrCompute">,
+	orgId: string,
+	runAutumn: Effect.Effect<AutumnResult, Error>,
+): Effect.Effect<{ readonly result: AutumnResult; readonly hit: boolean }, Error> =>
+	edgeCache
+		.getOrCompute(
+			{ bucket: CUSTOMER_CACHE_BUCKET, key: orgId, ttlSeconds: CUSTOMER_CACHE_TTL_SECONDS },
+			runAutumn.pipe(
+				Effect.flatMap((res) =>
+					res.statusCode === 200
+						? Effect.succeed(res)
+						: Effect.fail(new UncacheableAutumnResult({ result: res })),
+				),
+			),
+		)
+		.pipe(
+			Effect.map((cached) => ({ result: cached.value, hit: cached.hit })),
+			Effect.catchTag("@maple/api/autumn/UncacheableAutumnResult", (error) =>
+				Effect.succeed({ result: error.result, hit: false }),
+			),
+		)
 
 export const AutumnRouter = HttpRouter.use((router) =>
 	Effect.gen(function* () {
 		const env = yield* Env
 		const authService = yield* AuthService
+		const edgeCache = yield* EdgeCacheService
 		const secretKey = Option.match(env.AUTUMN_SECRET_KEY, {
 			onNone: () => undefined,
 			onSome: (value) => Redacted.value(value),
@@ -25,6 +80,22 @@ export const AutumnRouter = HttpRouter.use((router) =>
 		// These are user-initiated billing actions, so the extra Clerk lookups
 		// stay off hot paths and only run when someone is genuinely paying.
 		const ENRICHED_ROUTES = new Set(["attach", "multiAttach", "setupPayment", "updateSubscription"])
+
+		// User-initiated routes that change the customer / subscription, so the
+		// cached getOrCreateCustomer response must be evicted afterwards. NOTE:
+		// caches.default is per-colo and best-effort — the acting user's mutation
+		// and their immediate refetch normally hit the same colo (fresh at once),
+		// but another org member or a different colo may see up to the 5-minute TTL
+		// of staleness. That's acceptable for billing display/gating; hard limit
+		// enforcement runs separately in the ingest gateway via Autumn /v1/check.
+		const MUTATION_ROUTES = new Set([
+			"attach",
+			"multiAttach",
+			"setupPayment",
+			"updateSubscription",
+			"redeemReferralCode",
+			"openCustomerPortal",
+		])
 
 		// The plan catalog is global, not customer-specific (autumn-js marks
 		// listPlans' customerId optional). Resolve the tenant optionally for it so a
@@ -54,7 +125,7 @@ export const AutumnRouter = HttpRouter.use((router) =>
 					}
 				}
 
-				const result = yield* Effect.tryPromise({
+				const runAutumn = Effect.tryPromise({
 					try: () =>
 						autumnHandler({
 							request: { url: req.url, method: req.method, body },
@@ -64,6 +135,32 @@ export const AutumnRouter = HttpRouter.use((router) =>
 						}),
 					catch: (error) => (error instanceof Error ? error : new Error(String(error))),
 				})
+
+				let result: AutumnResult
+				let cacheHit = false
+				if (route === "getOrCreateCustomer" && Option.isSome(tenant)) {
+					const outcome = yield* readCustomerCached(edgeCache, tenant.value.orgId, runAutumn)
+					result = outcome.result
+					cacheHit = outcome.hit
+				} else {
+					result = yield* runAutumn
+				}
+
+				yield* Effect.annotateCurrentSpan({
+					"autumn.route": route,
+					"cache.hit": cacheHit,
+					...(Option.isSome(tenant) ? { orgId: tenant.value.orgId } : {}),
+				})
+
+				// Evict the cached customer after a successful billing mutation so the
+				// next getOrCreateCustomer recomputes instead of serving pre-mutation
+				// state. Same { bucket, key } as the read above.
+				if (MUTATION_ROUTES.has(route) && Option.isSome(tenant) && result.statusCode === 200) {
+					yield* edgeCache.invalidate({
+						bucket: CUSTOMER_CACHE_BUCKET,
+						key: tenant.value.orgId,
+					})
+				}
 
 				return yield* HttpServerResponse.json(result.response, {
 					status: result.statusCode,

--- a/apps/web/src/hooks/use-maple-customer.ts
+++ b/apps/web/src/hooks/use-maple-customer.ts
@@ -19,6 +19,11 @@ export function useMapleCustomer(params?: UseCustomerParams) {
 		queryOptions: {
 			retry: 3,
 			retryDelay: (attempt: number) => Math.min(250 * 2 ** attempt, 1000),
+			// getOrCreateCustomer is on the whole-app hot path; the API edge-caches
+			// it per org for 5 min and invalidates on billing mutations, so refetch
+			// on every navigation is wasted. Match that window here (autumn-js still
+			// force-refetches on its own attach/updateSubscription invalidations).
+			staleTime: 1000 * 60 * 5,
 			...params?.queryOptions,
 		},
 	})

--- a/packages/query-engine/src/caching/cache-backend.ts
+++ b/packages/query-engine/src/caching/cache-backend.ts
@@ -16,6 +16,7 @@ export interface EdgeCacheBackend {
 		ttlSeconds: number,
 		nowMs: number,
 	) => Promise<void>
+	readonly delete: (bucket: string, hash: string) => Promise<void>
 }
 
 /** Injected edge-cache storage backend (Workers KV in prod, in-memory in tests/dev). */
@@ -48,6 +49,9 @@ export const makeMemoryBackend = (): EdgeCacheBackend => {
 				value,
 				expiresAt: nowMs + ttlSeconds * 1000,
 			})
+		},
+		delete: async (bucket, hash) => {
+			store.delete(composite(bucket, hash))
 		},
 	}
 }

--- a/packages/query-engine/src/caching/edge-cache.test.ts
+++ b/packages/query-engine/src/caching/edge-cache.test.ts
@@ -24,6 +24,9 @@ const makeJsonRoundtripBackend = (): EdgeCacheBackend & {
 		put: async (bucket, hash, value) => {
 			store.set(composite(bucket, hash), JSON.stringify(value))
 		},
+		delete: async (bucket, hash) => {
+			store.delete(composite(bucket, hash))
+		},
 	}
 }
 
@@ -50,6 +53,57 @@ describe("EdgeCacheService.getOrCompute (no schema)", () => {
 			assert.strictEqual(second.hit, true)
 			assert.deepStrictEqual(second.value, { hello: "world", n: 42 })
 		}).pipe(Effect.provide(makeLayer(backend)))
+	})
+})
+
+describe("EdgeCacheService.invalidate", () => {
+	it.effect("evicts an entry so the next getOrCompute recomputes", () => {
+		const backend = makeJsonRoundtripBackend()
+		let computeCalls = 0
+
+		return Effect.gen(function* () {
+			const cache = yield* EdgeCacheService
+			const compute = Effect.sync(() => {
+				computeCalls += 1
+				return { n: computeCalls }
+			})
+			const opts = { bucket: "autumn-customer", key: "org_123", ttlSeconds: 300 }
+
+			const first = yield* cache.getOrCompute(opts, compute)
+			const cached = yield* cache.getOrCompute(opts, compute)
+			// Invalidate with the SAME { bucket, key } — must hash identically and hit.
+			yield* cache.invalidate({ bucket: opts.bucket, key: opts.key })
+			const afterInvalidate = yield* cache.getOrCompute(opts, compute)
+
+			assert.strictEqual(first.hit, false)
+			assert.strictEqual(cached.hit, true)
+			assert.strictEqual(afterInvalidate.hit, false)
+			assert.strictEqual(computeCalls, 2)
+			assert.deepStrictEqual(afterInvalidate.value, { n: 2 })
+		}).pipe(Effect.provide(makeLayer(backend)))
+	})
+
+	it.effect("is a no-op when the entry does not exist", () => {
+		const backend = makeJsonRoundtripBackend()
+		return Effect.gen(function* () {
+			const cache = yield* EdgeCacheService
+			yield* cache.invalidate({ bucket: "autumn-customer", key: "missing" })
+		}).pipe(Effect.provide(makeLayer(backend)))
+	})
+
+	it.effect("swallows backend delete failures (best-effort)", () => {
+		const failing: EdgeCacheBackend = {
+			get: async () => undefined,
+			put: async () => {},
+			delete: async () => {
+				throw new Error("kv unavailable")
+			},
+		}
+		return Effect.gen(function* () {
+			const cache = yield* EdgeCacheService
+			// Must not fail the effect — invalidate is best-effort.
+			yield* cache.invalidate({ bucket: "autumn-customer", key: "org_123" })
+		}).pipe(Effect.provide(makeLayer(failing)))
 	})
 })
 

--- a/packages/query-engine/src/caching/edge-cache.ts
+++ b/packages/query-engine/src/caching/edge-cache.ts
@@ -191,8 +191,13 @@ export const makeEdgeCacheService = (backend: EdgeCacheBackend): EdgeCacheServic
 		options: EdgeCacheInvalidateOptions,
 	) {
 		const hash = yield* Effect.promise(() => sha256Hex(options.key))
-		// Drop any in-flight single-flight awaiter so a concurrent recompute
-		// doesn't re-publish the value we're evicting.
+		// Drop any in-flight single-flight awaiter so NEW callers don't join an
+		// in-progress compute and get handed the value we're evicting. This does
+		// NOT stop a compute already past its get/inFlight check: its backend.put
+		// can still land after the backend.delete below and re-publish the evicted
+		// value, stale until the TTL (the next read then recomputes). Acceptable as
+		// best-effort display/gating state; closing the window fully would need an
+		// invalidation epoch, which is overkill for a 5-min-TTL hot-path cache.
 		inFlight.delete(`${options.bucket}:${hash}`)
 		yield* Effect.tryPromise({
 			try: () => backend.delete(options.bucket, hash),

--- a/packages/query-engine/src/caching/edge-cache.ts
+++ b/packages/query-engine/src/caching/edge-cache.ts
@@ -42,11 +42,23 @@ interface DeferredAwaiter<A = unknown, E = unknown> {
 	readonly await: Effect.Effect<A, E>
 }
 
+export interface EdgeCacheInvalidateOptions {
+	readonly bucket: string
+	readonly key: string
+}
+
 export interface EdgeCacheServiceShape {
 	readonly getOrCompute: <A, E, R, I = unknown>(
 		options: EdgeCacheGetOrComputeOptions<A, I>,
 		compute: Effect.Effect<A, E, R>,
 	) => Effect.Effect<EdgeCacheResult<A>, E, R>
+	/**
+	 * Evict a `getOrCompute` entry. Pass the SAME `{ bucket, key }` used to
+	 * populate it — `invalidate` derives the storage hash identically
+	 * (`sha256Hex(key)`), so the keys line up. Best-effort: a backend delete
+	 * failure is logged and swallowed (the entry simply expires via its TTL).
+	 */
+	readonly invalidate: (options: EdgeCacheInvalidateOptions) => Effect.Effect<void>
 	readonly rawGet: <A>(bucket: string, key: string) => Effect.Effect<Option.Option<A>, EdgeCacheIOError>
 	readonly rawPut: (
 		bucket: string,
@@ -175,6 +187,31 @@ export const makeEdgeCacheService = (backend: EdgeCacheBackend): EdgeCacheServic
 		return { value, hit: false }
 	})
 
+	const invalidate = Effect.fn("EdgeCacheService.invalidate")(function* (
+		options: EdgeCacheInvalidateOptions,
+	) {
+		const hash = yield* Effect.promise(() => sha256Hex(options.key))
+		// Drop any in-flight single-flight awaiter so a concurrent recompute
+		// doesn't re-publish the value we're evicting.
+		inFlight.delete(`${options.bucket}:${hash}`)
+		yield* Effect.tryPromise({
+			try: () => backend.delete(options.bucket, hash),
+			catch: (error) => error,
+		}).pipe(
+			Effect.tapError((error) =>
+				Effect.logWarning("Edge cache delete failed; entry will expire via TTL").pipe(
+					Effect.annotateLogs({
+						bucket: options.bucket,
+						key: options.key,
+						hash,
+						error: String(error),
+					}),
+				),
+			),
+			Effect.ignore,
+		)
+	})
+
 	const rawGet = <A>(bucket: string, key: string): Effect.Effect<Option.Option<A>, EdgeCacheIOError> =>
 		Effect.gen(function* () {
 			const nowMs = yield* Clock.currentTimeMillis
@@ -210,7 +247,7 @@ export const makeEdgeCacheService = (backend: EdgeCacheBackend): EdgeCacheServic
 			})
 		})
 
-	return { getOrCompute, rawGet, rawPut } satisfies EdgeCacheServiceShape
+	return { getOrCompute, invalidate, rawGet, rawPut } satisfies EdgeCacheServiceShape
 }
 
 export class EdgeCacheService extends Context.Service<EdgeCacheService, EdgeCacheServiceShape>()(


### PR DESCRIPTION
## What & why

`POST /api/autumn/getOrCreateCustomer` fires on **every page load** (mounted in `__root.tsx` via `useMapleCustomer`). Maple's own traces show p95 **~550–830ms**, broken down as:

- **~400–690ms** in the external `autumn-js` call to `api.useautumn.com` — the dominant cost, previously a single untraced span.
- **~110–220ms** `AuthService.resolveTenant` — Clerk auth network round-trip.

This caches the response so the hot path stops paying the upstream billing latency on most loads.

## Changes

- **Edge-cache per org (5-min TTL)** — `autumn.http.ts` routes `getOrCreateCustomer` through a new exported `readCustomerCached` helper using the shared `EdgeCacheService.getOrCompute` (Workers Cache, built-in single-flight dedup). **Only 200s are cached** — a `Schema.TaggedErrorClass` sentinel fails the compute on non-200 so errors/transients never poison the cache. Adds an `autumn.handler` span annotation (`autumn.route`, `cache.hit`, `orgId`) so the Autumn latency is attributable going forward.
- **Invalidation** — new `delete` on `EdgeCacheBackend` (in-memory + Workers `cache.delete`) and `EdgeCacheService.invalidate({bucket,key})` (hashes the key identically to `getOrCompute`). Wired to evict on billing mutation routes (`attach`/`multiAttach`/`setupPayment`/`updateSubscription`/`redeemReferralCode`/`openCustomerPortal`) so a fresh subscription shows immediately.
- **Client `staleTime` → 5 min** — `use-maple-customer.ts` (autumn-js still force-refetches on its own attach/updateSubscription invalidations, so post-mutation refresh is unaffected).
- **`app.ts`** — expose `EdgeCacheServiceLive` on `MainLive` explicitly (was only transitive).

## Reviewer notes

- **`caches.default` is per-colo + best-effort.** The acting user's mutation and immediate refetch hit the same colo (fresh at once); other org members / colos may see up to the 5-min TTL of staleness. Acceptable for billing **display/gating** — hard limit enforcement is separate in the ingest gateway via Autumn `/v1/check`.
- **Follow-up (infra, not in this PR):** set `CLERK_JWT_KEY` in Doppler (`maple/prd`, also `stg`/`pr`) — the code already forwards `jwtKey`, and setting it makes Clerk verification networkless (~1ms) for every authed route. Verify post-deploy via the `AuthService.resolveTenant` p95 in Maple.

## Tests

- `apps/api/src/routes/autumn.http.test.ts` — 4 cases: cache hit, 200-only gating, invalidation→recompute, per-org scoping.
- `packages/query-engine/src/caching/edge-cache.test.ts` — 3 new `invalidate` cases (hash parity, no-op on miss, best-effort on backend failure).
- Typechecks clean across `apps/api`, `packages/query-engine`, `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)