### PR TITLE
fix(web): polish GitHub integration UI for consistency

### DIFF
--- a/apps/web/src/components/icons/index.ts
+++ b/apps/web/src/components/icons/index.ts
@@ -7,6 +7,7 @@ export {
 	ArrowDownIcon,
 	ArrowLeftIcon,
 	ArrowRightIcon,
+	ArrowRotateClockwiseIcon,
 	CheckIcon,
 	ChevronDownIcon,
 	ChevronExpandYIcon,

--- a/apps/web/src/components/integrations/github-integration-card.tsx
+++ b/apps/web/src/components/integrations/github-integration-card.tsx
@@ -24,7 +24,7 @@ import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { toast } from "sonner"
 
 import {
-	ArrowPathIcon,
+	ArrowRotateClockwiseIcon,
 	CheckIcon,
 	ChevronDownIcon,
 	CircleCheckIcon,
@@ -467,7 +467,7 @@ function DeactivatedState({
 					{busy ? (
 						<LoaderIcon size={16} className="animate-spin" />
 					) : (
-						<ArrowPathIcon size={16} />
+						<ArrowRotateClockwiseIcon size={16} />
 					)}
 					Reconnect GitHub
 				</Button>
@@ -547,7 +547,10 @@ function ConnectedView({
 
 				<div className="flex items-center gap-1.5">
 					<Button size="sm" variant="outline" onClick={onRefresh} disabled={refreshing}>
-						<ArrowPathIcon size={14} className={refreshing ? "animate-spin" : ""} />
+						<ArrowRotateClockwiseIcon
+							size={14}
+							className={refreshing ? "animate-spin" : ""}
+						/>
 						Refresh
 					</Button>
 					<Button size="sm" variant="outline" onClick={onManage} disabled={busy !== null}>

--- a/apps/web/src/components/integrations/github-integration-card.tsx
+++ b/apps/web/src/components/integrations/github-integration-card.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { Exit } from "effect"
+import { Exit, Option } from "effect"
 import {
 	GithubSetTrackedBranchRequest,
 	GithubStartConnectRequest,
@@ -17,6 +17,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@maple/ui/components/ui/alert-dialog"
+import { Badge } from "@maple/ui/components/ui/badge"
 import { Button } from "@maple/ui/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@maple/ui/components/ui/popover"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
@@ -123,8 +124,17 @@ export function GithubIntegrationCard() {
 
 	const status = Result.builder(statusResult)
 		.onSuccess((s) => s)
-		.orElse(() => null)
+		.orElse(() =>
+			// Keep the last loaded status visible if a refresh/poll fails, so a transient error
+			// doesn't blow away the connected view.
+			Result.isFailure(statusResult)
+				? Option.getOrNull(Option.map(statusResult.previousSuccess, (prev) => prev.value))
+				: null,
+		)
 	const isLoading = Result.isInitial(statusResult) && status === null
+	// A genuine load failure with nothing to fall back on — surface a retry instead of silently
+	// rendering the first-run "Connect" screen (which is indistinguishable from "never connected").
+	const loadFailed = Result.isFailure(statusResult) && status === null
 
 	// Repos backfill in the VcsSyncQueue worker after connect, so status keeps changing
 	// server-side with no push channel. Poll while the connect popup is open, for a grace
@@ -250,6 +260,8 @@ export function GithubIntegrationCard() {
 		<>
 			{isLoading ? (
 				<LoadingState />
+			) : loadFailed ? (
+				<LoadFailedState onRetry={handleManualRefresh} />
 			) : status?.connected ? (
 				<ConnectedView
 					status={status}
@@ -340,14 +352,26 @@ function LoadingState() {
 	return (
 		<div className="space-y-4">
 			<Skeleton className="h-16 w-full rounded-lg" />
-			<div className="rounded-lg border border-border/60">
-				<Skeleton className="h-11 w-full rounded-t-lg" />
-				<div className="divide-y divide-border/40">
+			<div className="overflow-hidden rounded-lg border">
+				<Skeleton className="h-11 w-full rounded-none" />
+				<div className="divide-y">
 					{[0, 1, 2].map((i) => (
 						<Skeleton key={i} className="m-3 h-9 rounded-md" />
 					))}
 				</div>
 			</div>
+		</div>
+	)
+}
+
+/** Shown when the status query fails outright (and there's no prior value to fall back on). */
+function LoadFailedState({ onRetry }: { onRetry: () => void }) {
+	return (
+		<div className="flex flex-col items-center gap-3 py-8 text-center text-sm text-muted-foreground">
+			Failed to load the GitHub integration.
+			<Button variant="outline" size="sm" onClick={onRetry}>
+				Try again
+			</Button>
 		</div>
 	)
 }
@@ -360,12 +384,7 @@ function NotConnectedState({ busy, onConnect }: { busy: boolean; onConnect: () =
 			accent={GITHUB_ACCENT}
 			iconClassName="text-foreground"
 			title="Connect your GitHub organization"
-			description="Install the Maple GitHub App to sync repositories and commit history. Backfill runs in the background once connected."
-			features={[
-				"Sync commit history across your repositories",
-				"Track one branch per repo, backfilled automatically",
-				"Share all repositories or only the ones you pick",
-			]}
+			description="Install the Maple GitHub App to sync repositories and commit history across your org. Track one branch per repo — backfill runs in the background once connected."
 			footer="You'll choose which repositories to share during install."
 		>
 			<Button onClick={onConnect} disabled={busy}>
@@ -494,12 +513,9 @@ function ConnectedView({
 
 	return (
 		<div className="space-y-4">
-			<div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 bg-card px-4 py-3">
+			<div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-card px-4 py-3">
 				<div className="flex items-center gap-3">
-					<span className="relative flex size-2.5 shrink-0" aria-hidden>
-						<span className="absolute inline-flex size-full rounded-full bg-success/60 motion-safe:animate-ping" />
-						<span className="relative inline-flex size-2.5 rounded-full bg-success" />
-					</span>
+					<span className="size-2 shrink-0 rounded-full bg-success" aria-hidden />
 					<div className="leading-tight">
 						<div className="text-sm font-medium">
 							Connected
@@ -530,16 +546,9 @@ function ConnectedView({
 				</div>
 
 				<div className="flex items-center gap-1.5">
-					<Button
-						size="sm"
-						variant="ghost"
-						onClick={onRefresh}
-						disabled={refreshing}
-						aria-label="Refresh status"
-						title="Refresh status"
-					>
+					<Button size="sm" variant="outline" onClick={onRefresh} disabled={refreshing}>
 						<ArrowPathIcon size={14} className={refreshing ? "animate-spin" : ""} />
-						{refreshing ? "Refreshing…" : "Refresh"}
+						Refresh
 					</Button>
 					<Button size="sm" variant="outline" onClick={onManage} disabled={busy !== null}>
 						{busy === "connect" ? <LoaderIcon size={14} className="animate-spin" /> : null}
@@ -552,8 +561,8 @@ function ConnectedView({
 				</div>
 			</div>
 
-			<div className="overflow-hidden rounded-lg border border-border/60 bg-card">
-				<div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/60 px-4 py-2.5">
+			<div className="overflow-hidden rounded-lg border bg-card">
+				<div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-2.5">
 					<h3 className="text-sm font-medium">
 						Repositories
 						<span className="ml-1.5 text-muted-foreground">{activeRepos.length}</span>
@@ -588,7 +597,7 @@ function ConnectedView({
 						Syncing repositories from GitHub… this can take a moment.
 					</div>
 				) : (
-					<ul className="divide-y divide-border/40">
+					<ul className="divide-y">
 						{activeRepos.map((repo) => (
 							<RepoRow
 								key={repo.id}
@@ -602,14 +611,14 @@ function ConnectedView({
 
 			{/* Repos GitHub revoked access to — kept (with history) until explicitly deleted. */}
 			{removedRepos.length > 0 ? (
-				<div className="overflow-hidden rounded-lg border border-border/60 bg-card">
-					<div className="border-b border-border/60 px-4 py-2.5">
+				<div className="overflow-hidden rounded-lg border bg-card">
+					<div className="border-b px-4 py-2.5">
 						<h3 className="flex items-center gap-1.5 text-sm font-medium">
 							<CircleWarningIcon size={15} className="text-warning-foreground" />
 							Needs attention
 						</h3>
 					</div>
-					<ul className="divide-y divide-border/40">
+					<ul className="divide-y">
 						{removedRepos.map((repo) => (
 							<li key={repo.id} className="flex items-center gap-3 px-4 py-3">
 								<CircleWarningIcon size={17} className="shrink-0 text-warning-foreground" />
@@ -628,9 +637,9 @@ function ConnectedView({
 											/>
 										</a>
 										{repo.isPrivate ? (
-											<span className="shrink-0 rounded-sm border border-border/60 px-1.5 py-px text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+											<Badge variant="outline" size="sm" className="shrink-0">
 												Private
-											</span>
+											</Badge>
 										) : null}
 									</div>
 									<div className="text-xs text-muted-foreground">
@@ -639,8 +648,8 @@ function ConnectedView({
 								</div>
 								<Button
 									size="sm"
-									variant="ghost"
-									className="shrink-0 text-destructive-foreground hover:bg-destructive/10"
+									variant="destructive-outline"
+									className="shrink-0"
 									onClick={() => onRequestDelete(repo)}
 									disabled={deletingRepoId !== null}
 								>
@@ -654,7 +663,7 @@ function ConnectedView({
 							</li>
 						))}
 					</ul>
-					<p className="border-t border-border/60 px-4 py-2.5 text-xs text-muted-foreground">
+					<p className="border-t px-4 py-2.5 text-xs text-muted-foreground">
 						Re-enable these in the{" "}
 						<a
 							href="https://github.com/settings/installations"
@@ -704,9 +713,9 @@ function RepoRow({
 						/>
 					</a>
 					{repo.isPrivate ? (
-						<span className="shrink-0 rounded-sm border border-border/60 px-1.5 py-px text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+						<Badge variant="outline" size="sm" className="shrink-0">
 							Private
-						</span>
+						</Badge>
 					) : null}
 				</div>
 				<div className="flex items-center gap-1.5 text-xs">
@@ -804,26 +813,26 @@ function BranchSelector({
 					}
 				/>
 				<PopoverContent align="end" className="w-72 p-0">
-					<div className="border-b border-border/60 px-3 py-2.5">
+					<div className="border-b px-3 py-2.5">
 						<p className="text-xs font-medium text-foreground">Tracked branch</p>
-						<p className="mt-0.5 text-[11px] text-muted-foreground">
+						<p className="mt-0.5 text-xs text-muted-foreground">
 							Maple syncs commits from the one branch you track. Changing it re-syncs this
 							repo&apos;s commits from the new branch.
 						</p>
 					</div>
 					{repo.branches.length > 8 ? (
-						<div className="border-b border-border/60 p-2">
+						<div className="border-b p-2">
 							<input
 								value={query}
 								onChange={(e) => setQuery(e.target.value)}
 								placeholder="Search branches…"
-								className="w-full rounded-md border border-border/60 bg-transparent px-2 py-1 text-xs outline-none focus:border-border"
+								className="w-full rounded-md border bg-transparent px-2 py-1 text-xs outline-none focus:border-ring"
 							/>
 						</div>
 					) : null}
 					<div className="max-h-56 overflow-y-auto p-1">
 						{filtered.length === 0 ? (
-							<p className="px-2 py-1.5 text-[11px] text-muted-foreground">No matches.</p>
+							<p className="px-2 py-1.5 text-xs text-muted-foreground">No matches.</p>
 						) : (
 							filtered.map((b) => {
 								const selected = b.name === tracked
@@ -840,9 +849,9 @@ function BranchSelector({
 										/>
 										<span className="truncate">{b.name}</span>
 										{b.isDefault ? (
-											<span className="ml-auto text-[10px] uppercase tracking-wide text-muted-foreground">
+											<Badge variant="outline" size="sm" className="ml-auto">
 												default
-											</span>
+											</Badge>
 										) : null}
 									</button>
 								)

--- a/apps/web/src/components/integrations/integration-catalog.tsx
+++ b/apps/web/src/components/integrations/integration-catalog.tsx
@@ -236,8 +236,13 @@ export function IntegrationIconPlate({
 			<span
 				className="absolute inset-0 rounded-[inherit] opacity-70"
 				style={{
-					background:
-						"radial-gradient(circle at 30% 20%, color-mix(in srgb, var(--tile-accent) 16%, transparent), transparent 70%)",
+					// Brand-accent wash. Monochrome marks (iconClassName set, e.g. GitHub's near-black
+					// #181717) are darker than the card and leave no visible wash on the dark canvas, so
+					// derive theirs from --muted-foreground (warm-neutral, theme-aware) — the same visible
+					// neutral bloom PlanetScale's gray accent already produces.
+					background: iconClassName
+						? "radial-gradient(circle at 30% 20%, color-mix(in srgb, var(--muted-foreground) 22%, transparent), transparent 70%)"
+						: "radial-gradient(circle at 30% 20%, color-mix(in srgb, var(--tile-accent) 16%, transparent), transparent 70%)",
 				}}
 			/>
 			<span

--- a/apps/web/src/components/integrations/integration-empty-state.tsx
+++ b/apps/web/src/components/integrations/integration-empty-state.tsx
@@ -19,7 +19,7 @@ function IntegrationEmptyMedia({
 	accent: string
 	iconClassName?: string
 }) {
-	const backer = "absolute bottom-px size-12 rounded-xl border border-border/60 bg-card shadow-none"
+	const backer = "absolute bottom-px size-12 rounded-xl border border-border/60 bg-card"
 	return (
 		<div className="relative mb-6 flex items-end justify-center">
 			<span
@@ -35,7 +35,7 @@ function IntegrationEmptyMedia({
 				accent={accent}
 				iconClassName={iconClassName}
 				size={24}
-				plateClassName="relative size-12 rounded-xl shadow-sm"
+				plateClassName="relative size-12 rounded-xl"
 			/>
 		</div>
 	)


### PR DESCRIPTION
## Summary

A frontend/UI pass on the recently-merged GitHub integration, bringing it in line with the reworked integrations (Cloudflare, scrape targets, Hazel) and `DESIGN.md`. Verified against the running dev server with before/after screenshots.

## What was wrong & what changed

**Invisible icon-plate gradient** — the catalog wash is `color-mix(--tile-accent 16%)`, and GitHub's accent `#181717` (L≈0.21) is *darker* than the card (L≈0.22), so it composited to a ~1-level delta — effectively no wash, while every other integration had a visible one. `IntegrationIconPlate` now derives the wash from `--muted-foreground` for monochrome marks (those with `iconClassName`), producing a visible, theme-aware bloom that matches PlanetScale's neutral tile.

**"Horrendous" Refresh button** — it was a borderless `ghost` button wedged between two bordered `outline` buttons, and its label swapped `Refresh`↔`Refreshing…` causing layout shift. Now all three header buttons (Refresh/Manage/Disconnect) are a uniform `outline` group, and only the icon spins (frozen label, no shift) — matching Hazel and the app-wide `ReloadControls` convention.

**Empty state looked off** — GitHub was the only integration passing left-aligned `features` bullets into the otherwise-centered empty state. Removed; key value-props folded into the description so it matches the other integrations' centered shape.

**Silent failure (functional gap)** — a failed `githubStatus` query fell through to the first-run "Connect" screen, indistinguishable from "never connected", with no error or retry. Added a `LoadFailedState` with a retry (mirroring Cloudflare/Scrape), and `status` now falls back to `previousSuccess` so a transient *poll* failure doesn't blow away the connected view.

**Smaller consistency / DESIGN.md fixes**
- Hand-rolled `Private` / `default` pills → `Badge`; ghost+custom-class delete → the `destructive-outline` variant.
- Borders unified to full `--border` (was a mix of `border-border/60` + `divide-border/40`); decorative `animate-ping` removed; arbitrary `text-[10px]`/`text-[11px]` normalized to the type scale.
- `integration-empty-state`: dropped the `box-shadow` (DESIGN.md is a flat system; depth comes from tone + hairline).

## Verification
- `bun --filter=@maple/web typecheck` → exit 0.
- Live screenshots confirmed the gradient, refresh-button group, and header plate render correctly (0 console errors). The load-failure and removed-repo states mirror the verified Cloudflare/Scrape patterns (not reproducible in the test data).

## Follow-up (not in this PR)
The state audit found the **same loading-flash + silent-failure gaps in the Hazel card** (a sibling, out of scope here). Happy to fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)