### PR TITLE
perf(replays): partition-prune session-detail queries + memoize CH config resolution

### DIFF
--- a/apps/api/src/routes/session-replay.http.ts
+++ b/apps/api/src/routes/session-replay.http.ts
@@ -103,10 +103,16 @@ export const HttpSessionReplaysLive = HttpApiBuilder.group(MapleApi, "sessionRep
 						"maple.org_id": tenant.orgId,
 						"maple.session.id": payload.sessionId,
 					})
-					const compiled = CH.compile(CH.getSessionReplayQuery(), {
-						orgId: tenant.orgId,
-						sessionId: payload.sessionId,
-					})
+					const compiled = CH.compile(
+						CH.getSessionReplayQuery({
+							startTime: payload.windowStart,
+							endTime: payload.windowEnd,
+						}),
+						{
+							orgId: tenant.orgId,
+							sessionId: payload.sessionId,
+						},
+					)
 					const maybeData = yield* warehouse.compiledQueryFirst(tenant, compiled, {
 						profile: "discovery",
 						context: "getReplay",
@@ -131,10 +137,16 @@ export const HttpSessionReplaysLive = HttpApiBuilder.group(MapleApi, "sessionRep
 						"maple.org_id": tenant.orgId,
 						"maple.session.id": payload.sessionId,
 					})
-					const compiled = CH.compile(CH.sessionReplayEventsQuery(), {
-						orgId: tenant.orgId,
-						sessionId: payload.sessionId,
-					})
+					const compiled = CH.compile(
+						CH.sessionReplayEventsQuery({
+							startTime: payload.windowStart,
+							endTime: payload.windowEnd,
+						}),
+						{
+							orgId: tenant.orgId,
+							sessionId: payload.sessionId,
+						},
+					)
 					const chunks = yield* warehouse.compiledQuery(tenant, compiled, {
 						profile: "list",
 						context: "getReplayEvents",
@@ -181,7 +193,11 @@ export const HttpSessionReplaysLive = HttpApiBuilder.group(MapleApi, "sessionRep
 						return new SessionTraceSummariesResponse({ data: [] })
 					}
 					const compiled = CH.compile(
-						CH.sessionTraceSummariesQuery({ traceIds: payload.traceIds }),
+						CH.sessionTraceSummariesQuery({
+							traceIds: payload.traceIds,
+							startTime: payload.windowStart,
+							endTime: payload.windowEnd,
+						}),
 						{ orgId: tenant.orgId },
 					)
 					const rows = yield* warehouse.compiledQuery(tenant, compiled, {
@@ -206,10 +222,16 @@ export const HttpSessionReplaysLive = HttpApiBuilder.group(MapleApi, "sessionRep
 						"maple.org_id": tenant.orgId,
 						"maple.session.id": payload.sessionId,
 					})
-					const compiled = CH.compile(CH.sessionTranscriptQuery(), {
-						orgId: tenant.orgId,
-						sessionId: payload.sessionId,
-					})
+					const compiled = CH.compile(
+						CH.sessionTranscriptQuery({
+							startTime: payload.windowStart,
+							endTime: payload.windowEnd,
+						}),
+						{
+							orgId: tenant.orgId,
+							sessionId: payload.sessionId,
+						},
+					)
 					const rows = yield* warehouse.compiledQuery(tenant, compiled, {
 						profile: "list",
 						context: "sessionTranscript",

--- a/apps/api/src/services/OrgClickHouseSettingsService.ts
+++ b/apps/api/src/services/OrgClickHouseSettingsService.ts
@@ -68,6 +68,17 @@ type ActiveRow = typeof orgClickHouseSettings.$inferSelect
 const ORG_CH_CONFIG_BUCKET = "org-clickhouse-config"
 const ORG_CH_CONFIG_TTL_SECONDS = 300
 
+// In-isolate value cache in front of the edge cache for the same lookup. Even a
+// Cache-API hit is an async round-trip, and a miss pays the full Postgres read
+// over Hyperdrive (observed at 0.85–2.4s in production traces, dominating the
+// session-replay list load). Workers reuse an isolate across many requests, so a
+// module-scoped memo lets a warm isolate resolve config with ZERO network. TTL
+// is far tighter than the edge TTL, so cross-isolate staleness after a config
+// change (rare — BYO-CH onboarding/rotation) is bounded to seconds; the mutating
+// isolate also clears its own entry on write (see invalidateRuntimeConfigCache).
+const ORG_CH_CONFIG_MEMO_TTL_MS = 30_000
+const runtimeConfigMemo = new Map<string, { value: CachedChSettings | null; expiresAt: number }>()
+
 /**
  * JSON-safe projection of the settings row cached cross-request by
  * `resolveRuntimeConfig`. Holds the ENCRYPTED password material
@@ -689,18 +700,19 @@ export class OrgClickHouseSettingsService extends Context.Service<
 			return Option.fromNullishOr(rows[0])
 		})
 
-		// Bust the cross-request edge entry for an org's runtime config after any
-		// write to its settings row, so the next warehouse query re-resolves rather
-		// than serving the ≤5-min-stale value. The edge cache is optional (absent
-		// in tests / non-worker contexts) — a no-op when unavailable.
+		// Bust the cached runtime config for an org after any write to its settings
+		// row, so the next warehouse query re-resolves rather than serving a stale
+		// value. Clears both the in-isolate memo (this isolate only — other isolates
+		// fall off within ORG_CH_CONFIG_MEMO_TTL_MS) and the cross-request edge entry
+		// (optional — absent in tests / non-worker contexts, a no-op when unavailable).
 		const invalidateRuntimeConfigCache = (orgId: OrgId): Effect.Effect<void> =>
-			Effect.serviceOption(EdgeCacheService).pipe(
-				Effect.flatMap((cache) =>
-					Option.isNone(cache)
-						? Effect.void
-						: cache.value.invalidate({ bucket: ORG_CH_CONFIG_BUCKET, key: orgId }),
-				),
-			)
+			Effect.gen(function* () {
+				runtimeConfigMemo.delete(orgId)
+				const cache = yield* Effect.serviceOption(EdgeCacheService)
+				if (Option.isSome(cache)) {
+					yield* cache.value.invalidate({ bucket: ORG_CH_CONFIG_BUCKET, key: orgId })
+				}
+			})
 
 		const requireActiveRow = Effect.fn("OrgClickHouseSettingsService.requireActiveRow")(function* (
 			orgId: OrgId,
@@ -1079,33 +1091,48 @@ export class OrgClickHouseSettingsService extends Context.Service<
 			function* (orgId: OrgId) {
 				// `selectActiveRow` is a Postgres round-trip on the hot path of EVERY
 				// warehouse SQL execution, and the bucket-cache fan-out re-runs it once
-				// per missing range. Wrap it in the shared edge cache: its in-flight
-				// single-flight collapses the concurrent fan-out into one lookup, and the
-				// 5-min KV entry removes the cold round-trip on repeat loads. We cache the
-				// ENCRYPTED row projection (or `null`) and decrypt per-request below, so
-				// plaintext credentials never enter the cache.
-				const edgeCache = yield* Effect.serviceOption(EdgeCacheService)
-				const lookup = selectActiveRow(orgId).pipe(
-					Effect.map((row) => (Option.isSome(row) ? toCachedChSettings(row.value) : null)),
-				)
-				const cached = Option.isNone(edgeCache)
-					? yield* lookup
-					: yield* edgeCache.value
-							.getOrCompute(
-								{
-									bucket: ORG_CH_CONFIG_BUCKET,
-									key: orgId,
-									ttlSeconds: ORG_CH_CONFIG_TTL_SECONDS,
-									schema: CachedChSettingsOrNull,
-								},
-								lookup,
-							)
-							.pipe(
-								Effect.tap((result) =>
-									Effect.annotateCurrentSpan("clickhouse.config.cacheHit", result.hit),
-								),
-								Effect.map((result) => result.value),
-							)
+				// per missing range. Two cache layers sit in front: a module-scoped
+				// in-isolate memo (zero network on a warm isolate) and, on a memo miss,
+				// the shared edge cache (its in-flight single-flight collapses the
+				// concurrent fan-out into one lookup; the 5-min entry removes the cold
+				// round-trip on repeat loads). Both store the ENCRYPTED row projection
+				// (or `null`) and decrypt per-request below, so plaintext credentials
+				// never enter a cache.
+				const nowMs = yield* Clock.currentTimeMillis
+				const memoized = runtimeConfigMemo.get(orgId)
+				let cached: CachedChSettings | null
+				if (memoized !== undefined && memoized.expiresAt > nowMs) {
+					yield* Effect.annotateCurrentSpan("clickhouse.config.memoHit", true)
+					cached = memoized.value
+				} else {
+					yield* Effect.annotateCurrentSpan("clickhouse.config.memoHit", false)
+					const edgeCache = yield* Effect.serviceOption(EdgeCacheService)
+					const lookup = selectActiveRow(orgId).pipe(
+						Effect.map((row) => (Option.isSome(row) ? toCachedChSettings(row.value) : null)),
+					)
+					cached = Option.isNone(edgeCache)
+						? yield* lookup
+						: yield* edgeCache.value
+								.getOrCompute(
+									{
+										bucket: ORG_CH_CONFIG_BUCKET,
+										key: orgId,
+										ttlSeconds: ORG_CH_CONFIG_TTL_SECONDS,
+										schema: CachedChSettingsOrNull,
+									},
+									lookup,
+								)
+								.pipe(
+									Effect.tap((result) =>
+										Effect.annotateCurrentSpan("clickhouse.config.cacheHit", result.hit),
+									),
+									Effect.map((result) => result.value),
+								)
+					runtimeConfigMemo.set(orgId, {
+						value: cached,
+						expiresAt: nowMs + ORG_CH_CONFIG_MEMO_TTL_MS,
+					})
+				}
 
 				if (cached === null) {
 					return Option.none<RuntimeBackendConfig>()

--- a/apps/web/src/api/warehouse/replays.ts
+++ b/apps/web/src/api/warehouse/replays.ts
@@ -120,7 +120,13 @@ export const getReplaysFacets = Effect.fn("SessionReplays.facets")(function* ({
 // Session detail
 // ---------------------------------------------------------------------------
 
-const GetReplayInput = Schema.Struct({ sessionId: SessionId })
+const GetReplayInput = Schema.Struct({
+	sessionId: SessionId,
+	// Optional session time window (derived from the `t` navigation hint) so the
+	// warehouse prunes daily partitions instead of scanning the 30-day retention.
+	windowStart: Schema.optional(WarehouseDateTimeString),
+	windowEnd: Schema.optional(WarehouseDateTimeString),
+})
 // Encoded shape (plain strings) — callers pass raw route params; decodeInput brands them.
 export type GetReplayInput = (typeof GetReplayInput)["Encoded"]
 
@@ -134,7 +140,11 @@ export const getReplay = Effect.fn("SessionReplays.getReplay")(function* ({
 		Effect.gen(function* () {
 			const client = yield* MapleApiAtomClient
 			return yield* client.sessionReplays.getReplay({
-				payload: new GetReplayRequest({ sessionId: input.sessionId }),
+				payload: new GetReplayRequest({
+					sessionId: input.sessionId,
+					windowStart: input.windowStart,
+					windowEnd: input.windowEnd,
+				}),
 			})
 		}),
 	)
@@ -145,7 +155,11 @@ export const getReplay = Effect.fn("SessionReplays.getReplay")(function* ({
 // Session event chunks (rrweb payloads inline, from ClickHouse, ordered)
 // ---------------------------------------------------------------------------
 
-const GetReplayEventsInput = Schema.Struct({ sessionId: SessionId })
+const GetReplayEventsInput = Schema.Struct({
+	sessionId: SessionId,
+	windowStart: Schema.optional(WarehouseDateTimeString),
+	windowEnd: Schema.optional(WarehouseDateTimeString),
+})
 export type GetReplayEventsInput = (typeof GetReplayEventsInput)["Encoded"]
 
 export const getReplayEvents = Effect.fn("SessionReplays.getReplayEvents")(function* ({
@@ -158,7 +172,11 @@ export const getReplayEvents = Effect.fn("SessionReplays.getReplayEvents")(funct
 		Effect.gen(function* () {
 			const client = yield* MapleApiAtomClient
 			return yield* client.sessionReplays.getReplayEvents({
-				payload: new GetReplayEventsRequest({ sessionId: input.sessionId }),
+				payload: new GetReplayEventsRequest({
+					sessionId: input.sessionId,
+					windowStart: input.windowStart,
+					windowEnd: input.windowEnd,
+				}),
 			})
 		}),
 	)
@@ -169,7 +187,11 @@ export const getReplayEvents = Effect.fn("SessionReplays.getReplayEvents")(funct
 // Distilled session transcript (console / network / errors / nav / clicks)
 // ---------------------------------------------------------------------------
 
-const SessionTranscriptInput = Schema.Struct({ sessionId: SessionId })
+const SessionTranscriptInput = Schema.Struct({
+	sessionId: SessionId,
+	windowStart: Schema.optional(WarehouseDateTimeString),
+	windowEnd: Schema.optional(WarehouseDateTimeString),
+})
 export type SessionTranscriptInput = (typeof SessionTranscriptInput)["Encoded"]
 
 export const getSessionTranscript = Effect.fn("SessionReplays.sessionTranscript")(function* ({
@@ -182,7 +204,11 @@ export const getSessionTranscript = Effect.fn("SessionReplays.sessionTranscript"
 		Effect.gen(function* () {
 			const client = yield* MapleApiAtomClient
 			return yield* client.sessionReplays.sessionTranscript({
-				payload: new SessionTranscriptRequest({ sessionId: input.sessionId }),
+				payload: new SessionTranscriptRequest({
+					sessionId: input.sessionId,
+					windowStart: input.windowStart,
+					windowEnd: input.windowEnd,
+				}),
 			})
 		}),
 	)
@@ -226,7 +252,11 @@ export const getReplaysForTrace = Effect.fn("SessionReplays.replaysForTrace")(fu
 // Per-trace summaries for a session's correlated traces (timeline bars)
 // ---------------------------------------------------------------------------
 
-const SessionTraceSummariesInput = Schema.Struct({ traceIds: Schema.Array(TraceId) })
+const SessionTraceSummariesInput = Schema.Struct({
+	traceIds: Schema.Array(TraceId),
+	windowStart: Schema.optional(WarehouseDateTimeString),
+	windowEnd: Schema.optional(WarehouseDateTimeString),
+})
 export type SessionTraceSummariesInput = (typeof SessionTraceSummariesInput)["Encoded"]
 
 export const getSessionTraceSummaries = Effect.fn("SessionReplays.traceSummaries")(function* ({
@@ -239,7 +269,11 @@ export const getSessionTraceSummaries = Effect.fn("SessionReplays.traceSummaries
 		Effect.gen(function* () {
 			const client = yield* MapleApiAtomClient
 			return yield* client.sessionReplays.traceSummaries({
-				payload: new SessionTraceSummariesRequest({ traceIds: input.traceIds }),
+				payload: new SessionTraceSummariesRequest({
+					traceIds: input.traceIds,
+					windowStart: input.windowStart,
+					windowEnd: input.windowEnd,
+				}),
 			})
 		}),
 	)

--- a/apps/web/src/components/replays/replay-editor-timeline.tsx
+++ b/apps/web/src/components/replays/replay-editor-timeline.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/lib/services/atoms/warehouse-query-atoms"
 import { type DisplayMarker, useReplayPlayer, type ReplayPlayerContextValue } from "./replay-player-context"
 import { spanDisplayRange, type Timeline } from "./replay-timeline"
-import { formatClock, MARKER_STYLES } from "./replay-format"
+import { formatClock, MARKER_STYLES, type ReplayPartitionWindow } from "./replay-format"
 import {
 	ChevronRightIcon,
 	ChevronDownIcon,
@@ -76,10 +76,13 @@ export interface SessionTraceSummary {
 export function ReplayEditorTimeline({
 	traceIds,
 	previewSummaries,
+	window,
 }: {
 	traceIds: ReadonlyArray<string>
 	/** Placeholder-data preview: render these summaries instead of fetching them. */
 	previewSummaries?: ReadonlyArray<SessionTraceSummary>
+	/** Partition-pruning window for the trace-summaries query (the session's span). */
+	window?: ReplayPartitionWindow
 }) {
 	const player = useReplayPlayer()
 
@@ -116,7 +119,12 @@ export function ReplayEditorTimeline({
 					<ActivityTrack player={player} />
 					<ScrubSurface player={player} />
 				</div>
-				<TracesTrack traceIds={traceIds} seek={seek} previewSummaries={previewSummaries} />
+				<TracesTrack
+						traceIds={traceIds}
+						seek={seek}
+						previewSummaries={previewSummaries}
+						window={window}
+					/>
 				<Playhead player={player} />
 			</div>
 		</section>
@@ -309,12 +317,14 @@ const TracesTrack = React.memo(function TracesTrack({
 	traceIds,
 	seek,
 	previewSummaries,
+	window,
 }: {
 	traceIds: ReadonlyArray<string>
 	seek: SeekContext
 	previewSummaries?: ReadonlyArray<SessionTraceSummary>
+	window?: ReplayPartitionWindow
 }) {
-	const result = useAtomValue(getSessionTraceSummariesResultAtom({ data: { traceIds } }))
+	const result = useAtomValue(getSessionTraceSummariesResultAtom({ data: { traceIds, ...window } }))
 
 	const header = (count: number | null) => (
 		<div className="flex items-center gap-2 border-b border-border/60 bg-muted/20 px-3 py-1.5 font-display text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/apps/web/src/components/replays/replay-format.test.ts
+++ b/apps/web/src/components/replays/replay-format.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { replayPartitionWindow } from "./replay-format"
+
+// The session-detail warehouse queries are PARTITION BY toDate(...) over a 30-day
+// TTL; `replayPartitionWindow` turns a session's start (and optional end) into the
+// TinybirdDateTime window that prunes those daily partitions. The strings it emits
+// MUST match the `YYYY-MM-DD HH:mm:ss` shape the domain `TinybirdDateTime` schema
+// accepts, or the request would be rejected before it leaves the browser.
+describe("replayPartitionWindow", () => {
+	it("derives a [start - 1h, start + 24h] window from a start-only hint", () => {
+		const w = replayPartitionWindow("2026-06-24 05:16:41.023800000")
+		expect(w).toEqual({
+			windowStart: "2026-06-24 04:16:41",
+			windowEnd: "2026-06-25 05:16:41",
+		})
+	})
+
+	it("uses the session end (+1h margin) for the upper bound when provided", () => {
+		const w = replayPartitionWindow("2026-06-24 05:16:41", "2026-06-24 05:40:00")
+		expect(w).toEqual({
+			windowStart: "2026-06-24 04:16:41",
+			windowEnd: "2026-06-24 06:40:00",
+		})
+	})
+
+	it("emits `YYYY-MM-DD HH:mm:ss` strings (no fractional seconds, space-separated)", () => {
+		const w = replayPartitionWindow("2026-06-24 05:16:41.5")
+		expect(w?.windowStart).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+		expect(w?.windowEnd).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+	})
+
+	it("returns undefined for a missing or unparseable hint (deep-link full-scan fallback)", () => {
+		expect(replayPartitionWindow(undefined)).toBeUndefined()
+		expect(replayPartitionWindow(null)).toBeUndefined()
+		expect(replayPartitionWindow("")).toBeUndefined()
+		expect(replayPartitionWindow("not-a-timestamp")).toBeUndefined()
+	})
+})

--- a/apps/web/src/components/replays/replay-format.ts
+++ b/apps/web/src/components/replays/replay-format.ts
@@ -1,3 +1,4 @@
+import { warehouseDateTimeToIso } from "@maple/query-engine"
 import type { ActionKind } from "./replay-player-context"
 
 // Shared presentation helpers for the session-replay surfaces (list, detail,
@@ -73,6 +74,43 @@ const RELATIVE_UNITS: ReadonlyArray<readonly [Intl.RelativeTimeFormatUnit, numbe
 ]
 
 const relativeFmt = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" })
+
+// Partition-pruning window for the session-detail warehouse queries. The replay
+// tables are PARTITION BY toDate(...) over a 30-day TTL, so a query filtered only
+// by (OrgId, SessionId/TraceId) scans the index of every daily partition. Bounding
+// it to the session's span prunes to the 1-2 partitions that actually hold the rows.
+const WINDOW_MARGIN_MS = 60 * 60 * 1000 // 1h slack on each side (clock skew, late spans)
+const MAX_SESSION_MS = 24 * 60 * 60 * 1000 // cap when the session end is unknown (active sessions)
+
+/** A warehouse partition-pruning window, shared by the session-detail atom callers. */
+export interface ReplayPartitionWindow {
+	readonly windowStart: string
+	readonly windowEnd: string
+}
+
+/** Format an epoch-ms instant as a `YYYY-MM-DD HH:mm:ss` (UTC) TinybirdDateTime string. */
+const toWarehouseDateTime = (ms: number): string => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
+
+/**
+ * Derive `{ windowStart, windowEnd }` (TinybirdDateTime strings) bounding a
+ * session, from its start (and optional end) warehouse timestamps. Returns
+ * `undefined` when the start hint is missing/unparseable — callers then omit the
+ * window and the query falls back to a full scan (deep-link path, no regression).
+ */
+export function replayPartitionWindow(
+	startHint: string | null | undefined,
+	endHint?: string | null,
+): ReplayPartitionWindow | undefined {
+	if (!startHint) return undefined
+	const startMs = Date.parse(warehouseDateTimeToIso(startHint))
+	if (Number.isNaN(startMs)) return undefined
+	const endMs = endHint ? Date.parse(warehouseDateTimeToIso(endHint)) : Number.NaN
+	const upperMs = Number.isNaN(endMs) ? startMs + MAX_SESSION_MS : endMs + WINDOW_MARGIN_MS
+	return {
+		windowStart: toWarehouseDateTime(startMs - WINDOW_MARGIN_MS),
+		windowEnd: toWarehouseDateTime(upperMs),
+	}
+}
 
 /** `2h ago` / `just now` for an epoch-ms instant, relative to `nowMs` (defaults to Date.now()). */
 export function formatRelativeTime(epochMs: number, nowMs: number = Date.now()): string {

--- a/apps/web/src/components/replays/replay-format.ts
+++ b/apps/web/src/components/replays/replay-format.ts
@@ -80,7 +80,14 @@ const relativeFmt = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" })
 // by (OrgId, SessionId/TraceId) scans the index of every daily partition. Bounding
 // it to the session's span prunes to the 1-2 partitions that actually hold the rows.
 const WINDOW_MARGIN_MS = 60 * 60 * 1000 // 1h slack on each side (clock skew, late spans)
-const MAX_SESSION_MS = 24 * 60 * 60 * 1000 // cap when the session end is unknown (active sessions)
+// Upper bound when the session end is unknown (still active). This MUST stay >=
+// the browser SDK's session lifetime cap (`MAX_SESSION_MS` in
+// packages/browser/src/session.ts) — the SDK rotates to a fresh session once it
+// exceeds that age, so a session's events provably can't extend past
+// `start + cap`. Both constants are 24h. If the SDK cap is ever raised without
+// raising this one, this window would silently prune out a session's tail events
+// (no failing test would catch it), so keep them in lockstep.
+const MAX_SESSION_MS = 24 * 60 * 60 * 1000
 
 /** A warehouse partition-pruning window, shared by the session-detail atom callers. */
 export interface ReplayPartitionWindow {

--- a/apps/web/src/components/replays/replay-player-context.tsx
+++ b/apps/web/src/components/replays/replay-player-context.tsx
@@ -4,6 +4,7 @@ import { EventType, IncrementalSource, MouseInteractions, ReplayerEvents } from 
 import { Result, useAtomValue } from "@/lib/effect-atom"
 import { getReplayEventsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { normalizeEvents } from "./replay-events"
+import type { ReplayPartitionWindow } from "./replay-format"
 import { buildTimeline, type InactiveInterval, type Timeline } from "./replay-timeline"
 
 // ---------------------------------------------------------------------------
@@ -222,6 +223,7 @@ export function ReplayPlayerProvider({
 	sessionId,
 	children,
 	previewEvents,
+	window,
 }: {
 	sessionId: string
 	children: React.ReactNode
@@ -231,11 +233,13 @@ export function ReplayPlayerProvider({
 	 * never pass this, so the atom path below is unchanged.
 	 */
 	previewEvents?: ReadonlyArray<unknown>
+	/** Partition-pruning window; must match the route prefetch key (see $sessionId.tsx). */
+	window?: ReplayPartitionWindow
 }) {
 	// Chunks carry their rrweb events inline (read straight from ClickHouse); parse
 	// + concatenate them in order. Memoized on the (referentially stable) result so
 	// deriveMeta/engine memos hold across the player's frequent re-renders.
-	const eventsResult = useAtomValue(getReplayEventsResultAtom({ data: { sessionId } }))
+	const eventsResult = useAtomValue(getReplayEventsResultAtom({ data: { sessionId, ...window } }))
 
 	const { status, error, events } = React.useMemo<{
 		status: ReplayLoadStatus

--- a/apps/web/src/components/replays/replay-studio.tsx
+++ b/apps/web/src/components/replays/replay-studio.tsx
@@ -4,7 +4,7 @@ import { ReplaySurface, ReplayTransport } from "@/components/replays/replay-play
 import { ReplayPlayerProvider } from "@/components/replays/replay-player-context"
 import { ReplayEditorTimeline, type SessionTraceSummary } from "@/components/replays/replay-editor-timeline"
 import { SessionEventsPanel, type EventRow } from "@/components/replays/session-events-panel"
-import { formatDuration } from "@/components/replays/replay-format"
+import { formatDuration, type ReplayPartitionWindow } from "@/components/replays/replay-format"
 import { CopyButton, Reveal, SessionIdentityHeader } from "@/components/replays/session-detail-parts"
 
 // ---------------------------------------------------------------------------
@@ -53,11 +53,15 @@ export function ReplayStudio({
 	session,
 	traceIds,
 	preview,
+	window,
 }: {
 	sessionId: string
 	session: ReplayStudioSession
 	traceIds: ReadonlyArray<string>
 	preview?: ReplayStudioPreview
+	/** Partition-pruning window threaded into the detail atoms (matches the
+	 *  route prefetch key). Omitted on the preview route, which bypasses fetches. */
+	window?: ReplayPartitionWindow
 }) {
 	const isActive = session.status === "active"
 	const label = session.userId || "Anonymous session"
@@ -82,7 +86,7 @@ export function ReplayStudio({
 				</div>
 			</Reveal>
 
-			<ReplayPlayerProvider sessionId={sessionId} previewEvents={preview?.rrwebEvents}>
+			<ReplayPlayerProvider sessionId={sessionId} previewEvents={preview?.rrwebEvents} window={window}>
 				{/* Browser chrome + video next to the event stream. The transport is
 				    detached (rendered below) so the events panel matches the height of
 				    the video block exactly — no dead space. */}
@@ -97,6 +101,7 @@ export function ReplayStudio({
 						<SessionEventsPanel
 							sessionId={sessionId}
 							previewEvents={preview?.transcript}
+							window={window}
 							className="h-[clamp(20rem,60vh,28rem)] lg:absolute lg:inset-0 lg:h-auto"
 						/>
 					</div>
@@ -107,7 +112,11 @@ export function ReplayStudio({
 
 				{/* Trace timeline — full width below. */}
 				<Reveal delay={0.08}>
-					<ReplayEditorTimeline traceIds={traceIds} previewSummaries={preview?.traceSummaries} />
+					<ReplayEditorTimeline
+							traceIds={traceIds}
+							previewSummaries={preview?.traceSummaries}
+							window={window}
+						/>
 				</Reveal>
 			</ReplayPlayerProvider>
 		</div>

--- a/apps/web/src/components/replays/session-events-panel.tsx
+++ b/apps/web/src/components/replays/session-events-panel.tsx
@@ -4,6 +4,7 @@ import { cn } from "@maple/ui/utils"
 import { Result, useAtomValue } from "@/lib/effect-atom"
 import { getSessionTranscriptResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
+import type { ReplayPartitionWindow } from "./replay-format"
 import { useReplayPlayer } from "./replay-player-context"
 import { parseChTimestampMs } from "./replay-timeline"
 
@@ -39,15 +40,18 @@ const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
 export function SessionEventsPanel({
 	sessionId,
 	previewEvents,
+	window,
 	className,
 }: {
 	sessionId: string
 	/** Placeholder-data preview: render these events instead of fetching them. */
 	previewEvents?: ReadonlyArray<EventRow>
+	/** Partition-pruning window; must match the route prefetch key (see $sessionId.tsx). */
+	window?: ReplayPartitionWindow
 	/** Sizing handed down by the layout (the panel fills/scrolls within it). */
 	className?: string
 }) {
-	const result = useAtomValue(getSessionTranscriptResultAtom({ data: { sessionId } }))
+	const result = useAtomValue(getSessionTranscriptResultAtom({ data: { sessionId, ...window } }))
 	const [tab, setTab] = React.useState<Tab>("console")
 	const { timeline, recordingStartEpochMs, realTotalMs, seekDisplay } = useReplayPlayer()
 

--- a/apps/web/src/routes/replays/$sessionId.tsx
+++ b/apps/web/src/routes/replays/$sessionId.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import { createFileRoute } from "@tanstack/react-router"
 import { effectRoute } from "@effect-router/core"
 import { Schema } from "effect"
@@ -12,23 +13,38 @@ import {
 } from "@/lib/services/atoms/warehouse-query-atoms"
 import { QueryErrorState } from "@/components/common/query-error-state"
 import { ReplayDetailSkeleton } from "@/components/replays/session-detail-parts"
+import { replayPartitionWindow } from "@/components/replays/replay-format"
 
 const detailSearchSchema = Schema.Struct({
+	// Session start (warehouse timestamp), set by the list-row link. Used as a
+	// partition-pruning hint so the detail queries don't scan the full 30-day
+	// retention; absent on deep-links, which then fall back to a full scan.
 	t: Schema.optional(Schema.String),
 })
 
-export const Route = effectRoute(createFileRoute("/replays/$sessionId"), ({ params }) => [
-	getReplayResultAtom({ data: { sessionId: params.sessionId } }),
-	getReplayEventsResultAtom({ data: { sessionId: params.sessionId } }),
-	getSessionTranscriptResultAtom({ data: { sessionId: params.sessionId } }),
-])({
+export const Route = effectRoute(createFileRoute("/replays/$sessionId"), ({ params, search }) => {
+	const window = replayPartitionWindow(typeof search.t === "string" ? search.t : undefined)
+	const data = { sessionId: params.sessionId, ...window }
+	return [
+		getReplayResultAtom({ data }),
+		getReplayEventsResultAtom({ data }),
+		getSessionTranscriptResultAtom({ data }),
+	]
+})({
 	component: ReplayDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(detailSearchSchema),
 })
 
 function ReplayDetailPage() {
 	const { sessionId } = Route.useParams()
-	const detailResult = useAtomValue(getReplayResultAtom({ data: { sessionId } }))
+	const search = Route.useSearch()
+	// Recompute the same window the loader prefetched with, so every atom read
+	// keys to the identical (prefetched) family entry rather than refetching.
+	// Memoized on `t` so its identity is stable — it threads down to the memoized
+	// TracesTrack, which must not re-render while the playhead scrubs.
+	const t = typeof search.t === "string" ? search.t : undefined
+	const window = useMemo(() => replayPartitionWindow(t), [t])
+	const detailResult = useAtomValue(getReplayResultAtom({ data: { sessionId, ...window } }))
 
 	const breadcrumbs = [{ label: "Session Replays", href: "/replays" }, { label: sessionId.slice(0, 8) }]
 
@@ -61,7 +77,12 @@ function ReplayDetailPage() {
 
 			return (
 				<DashboardLayout breadcrumbs={breadcrumbs} title="Session Replay">
-					<ReplayStudio sessionId={sessionId} session={session} traceIds={session.traceIds} />
+					<ReplayStudio
+							sessionId={sessionId}
+							session={session}
+							traceIds={session.traceIds}
+							window={window}
+						/>
 				</DashboardLayout>
 			)
 		})

--- a/packages/domain/src/http/session-replay.ts
+++ b/packages/domain/src/http/session-replay.ts
@@ -90,6 +90,13 @@ export class ReplaysFacetsResponse extends Schema.Class<ReplaysFacetsResponse>("
 
 export class GetReplayRequest extends Schema.Class<GetReplayRequest>("GetReplayRequest")({
 	sessionId: SessionId,
+	// Optional session time window — lets the warehouse prune daily partitions
+	// instead of scanning the full 30-day retention. The web client derives it
+	// from the `t` (session start) navigation hint; deep-links omit it and fall
+	// back to a full scan. `Schema.optional` (not `optionalKey`) because the
+	// client constructs the payload JS-side and passes explicit `undefined`.
+	windowStart: Schema.optional(TinybirdDateTime),
+	windowEnd: Schema.optional(TinybirdDateTime),
 }) {}
 
 export class GetReplayResponse extends Schema.Class<GetReplayResponse>("GetReplayResponse")({
@@ -121,6 +128,9 @@ export class GetReplayResponse extends Schema.Class<GetReplayResponse>("GetRepla
 
 export class GetReplayEventsRequest extends Schema.Class<GetReplayEventsRequest>("GetReplayEventsRequest")({
 	sessionId: SessionId,
+	// See GetReplayRequest — optional partition-pruning window.
+	windowStart: Schema.optional(TinybirdDateTime),
+	windowEnd: Schema.optional(TinybirdDateTime),
 }) {}
 
 export const SessionReplayChunk = Schema.Struct({
@@ -167,6 +177,10 @@ export class SessionTraceSummariesRequest extends Schema.Class<SessionTraceSumma
 )({
 	/** The session's correlated trace ids (from the detail response's `traceIds`). */
 	traceIds: Schema.Array(TraceId),
+	// See GetReplayRequest — optional partition-pruning window (the session's
+	// time span; its correlated traces fired within it).
+	windowStart: Schema.optional(TinybirdDateTime),
+	windowEnd: Schema.optional(TinybirdDateTime),
 }) {}
 
 export const SessionTraceSummary = Schema.Struct({
@@ -195,6 +209,9 @@ export class SessionTranscriptRequest extends Schema.Class<SessionTranscriptRequ
 	"SessionTranscriptRequest",
 )({
 	sessionId: SessionId,
+	// See GetReplayRequest — optional partition-pruning window.
+	windowStart: Schema.optional(TinybirdDateTime),
+	windowEnd: Schema.optional(TinybirdDateTime),
 }) {}
 
 export const SessionEventItem = Schema.Struct({

--- a/packages/query-engine/src/ch/queries/session-events.ts
+++ b/packages/query-engine/src/ch/queries/session-events.ts
@@ -37,6 +37,11 @@ function argMinExpr<T>(value: CH.Expr<T>, ordering: CH.Expr<unknown>): CH.Expr<T
 //
 // (OrgId, SessionId) is the sort-key prefix, so this is a contiguous range
 // scan. Timestamp + Seq give a stable playback/reading order.
+//
+// session_events is PARTITION BY toDate(Timestamp) with a 30-day TTL; without a
+// Timestamp predicate ClickHouse reads the primary index of every daily
+// partition. The optional startTime/endTime bounds (the session's time window)
+// prune to the 1-2 partitions the session spans. Omit to scan all.
 // ---------------------------------------------------------------------------
 
 export interface SessionTranscriptOutput {
@@ -63,6 +68,9 @@ export interface SessionTranscriptOpts {
 	traceId?: string
 	/** Only "things that went wrong": error events, console errors, and failed (>=400) requests. */
 	errorsOnly?: boolean
+	/** Optional session time window — prunes daily partitions. Omit to scan all. */
+	startTime?: string
+	endTime?: string
 	/** Page size. Transcripts are unbounded otherwise — always cap for agents. */
 	limit?: number
 	offset?: number
@@ -89,6 +97,8 @@ export function sessionTranscriptQuery(opts: SessionTranscriptOpts = {}) {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.SessionId.eq(param.string("sessionId")),
+			CH.when(opts.startTime, (v: string) => $.Timestamp.gte(v)),
+			CH.when(opts.endTime, (v: string) => $.Timestamp.lte(v)),
 			opts.types && opts.types.length > 0 ? CH.inList($.Type, opts.types) : undefined,
 			CH.when(opts.traceId, (v: string) => $.TraceId.eq(v)),
 			CH.whenTrue(opts.errorsOnly, () =>

--- a/packages/query-engine/src/ch/queries/session-replays.test.ts
+++ b/packages/query-engine/src/ch/queries/session-replays.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest"
 import { compileCH } from "@maple-dev/clickhouse-builder"
-import { sessionTraceSummariesQuery } from "./session-replays"
+import {
+	getSessionReplayQuery,
+	sessionReplayEventsQuery,
+	sessionTraceSummariesQuery,
+} from "./session-replays"
 
 const baseParams = { orgId: "org_1" }
+const sessionParams = { orgId: "org_1", sessionId: "sess_1" }
+const WINDOW = { startTime: "2026-06-24 04:00:00", endTime: "2026-06-25 06:00:00" }
 
 // ---------------------------------------------------------------------------
 // sessionTraceSummariesQuery
@@ -29,5 +35,54 @@ describe("sessionTraceSummariesQuery", () => {
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("OrgId = 'org_1'")
 		expect(sql).toContain("TraceId IN ('t1', 't2')")
+	})
+
+	// The table is PARTITION BY toDate(Timestamp); the session window prunes the
+	// daily partitions an unbounded TraceId-IN scan would otherwise touch.
+	it("adds the session time window as a partition-pruning predicate when provided", () => {
+		const q = sessionTraceSummariesQuery({ traceIds: ["t1"], ...WINDOW })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("Timestamp >= '2026-06-24 04:00:00'")
+		expect(sql).toContain("Timestamp <= '2026-06-25 06:00:00'")
+	})
+
+	it("omits the time window when absent (deep-link path, unchanged full scan)", () => {
+		const q = sessionTraceSummariesQuery({ traceIds: ["t1"] })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).not.toContain("Timestamp >=")
+		expect(sql).not.toContain("Timestamp <=")
+	})
+})
+
+describe("sessionReplayEventsQuery", () => {
+	it("adds the session time window as a partition-pruning predicate when provided", () => {
+		const q = sessionReplayEventsQuery(WINDOW)
+		const { sql } = compileCH(q, sessionParams)
+		expect(sql).toContain("FROM session_replay_events")
+		expect(sql).toContain("Timestamp >= '2026-06-24 04:00:00'")
+		expect(sql).toContain("Timestamp <= '2026-06-25 06:00:00'")
+	})
+
+	it("omits the time window when absent (full scan)", () => {
+		const q = sessionReplayEventsQuery()
+		const { sql } = compileCH(q, sessionParams)
+		expect(sql).not.toContain("Timestamp >=")
+	})
+})
+
+describe("getSessionReplayQuery", () => {
+	// session_replays is PARTITION BY toDate(StartTime); StartTime is version-
+	// invariant so the window is safe alongside the ORDER BY Version DESC dedup.
+	it("adds the session time window on StartTime when provided", () => {
+		const q = getSessionReplayQuery(WINDOW)
+		const { sql } = compileCH(q, sessionParams)
+		expect(sql).toContain("StartTime >= '2026-06-24 04:00:00'")
+		expect(sql).toContain("StartTime <= '2026-06-25 06:00:00'")
+	})
+
+	it("omits the time window when absent (full scan)", () => {
+		const q = getSessionReplayQuery()
+		const { sql } = compileCH(q, sessionParams)
+		expect(sql).not.toContain("StartTime >=")
 	})
 })

--- a/packages/query-engine/src/ch/queries/session-replays.ts
+++ b/packages/query-engine/src/ch/queries/session-replays.ts
@@ -213,7 +213,16 @@ export function sessionReplaysFacetsQuery(
 //
 // (OrgId, SessionId) is the full sort-key prefix, so this is an O(log N)
 // lookup. Dedup the ReplacingMergeTree versions by taking the highest Version.
+//
+// session_replays is PARTITION BY toDate(StartTime); the optional startTime/
+// endTime bounds (version-invariant column, identical across v1/v2) prune the
+// daily partitions a deep-scan would otherwise touch. Omit to scan all.
 // ---------------------------------------------------------------------------
+
+export interface SessionReplayDetailOpts {
+	startTime?: string
+	endTime?: string
+}
 
 export interface SessionReplayDetailOutput {
 	readonly sessionId: string
@@ -237,7 +246,7 @@ export interface SessionReplayDetailOutput {
 	readonly version: number
 }
 
-export function getSessionReplayQuery() {
+export function getSessionReplayQuery(opts: SessionReplayDetailOpts = {}) {
 	return from(SessionReplays)
 		.select(($) => ({
 			version: $.Version,
@@ -260,7 +269,12 @@ export function getSessionReplayQuery() {
 			traceIds: $.TraceIds,
 			resourceAttributes: CH.toJSONString($.ResourceAttributes),
 		}))
-		.where(($) => [$.OrgId.eq(param.string("orgId")), $.SessionId.eq(param.string("sessionId"))])
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.SessionId.eq(param.string("sessionId")),
+			CH.when(opts.startTime, (v: string) => $.StartTime.gte(v)),
+			CH.when(opts.endTime, (v: string) => $.StartTime.lte(v)),
+		])
 		.orderBy(["version", "desc"])
 		.limit(1)
 		.format("JSON")
@@ -270,9 +284,21 @@ export function getSessionReplayQuery() {
 // Chunk index for one session (ordered for playback)
 //
 // session_replay_events is a plain MergeTree — each chunk is written exactly
-// once, so no dedup is needed. Sorted by (Timestamp, ChunkSeq) so the player
-// receives chunks in replay order.
+// once, so no dedup is needed. Sorted by (OrgId, SessionId, ChunkSeq) so the
+// player receives chunks in replay order.
+//
+// The table is PARTITION BY toDate(Timestamp) with a 30-day TTL. (OrgId,
+// SessionId) is a perfect sort-key prefix, but without a Timestamp predicate
+// ClickHouse must read the primary index of every daily partition to find this
+// session's chunks. The optional startTime/endTime bounds (the caller passes
+// the session's time window) prune to the 1-2 partitions the session spans.
 // ---------------------------------------------------------------------------
+
+export interface SessionReplayEventsOpts {
+	/** Optional session time window — prunes daily partitions. Omit to scan all. */
+	startTime?: string
+	endTime?: string
+}
 
 export interface SessionReplayEventsOutput {
 	readonly chunkSeq: number
@@ -285,7 +311,7 @@ export interface SessionReplayEventsOutput {
 	readonly isCheckpoint: number
 }
 
-export function sessionReplayEventsQuery() {
+export function sessionReplayEventsQuery(opts: SessionReplayEventsOpts = {}) {
 	return from(SessionReplayEvents)
 		.select(($) => ({
 			chunkSeq: $.ChunkSeq,
@@ -296,7 +322,12 @@ export function sessionReplayEventsQuery() {
 			events: $.Events,
 			isCheckpoint: $.IsCheckpoint,
 		}))
-		.where(($) => [$.OrgId.eq(param.string("orgId")), $.SessionId.eq(param.string("sessionId"))])
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.SessionId.eq(param.string("sessionId")),
+			CH.when(opts.startTime, (v: string) => $.Timestamp.gte(v)),
+			CH.when(opts.endTime, (v: string) => $.Timestamp.lte(v)),
+		])
 		.orderBy(["chunkSeq", "asc"])
 		.format("JSON")
 }
@@ -341,15 +372,23 @@ export function sessionsForTraceQuery(opts: SessionsForTraceOpts) {
 // One row per TraceId, used to draw a single bar per trace on the session
 // replay timeline (the expandable span lanes fetch full spans on demand via
 // spanHierarchyQuery). Reads `trace_detail_spans`, whose sort key
-// (OrgId, TraceId, SpanId) makes `TraceId IN (...)` a cheap prefix lookup —
-// no time-window scan needed. The root span (ParentSpanId = '') supplies the
-// trace's name/service/duration, with a fallback for traces whose root span
-// wasn't ingested.
+// (OrgId, TraceId, SpanId) makes `TraceId IN (...)` a cheap prefix lookup
+// WITHIN a part. But the table is PARTITION BY toDate(Timestamp) with a 30-day
+// TTL, so without a Timestamp predicate ClickHouse reads the primary index of
+// every daily partition to find these traces — pure scan fan-out (observed at
+// 7s+ for a handful of matching spans on a high-volume org). The optional
+// startTime/endTime bounds (the session's time window — its correlated traces
+// fired within it) prune to the 1-2 partitions the session spans. The root
+// span (ParentSpanId = '') supplies the trace's name/service/duration, with a
+// fallback for traces whose root span wasn't ingested.
 // ---------------------------------------------------------------------------
 
 export interface SessionTraceSummariesOpts {
 	/** The correlated trace ids to summarize (from session_replays.TraceIds). */
 	traceIds: ReadonlyArray<string>
+	/** Optional session time window — prunes daily partitions. Omit to scan all. */
+	startTime?: string
+	endTime?: string
 	limit?: number
 }
 
@@ -396,7 +435,12 @@ export function sessionTraceSummariesQuery(opts: SessionTraceSummariesOpts) {
 				hasError: CH.if_(CH.countIf($.StatusCode.eq("Error")).gt(0), CH.lit(1), CH.lit(0)),
 			}
 		})
-		.where(($) => [$.OrgId.eq(param.string("orgId")), $.TraceId.in_(...opts.traceIds)])
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.TraceId.in_(...opts.traceIds),
+			CH.when(opts.startTime, (v: string) => $.Timestamp.gte(v)),
+			CH.when(opts.endTime, (v: string) => $.Timestamp.lte(v)),
+		])
 		.groupBy("traceId")
 		.orderBy(["startTime", "asc"])
 		.limit(limit)


### PR DESCRIPTION
## Why

Browser-session (replay) detail pages loaded in **5–8s** on high-volume orgs. Root-caused via the Maple MCP by breaking down `WarehouseQueryService.executeSql` p95 by `query.context`:

| query.context | p95 | cause |
|---|---|---|
| `sessionTraceSummaries` | 7.5s | no partition pruning |
| `getReplayEvents` | 5.5s | no partition pruning |
| `listReplays` | 2.3s | config-resolution cache miss (SQL was only ~700ms) |
| `getReplay` / `sessionTranscript` | 1.2–1.7s | no partition pruning |

Two independent causes.

### Cause 1 — detail queries don't prune partitions
All replay tables are `PARTITION BY toDate(...)` with a 30-day TTL (`packages/domain/src/tinybird/datasources.ts`), but the detail queries filtered only by `OrgId + SessionId` / `TraceId IN (...)` with **no time predicate** → ClickHouse reads the primary index of every daily partition. Proof against the warehouse: a `sessionTraceSummaries` over 2 traces (**6 spans total**) took **7.7s** — pure scan fan-out, nothing to compute.

The optimization was **scaffolded but never wired**: the list row already passes `search:{ t: session.startTime }` and the route already declared `t`, but `t` was never read. Now `replayPartitionWindow(t)` derives a `[t-1h, t+24h]` window and threads it through the route loader + every atom consumer (player / events panel / timeline) as a `window` prop. Deep-links without `t` fall back to today's full scan — no regression.

### Cause 2 — per-org CH config resolution misses its cache
`OrgClickHouseSettingsService.resolveRuntimeConfig` runs on every `executeSql`; its Cloudflare-Cache-API edge cache (300s) missed often, paying a 0.85–2.4s Postgres-over-Hyperdrive read (the [PG hot-path](https://github.com/Makisuo/maple/commit/5c0dcaf3b) regression still leaking — it *dominated* the list page). Added a module-scoped **in-isolate memo** (30s TTL) in front of the edge cache so warm isolates resolve config with zero network.

## What changed

- **Queries** (`packages/query-engine/src/ch/queries/{session-replays,session-events}.ts`): optional `startTime`/`endTime` → `Timestamp`/`StartTime` bounds on the 4 detail queries; fixed the now-wrong "no time-window scan needed" comment.
- **HTTP contract** (`packages/domain/src/http/session-replay.ts`): optional `windowStart`/`windowEnd` (`TinybirdDateTime`) on 4 requests.
- **API handlers** (`apps/api/src/routes/session-replay.http.ts`): pass the window into the compiled queries.
- **Web** (`apps/web/src/...`): request builders forward the window; route reads `t` and threads a memoized `window` prop to the player / events panel / timeline (atom families key on serialized data, so every consumer must read the same window to hit the prefetch).
- **Config memo** (`apps/api/src/services/OrgClickHouseSettingsService.ts`): in-isolate cache + clear on invalidation + `clickhouse.config.memoHit` span attr.

## Reviewer notes

- **Window source of truth:** the `t` hint (= `session.startTime`) is plumbed list → route → all atom consumers. The window is memoized (stable identity) so the `React.memo` `TracesTrack` doesn't regress.
- **Config-memo staleness** is bounded to 30s across isolates (far tighter than the existing 300s edge TTL); the mutating isolate clears its own entry. Config changes are rare (BYO-CH onboarding/rotation).
- **rrweb payload size** is unchanged — this fixes the *scan* cost, not transfer size. Lazy/streamed chunk loading is a possible follow-up if transfer dominates after deploy.

## Verification

- `bun typecheck` — 23/23 packages
- query-engine — 618 tests (**+6** SQL-shape: bounds present when window given, omitted when absent)
- apps/api — 41 tests (config caching + invalidation cover the memo)
- apps/web — **4 new** `replayPartitionWindow` tests (`t` → valid `YYYY-MM-DD HH:mm:ss` window)
- Browser e2e: list `/list`+`/facets` → 200; detail `/get`,`/events`,`/transcript` → 200 with `?t=` (valid window accepted by the strict server schema); deep-link to a missing session renders gracefully.

⚠️ **The wall-clock win is unproven until deploy.** The 7.5/5.5s figures are production p95 samples; an on-demand re-run of the same query is fast, so the slowness is an intermittent **p95 tail** (load / merge / cold-partition dependent), not a constant. The structural change strictly shrinks worst-case partition fan-out, but the real acceptance test is re-pulling the MCP `query.context` p95 breakdown on production traffic post-deploy (and confirming `clickhouse.config.memoHit=true` on warm-isolate spans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)