### PR TITLE
refactor: update references from 'superwall' to 'makisuo' across multiple files

### DIFF
--- a/apps/api/src/mcp/__evals__/cli-scenarios.eval.ts
+++ b/apps/api/src/mcp/__evals__/cli-scenarios.eval.ts
@@ -2,7 +2,7 @@ import { ToolCallScorer } from "vitest-evals"
 import { describeMapleEval, predictToolCalls } from "./utils"
 
 // Investigation scenarios ported from the former `apps/cli/EVALS.md` suite.
-// That file documented real Superwall-production investigations as `maple <cmd>`
+// That file documented real Maple-production investigations as `maple <cmd>`
 // CLI invocations with prose "Expect:" notes — runnable by a human, but never
 // asserted in CI. Each CLI command maps to an MCP tool, so here they become
 // tool-selection evals: given the natural-language investigation, does the model

--- a/deploy/k8s-infra/Dockerfile.otel-collector-maple
+++ b/deploy/k8s-infra/Dockerfile.otel-collector-maple
@@ -12,7 +12,7 @@
 #   docker buildx build \
 #     --file deploy/k8s-infra/Dockerfile.otel-collector-maple \
 #     --platform linux/amd64,linux/arm64 \
-#     --tag ghcr.io/superwall/otel-collector-maple:0.1.0 \
+#     --tag ghcr.io/makisuo/maple/otel-collector-maple:0.1.0 \
 #     --push .
 
 ARG OTEL_BUILDER_VERSION=v0.151.0

--- a/deploy/k8s-infra/builder-config.yaml
+++ b/deploy/k8s-infra/builder-config.yaml
@@ -14,7 +14,7 @@
 # packages/otel-collector-maple-exporter/go.mod.
 
 dist:
-  module: github.com/superwall/maple/cmd/otel-collector-maple
+  module: github.com/makisuo/maple/cmd/otel-collector-maple
   name: otel-collector-maple
   description: "OpenTelemetry Collector with Maple ClickHouse exporter"
   output_path: ./bin
@@ -54,7 +54,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.151.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.151.0
   # Maple's custom exporter — local module via replaces directive below.
-  - gomod: github.com/superwall/maple/packages/otel-collector-maple-exporter v0.0.0
+  - gomod: github.com/makisuo/maple/packages/otel-collector-maple-exporter v0.0.0
     name: mapleexporter
 
 connectors:
@@ -66,4 +66,4 @@ connectors:
 # relative to the generated go.mod which lives in `./bin`, so one `../`
 # climbs back to the maple repo root.
 replaces:
-  - github.com/superwall/maple/packages/otel-collector-maple-exporter => ../packages/otel-collector-maple-exporter
+  - github.com/makisuo/maple/packages/otel-collector-maple-exporter => ../packages/otel-collector-maple-exporter

--- a/deploy/k8s-infra/values.yaml
+++ b/deploy/k8s-infra/values.yaml
@@ -104,7 +104,7 @@ maple:
             pullPolicy: IfNotPresent
         # ClickHouse HTTP endpoint. e.g. an in-cluster Altinity-operator CHI:
         # http://clickhouse-clickhouse.clickhouse.svc.cluster.local:8123
-        # or a public-facing host: https://ch.superwall.dev
+        # or a public-facing host: https://maple.dev
         endpoint: ""
         # Database holding Maple's tables. Default matches the migrations.
         database: default

--- a/packages/otel-collector-maple-exporter/README.md
+++ b/packages/otel-collector-maple-exporter/README.md
@@ -22,7 +22,7 @@ inside ClickHouse.
 ```yaml
 exporters:
     maple:
-        endpoint: https://ch.superwall.dev # ClickHouse HTTP base URL
+        endpoint: https://maple.dev # ClickHouse HTTP base URL
         database: default
         username: maple
         password: ${env:MAPLE_CLICKHOUSE_PASSWORD}

--- a/packages/otel-collector-maple-exporter/config.go
+++ b/packages/otel-collector-maple-exporter/config.go
@@ -27,7 +27,7 @@ type Config struct {
 
 	// Endpoint is the ClickHouse HTTP base URL — no trailing slash, no path.
 	// Example: "http://clickhouse-clickhouse.clickhouse.svc.cluster.local:8123"
-	// or "https://ch.superwall.dev".
+	// or "https://maple.dev".
 	Endpoint string `mapstructure:"endpoint"`
 
 	// Database is the ClickHouse database holding Maple's schema. Defaults to

--- a/packages/otel-collector-maple-exporter/exporter_logs.go
+++ b/packages/otel-collector-maple-exporter/exporter_logs.go
@@ -7,7 +7,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 
-	"github.com/superwall/maple/packages/otel-collector-maple-exporter/internal"
+	"github.com/makisuo/maple/packages/otel-collector-maple-exporter/internal"
 )
 
 type logsExporter struct {

--- a/packages/otel-collector-maple-exporter/exporter_metrics.go
+++ b/packages/otel-collector-maple-exporter/exporter_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 
-	"github.com/superwall/maple/packages/otel-collector-maple-exporter/internal"
+	"github.com/makisuo/maple/packages/otel-collector-maple-exporter/internal"
 )
 
 type metricsExporter struct {

--- a/packages/otel-collector-maple-exporter/exporter_traces.go
+++ b/packages/otel-collector-maple-exporter/exporter_traces.go
@@ -8,7 +8,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 
-	"github.com/superwall/maple/packages/otel-collector-maple-exporter/internal"
+	"github.com/makisuo/maple/packages/otel-collector-maple-exporter/internal"
 )
 
 type tracesExporter struct {

--- a/packages/otel-collector-maple-exporter/factory_test.go
+++ b/packages/otel-collector-maple-exporter/factory_test.go
@@ -45,7 +45,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "valid_minimal",
 			mutate: func(c *Config) {
-				c.Endpoint = "https://ch.superwall.dev"
+				c.Endpoint = "https://maple.dev"
 				c.OrgID = "org_x"
 			},
 			wantErr: false,
@@ -53,7 +53,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "missing_org",
 			mutate: func(c *Config) {
-				c.Endpoint = "https://ch.superwall.dev"
+				c.Endpoint = "https://maple.dev"
 			},
 			wantErr: true,
 		},
@@ -76,7 +76,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "zero_timeout",
 			mutate: func(c *Config) {
-				c.Endpoint = "https://ch.superwall.dev"
+				c.Endpoint = "https://maple.dev"
 				c.OrgID = "org_x"
 				c.TimeoutConfig.Timeout = 0
 			},

--- a/packages/otel-collector-maple-exporter/go.mod
+++ b/packages/otel-collector-maple-exporter/go.mod
@@ -1,4 +1,4 @@
-module github.com/superwall/maple/packages/otel-collector-maple-exporter
+module github.com/makisuo/maple/packages/otel-collector-maple-exporter
 
 go 1.25.0
 

--- a/packages/otel-collector-maple-exporter/internal/clickhouse_client.go
+++ b/packages/otel-collector-maple-exporter/internal/clickhouse_client.go
@@ -36,7 +36,7 @@ type Client struct {
 
 // ClientOptions for constructing a Client.
 type ClientOptions struct {
-	Endpoint string        // e.g. "https://ch.superwall.dev" — no trailing slash.
+	Endpoint string        // e.g. "https://maple.dev" — no trailing slash.
 	User     string        // basic auth username.
 	Password string        // basic auth password.
 	Database string        // ClickHouse database (e.g. "default").

--- a/packages/query-engine/src/profiles/query-profile.ts
+++ b/packages/query-engine/src/profiles/query-profile.ts
@@ -25,7 +25,7 @@ export type WarehouseQuerySettings = {
 	 * ~100KB) the default 65536 produces ~256MB chunks × 9 read threads — an
 	 * instant `max_memory_usage` breach for any query whose filter has to read
 	 * the column (`Body ILIKE '%…%'`). Capping rows-per-block bounds peak
-	 * memory while keeping full read parallelism: benchmarked on the superwall
+	 * memory while keeping full read parallelism: benchmarked on the maple
 	 * cluster, `512` turned both OOMing log-search shapes into sub-2s queries
 	 * at ~260-420MB peak. BYO-ClickHouse-only — stripped for the managed Tinybird
 	 * backend (Tinybird SDK or its ClickHouse-compatible gateway).


### PR DESCRIPTION
This PR fixes some imports in the `otel-collector-maple-exporter` but also remove any reference to superwall that could be misleading in the documentation