### PR TITLE
fix(effect): resolve Effect v4 review criticals + warnings across the monorepo

### DIFF
--- a/apps/api/scripts/bench-queries.ts
+++ b/apps/api/scripts/bench-queries.ts
@@ -24,6 +24,7 @@
 import { dirname, resolve } from "node:path"
 import { randomUUID } from "node:crypto"
 import {
+	Clock,
 	Config,
 	Console,
 	Context,
@@ -562,9 +563,9 @@ interface FetchConfig {
 const fetchHandler = Effect.fn("bench.fetch")(function* (config: FetchConfig) {
 	const tinybird = yield* Tinybird
 	const sinceMs = yield* parseRelativeDuration(config.since)
-	const now = new Date()
-	const startTime = formatCHDateTime(new Date(now.getTime() - sinceMs))
-	const endTime = formatCHDateTime(now)
+	const nowMs = yield* Clock.currentTimeMillis
+	const startTime = formatCHDateTime(new Date(nowMs - sinceMs))
+	const endTime = formatCHDateTime(new Date(nowMs))
 	const topN = config.top
 	const orgId = yield* Option.match(config.org, {
 		onNone: () => tinybird.internalOrgId,
@@ -665,57 +666,71 @@ const benchmarkSample = Effect.fn("bench.sample")(function* (
 	const replaySql = stripTrailingSemi(sample.sampleSql)
 
 	const result = yield* Effect.gen(function* () {
-		for (let w = 0; w < warmupRuns; w++) {
-			const warm = yield* ch.run(replaySql)
-			if (warm.status !== 200) {
-				return yield* Effect.fail(
-					new UpstreamStatusError({
-						source: "ClickHouse",
-						status: warm.status,
-						message: warm.body.slice(0, 200),
-					}),
-				)
-			}
-		}
+		// Sequential by default — timing is measured inside each `ch.run`, so the
+		// per-iteration wall/server stats are unaffected. A non-200 short-circuits
+		// the run (forEach stops on the first failure), as the old `for` loop did.
+		yield* Effect.forEach(
+			Array.from({ length: warmupRuns }),
+			() =>
+				Effect.gen(function* () {
+					const warm = yield* ch.run(replaySql)
+					if (warm.status !== 200) {
+						return yield* Effect.fail(
+							new UpstreamStatusError({
+								source: "ClickHouse",
+								status: warm.status,
+								message: warm.body.slice(0, 200),
+							}),
+						)
+					}
+				}),
+			{ discard: true },
+		)
 
-		const runs: RunMetrics[] = []
-		for (let r = 0; r < runsPerQuery; r++) {
-			const res = yield* ch.run(replaySql)
-			if (res.status !== 200) {
-				return yield* Effect.fail(
-					new UpstreamStatusError({
-						source: "ClickHouse",
-						status: res.status,
-						message: res.body.slice(0, 200),
-					}),
-				)
-			}
-			const log = yield* ch.queryLog(res.queryId)
-			const fromSummary = (key: string) =>
-				Option.match(res.summary, {
-					onNone: () => null,
-					onSome: (s) => (s[key] !== undefined ? Number(s[key]) : null),
-				})
-			runs.push({
-				wallMs: res.wallMs,
-				serverElapsedMs: Option.match(log, {
-					onNone: () => {
-						const ns = fromSummary("elapsed_ns")
-						return ns == null ? null : ns / 1e6
-					},
-					onSome: (l) => l.queryDurationMs,
+		const runs: RunMetrics[] = yield* Effect.forEach(
+			Array.from({ length: runsPerQuery }),
+			() =>
+				Effect.gen(function* () {
+					const res = yield* ch.run(replaySql)
+					if (res.status !== 200) {
+						return yield* Effect.fail(
+							new UpstreamStatusError({
+								source: "ClickHouse",
+								status: res.status,
+								message: res.body.slice(0, 200),
+							}),
+						)
+					}
+					const log = yield* ch.queryLog(res.queryId)
+					const fromSummary = (key: string) =>
+						Option.match(res.summary, {
+							onNone: () => null,
+							onSome: (s) => (s[key] !== undefined ? Number(s[key]) : null),
+						})
+					return {
+						wallMs: res.wallMs,
+						serverElapsedMs: Option.match(log, {
+							onNone: () => {
+								const ns = fromSummary("elapsed_ns")
+								return ns == null ? null : ns / 1e6
+							},
+							onSome: (l) => l.queryDurationMs,
+						}),
+						readRows: Option.match(log, {
+							onNone: () => fromSummary("read_rows"),
+							onSome: (l) => l.readRows,
+						}),
+						readBytes: Option.match(log, {
+							onNone: () => fromSummary("read_bytes"),
+							onSome: (l) => l.readBytes,
+						}),
+						memoryUsage: Option.match(log, {
+							onNone: () => null,
+							onSome: (l) => l.memoryUsage,
+						}),
+					} satisfies RunMetrics
 				}),
-				readRows: Option.match(log, {
-					onNone: () => fromSummary("read_rows"),
-					onSome: (l) => l.readRows,
-				}),
-				readBytes: Option.match(log, {
-					onNone: () => fromSummary("read_bytes"),
-					onSome: (l) => l.readBytes,
-				}),
-				memoryUsage: Option.match(log, { onNone: () => null, onSome: (l) => l.memoryUsage }),
-			})
-		}
+		)
 
 		const wallValues = runs.map((r) => r.wallMs)
 		return {
@@ -830,20 +845,25 @@ const inspectHandler = Effect.fn("bench.inspect")(function* (config: { readonly 
 			yield* Console.log(`${sample.context}  ${sample.fingerprint}  (profile=${sample.profile || "—"})`)
 			yield* Console.log("━".repeat(80))
 
-			for (const variant of ["EXPLAIN", "EXPLAIN PIPELINE"] as const) {
-				const res = yield* ch.run(`${variant} ${baseSql} FORMAT TabSeparatedRaw`)
-				yield* Console.log(`\n── ${variant} ───────────────────────────────`)
-				if (res.status !== 200) {
-					yield* Console.log(`  ERROR (${res.status}): ${res.body.slice(0, 500)}`)
-				} else {
-					const indented = res.body
-						.trimEnd()
-						.split("\n")
-						.map((l) => `  ${l}`)
-						.join("\n")
-					yield* Console.log(indented || "  (empty)")
-				}
-			}
+			yield* Effect.forEach(
+				["EXPLAIN", "EXPLAIN PIPELINE"] as const,
+				(variant) =>
+					Effect.gen(function* () {
+						const res = yield* ch.run(`${variant} ${baseSql} FORMAT TabSeparatedRaw`)
+						yield* Console.log(`\n── ${variant} ───────────────────────────────`)
+						if (res.status !== 200) {
+							yield* Console.log(`  ERROR (${res.status}): ${res.body.slice(0, 500)}`)
+						} else {
+							const indented = res.body
+								.trimEnd()
+								.split("\n")
+								.map((l) => `  ${l}`)
+								.join("\n")
+							yield* Console.log(indented || "  (empty)")
+						}
+					}),
+				{ discard: true },
+			)
 		}),
 	)
 })

--- a/apps/api/src/lib/WarehouseQueryService.test.ts
+++ b/apps/api/src/lib/WarehouseQueryService.test.ts
@@ -583,7 +583,7 @@ describe("WarehouseUpstreamError surfaces transient classification", () => {
 	it("carries upstreamStatus on 503", () => {
 		// Sanity check that the constructor flow we depend on for retry is intact.
 		const err = new WarehouseUpstreamError({
-			pipe: "test",
+			pipeName: "test",
 			message: "upstream",
 			upstreamStatus: 503,
 		})

--- a/apps/api/src/lib/ai-triage-enqueue.ts
+++ b/apps/api/src/lib/ai-triage-enqueue.ts
@@ -3,7 +3,7 @@ import type { AiTriageIncidentKind, ErrorIssueId, OrgId } from "@maple/domain/ht
 import { AiTriageRunId } from "@maple/domain/primitives"
 import { aiTriageRuns, aiTriageSettings, type AiTriageSettingsRow } from "@maple/db"
 import { and, eq, gte, sql } from "drizzle-orm"
-import { Cause, Clock, Data, Effect, Schema } from "effect"
+import { Cause, Clock, Effect, Schema } from "effect"
 import { Database } from "./DatabaseLive"
 
 // Cloudflare Workflow binding that runs the headless triage agent. Hosted by
@@ -69,10 +69,13 @@ export interface MaybeEnqueueTriageResult {
 	readonly reason?: "disabled" | "daily_cap" | "duplicate" | "no_binding" | "error"
 }
 
-class AiTriageWorkflowCreateError extends Data.TaggedError("AiTriageWorkflowCreateError")<{
-	readonly message: string
-	readonly cause: unknown
-}> {}
+class AiTriageWorkflowCreateError extends Schema.TaggedErrorClass<AiTriageWorkflowCreateError>()(
+	"AiTriageWorkflowCreateError",
+	{
+		message: Schema.String,
+		cause: Schema.Unknown,
+	},
+) {}
 
 /**
  * Gate, record, and kick off an AI triage run for a freshly opened incident.

--- a/apps/api/src/lib/url-validator.ts
+++ b/apps/api/src/lib/url-validator.ts
@@ -1,9 +1,12 @@
-import { Data, Effect } from "effect"
+import { Effect, Schema } from "effect"
 
-export class UrlValidationError extends Data.TaggedError("@maple/api/lib/UrlValidationError")<{
-	readonly message: string
-	readonly url?: string
-}> {}
+export class UrlValidationError extends Schema.TaggedErrorClass<UrlValidationError>()(
+	"@maple/api/lib/UrlValidationError",
+	{
+		message: Schema.String,
+		url: Schema.optional(Schema.String),
+	},
+) {}
 
 const BLOCKED_HOSTNAMES = new Set([
 	"localhost",

--- a/apps/api/src/mcp/lib/dashboard-mutations.ts
+++ b/apps/api/src/mcp/lib/dashboard-mutations.ts
@@ -13,7 +13,7 @@ import { resolveTenant } from "@/mcp/lib/query-warehouse"
 import { DashboardPersistenceService } from "@/services/DashboardPersistenceService"
 import { McpQueryError } from "@/mcp/tools/types"
 
-const decodeDashboardId = Schema.decodeUnknownSync(DashboardId)
+const decodeDashboardId = Schema.decodeUnknownEffect(DashboardId)
 
 export type DashboardWidget = typeof DashboardWidgetSchema.Type
 
@@ -29,7 +29,7 @@ const LayoutFromJson = Schema.fromJsonString(WidgetLayoutSchema)
 const jsonDecodeError = (field: string, tool: string) => (error: unknown) =>
 	new McpQueryError({
 		message: `Invalid ${field}: ${String(error)}`,
-		pipe: tool,
+		pipeName: tool,
 		cause: error,
 	})
 
@@ -127,7 +127,16 @@ export const withDashboardMutation = Effect.fn("withDashboardMutation")(function
 	// the not-found case into the structured `notFound` return shape that
 	// callers already render to the user, and map the remaining persistence
 	// error tags onto `McpQueryError`.
-	const dashboardIdBranded = decodeDashboardId(dashboardId)
+	const dashboardIdBranded = yield* decodeDashboardId(dashboardId).pipe(
+		Effect.mapError(
+			(cause) =>
+				new McpQueryError({
+					message: `Invalid dashboard_id: ${dashboardId}. Use list_dashboards to find available dashboard IDs.`,
+					pipeName: tool,
+					cause,
+				}),
+		),
+	)
 
 	return yield* persistence
 		.mutate(tenant.orgId, tenant.userId, dashboardIdBranded, (existing) =>
@@ -163,11 +172,11 @@ export const withDashboardMutation = Effect.fn("withDashboardMutation")(function
 			),
 			Effect.catchTags({
 				"@maple/http/errors/DashboardPersistenceError": (error) =>
-					Effect.fail(new McpQueryError({ message: error.message, pipe: tool, cause: error })),
+					Effect.fail(new McpQueryError({ message: error.message, pipeName: tool, cause: error })),
 				"@maple/http/errors/DashboardConcurrencyError": (error) =>
-					Effect.fail(new McpQueryError({ message: error.message, pipe: tool, cause: error })),
+					Effect.fail(new McpQueryError({ message: error.message, pipeName: tool, cause: error })),
 				"@maple/http/errors/DashboardValidationError": (error) =>
-					Effect.fail(new McpQueryError({ message: error.message, pipe: tool, cause: error })),
+					Effect.fail(new McpQueryError({ message: error.message, pipeName: tool, cause: error })),
 			}),
 		)
 })

--- a/apps/api/src/mcp/lib/inspect-widget.ts
+++ b/apps/api/src/mcp/lib/inspect-widget.ts
@@ -243,7 +243,7 @@ const metricExistsInCatalog = Effect.fn("metricExistsInCatalog")(function* (
 	const warehouse = yield* WarehouseQueryService
 	return yield* warehouse
 		.query(tenant, {
-			pipe: "list_metrics",
+			pipeName: "list_metrics",
 			params: {
 				start_time: startTime,
 				end_time: endTime,
@@ -723,15 +723,15 @@ export const inspectWidgetsAfterMutation = Effect.fn("inspectWidgetsAfterMutatio
 					return { startTime: fallback.st, endTime: fallback.et, source: "fallback" as const }
 				})()
 
-		const outcomes = yield* Effect.all(
-			toInspect.map((widget) =>
+		const outcomes = yield* Effect.forEach(
+			toInspect,
+			(widget) =>
 				inspectWidget({
 					tenant,
 					dashboardName: dashboard.name,
 					widget,
 					timeRange,
 				}),
-			),
 			{ concurrency: maxConcurrent },
 		)
 

--- a/apps/api/src/mcp/lib/map-warehouse-error.test.ts
+++ b/apps/api/src/mcp/lib/map-warehouse-error.test.ts
@@ -4,16 +4,16 @@ import { toMcpQueryError } from "./map-warehouse-error"
 
 describe("toMcpQueryError", () => {
 	it("forwards plain query errors verbatim with the pipe label", () => {
-		const err = new WarehouseQueryError({ message: "boom", pipe: "service_overview" })
+		const err = new WarehouseQueryError({ message: "boom", pipeName: "service_overview" })
 		const mcp = toMcpQueryError("service_overview")(err)
 		expect(mcp.message).toBe("boom")
-		expect(mcp.pipe).toBe("service_overview")
+		expect(mcp.pipeName).toBe("service_overview")
 	})
 
 	it("appends the schema-apply hint for a WarehouseSchemaDriftError", () => {
 		const err = new WarehouseSchemaDriftError({
 			message: "Unknown expression or function identifier 'SampleRate' in scope SELECT ServiceName ...",
-			pipe: "service_overview",
+			pipeName: "service_overview",
 			clickhouseType: "UNKNOWN_IDENTIFIER",
 		})
 		const mcp = toMcpQueryError("service_overview")(err)
@@ -23,7 +23,7 @@ describe("toMcpQueryError", () => {
 	})
 
 	it("does not enrich non-schema-drift errors", () => {
-		const err = new WarehouseQueryError({ message: "boom", pipe: "service_overview" })
+		const err = new WarehouseQueryError({ message: "boom", pipeName: "service_overview" })
 		const mcp = toMcpQueryError("service_overview")(err)
 		expect(mcp.message).toBe("boom")
 	})

--- a/apps/api/src/mcp/lib/map-warehouse-error.ts
+++ b/apps/api/src/mcp/lib/map-warehouse-error.ts
@@ -22,7 +22,7 @@ const enrich = (error: WarehouseError): string =>
 export const toMcpQueryError =
 	(pipe: string) =>
 	(error: WarehouseError): McpQueryError =>
-		new McpQueryError({ message: enrich(error), pipe, cause: error })
+		new McpQueryError({ message: enrich(error), pipeName: pipe, cause: error })
 
 /**
  * Pipe combinator that converts every warehouse error tag into an

--- a/apps/api/src/mcp/lib/query-warehouse.ts
+++ b/apps/api/src/mcp/lib/query-warehouse.ts
@@ -30,7 +30,7 @@ export const queryWarehouse = Effect.fn("queryWarehouse")(function* <T = any>(
 	const tenant = yield* resolveTenant
 	const service = yield* WarehouseQueryService
 	const response = yield* service
-		.query(tenant, { pipe, params })
+		.query(tenant, { pipeName: pipe, params })
 		.pipe(Effect.mapError(toMcpQueryError(pipe)))
 
 	return { data: response.data as T[] }

--- a/apps/api/src/mcp/lib/resolve-actor.ts
+++ b/apps/api/src/mcp/lib/resolve-actor.ts
@@ -16,7 +16,7 @@ export const resolveActorId = Effect.fn("resolveActorId")(function* (tenant: Ten
 			(error) =>
 				new McpQueryError({
 					message: error.message,
-					pipe: "resolve_actor",
+					pipeName: "resolve_actor",
 					cause: error,
 				}),
 		),

--- a/apps/api/src/mcp/lib/session-store.ts
+++ b/apps/api/src/mcp/lib/session-store.ts
@@ -22,7 +22,9 @@ export const preloadSession = (kv: SessionsBinding, sessionId: string): Promise<
 		if (value) sessionStore.set(sessionId, value as SessionPayload)
 	}).pipe(
 		Effect.catchCause((cause) =>
-			Effect.logError("[mcp-session-kv] preload failed", { sessionId, cause }),
+			Effect.logError("[mcp-session-kv] preload failed").pipe(
+				Effect.annotateLogs({ sessionId, cause }),
+			),
 		),
 		Effect.runPromise,
 	)
@@ -33,7 +35,11 @@ export const persistSession = (kv: SessionsBinding, sessionId: string): Promise<
 	return Effect.tryPromise(() =>
 		kv.put(sessionId, JSON.stringify(payload), { expirationTtl: SESSION_TTL_SECONDS }),
 	).pipe(
-		Effect.catchCause((cause) => Effect.logError("[mcp-session-kv] put failed", { sessionId, cause })),
+		Effect.catchCause((cause) =>
+			Effect.logError("[mcp-session-kv] put failed").pipe(
+				Effect.annotateLogs({ sessionId, cause }),
+			),
+		),
 		Effect.runPromise,
 	)
 }

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -3,6 +3,10 @@ import { Effect, Layer, Schema, Context } from "effect"
 import { mapleToolDefinitions, toInputSchema, type MapleToolDefinition } from "./tools/registry"
 import type { McpToolResult } from "./tools/types"
 
+class McpDecodeError extends Schema.TaggedErrorClass<McpDecodeError>()("@maple/mcp/decode-error", {
+	errorMessage: Schema.String,
+}) {}
+
 const toErrorMessage = (error: unknown): string => {
 	if (error instanceof Error && "error" in error && (error as any).error != null) {
 		const inner = (error as any).error
@@ -39,46 +43,48 @@ export const McpToolsLive = Layer.effectDiscard(
 					inputSchema: toInputSchema(definition.schema),
 				}),
 				annotations: Context.empty(),
-				handle: (payload) =>
-					Effect.gen(function* () {
+				handle: Effect.fn("McpTool.handle")(
+					function* (payload) {
 						yield* Effect.annotateCurrentSpan({ tool: definition.name })
 						const decoded = yield* Effect.try({
 							try: () => Schema.decodeUnknownSync(definition.schema)(payload),
 							catch: (error) => error,
 						}).pipe(
-							Effect.mapError((error) => {
-								const errorMessage = toDecodeErrorMessage(definition, error)
-								return { _tag: "@maple/mcp/decode-error" as const, errorMessage }
-							}),
+							Effect.mapError(
+								(error) =>
+									new McpDecodeError({
+										errorMessage: toDecodeErrorMessage(definition, error),
+									}),
+							),
 						)
 
 						return yield* definition.handler(decoded).pipe(
 							Effect.tap(() => Effect.logInfo("Tool completed")),
 							Effect.map(toCallToolResult),
 						)
-					}).pipe(
-						Effect.catchTag("@maple/mcp/decode-error", (error) =>
-							Effect.logWarning("Invalid parameters").pipe(
-								Effect.annotateLogs({ error: error.errorMessage }),
-								Effect.as(
-									toCallToolResult({
-										isError: true,
-										content: [
-											{
-												type: "text",
-												text: `Invalid parameters: ${error.errorMessage}`,
-											},
-										],
-									}),
-								),
+					},
+					Effect.catchTag("@maple/mcp/decode-error", (error) =>
+						Effect.logWarning("Invalid parameters").pipe(
+							Effect.annotateLogs({ error: error.errorMessage }),
+							Effect.as(
+								toCallToolResult({
+									isError: true,
+									content: [
+										{
+											type: "text",
+											text: `Invalid parameters: ${error.errorMessage}`,
+										},
+									],
+								}),
 							),
 						),
-						Effect.catchTags({
+					),
+					Effect.catchTags({
 							"@maple/mcp/errors/McpQueryError": (error) =>
 								Effect.logError(`Tool error: ${error.message}`).pipe(
 									Effect.annotateLogs({
 										errorTag: error._tag,
-										pipe: error.pipe,
+										pipe: error.pipeName,
 									}),
 									Effect.as(
 										toCallToolResult({
@@ -154,7 +160,6 @@ export const McpToolsLive = Layer.effectDiscard(
 							),
 						),
 						Effect.annotateLogs({ tool: definition.name }),
-						Effect.withSpan("McpTool.handle"),
 					),
 			}),
 		)

--- a/apps/api/src/mcp/tools/add-dashboard-widget.ts
+++ b/apps/api/src/mcp/tools/add-dashboard-widget.ts
@@ -148,7 +148,7 @@ export function registerAddDashboardWidgetTool(server: McpToolRegistrar) {
 						return yield* Effect.fail(
 							new McpQueryError({
 								message: `Widget id "${newId}" already exists on dashboard ${dashboard_id}. Pass a different widget_id or omit it to auto-generate one.`,
-								pipe: TOOL,
+								pipeName: TOOL,
 							}),
 						)
 					}

--- a/apps/api/src/mcp/tools/claim-error-issue.ts
+++ b/apps/api/src/mcp/tools/claim-error-issue.ts
@@ -50,7 +50,7 @@ export function registerClaimErrorIssueTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "claim_error_issue",
+							pipeName: "claim_error_issue",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/comment-on-error-issue.ts
+++ b/apps/api/src/mcp/tools/comment-on-error-issue.ts
@@ -51,7 +51,7 @@ export function registerCommentOnErrorIssueTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: error.message,
-								pipe: "comment_on_error_issue",
+								pipeName: "comment_on_error_issue",
 								cause: error,
 							}),
 					),

--- a/apps/api/src/mcp/tools/compare-periods.ts
+++ b/apps/api/src/mcp/tools/compare-periods.ts
@@ -43,7 +43,7 @@ export function registerComparePeriodsTool(server: McpToolRegistrar) {
 				if (!Number.isFinite(center.getTime())) {
 					return yield* new McpQueryError({
 						message: `Invalid around_time: ${around_time}`,
-						pipe: "compare_periods",
+						pipeName: "compare_periods",
 					})
 				}
 				const halfWindow = 30 * 60 * 1000 // 30 minutes
@@ -66,7 +66,7 @@ export function registerComparePeriodsTool(server: McpToolRegistrar) {
 				) {
 					return yield* new McpQueryError({
 						message: `Invalid current period: ${current_start ?? "(default)"} to ${current_end ?? "(default)"}`,
-						pipe: "compare_periods",
+						pipeName: "compare_periods",
 					})
 				}
 				const durationMs = currentEndDate.getTime() - currentStartDate.getTime()

--- a/apps/api/src/mcp/tools/create-alert-rule.ts
+++ b/apps/api/src/mcp/tools/create-alert-rule.ts
@@ -331,7 +331,7 @@ export function registerCreateAlertRuleTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: `Invalid alert rule: ${String(error)}`,
-							pipe: "create_alert_rule",
+							pipeName: "create_alert_rule",
 							cause: error,
 						}),
 				),
@@ -345,7 +345,7 @@ export function registerCreateAlertRuleTool(server: McpToolRegistrar) {
 					Effect.fail(
 						new McpQueryError({
 							message: `${error._tag}: ${error.message}\n${error.details.join("\n")}`,
-							pipe: "create_alert_rule",
+							pipeName: "create_alert_rule",
 							cause: error,
 						}),
 					),
@@ -355,7 +355,7 @@ export function registerCreateAlertRuleTool(server: McpToolRegistrar) {
 						Effect.fail(
 							new McpQueryError({
 								message: `${error._tag}: ${error.message}`,
-								pipe: "create_alert_rule",
+								pipeName: "create_alert_rule",
 								cause: error,
 							}),
 						),
@@ -363,7 +363,7 @@ export function registerCreateAlertRuleTool(server: McpToolRegistrar) {
 						Effect.fail(
 							new McpQueryError({
 								message: `${error._tag}: ${error.message}`,
-								pipe: "create_alert_rule",
+								pipeName: "create_alert_rule",
 								cause: error,
 							}),
 						),
@@ -371,7 +371,7 @@ export function registerCreateAlertRuleTool(server: McpToolRegistrar) {
 						Effect.fail(
 							new McpQueryError({
 								message: `${error._tag}: ${error.message}`,
-								pipe: "create_alert_rule",
+								pipeName: "create_alert_rule",
 								cause: error,
 							}),
 						),

--- a/apps/api/src/mcp/tools/create-dashboard.ts
+++ b/apps/api/src/mcp/tools/create-dashboard.ts
@@ -359,7 +359,7 @@ export function registerCreateDashboardTool(server: McpToolRegistrar) {
 						(cause) =>
 							new McpQueryError({
 								message: "Invalid dashboard JSON",
-								pipe: "create_dashboard",
+								pipeName: "create_dashboard",
 								cause,
 							}),
 					),
@@ -385,7 +385,7 @@ export function registerCreateDashboardTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: `Widget generation error: ${String(error)}`,
-								pipe: "create_dashboard",
+								pipeName: "create_dashboard",
 								cause: error,
 							}),
 					),
@@ -445,7 +445,7 @@ export function registerCreateDashboardTool(server: McpToolRegistrar) {
 					catch: (error) =>
 						new McpQueryError({
 							message: `Template generation error: ${String(error)}`,
-							pipe: "create_dashboard",
+							pipeName: "create_dashboard",
 							cause: error,
 						}),
 				})
@@ -473,7 +473,7 @@ export function registerCreateDashboardTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "create_dashboard",
+							pipeName: "create_dashboard",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/delete-alert-rule.ts
+++ b/apps/api/src/mcp/tools/delete-alert-rule.ts
@@ -54,7 +54,7 @@ export function registerDeleteAlertRuleTool(server: McpToolRegistrar) {
 						Effect.fail(
 							new McpQueryError({
 								message: `${error._tag}: ${error.message}`,
-								pipe: "delete_alert_rule",
+								pipeName: "delete_alert_rule",
 								cause: error,
 							}),
 						),
@@ -62,7 +62,7 @@ export function registerDeleteAlertRuleTool(server: McpToolRegistrar) {
 						Effect.fail(
 							new McpQueryError({
 								message: `${error._tag}: ${error.message}`,
-								pipe: "delete_alert_rule",
+								pipeName: "delete_alert_rule",
 								cause: error,
 							}),
 						),
@@ -70,7 +70,7 @@ export function registerDeleteAlertRuleTool(server: McpToolRegistrar) {
 						Effect.fail(
 							new McpQueryError({
 								message: `${error._tag}: ${error.message}. Use list_alert_rules to find available rule IDs.`,
-								pipe: "delete_alert_rule",
+								pipeName: "delete_alert_rule",
 								cause: error,
 							}),
 						),

--- a/apps/api/src/mcp/tools/get-alert-rule.ts
+++ b/apps/api/src/mcp/tools/get-alert-rule.ts
@@ -28,7 +28,7 @@ export function registerGetAlertRuleTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "get_alert_rule",
+							pipeName: "get_alert_rule",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/get-dashboard.ts
+++ b/apps/api/src/mcp/tools/get-dashboard.ts
@@ -20,7 +20,7 @@ export function registerGetDashboardTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "get_dashboard",
+							pipeName: "get_dashboard",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/get-incident-timeline.ts
+++ b/apps/api/src/mcp/tools/get-incident-timeline.ts
@@ -49,7 +49,7 @@ export function registerGetIncidentTimelineTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "get_incident_timeline",
+							pipeName: "get_incident_timeline",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/get-instrumentation-recommendations.ts
+++ b/apps/api/src/mcp/tools/get-instrumentation-recommendations.ts
@@ -133,7 +133,7 @@ export function registerGetInstrumentationRecommendationsTool(server: McpToolReg
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "get_instrumentation_recommendations",
+							pipeName: "get_instrumentation_recommendations",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/heartbeat-error-issue.ts
+++ b/apps/api/src/mcp/tools/heartbeat-error-issue.ts
@@ -31,7 +31,7 @@ export function registerHeartbeatErrorIssueTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "heartbeat_error_issue",
+							pipeName: "heartbeat_error_issue",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/inspect-chart-data.ts
+++ b/apps/api/src/mcp/tools/inspect-chart-data.ts
@@ -160,7 +160,7 @@ export function registerInspectChartDataTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "inspect_chart_data",
+							pipeName: "inspect_chart_data",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/list-alert-checks.ts
+++ b/apps/api/src/mcp/tools/list-alert-checks.ts
@@ -36,7 +36,7 @@ export function registerListAlertChecksTool(server: McpToolRegistrar) {
 				catch: (cause) =>
 					new McpQueryError({
 						message: `Invalid rule_id: ${rule_id}`,
-						pipe: "list_alert_checks",
+						pipeName: "list_alert_checks",
 						cause,
 					}),
 			})
@@ -53,7 +53,7 @@ export function registerListAlertChecksTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: error.message,
-								pipe: "list_alert_checks",
+								pipeName: "list_alert_checks",
 								cause: error,
 							}),
 					),

--- a/apps/api/src/mcp/tools/list-alert-incidents.ts
+++ b/apps/api/src/mcp/tools/list-alert-incidents.ts
@@ -32,7 +32,7 @@ export function registerListAlertIncidentsTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "list_alert_incidents",
+							pipeName: "list_alert_incidents",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/list-alert-rules.ts
+++ b/apps/api/src/mcp/tools/list-alert-rules.ts
@@ -39,7 +39,7 @@ export function registerListAlertRulesTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "list_alert_rules",
+							pipeName: "list_alert_rules",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/list-dashboards.ts
+++ b/apps/api/src/mcp/tools/list-dashboards.ts
@@ -22,7 +22,7 @@ export function registerListDashboardsTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "list_dashboards",
+							pipeName: "list_dashboards",
 							cause: error,
 						}),
 				),

--- a/apps/api/src/mcp/tools/list-error-incidents.ts
+++ b/apps/api/src/mcp/tools/list-error-incidents.ts
@@ -42,7 +42,7 @@ export function registerListErrorIncidentsTool(server: McpToolRegistrar) {
 							(error) =>
 								new McpQueryError({
 									message: error.message,
-									pipe: "list_error_incidents",
+									pipeName: "list_error_incidents",
 									cause: error,
 								}),
 						),
@@ -52,7 +52,7 @@ export function registerListErrorIncidentsTool(server: McpToolRegistrar) {
 							(error) =>
 								new McpQueryError({
 									message: error.message,
-									pipe: "list_error_incidents",
+									pipeName: "list_error_incidents",
 									cause: error,
 								}),
 						),

--- a/apps/api/src/mcp/tools/list-error-issue-events.ts
+++ b/apps/api/src/mcp/tools/list-error-issue-events.ts
@@ -39,7 +39,7 @@ export function registerListErrorIssueEventsTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: error.message,
-								pipe: "list_error_issue_events",
+								pipeName: "list_error_issue_events",
 								cause: error,
 							}),
 					),

--- a/apps/api/src/mcp/tools/list-error-issues.ts
+++ b/apps/api/src/mcp/tools/list-error-issues.ts
@@ -102,7 +102,7 @@ export function registerListErrorIssuesTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: error.message,
-								pipe: "list_error_issues",
+								pipeName: "list_error_issues",
 								cause: error,
 							}),
 					),

--- a/apps/api/src/mcp/tools/propose-fix.ts
+++ b/apps/api/src/mcp/tools/propose-fix.ts
@@ -57,7 +57,7 @@ export function registerProposeFixTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: error.message,
-								pipe: "propose_fix",
+								pipeName: "propose_fix",
 								cause: error,
 							}),
 					),

--- a/apps/api/src/mcp/tools/query-data.ts
+++ b/apps/api/src/mcp/tools/query-data.ts
@@ -334,7 +334,7 @@ export function registerQueryDataTool(server: McpToolRegistrar) {
 				catch: (error) =>
 					new McpQueryError({
 						message: `Invalid query specification:\n${String(error)}`,
-						pipe: "query_data",
+						pipeName: "query_data",
 						cause: error,
 					}),
 			})

--- a/apps/api/src/mcp/tools/register-agent.ts
+++ b/apps/api/src/mcp/tools/register-agent.ts
@@ -52,7 +52,7 @@ export function registerRegisterAgentTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: error.message,
-								pipe: "register_agent",
+								pipeName: "register_agent",
 								cause: error,
 							}),
 					),

--- a/apps/api/src/mcp/tools/release-error-issue.ts
+++ b/apps/api/src/mcp/tools/release-error-issue.ts
@@ -55,7 +55,7 @@ export function registerReleaseErrorIssueTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: error.message,
-								pipe: "release_error_issue",
+								pipeName: "release_error_issue",
 								cause: error,
 							}),
 					),

--- a/apps/api/src/mcp/tools/remove-dashboard-widget.ts
+++ b/apps/api/src/mcp/tools/remove-dashboard-widget.ts
@@ -24,7 +24,7 @@ export function registerRemoveDashboardWidgetTool(server: McpToolRegistrar) {
 						return yield* Effect.fail(
 							new McpQueryError({
 								message: `Widget not found: ${widget_id}. Use get_dashboard to see existing widget ids.`,
-								pipe: TOOL,
+								pipeName: TOOL,
 							}),
 						)
 					}

--- a/apps/api/src/mcp/tools/reorder-dashboard-widgets.ts
+++ b/apps/api/src/mcp/tools/reorder-dashboard-widgets.ts
@@ -77,7 +77,7 @@ export function registerReorderDashboardWidgetsTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: `Invalid layouts_json: ${String(error)}`,
-							pipe: TOOL,
+							pipeName: TOOL,
 							cause: error,
 						}),
 				),
@@ -120,7 +120,7 @@ export function registerReorderDashboardWidgetsTool(server: McpToolRegistrar) {
 						return yield* Effect.fail(
 							new McpQueryError({
 								message: `Unknown widget ids in layouts_json: ${unknownIds.join(", ")}. Use get_dashboard to see existing widget ids.`,
-								pipe: TOOL,
+								pipeName: TOOL,
 							}),
 						)
 					}

--- a/apps/api/src/mcp/tools/replace-dashboard-widgets.ts
+++ b/apps/api/src/mcp/tools/replace-dashboard-widgets.ts
@@ -1,5 +1,5 @@
 import { McpQueryError, requiredStringParam, validationError, type McpToolRegistrar } from "./types"
-import { Effect, Schema } from "effect"
+import { Effect, Result, Schema } from "effect"
 import { DashboardWidgetSchema } from "@maple/domain/http"
 import { createDualContent } from "../lib/structured-output"
 import {
@@ -33,15 +33,19 @@ export function registerReplaceDashboardWidgetsTool(server: McpToolRegistrar) {
 			),
 		}),
 		Effect.fn("McpTool.replaceDashboardWidgets")(function* ({ dashboard_id, widgets_json }) {
-			let parsed: unknown
-			try {
-				parsed = JSON.parse(widgets_json)
-			} catch (e) {
+			const parseResult = yield* Effect.result(
+				Effect.try({
+					try: () => JSON.parse(widgets_json) as unknown,
+					catch: (e) => e,
+				}),
+			)
+			if (Result.isFailure(parseResult)) {
 				return validationError(
-					`widgets_json is not valid JSON: ${String(e)}`,
+					`widgets_json is not valid JSON: ${String(parseResult.failure)}`,
 					'[{ "visualization": "stat", "dataSource": { ... }, "display": { ... } }]',
 				)
 			}
+			const parsed = parseResult.success
 			if (!Array.isArray(parsed)) {
 				return validationError("widgets_json must be a JSON array of widget objects.")
 			}
@@ -77,7 +81,7 @@ export function registerReplaceDashboardWidgetsTool(server: McpToolRegistrar) {
 						(cause) =>
 							new McpQueryError({
 								message: `widgets_json[${i}] is not a valid widget: ${String(cause)}`,
-								pipe: TOOL,
+								pipeName: TOOL,
 								cause,
 							}),
 					),
@@ -97,11 +101,11 @@ export function registerReplaceDashboardWidgetsTool(server: McpToolRegistrar) {
 
 			// Validate every widget's query before persisting anything — an atomic,
 			// all-or-nothing guard so a single bad widget can't corrupt the board.
-			const blocking: string[] = []
-			for (const w of widgets) {
-				const warns = yield* collectBlockingBuilderWarnings(w.dataSource)
-				for (const warn of warns) blocking.push(`[${w.id}] ${warn}`)
-			}
+			const blocking = yield* Effect.forEach(widgets, (w) =>
+				collectBlockingBuilderWarnings(w.dataSource).pipe(
+					Effect.map((warns) => warns.map((warn) => `[${w.id}] ${warn}`)),
+				),
+			).pipe(Effect.map((nested) => nested.flat()))
 			if (blocking.length > 0) {
 				return validationError(
 					`Some widgets have clauses the engine can't honor — NOTHING was saved:\n- ${blocking.join("\n- ")}\n\nFix and retry. Span/resource attributes work automatically but cap at 5 attr filters; logs/metrics accept only a fixed set of filter/groupBy keys.`,

--- a/apps/api/src/mcp/tools/service-map.ts
+++ b/apps/api/src/mcp/tools/service-map.ts
@@ -34,7 +34,7 @@ export function registerServiceMapTool(server: McpToolRegistrar) {
 			}).pipe(
 				Effect.provide(makeWarehouseExecutorFromTenant(tenant)),
 				Effect.mapError(
-					(e) => new McpQueryError({ message: e.message, pipe: "service_dependencies", cause: e }),
+					(e) => new McpQueryError({ message: e.message, pipeName: "service_dependencies", cause: e }),
 				),
 			)
 
@@ -90,7 +90,6 @@ export function registerServiceMapTool(server: McpToolRegistrar) {
 
 			lines.push(formatTable(headers, rows))
 
-			const nextSteps: string[] = []
 			const errorEdges = Arr.sort(
 				Arr.filter(
 					Arr.map(edges, (e) => ({
@@ -102,14 +101,15 @@ export function registerServiceMapTool(server: McpToolRegistrar) {
 				Order.mapInput(Order.flip(Order.Number), (e: { errorRate: number }) => e.errorRate),
 			)
 
-			for (const e of Arr.take(errorEdges, 2)) {
-				nextSteps.push(
+			const errorEdgeSteps = Arr.map(
+				Arr.take(errorEdges, 2),
+				(e) =>
 					`\`diagnose_service service_name="${e.service}"\` — investigate high error rate dependency`,
-				)
-			}
-			if (nextSteps.length === 0) {
-				nextSteps.push("`list_services` — see all services with health metrics")
-			}
+			)
+			const nextSteps =
+				errorEdgeSteps.length > 0
+					? errorEdgeSteps
+					: ["`list_services` — see all services with health metrics"]
 			lines.push(formatNextSteps(nextSteps))
 
 			return {

--- a/apps/api/src/mcp/tools/set-issue-severity.ts
+++ b/apps/api/src/mcp/tools/set-issue-severity.ts
@@ -34,18 +34,16 @@ export function registerSetIssueSeverityTool(server: McpToolRegistrar) {
 					`Invalid issue_id: '${issue_id}'. Must be a UUID from list_error_issues.`,
 				)
 			}
-			let target: IssueSeverity | null
-			if (severity === "none") {
-				target = null
-			} else {
-				const decoded = decodeSeverity(severity)
-				if (Option.isNone(decoded)) {
-					return validationError(
-						`Invalid severity: '${severity}'. Must be one of: critical, high, medium, low, none.`,
-					)
-				}
-				target = decoded.value
+			// `none` clears the severity (null); any other value must decode to a
+			// valid IssueSeverity or we bail with a validation error.
+			const decodedSeverity: Option.Option<IssueSeverity | null> =
+				severity === "none" ? Option.some(null) : decodeSeverity(severity)
+			if (Option.isNone(decodedSeverity)) {
+				return validationError(
+					`Invalid severity: '${severity}'. Must be one of: critical, high, medium, low, none.`,
+				)
 			}
+			const target = decodedSeverity.value
 
 			const actorId = yield* resolveActorId(tenant)
 			// API-key-backed agent identities write with "ai" precedence so they
@@ -60,7 +58,7 @@ export function registerSetIssueSeverityTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: error.message,
-								pipe: "set_issue_severity",
+								pipeName: "set_issue_severity",
 								cause: error,
 							}),
 					),

--- a/apps/api/src/mcp/tools/transition-error-issue.ts
+++ b/apps/api/src/mcp/tools/transition-error-issue.ts
@@ -56,7 +56,7 @@ export function registerTransitionErrorIssueTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: error.message,
-								pipe: "transition_error_issue",
+								pipeName: "transition_error_issue",
 								cause: error,
 							}),
 					),

--- a/apps/api/src/mcp/tools/types.ts
+++ b/apps/api/src/mcp/tools/types.ts
@@ -22,7 +22,7 @@ export class McpInvalidTenantError extends Schema.TaggedErrorClass<McpInvalidTen
 
 export class McpQueryError extends Schema.TaggedErrorClass<McpQueryError>()(
 	"@maple/mcp/errors/McpQueryError",
-	{ message: Schema.String, pipe: Schema.String, cause: Schema.optionalKey(Schema.Defect()) },
+	{ message: Schema.String, pipeName: Schema.String, cause: Schema.optionalKey(Schema.Defect()) },
 ) {}
 
 export type McpToolError =

--- a/apps/api/src/mcp/tools/update-alert-rule.ts
+++ b/apps/api/src/mcp/tools/update-alert-rule.ts
@@ -208,7 +208,7 @@ export function registerUpdateAlertRuleTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: error.message,
-							pipe: "update_alert_rule",
+							pipeName: "update_alert_rule",
 							cause: error,
 						}),
 				),
@@ -240,7 +240,7 @@ export function registerUpdateAlertRuleTool(server: McpToolRegistrar) {
 					(error) =>
 						new McpQueryError({
 							message: `Invalid alert rule: ${String(error)}`,
-							pipe: "update_alert_rule",
+							pipeName: "update_alert_rule",
 							cause: error,
 						}),
 				),
@@ -253,7 +253,7 @@ export function registerUpdateAlertRuleTool(server: McpToolRegistrar) {
 						Effect.fail(
 							new McpQueryError({
 								message: `${error._tag}: ${error.message}\n${error.details.join("\n")}`,
-								pipe: "update_alert_rule",
+								pipeName: "update_alert_rule",
 								cause: error,
 							}),
 						),
@@ -263,7 +263,7 @@ export function registerUpdateAlertRuleTool(server: McpToolRegistrar) {
 							Effect.fail(
 								new McpQueryError({
 									message: `${error._tag}: ${error.message}`,
-									pipe: "update_alert_rule",
+									pipeName: "update_alert_rule",
 									cause: error,
 								}),
 							),
@@ -271,7 +271,7 @@ export function registerUpdateAlertRuleTool(server: McpToolRegistrar) {
 							Effect.fail(
 								new McpQueryError({
 									message: `${error._tag}: ${error.message}`,
-									pipe: "update_alert_rule",
+									pipeName: "update_alert_rule",
 									cause: error,
 								}),
 							),
@@ -279,7 +279,7 @@ export function registerUpdateAlertRuleTool(server: McpToolRegistrar) {
 							Effect.fail(
 								new McpQueryError({
 									message: `${error._tag}: ${error.message}`,
-									pipe: "update_alert_rule",
+									pipeName: "update_alert_rule",
 									cause: error,
 								}),
 							),

--- a/apps/api/src/mcp/tools/update-dashboard-widget.ts
+++ b/apps/api/src/mcp/tools/update-dashboard-widget.ts
@@ -45,7 +45,7 @@ export function registerUpdateDashboardWidgetTool(server: McpToolRegistrar) {
 						return yield* Effect.fail(
 							new McpQueryError({
 								message: `Widget not found: ${widget_id}. Use get_dashboard to see existing widget ids.`,
-								pipe: TOOL,
+								pipeName: TOOL,
 							}),
 						)
 					}

--- a/apps/api/src/mcp/tools/update-dashboard.ts
+++ b/apps/api/src/mcp/tools/update-dashboard.ts
@@ -48,7 +48,7 @@ export function registerUpdateDashboardTool(server: McpToolRegistrar) {
 							(cause) =>
 								new McpQueryError({
 									message: "Invalid dashboard JSON",
-									pipe: "update_dashboard",
+									pipeName: "update_dashboard",
 									cause,
 								}),
 						),
@@ -112,7 +112,7 @@ export function registerUpdateDashboardTool(server: McpToolRegistrar) {
 						(error) =>
 							new McpQueryError({
 								message: error.message,
-								pipe: "update_dashboard",
+								pipeName: "update_dashboard",
 								cause: error,
 							}),
 					),

--- a/apps/api/src/mcp/tools/update-error-notification-policy.ts
+++ b/apps/api/src/mcp/tools/update-error-notification-policy.ts
@@ -45,16 +45,14 @@ export function registerUpdateErrorNotificationPolicyTool(server: McpToolRegistr
 			min_occurrence_count,
 			severity,
 		}) {
-			let decodedSeverity: AlertSeverity | undefined
-			if (severity !== undefined) {
-				const parsed = decodeSeverity(severity)
-				if (Option.isNone(parsed)) {
-					return validationError(
-						`Invalid severity: ${severity}. Must be one of: warning, critical.`,
-					)
-				}
-				decodedSeverity = parsed.value
+			// `severity` is optional; when present it must decode to a valid
+			// AlertSeverity. Model the parsed-or-absent value as an Option.
+			const parsedSeverity =
+				severity === undefined ? Option.none<AlertSeverity>() : decodeSeverity(severity)
+			if (severity !== undefined && Option.isNone(parsedSeverity)) {
+				return validationError(`Invalid severity: ${severity}. Must be one of: warning, critical.`)
 			}
+			const decodedSeverity = Option.getOrUndefined(parsedSeverity)
 
 			const tenant = yield* resolveTenant
 			const errors = yield* ErrorsService
@@ -80,7 +78,7 @@ export function registerUpdateErrorNotificationPolicyTool(server: McpToolRegistr
 							(cause) =>
 								new McpQueryError({
 									message: `Invalid alert destination ID: ${token}`,
-									pipe: "update_error_notification_policy",
+									pipeName: "update_error_notification_policy",
 									cause,
 								}),
 						),
@@ -100,7 +98,7 @@ export function registerUpdateErrorNotificationPolicyTool(server: McpToolRegistr
 					(error) =>
 						new McpQueryError({
 							message: `Invalid notification policy payload: ${String(error)}`,
-							pipe: "update_error_notification_policy",
+							pipeName: "update_error_notification_policy",
 							cause: error,
 						}),
 				),
@@ -114,7 +112,7 @@ export function registerUpdateErrorNotificationPolicyTool(server: McpToolRegistr
 							Effect.fail(
 								new McpQueryError({
 									message: error.message,
-									pipe: "update_error_notification_policy",
+									pipeName: "update_error_notification_policy",
 									cause: error,
 								}),
 							),
@@ -122,7 +120,7 @@ export function registerUpdateErrorNotificationPolicyTool(server: McpToolRegistr
 							Effect.fail(
 								new McpQueryError({
 									message: error.message,
-									pipe: "update_error_notification_policy",
+									pipeName: "update_error_notification_policy",
 									cause: error,
 								}),
 							),

--- a/apps/api/src/routes/alerts.http.ts
+++ b/apps/api/src/routes/alerts.http.ts
@@ -11,18 +11,25 @@ export const HttpAlertsLive = HttpApiBuilder.group(MapleApi, "alerts", (handlers
 			.handle("listDestinations", () =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
 					return yield* alerts.listDestinations(tenant.orgId)
-				}),
+				}).pipe(Effect.withSpan("alerts.listDestinations")),
 			)
 			.handle("createDestination", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId, userId: tenant.userId })
 					return yield* alerts.createDestination(tenant.orgId, tenant.userId, tenant.roles, payload)
-				}),
+				}).pipe(Effect.withSpan("alerts.createDestination")),
 			)
 			.handle("updateDestination", ({ params, payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({
+						orgId: tenant.orgId,
+						userId: tenant.userId,
+						destinationId: params.destinationId,
+					})
 					return yield* alerts.updateDestination(
 						tenant.orgId,
 						tenant.userId,
@@ -30,40 +37,56 @@ export const HttpAlertsLive = HttpApiBuilder.group(MapleApi, "alerts", (handlers
 						params.destinationId,
 						payload,
 					)
-				}),
+				}).pipe(Effect.withSpan("alerts.updateDestination")),
 			)
 			.handle("deleteDestination", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({
+						orgId: tenant.orgId,
+						destinationId: params.destinationId,
+					})
 					return yield* alerts.deleteDestination(tenant.orgId, tenant.roles, params.destinationId)
-				}),
+				}).pipe(Effect.withSpan("alerts.deleteDestination")),
 			)
 			.handle("testDestination", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({
+						orgId: tenant.orgId,
+						userId: tenant.userId,
+						destinationId: params.destinationId,
+					})
 					return yield* alerts.testDestination(
 						tenant.orgId,
 						tenant.userId,
 						tenant.roles,
 						params.destinationId,
 					)
-				}),
+				}).pipe(Effect.withSpan("alerts.testDestination")),
 			)
 			.handle("listRules", () =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
 					return yield* alerts.listRules(tenant.orgId)
-				}),
+				}).pipe(Effect.withSpan("alerts.listRules")),
 			)
 			.handle("createRule", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId, userId: tenant.userId })
 					return yield* alerts.createRule(tenant.orgId, tenant.userId, tenant.roles, payload)
-				}),
+				}).pipe(Effect.withSpan("alerts.createRule")),
 			)
 			.handle("updateRule", ({ params, payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({
+						orgId: tenant.orgId,
+						userId: tenant.userId,
+						ruleId: params.ruleId,
+					})
 					return yield* alerts.updateRule(
 						tenant.orgId,
 						tenant.userId,
@@ -71,17 +94,19 @@ export const HttpAlertsLive = HttpApiBuilder.group(MapleApi, "alerts", (handlers
 						params.ruleId,
 						payload,
 					)
-				}),
+				}).pipe(Effect.withSpan("alerts.updateRule")),
 			)
 			.handle("deleteRule", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId, ruleId: params.ruleId })
 					return yield* alerts.deleteRule(tenant.orgId, tenant.roles, params.ruleId)
-				}),
+				}).pipe(Effect.withSpan("alerts.deleteRule")),
 			)
 			.handle("testRule", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId, userId: tenant.userId })
 					return yield* alerts.testRule(
 						tenant.orgId,
 						tenant.userId,
@@ -89,30 +114,33 @@ export const HttpAlertsLive = HttpApiBuilder.group(MapleApi, "alerts", (handlers
 						payload.rule,
 						payload.sendNotification ?? false,
 					)
-				}),
+				}).pipe(Effect.withSpan("alerts.testRule")),
 			)
 			.handle("listIncidents", () =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
 					return yield* alerts.listIncidents(tenant.orgId)
-				}),
+				}).pipe(Effect.withSpan("alerts.listIncidents")),
 			)
 			.handle("listRuleChecks", ({ params, query }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId, ruleId: params.ruleId })
 					return yield* alerts.listRuleChecks(tenant.orgId, params.ruleId, {
 						groupKey: query.groupKey,
 						since: query.since,
 						until: query.until,
 						limit: query.limit ?? 500,
 					})
-				}),
+				}).pipe(Effect.withSpan("alerts.listRuleChecks")),
 			)
 			.handle("listDeliveryEvents", () =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
 					return yield* alerts.listDeliveryEvents(tenant.orgId)
-				}),
+				}).pipe(Effect.withSpan("alerts.listDeliveryEvents")),
 			)
 	}),
 )

--- a/apps/api/src/routes/autumn.http.test.ts
+++ b/apps/api/src/routes/autumn.http.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
 import { makeEdgeCacheService, makeMemoryBackend } from "@maple/query-engine/caching"
 import { CUSTOMER_CACHE_BUCKET, readCustomerCached } from "./autumn.http"
@@ -8,87 +8,77 @@ const ORG = "org_test_123"
 const makeCache = () => makeEdgeCacheService(makeMemoryBackend())
 
 describe("readCustomerCached", () => {
-	it("caches a 200 response: 2nd call hits the cache, upstream runs once", async () => {
-		const cache = makeCache()
-		let calls = 0
-		const run = Effect.sync(() => {
-			calls += 1
-			return { statusCode: 200, response: { customer: ORG, calls } }
-		})
+	it.effect("caches a 200 response: 2nd call hits the cache, upstream runs once", () =>
+		Effect.gen(function* () {
+			const cache = makeCache()
+			let calls = 0
+			const run = Effect.sync(() => {
+				calls += 1
+				return { statusCode: 200, response: { customer: ORG, calls } }
+			})
 
-		const { first, second } = await Effect.runPromise(
-			Effect.gen(function* () {
-				const first = yield* readCustomerCached(cache, ORG, run)
-				const second = yield* readCustomerCached(cache, ORG, run)
-				return { first, second }
-			}),
-		)
+			const first = yield* readCustomerCached(cache, ORG, run)
+			const second = yield* readCustomerCached(cache, ORG, run)
 
-		expect(calls).toBe(1)
-		expect(first.hit).toBe(false)
-		expect(second.hit).toBe(true)
-		expect(second.result.response).toEqual({ customer: ORG, calls: 1 })
-	})
+			assert.strictEqual(calls, 1)
+			assert.isFalse(first.hit)
+			assert.isTrue(second.hit)
+			assert.deepStrictEqual(second.result.response, { customer: ORG, calls: 1 })
+		}),
+	)
 
-	it("does NOT cache a non-200 response — recomputes on every call", async () => {
-		const cache = makeCache()
-		let calls = 0
-		const run = Effect.sync(() => {
-			calls += 1
-			return { statusCode: 500, response: { error: "boom" } }
-		})
+	it.effect("does NOT cache a non-200 response — recomputes on every call", () =>
+		Effect.gen(function* () {
+			const cache = makeCache()
+			let calls = 0
+			const run = Effect.sync(() => {
+				calls += 1
+				return { statusCode: 500, response: { error: "boom" } }
+			})
 
-		const { first, second } = await Effect.runPromise(
-			Effect.gen(function* () {
-				const first = yield* readCustomerCached(cache, ORG, run)
-				const second = yield* readCustomerCached(cache, ORG, run)
-				return { first, second }
-			}),
-		)
+			const first = yield* readCustomerCached(cache, ORG, run)
+			const second = yield* readCustomerCached(cache, ORG, run)
 
-		expect(calls).toBe(2)
-		expect(first.hit).toBe(false)
-		expect(second.hit).toBe(false)
-		expect(first.result.statusCode).toBe(500)
-	})
+			assert.strictEqual(calls, 2)
+			assert.isFalse(first.hit)
+			assert.isFalse(second.hit)
+			assert.strictEqual(first.result.statusCode, 500)
+		}),
+	)
 
-	it("recomputes after the org entry is invalidated", async () => {
-		const cache = makeCache()
-		let calls = 0
-		const run = Effect.sync(() => {
-			calls += 1
-			return { statusCode: 200, response: { calls } }
-		})
+	it.effect("recomputes after the org entry is invalidated", () =>
+		Effect.gen(function* () {
+			const cache = makeCache()
+			let calls = 0
+			const run = Effect.sync(() => {
+				calls += 1
+				return { statusCode: 200, response: { calls } }
+			})
 
-		const after = await Effect.runPromise(
-			Effect.gen(function* () {
-				yield* readCustomerCached(cache, ORG, run)
-				yield* readCustomerCached(cache, ORG, run) // served from cache
-				yield* cache.invalidate({ bucket: CUSTOMER_CACHE_BUCKET, key: ORG })
-				return yield* readCustomerCached(cache, ORG, run)
-			}),
-		)
+			yield* readCustomerCached(cache, ORG, run)
+			yield* readCustomerCached(cache, ORG, run) // served from cache
+			yield* cache.invalidate({ bucket: CUSTOMER_CACHE_BUCKET, key: ORG })
+			const after = yield* readCustomerCached(cache, ORG, run)
 
-		expect(calls).toBe(2)
-		expect(after.hit).toBe(false)
-		expect(after.result.response).toEqual({ calls: 2 })
-	})
+			assert.strictEqual(calls, 2)
+			assert.isFalse(after.hit)
+			assert.deepStrictEqual(after.result.response, { calls: 2 })
+		}),
+	)
 
-	it("scopes the cache per org — a different orgId is a separate entry", async () => {
-		const cache = makeCache()
-		let calls = 0
-		const run = Effect.sync(() => {
-			calls += 1
-			return { statusCode: 200, response: { calls } }
-		})
+	it.effect("scopes the cache per org — a different orgId is a separate entry", () =>
+		Effect.gen(function* () {
+			const cache = makeCache()
+			let calls = 0
+			const run = Effect.sync(() => {
+				calls += 1
+				return { statusCode: 200, response: { calls } }
+			})
 
-		await Effect.runPromise(
-			Effect.gen(function* () {
-				yield* readCustomerCached(cache, "org_a", run)
-				yield* readCustomerCached(cache, "org_b", run)
-			}),
-		)
+			yield* readCustomerCached(cache, "org_a", run)
+			yield* readCustomerCached(cache, "org_b", run)
 
-		expect(calls).toBe(2)
-	})
+			assert.strictEqual(calls, 2)
+		}),
+	)
 })

--- a/apps/api/src/routes/autumn.http.ts
+++ b/apps/api/src/routes/autumn.http.ts
@@ -2,10 +2,24 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstab
 import { Effect, Option, Redacted, Schema } from "effect"
 import { autumnHandler, type CustomerData } from "autumn-js/backend"
 import { EdgeCacheService, type EdgeCacheServiceShape } from "@maple/query-engine/caching"
+import { UnauthorizedError } from "@maple/domain/http"
 import { Env } from "../lib/Env"
 import { AuthService } from "../services/AuthService"
 
 type AutumnResult = Awaited<ReturnType<typeof autumnHandler>>
+
+/**
+ * Tagged wrapper for a failed upstream Autumn SDK call. Carries the original
+ * message so the handler's catch-all can surface it to the client; tagging it
+ * (vs a bare `Error`) keeps the handler's error channel explicit so the
+ * UnauthorizedError 401 path can be split out via `catchTag`.
+ */
+class AutumnRequestError extends Schema.TaggedErrorClass<AutumnRequestError>()(
+	"@maple/api/autumn/AutumnRequestError",
+	{
+		message: Schema.String,
+	},
+) {}
 
 /**
  * Sentinel used to keep non-200 Autumn responses out of the edge cache: the
@@ -38,8 +52,8 @@ export const CUSTOMER_CACHE_TTL_SECONDS = 300
 export const readCustomerCached = (
 	edgeCache: Pick<EdgeCacheServiceShape, "getOrCompute">,
 	orgId: string,
-	runAutumn: Effect.Effect<AutumnResult, Error>,
-): Effect.Effect<{ readonly result: AutumnResult; readonly hit: boolean }, Error> =>
+	runAutumn: Effect.Effect<AutumnResult, AutumnRequestError>,
+): Effect.Effect<{ readonly result: AutumnResult; readonly hit: boolean }, AutumnRequestError> =>
 	edgeCache
 		.getOrCompute(
 			{ bucket: CUSTOMER_CACHE_BUCKET, key: orgId, ttlSeconds: CUSTOMER_CACHE_TTL_SECONDS },
@@ -133,7 +147,10 @@ export const AutumnRouter = HttpRouter.use((router) =>
 							customerData,
 							clientOptions: { secretKey },
 						}),
-					catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+					catch: (error) =>
+						new AutumnRequestError({
+							message: error instanceof Error ? error.message : String(error),
+						}),
 				})
 
 				let result: AutumnResult
@@ -172,24 +189,19 @@ export const AutumnRouter = HttpRouter.use((router) =>
 				// on every page load — including during sign-up before a Clerk org is
 				// active, where resolveTenant raises UnauthorizedError — so always
 				// return a JSON body with a sensible status.
-				Effect.catch((error: unknown) => {
-					const tag =
-						typeof error === "object" && error !== null && "_tag" in error
-							? (error as { _tag?: unknown })._tag
-							: undefined
-					const isUnauthorized = tag === "@maple/http/errors/UnauthorizedError"
-					const message =
-						typeof error === "object" && error !== null && "message" in error
-							? String((error as { message?: unknown }).message)
-							: String(error)
-					const status = isUnauthorized ? 401 : 500
-					return Effect.flatMap(
-						isUnauthorized
-							? Effect.void
-							: Effect.logError("[autumn] handler failed", { route, error: message }),
-						() => HttpServerResponse.json({ error: message }, { status }),
-					)
-				}),
+				//
+				// UnauthorizedError is the expected sign-up-before-org case: 401, no
+				// log. Anything else is a genuine handler failure: 500 + logError.
+				Effect.catchTag("@maple/http/errors/UnauthorizedError", (error) =>
+					HttpServerResponse.json({ error: error.message }, { status: 401 }),
+				),
+				Effect.catch((error) =>
+					Effect.logError("[autumn] handler failed", { route, error: error.message }).pipe(
+						Effect.flatMap(() =>
+							HttpServerResponse.json({ error: error.message }, { status: 500 }),
+						),
+					),
+				),
 			)
 
 		const routes = [

--- a/apps/api/src/routes/observability.http.ts
+++ b/apps/api/src/routes/observability.http.ts
@@ -14,7 +14,7 @@ import {
 import { makeWarehouseExecutorFromTenant } from "../lib/WarehouseQueryService"
 
 const mapError = (e: WarehouseExecutorError) =>
-	new ObservabilityApiError({ message: e.message, pipe: e.pipe, cause: e })
+	new ObservabilityApiError({ message: e.message, pipeName: e.pipeName, cause: e })
 
 const decodeTraceId = Schema.decodeSync(TraceId)
 const decodeSpanId = Schema.decodeSync(SpanId)

--- a/apps/api/src/routes/prometheus-scrape-proxy.http.ts
+++ b/apps/api/src/routes/prometheus-scrape-proxy.http.ts
@@ -22,23 +22,6 @@ const errorText = (message: string, status: number) =>
 		headers: { "content-type": "text/plain; charset=utf-8" },
 	})
 
-const statusForProxyError = (error: unknown): number => {
-	const tag =
-		typeof error === "object" && error !== null && "_tag" in error
-			? (error as { _tag?: unknown })._tag
-			: undefined
-	if (tag === "@maple/http/errors/ScrapeTargetNotFoundError") return 404
-	if (tag === "@maple/http/errors/ScrapeTargetEncryptionError") return 500
-	return 502
-}
-
-const messageForProxyError = (error: unknown): string => {
-	if (typeof error === "object" && error !== null && "message" in error) {
-		return String((error as { message?: unknown }).message)
-	}
-	return "Failed to scrape target"
-}
-
 export const PrometheusScrapeProxyRouter = HttpRouter.use((router) =>
 	Effect.gen(function* () {
 		const env = yield* Env
@@ -77,9 +60,17 @@ export const PrometheusScrapeProxyRouter = HttpRouter.use((router) =>
 							}),
 						),
 					),
-					Effect.catch((error: unknown) =>
-						Effect.succeed(errorText(messageForProxyError(error), statusForProxyError(error))),
-					),
+					// Map each concrete scrape error to its HTTP status: missing/disabled
+					// target → 404, decryption failure → 500, persistence/discovery →
+					// 502 (upstream/dependency).
+					Effect.catchTags({
+						"@maple/http/errors/ScrapeTargetNotFoundError": (error) =>
+							Effect.succeed(errorText(error.message, 404)),
+						"@maple/http/errors/ScrapeTargetEncryptionError": (error) =>
+							Effect.succeed(errorText(error.message, 500)),
+						"@maple/http/errors/ScrapeTargetPersistenceError": (error) =>
+							Effect.succeed(errorText(error.message, 502)),
+					}),
 				)
 			})
 

--- a/apps/api/src/routes/query-engine.http.ts
+++ b/apps/api/src/routes/query-engine.http.ts
@@ -1061,35 +1061,37 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 						type Point = { bucket: string; series: Record<string, number> }
 						const perQueryPoints: Array<{ name: string; points: Point[] }> = []
 
-						for (const query of enabledQueries) {
-							const built = buildTimeseriesQuerySpec(query)
-							for (const w of built.warnings) allWarnings.push(`${query.name}: ${w}`)
+						yield* Effect.forEach(enabledQueries, (query) =>
+							Effect.gen(function* () {
+								const built = buildTimeseriesQuerySpec(query)
+								for (const w of built.warnings) allWarnings.push(`${query.name}: ${w}`)
 
-							if (!built.query) {
-								if (built.error) allWarnings.push(`${query.name}: ${built.error}`)
-								continue
-							}
+								if (!built.query) {
+									if (built.error) allWarnings.push(`${query.name}: ${built.error}`)
+									return
+								}
 
-							const request = new QueryEngineExecuteRequest({
-								startTime: payload.startTime,
-								endTime: payload.endTime,
-								query: built.query,
-							})
+								const request = new QueryEngineExecuteRequest({
+									startTime: payload.startTime,
+									endTime: payload.endTime,
+									query: built.query,
+								})
 
-							const response = yield* queryEngine.execute(tenant, request)
-							if (response.result.kind !== "timeseries") {
-								allWarnings.push(`${query.name}: unexpected non-timeseries result`)
-								continue
-							}
+								const response = yield* queryEngine.execute(tenant, request)
+								if (response.result.kind !== "timeseries") {
+									allWarnings.push(`${query.name}: unexpected non-timeseries result`)
+									return
+								}
 
-							perQueryPoints.push({
-								name: query.legend?.trim() || query.name,
-								points: response.result.data.map((p) => ({
-									bucket: p.bucket,
-									series: { ...p.series },
-								})),
-							})
-						}
+								perQueryPoints.push({
+									name: query.legend?.trim() || query.name,
+									points: response.result.data.map((p) => ({
+										bucket: p.bucket,
+										series: { ...p.series },
+									})),
+								})
+							}),
+						)
 
 						const multiQuery = perQueryPoints.length > 1
 						const rowsByBucket = new Map<string, Record<string, number>>()

--- a/apps/api/src/routes/scraper-internal.http.ts
+++ b/apps/api/src/routes/scraper-internal.http.ts
@@ -139,57 +139,61 @@ export const ScraperInternalRouter = HttpRouter.use((router) =>
 					})
 
 				const targets: Array<InternalScrapeTarget> = []
-				for (const row of rows) {
-					const ingestKey = yield* ingestKeyForOrg(row.orgId)
-					if (ingestKey === null) {
-						yield* Effect.logWarning("Skipping scrape target (no ingest key)").pipe(
-							Effect.annotateLogs({ scrapeTargetId: row.id, orgId: row.orgId }),
-						)
-						continue
-					}
-
-					if (row.targetType === "planetscale") {
-						// Expand the logical target into its discovered per-branch
-						// endpoints. Discovery failure with no cache skips the row this
-						// round; the scheduler re-fetches the list every reconcile.
-						const subTargets = yield* discovery.discover(row).pipe(
-							Effect.catch((error) =>
-								Effect.logWarning("Skipping PlanetScale target (discovery failed)").pipe(
-									Effect.annotateLogs({
-										scrapeTargetId: row.id,
-										orgId: row.orgId,
-										error: error.message,
-									}),
-									Effect.as([] as ReadonlyArray<PlanetScaleSubTarget>),
-								),
-							),
-						)
-						for (const subTarget of subTargets) {
-							const target = yield* toInternalScrapeTarget(row, ingestKey, subTarget)
-							if (Option.isSome(target)) {
-								targets.push(target.value)
-							} else {
-								yield* Effect.logWarning("Skipping scrape sub-target (invalid row)").pipe(
-									Effect.annotateLogs({
-										scrapeTargetId: row.id,
-										orgId: row.orgId,
-										subTargetKey: subTarget.subTargetKey,
-									}),
-								)
-							}
+				yield* Effect.forEach(rows, (row) =>
+					Effect.gen(function* () {
+						const ingestKey = yield* ingestKeyForOrg(row.orgId)
+						if (ingestKey === null) {
+							yield* Effect.logWarning("Skipping scrape target (no ingest key)").pipe(
+								Effect.annotateLogs({ scrapeTargetId: row.id, orgId: row.orgId }),
+							)
+							return
 						}
-						continue
-					}
 
-					const target = yield* toInternalScrapeTarget(row, ingestKey)
-					if (Option.isSome(target)) {
-						targets.push(target.value)
-					} else {
-						yield* Effect.logWarning("Skipping scrape target (invalid row)").pipe(
-							Effect.annotateLogs({ scrapeTargetId: row.id, orgId: row.orgId }),
-						)
-					}
-				}
+						if (row.targetType === "planetscale") {
+							// Expand the logical target into its discovered per-branch
+							// endpoints. Discovery failure with no cache skips the row this
+							// round; the scheduler re-fetches the list every reconcile.
+							const subTargets = yield* discovery.discover(row).pipe(
+								Effect.catch((error) =>
+									Effect.logWarning("Skipping PlanetScale target (discovery failed)").pipe(
+										Effect.annotateLogs({
+											scrapeTargetId: row.id,
+											orgId: row.orgId,
+											error: error.message,
+										}),
+										Effect.as([] as ReadonlyArray<PlanetScaleSubTarget>),
+									),
+								),
+							)
+							yield* Effect.forEach(subTargets, (subTarget) =>
+								Effect.gen(function* () {
+									const target = yield* toInternalScrapeTarget(row, ingestKey, subTarget)
+									if (Option.isSome(target)) {
+										targets.push(target.value)
+									} else {
+										yield* Effect.logWarning("Skipping scrape sub-target (invalid row)").pipe(
+											Effect.annotateLogs({
+												scrapeTargetId: row.id,
+												orgId: row.orgId,
+												subTargetKey: subTarget.subTargetKey,
+											}),
+										)
+									}
+								}),
+							)
+							return
+						}
+
+						const target = yield* toInternalScrapeTarget(row, ingestKey)
+						if (Option.isSome(target)) {
+							targets.push(target.value)
+						} else {
+							yield* Effect.logWarning("Skipping scrape target (invalid row)").pipe(
+								Effect.annotateLogs({ scrapeTargetId: row.id, orgId: row.orgId }),
+							)
+						}
+					}),
+				)
 
 				return yield* HttpServerResponse.json(targets)
 			}).pipe(Effect.withSpan("ScraperInternal.listTargets"))

--- a/apps/api/src/routes/scraper-internal.test.ts
+++ b/apps/api/src/routes/scraper-internal.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { Effect, Option, Schema } from "effect"
 import { ScrapeResultReportList } from "@maple/domain/http"
 import { isValidInternalBearer } from "../lib/internal-auth"
@@ -6,11 +6,11 @@ import { toInternalScrapeTarget } from "./scraper-internal.http"
 
 describe("internal bearer auth", () => {
 	it("validates internal bearer tokens with exact match", () => {
-		expect(isValidInternalBearer("Bearer secret-token", "secret-token")).toBe(true)
-		expect(isValidInternalBearer("Bearer wrong", "secret-token")).toBe(false)
-		expect(isValidInternalBearer(undefined, "secret-token")).toBe(false)
-		expect(isValidInternalBearer("Bearer secret-token", undefined)).toBe(false)
-		expect(isValidInternalBearer("secret-token", "secret-token")).toBe(false)
+		assert.isTrue(isValidInternalBearer("Bearer secret-token", "secret-token"))
+		assert.isFalse(isValidInternalBearer("Bearer wrong", "secret-token"))
+		assert.isFalse(isValidInternalBearer(undefined, "secret-token"))
+		assert.isFalse(isValidInternalBearer("Bearer secret-token", undefined))
+		assert.isFalse(isValidInternalBearer("secret-token", "secret-token"))
 	})
 })
 
@@ -27,77 +27,84 @@ describe("toInternalScrapeTarget", () => {
 
 	const INGEST_KEY = "maple_pk_test_key"
 
-	it("marshals a row with parsed labels and the org's ingest key", async () => {
-		const result = await Effect.runPromise(toInternalScrapeTarget(baseRow, INGEST_KEY))
-		expect(Option.isSome(result)).toBe(true)
-		if (Option.isNone(result)) return
-		expect(result.value.id).toBe(baseRow.id)
-		expect(result.value.orgId).toBe("org_1")
-		expect(result.value.serviceName).toBe("node")
-		expect(result.value.scrapeIntervalSeconds).toBe(15)
-		expect(result.value.labels).toEqual({ env: "prod" })
-		expect(result.value.ingestKey).toBe(INGEST_KEY)
-	})
+	it.effect("marshals a row with parsed labels and the org's ingest key", () =>
+		Effect.gen(function* () {
+			const result = yield* toInternalScrapeTarget(baseRow, INGEST_KEY)
+			assert.isTrue(Option.isSome(result))
+			if (Option.isNone(result)) return
+			assert.strictEqual(result.value.id, baseRow.id)
+			assert.strictEqual(result.value.orgId, "org_1")
+			assert.strictEqual(result.value.serviceName, "node")
+			assert.strictEqual(result.value.scrapeIntervalSeconds, 15)
+			assert.deepStrictEqual(result.value.labels, { env: "prod" })
+			assert.strictEqual(result.value.ingestKey, INGEST_KEY)
+		}),
+	)
 
-	it("degrades invalid labelsJson to an empty record", async () => {
-		// jsonb drift: the column should hold Record<string, string>, but a row
-		// written by an older deploy (or by hand) may not — the decode guard must
-		// degrade it to {} instead of failing the list.
-		const driftedLabels: unknown = { env: 123 }
-		const result = await Effect.runPromise(
-			toInternalScrapeTarget(
+	it.effect("degrades invalid labelsJson to an empty record", () =>
+		Effect.gen(function* () {
+			// jsonb drift: the column should hold Record<string, string>, but a row
+			// written by an older deploy (or by hand) may not — the decode guard must
+			// degrade it to {} instead of failing the list.
+			const driftedLabels: unknown = { env: 123 }
+			const result = yield* toInternalScrapeTarget(
 				{ ...baseRow, labelsJson: driftedLabels as Record<string, string> },
 				INGEST_KEY,
-			),
-		)
-		expect(Option.isSome(result)).toBe(true)
-		if (Option.isNone(result)) return
-		expect(result.value.labels).toEqual({})
-	})
+			)
+			assert.isTrue(Option.isSome(result))
+			if (Option.isNone(result)) return
+			assert.deepStrictEqual(result.value.labels, {})
+		}),
+	)
 
-	it("handles null labelsJson and null serviceName", async () => {
-		const result = await Effect.runPromise(
-			toInternalScrapeTarget({ ...baseRow, labelsJson: null, serviceName: null }, INGEST_KEY),
-		)
-		expect(Option.isSome(result)).toBe(true)
-		if (Option.isNone(result)) return
-		expect(result.value.labels).toEqual({})
-		expect(result.value.serviceName).toBeNull()
-	})
+	it.effect("handles null labelsJson and null serviceName", () =>
+		Effect.gen(function* () {
+			const result = yield* toInternalScrapeTarget(
+				{ ...baseRow, labelsJson: null, serviceName: null },
+				INGEST_KEY,
+			)
+			assert.isTrue(Option.isSome(result))
+			if (Option.isNone(result)) return
+			assert.deepStrictEqual(result.value.labels, {})
+			assert.isNull(result.value.serviceName)
+		}),
+	)
 
-	it("drops rows that violate the schema brands instead of failing the list", async () => {
-		const outOfRange = await Effect.runPromise(
-			toInternalScrapeTarget({ ...baseRow, scrapeIntervalSeconds: 2 }, INGEST_KEY),
-		)
-		expect(Option.isNone(outOfRange)).toBe(true)
-	})
+	it.effect("drops rows that violate the schema brands instead of failing the list", () =>
+		Effect.gen(function* () {
+			const outOfRange = yield* toInternalScrapeTarget({ ...baseRow, scrapeIntervalSeconds: 2 }, INGEST_KEY)
+			assert.isTrue(Option.isNone(outOfRange))
+		}),
+	)
 
-	it("expands a discovered sub-target with its url, key, and merged labels", async () => {
-		const result = await Effect.runPromise(
-			toInternalScrapeTarget(baseRow, INGEST_KEY, {
+	it.effect("expands a discovered sub-target with its url, key, and merged labels", () =>
+		Effect.gen(function* () {
+			const result = yield* toInternalScrapeTarget(baseRow, INGEST_KEY, {
 				url: "https://branch-1.metrics.psdb.cloud/metrics",
 				subTargetKey: "branch-1",
 				labels: { planetscale_database_branch_id: "branch-1", env: "discovery" },
-			}),
-		)
-		expect(Option.isSome(result)).toBe(true)
-		if (Option.isNone(result)) return
-		expect(result.value.id).toBe(baseRow.id)
-		expect(result.value.url).toBe("https://branch-1.metrics.psdb.cloud/metrics")
-		expect(result.value.subTargetKey).toBe("branch-1")
-		// The target's own labelsJson wins over discovery labels on conflicts.
-		expect(result.value.labels).toEqual({
-			planetscale_database_branch_id: "branch-1",
-			env: "prod",
-		})
-	})
+			})
+			assert.isTrue(Option.isSome(result))
+			if (Option.isNone(result)) return
+			assert.strictEqual(result.value.id, baseRow.id)
+			assert.strictEqual(result.value.url, "https://branch-1.metrics.psdb.cloud/metrics")
+			assert.strictEqual(result.value.subTargetKey, "branch-1")
+			// The target's own labelsJson wins over discovery labels on conflicts.
+			assert.deepStrictEqual(result.value.labels, {
+				planetscale_database_branch_id: "branch-1",
+				env: "prod",
+			})
+		}),
+	)
 
-	it("defaults subTargetKey to null for plain targets", async () => {
-		const result = await Effect.runPromise(toInternalScrapeTarget(baseRow, INGEST_KEY))
-		expect(Option.isSome(result)).toBe(true)
-		if (Option.isNone(result)) return
-		expect(result.value.subTargetKey).toBeNull()
-	})
+	it.effect("defaults subTargetKey to null for plain targets", () =>
+		Effect.gen(function* () {
+			const result = yield* toInternalScrapeTarget(baseRow, INGEST_KEY)
+			assert.isTrue(Option.isSome(result))
+			if (Option.isNone(result)) return
+			assert.isNull(result.value.subTargetKey)
+		}),
+	)
 })
 
 describe("ScrapeResultReportList decoding", () => {
@@ -115,9 +122,9 @@ describe("ScrapeResultReportList decoding", () => {
 				samplesPostMetricRelabeling: 118,
 			},
 		])
-		expect(reports[0]?.durationMs).toBe(250)
-		expect(reports[0]?.samplesScraped).toBe(120)
-		expect(reports[0]?.samplesPostMetricRelabeling).toBe(118)
+		assert.strictEqual(reports[0]?.durationMs, 250)
+		assert.strictEqual(reports[0]?.samplesScraped, 120)
+		assert.strictEqual(reports[0]?.samplesPostMetricRelabeling, 118)
 	})
 
 	it("accepts legacy reports without check metadata (older scraper deploys)", () => {
@@ -128,7 +135,7 @@ describe("ScrapeResultReportList decoding", () => {
 				error: "target returned HTTP 503",
 			},
 		])
-		expect(reports[0]?.error).toBe("target returned HTTP 503")
-		expect(reports[0]?.durationMs).toBeUndefined()
+		assert.strictEqual(reports[0]?.error, "target returned HTTP 503")
+		assert.strictEqual(reports[0]?.durationMs, undefined)
 	})
 })

--- a/apps/api/src/routes/vcs-webhook.http.ts
+++ b/apps/api/src/routes/vcs-webhook.http.ts
@@ -1,8 +1,17 @@
 import { HttpRouter, type HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
-import { Effect, Option } from "effect"
+import { Data, Effect, Option } from "effect"
 import type { VcsProviderClient } from "../services/vcs/VcsProviderClient"
 import { VcsProviderRegistry } from "../services/vcs/VcsProviderRegistry"
 import { VcsSyncQueue } from "../services/vcs/VcsSyncQueue"
+
+/**
+ * In-memory sentinel: lets the span exit Error while the HTTP layer returns a
+ * 500. Failed immediately after the span annotation, then caught outside the
+ * span (never serialized).
+ */
+class EnqueueFailure extends Data.TaggedError("EnqueueFailure")<{
+	readonly message: string
+}> {}
 
 // ---------------------------------------------------------------------------
 // Public webhook receiver, one static route per registered provider
@@ -21,12 +30,6 @@ export const VcsWebhookRouter = HttpRouter.use((router) =>
 
 		const makeHandler =
 			(provider: VcsProviderClient, route: string) => (req: HttpServerRequest.HttpServerRequest) => {
-				// Sentinel: lets the span exit Error while the HTTP layer returns a 500.
-				class EnqueueFailure {
-					readonly _tag = "EnqueueFailure"
-					constructor(readonly message: string) {}
-				}
-
 				return Effect.gen(function* () {
 					const deliveryId = (req.headers as Record<string, string | undefined>)[
 						"x-github-delivery"
@@ -95,7 +98,9 @@ export const VcsWebhookRouter = HttpRouter.use((router) =>
 											Effect.annotateLogs({ error: error.message }),
 										),
 									),
-									Effect.flatMap(() => Effect.fail(new EnqueueFailure(error.message))),
+									Effect.flatMap(() =>
+								Effect.fail(new EnqueueFailure({ message: error.message })),
+							),
 								),
 						}),
 					)

--- a/apps/api/src/services/AlertDeliveryDispatch.test.ts
+++ b/apps/api/src/services/AlertDeliveryDispatch.test.ts
@@ -1,7 +1,7 @@
 import type { AlertDestinationRow } from "@maple/db"
 import { AlertDeliveryError } from "@maple/domain/http"
+import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
-import { describe, expect, it } from "vitest"
 import {
 	buildDiscordEmbedsFromTemplate,
 	buildSlackBlocksFromTemplate,
@@ -40,34 +40,34 @@ describe("buildTemplateContext", () => {
 	const ctx = buildTemplateContext(baseContext, LINK, CHAT)
 
 	it("exposes pre-formatted variables", () => {
-		expect(ctx["rule.name"]).toBe("Checkout error rate")
-		expect(ctx.severity).toBe("critical")
-		expect(ctx["signal.label"]).toBe("Error Rate")
-		expect(ctx["event.label"]).toBe("Triggered")
-		expect(ctx["comparator.label"]).toBe(">")
+		assert.strictEqual(ctx["rule.name"], "Checkout error rate")
+		assert.strictEqual(ctx.severity, "critical")
+		assert.strictEqual(ctx["signal.label"], "Error Rate")
+		assert.strictEqual(ctx["event.label"], "Triggered")
+		assert.strictEqual(ctx["comparator.label"], ">")
 		// error_rate values render as percentages
-		expect(ctx.value).toBe("8%")
-		expect(ctx.threshold).toBe("5%")
-		expect(ctx["observed.summary"]).toBe("8% > 5%")
-		expect(ctx.window).toBe("5m")
-		expect(ctx.group).toBe("all")
-		expect(ctx["links.app"]).toBe(LINK)
-		expect(ctx["links.chat"]).toBe(CHAT)
-		expect(ctx.sentAt).toBe("2026-06-02T00:00:00.000Z")
+		assert.strictEqual(ctx.value, "8%")
+		assert.strictEqual(ctx.threshold, "5%")
+		assert.strictEqual(ctx["observed.summary"], "8% > 5%")
+		assert.strictEqual(ctx.window, "5m")
+		assert.strictEqual(ctx.group, "all")
+		assert.strictEqual(ctx["links.app"], LINK)
+		assert.strictEqual(ctx["links.chat"], CHAT)
+		assert.strictEqual(ctx.sentAt, "2026-06-02T00:00:00.000Z")
 	})
 
 	it("leaves thresholdUpper empty for non-range comparators", () => {
-		expect(ctx.thresholdUpper).toBe("")
+		assert.strictEqual(ctx.thresholdUpper, "")
 	})
 
 	it("renders the default templates without any missing variables", () => {
 		const title = renderTemplate(DEFAULT_TITLE_TEMPLATE, ctx)
 		const body = renderTemplate(DEFAULT_BODY_TEMPLATE, ctx)
-		expect(title.missing).toEqual([])
-		expect(body.missing).toEqual([])
-		expect(title.text).toContain("Checkout error rate")
-		expect(title.text).toContain("Triggered")
-		expect(body.text).toContain("*Observed:* 8% > 5%")
+		assert.deepStrictEqual(title.missing, [])
+		assert.deepStrictEqual(body.missing, [])
+		assert.include(title.text, "Checkout error rate")
+		assert.include(title.text, "Triggered")
+		assert.include(body.text, "*Observed:* 8% > 5%")
 	})
 })
 
@@ -82,20 +82,20 @@ describe("buildSlackBlocksFromTemplate", () => {
 		)
 		const header = blocks[0] as { type: string; text: { text: string } }
 		const section = blocks[1] as { type: string; text: { type: string; text: string } }
-		expect(header.type).toBe("header")
-		expect(header.text.text).toBe("My Title")
-		expect(section.type).toBe("section")
-		expect(section.text.type).toBe("mrkdwn")
+		assert.strictEqual(header.type, "header")
+		assert.strictEqual(header.text.text, "My Title")
+		assert.strictEqual(section.type, "section")
+		assert.strictEqual(section.text.type, "mrkdwn")
 		// **bold** → *bold*, [link](url) → <url|link>
-		expect(section.text.text).toBe("*bold* and <https://x.test|link>")
-		expect(blocks.some((b) => (b as { type: string }).type === "actions")).toBe(true)
+		assert.strictEqual(section.text.text, "*bold* and <https://x.test|link>")
+		assert.isTrue(blocks.some((b) => (b as { type: string }).type === "actions"))
 	})
 
 	it("truncates an over-long Slack header", () => {
 		const long = "x".repeat(200)
 		const blocks = buildSlackBlocksFromTemplate(long, "body", baseContext, LINK, CHAT)
 		const header = blocks[0] as { text: { text: string } }
-		expect(header.text.text.length).toBeLessThanOrEqual(150)
+		assert.isAtMost(header.text.text.length, 150)
 	})
 })
 
@@ -107,11 +107,11 @@ describe("buildDiscordEmbedsFromTemplate", () => {
 			color: number
 			url: string
 		}>
-		expect(embed.title).toBe("T")
-		expect(embed.description).toBe("B")
-		expect(embed.url).toBe(LINK)
+		assert.strictEqual(embed.title, "T")
+		assert.strictEqual(embed.description, "B")
+		assert.strictEqual(embed.url, LINK)
 		// critical (non-resolve) → red
-		expect(embed.color).toBe(0xe01e5a)
+		assert.strictEqual(embed.color, 0xe01e5a)
 	})
 })
 
@@ -158,19 +158,21 @@ describe("dispatchDelivery", () => {
 		sentAtMs: Date.parse("2026-06-02T00:00:00.000Z"),
 	}
 
-	it("includes the provider's response body in the delivery error", async () => {
-		const body =
-			'{"status":"invalid event","message":"Event object is invalid","errors":["routing_key is invalid"]}'
-		const fetchFn: typeof fetch = async () => new Response(body, { status: 400 })
+	it.effect("includes the provider's response body in the delivery error", () =>
+		Effect.gen(function* () {
+			const body =
+				'{"status":"invalid event","message":"Event object is invalid","errors":["routing_key is invalid"]}'
+			const fetchFn: typeof fetch = async () => new Response(body, { status: 400 })
 
-		const error = await Effect.runPromise(
-			Effect.flip(dispatchDelivery(pagerdutyContext, "{}", fetchFn, 5_000, LINK, CHAT)),
-		)
+			const error = yield* Effect.flip(
+				dispatchDelivery(pagerdutyContext, "{}", fetchFn, 5_000, LINK, CHAT),
+			)
 
-		expect(error).toBeInstanceOf(AlertDeliveryError)
-		expect(error.destinationType).toBe("pagerduty")
-		expect(error.message).toContain("PagerDuty delivery failed with 400")
-		// The PagerDuty rejection reason is now surfaced instead of swallowed.
-		expect(error.message).toContain("routing_key is invalid")
-	})
+			assert.instanceOf(error, AlertDeliveryError)
+			assert.strictEqual(error.destinationType, "pagerduty")
+			assert.include(error.message, "PagerDuty delivery failed with 400")
+			// The PagerDuty rejection reason is now surfaced instead of swallowed.
+			assert.include(error.message, "routing_key is invalid")
+		}),
+	)
 })

--- a/apps/api/src/services/AlertsService.test.ts
+++ b/apps/api/src/services/AlertsService.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from "@effect/vitest"
+import { afterEach, assert, describe, it } from "@effect/vitest"
 import { Cause, Clock, ConfigProvider, Duration, Effect, Exit, Layer, Option, Schema } from "effect"
+import { TestClock } from "effect/testing"
 import {
 	AlertDestinationInUseError,
 	AlertForbiddenError,
@@ -31,16 +32,6 @@ const getError = <A, E>(exit: Exit.Exit<A, E>): unknown => {
 
 	return Cause.squash(exit.cause)
 }
-
-/**
- * Runs an Effect-returning test body via `Effect.runPromise`. We deliberately
- * avoid `@effect/vitest`'s `it.effect`/`it.live`: under bun those wrappers never
- * settle real timers (`Effect.sleep`) or macrotask promises, which the embedded
- * DB driver and the delivery dispatcher's `fetch` + `Effect.timeout` depend on.
- * Plain `runPromise` drives the real event loop correctly.
- */
-const itEffect = (name: string, body: () => Effect.Effect<unknown, unknown, never>) =>
-	it(name, () => Effect.runPromise(body()))
 
 const makeConfig = () =>
 	ConfigProvider.layer(
@@ -83,7 +74,7 @@ function makeWarehouseStub(state: {
 	}
 
 	return {
-		query: (_tenant, payload) => Effect.fail(new Error(`Unexpected pipe ${payload.pipe}`)) as never,
+		query: (_tenant, payload) => Effect.fail(new Error(`Unexpected pipe ${payload.pipeName}`)) as never,
 		sqlQuery: sqlQueryStub,
 		compiledQuery: (_tenant, compiled) =>
 			sqlQueryStub().pipe(Effect.flatMap((rows) => compiled.decodeRows(rows).pipe(Effect.orDie))),
@@ -97,44 +88,18 @@ function makeWarehouseStub(state: {
 }
 
 const defaultTestRuntime: AlertRuntimeShape = {
-	// Time is sourced from Effect's Clock (overridden per-test by a manual clock
-	// for deterministic scheduler timestamps).
+	// Time is sourced from Effect's Clock, which `it.effect` swaps for TestClock —
+	// scheduler-timestamp tests drive it deterministically via TestClock.setTime /
+	// TestClock.adjust. Real `fetch`/`Effect.timeout` settle on the live event loop.
 	now: Clock.currentTimeMillis,
 	makeUuid: () => crypto.randomUUID(),
 	fetch: globalThis.fetch,
 	deliveryTimeoutMs: () => 15_000,
 }
 
-/**
- * A controllable clock that backs the `AlertRuntime.now` seam. Time for the
- * alerts domain itself (scheduler timestamps and the per-rule scheduler lock) is
- * fully deterministic: it starts from a fixed epoch and only moves when a test
- * calls `adjust`/`setTime`, mirroring `TestClock` semantics without ever reading
- * wall-clock time (`Date.now`). The runtime clock stays live so the embedded
- * DB driver and the dispatcher's real `fetch` + `Effect.timeout` keep working.
- */
-interface ManualClock {
-	readonly now: Effect.Effect<number>
-	readonly setTime: (epochMs: number) => Effect.Effect<void>
-	readonly adjust: (duration: Duration.Input) => Effect.Effect<void>
-}
-
+// The fixed epoch scheduler tests start TestClock at, mirroring the previous
+// manual clock's default start time.
 const DEFAULT_CLOCK_EPOCH_MS = 1_700_000_000_000
-
-const makeManualClock = (startMs: number = DEFAULT_CLOCK_EPOCH_MS): ManualClock => {
-	let currentMs = startMs
-	return {
-		now: Effect.sync(() => currentMs),
-		setTime: (epochMs) =>
-			Effect.sync(() => {
-				currentMs = epochMs
-			}),
-		adjust: (duration) =>
-			Effect.sync(() => {
-				currentMs += Duration.toMillis(duration)
-			}),
-	}
-}
 
 const makeLayer = (
 	testDb: TestDb,
@@ -294,7 +259,7 @@ const insertDeliveryEventRow = async (
 }
 
 describe("AlertsService", () => {
-	itEffect("opens an incident after consecutive breaches and delivers the webhook notification", () => {
+	it.effect("opens an incident after consecutive breaches and delivers the webhook notification", () => {
 		const testDb = createTestDb(trackedDbs)
 		const state = {
 			tracesAggregateRows: [
@@ -320,9 +285,8 @@ describe("AlertsService", () => {
 			return new Response("ok", { status: 200 })
 		}) as typeof fetch
 
-		const clock = makeManualClock()
-
 		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_alerts")
 			const userId = asUserId("user_alerts")
@@ -333,31 +297,32 @@ describe("AlertsService", () => {
 			const incidentsAfterFirstTick = yield* alerts.listIncidents(orgId)
 
 			// Advance past the scheduler lock TTL so the rule can be claimed again.
-			yield* clock.adjust(Duration.minutes(1))
+			yield* TestClock.adjust(Duration.minutes(1))
 			yield* alerts.runSchedulerTick()
 			const incidentsAfterSecondTick = yield* alerts.listIncidents(orgId)
 			const events = yield* alerts.listDeliveryEvents(orgId)
 
-			expect(incidentsAfterFirstTick.incidents).toHaveLength(0)
-			expect(incidentsAfterSecondTick.incidents).toHaveLength(1)
-			expect(incidentsAfterSecondTick.incidents[0]?.status).toBe("open")
-			expect(events.events).toHaveLength(1)
-			expect(events.events[0]?.status).toBe("success")
-			expect(events.events[0]?.eventType).toBe("trigger")
-			expect(requests).toHaveLength(1)
-			expect(requests[0]?.url).toBe("https://example.com/maple-alerts")
-			expect(requests[0]?.headers.get("x-maple-signature")).toBeTruthy()
-			expect(requests[0]?.headers.get("x-maple-event-type")).toBe("trigger")
-			expect(requests[0]?.headers.get("x-maple-delivery-key")).toBe(events.events[0]?.deliveryKey)
-			expect(requests[0]?.headers.get("x-maple-delivery-key")).not.toBe(
+			assert.lengthOf(incidentsAfterFirstTick.incidents, 0)
+			assert.lengthOf(incidentsAfterSecondTick.incidents, 1)
+			assert.strictEqual(incidentsAfterSecondTick.incidents[0]?.status, "open")
+			assert.lengthOf(events.events, 1)
+			assert.strictEqual(events.events[0]?.status, "success")
+			assert.strictEqual(events.events[0]?.eventType, "trigger")
+			assert.lengthOf(requests, 1)
+			assert.strictEqual(requests[0]?.url, "https://example.com/maple-alerts")
+			assert.isNotEmpty(requests[0]?.headers.get("x-maple-signature") ?? "")
+			assert.strictEqual(requests[0]?.headers.get("x-maple-event-type"), "trigger")
+			assert.strictEqual(requests[0]?.headers.get("x-maple-delivery-key"), events.events[0]?.deliveryKey)
+			assert.notStrictEqual(
+				requests[0]?.headers.get("x-maple-delivery-key"),
 				incidentsAfterSecondTick.incidents[0]?.dedupeKey,
 			)
 		}).pipe(
-			Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { now: clock.now, fetch: fetchImpl })),
+			Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: fetchImpl })),
 		)
 	})
 
-	itEffect("snapshots a custom notification template into the delivered payload", () => {
+	it.effect("snapshots a custom notification template into the delivered payload", () => {
 		const testDb = createTestDb(trackedDbs)
 		const state = {
 			tracesAggregateRows: [
@@ -380,9 +345,8 @@ describe("AlertsService", () => {
 			return new Response("ok", { status: 200 })
 		}) as typeof fetch
 
-		const clock = makeManualClock()
-
 		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_tpl")
 			const userId = asUserId("user_tpl")
@@ -413,35 +377,35 @@ describe("AlertsService", () => {
 			)
 
 			yield* alerts.runSchedulerTick()
-			yield* clock.adjust(Duration.minutes(1))
+			yield* TestClock.adjust(Duration.minutes(1))
 			yield* alerts.runSchedulerTick()
 
 			// The custom template is re-read from the rule and surfaces through
 			// get_alert_rule / listRules.
 			const rules = yield* alerts.listRules(orgId)
-			expect(rules.rules[0]?.notificationTemplate?.title).toBe("{{ severity }} on {{ rule.name }}")
+			assert.strictEqual(rules.rules[0]?.notificationTemplate?.title, "{{ severity }} on {{ rule.name }}")
 
 			// The webhook body is the snapshotted delivery payload — it carries the
 			// template so retries and downstream consumers render the same message.
-			expect(bodies).toHaveLength(1)
+			assert.lengthOf(bodies, 1)
 			const payload = JSON.parse(bodies[0]!) as {
 				template?: { title?: string; body?: string }
 			}
-			expect(payload.template?.title).toBe("{{ severity }} on {{ rule.name }}")
-			expect(payload.template?.body).toBe("*Observed:* {{ observed.summary }}")
+			assert.strictEqual(payload.template?.title, "{{ severity }} on {{ rule.name }}")
+			assert.strictEqual(payload.template?.body, "*Observed:* {{ observed.summary }}")
 		}).pipe(
-			Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { now: clock.now, fetch: fetchImpl })),
+			Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: fetchImpl })),
 		)
 	})
 
-	itEffect("skips no-data error-rate rules instead of opening incidents", () => {
+	it.effect("skips no-data error-rate rules instead of opening incidents", () => {
 		const testDb = createTestDb(trackedDbs)
 		const state = {
 			tracesAggregateRows: emptyWarehouseRows,
 		}
-		const clock = makeManualClock()
 
 		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_skipped")
 			const userId = asUserId("user_skipped")
@@ -449,25 +413,25 @@ describe("AlertsService", () => {
 			yield* createErrorRateRule(alerts, orgId, userId, destination.id)
 
 			yield* alerts.runSchedulerTick()
-			yield* clock.adjust(Duration.minutes(1))
+			yield* TestClock.adjust(Duration.minutes(1))
 			yield* alerts.runSchedulerTick()
 
 			const incidents = yield* alerts.listIncidents(orgId)
 			const events = yield* alerts.listDeliveryEvents(orgId)
 
-			expect(incidents.incidents).toHaveLength(0)
-			expect(events.events).toHaveLength(0)
-		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { now: clock.now })))
+			assert.lengthOf(incidents.incidents, 0)
+			assert.lengthOf(events.events, 0)
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state))))
 	})
 
-	itEffect("treats no data as a breach for throughput-below-threshold rules", () => {
+	it.effect("treats no data as a breach for throughput-below-threshold rules", () => {
 		const testDb = createTestDb(trackedDbs)
 		const state = {
 			tracesAggregateRows: emptyWarehouseRows,
 		}
-		const clock = makeManualClock()
 
 		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_throughput")
 			const userId = asUserId("user_throughput")
@@ -495,17 +459,17 @@ describe("AlertsService", () => {
 			)
 
 			yield* alerts.runSchedulerTick()
-			yield* clock.adjust(Duration.minutes(1))
+			yield* TestClock.adjust(Duration.minutes(1))
 			yield* alerts.runSchedulerTick()
 
 			const incidents = yield* alerts.listIncidents(orgId)
-			expect(incidents.incidents).toHaveLength(1)
-			expect(incidents.incidents[0]?.status).toBe("open")
-			expect(incidents.incidents[0]?.signalType).toBe("throughput")
-		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { now: clock.now, fetch: okFetch })))
+			assert.lengthOf(incidents.incidents, 1)
+			assert.strictEqual(incidents.incidents[0]?.status, "open")
+			assert.strictEqual(incidents.incidents[0]?.signalType, "throughput")
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: okFetch })))
 	})
 
-	itEffect("persists compiled query plans when rules are created", () => {
+	it.effect("persists compiled query plans when rules are created", () => {
 		const testDb = createTestDb(trackedDbs)
 
 		return Effect.gen(function* () {
@@ -531,25 +495,28 @@ describe("AlertsService", () => {
 				),
 			)
 
-			expect(row).toBeTruthy()
-			expect(row?.reducer).toBe("identity")
-			expect(row?.sampleCountStrategy).toBe("trace_count")
-			expect(row?.noDataBehavior).toBe("skip")
-			expect(row?.querySpecJson).toMatchObject({
-				kind: "timeseries",
-				source: "traces",
-				metric: "error_rate",
-				groupBy: ["none"],
-				filters: {
-					serviceName: "checkout",
-				},
-			})
+			assert.isOk(row)
+			assert.strictEqual(row?.reducer, "identity")
+			assert.strictEqual(row?.sampleCountStrategy, "trace_count")
+			assert.strictEqual(row?.noDataBehavior, "skip")
+			const spec = row?.querySpecJson as {
+				kind: string
+				source: string
+				metric: string
+				groupBy: ReadonlyArray<string>
+				filters: { serviceName: string }
+			}
+			assert.strictEqual(spec.kind, "timeseries")
+			assert.strictEqual(spec.source, "traces")
+			assert.strictEqual(spec.metric, "error_rate")
+			assert.deepStrictEqual(spec.groupBy, ["none"])
+			assert.strictEqual(spec.filters.serviceName, "checkout")
 		}).pipe(
 			Effect.provide(makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }))),
 		)
 	})
 
-	itEffect("resolves an open incident after consecutive healthy evaluations", () => {
+	it.effect("resolves an open incident after consecutive healthy evaluations", () => {
 		const testDb = createTestDb(trackedDbs)
 		const state = {
 			tracesAggregateRows: [
@@ -566,9 +533,9 @@ describe("AlertsService", () => {
 				},
 			] as ReadonlyArray<Record<string, unknown>>,
 		}
-		const clock = makeManualClock()
 
 		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_resolve")
 			const userId = asUserId("user_resolve")
@@ -576,7 +543,7 @@ describe("AlertsService", () => {
 			yield* createErrorRateRule(alerts, orgId, userId, destination.id)
 
 			yield* alerts.runSchedulerTick()
-			yield* clock.adjust(Duration.minutes(1))
+			yield* TestClock.adjust(Duration.minutes(1))
 			yield* alerts.runSchedulerTick()
 
 			state.tracesAggregateRows = [
@@ -593,24 +560,24 @@ describe("AlertsService", () => {
 				},
 			]
 
-			yield* clock.adjust(Duration.minutes(1))
+			yield* TestClock.adjust(Duration.minutes(1))
 			yield* alerts.runSchedulerTick()
-			yield* clock.adjust(Duration.minutes(1))
+			yield* TestClock.adjust(Duration.minutes(1))
 			yield* alerts.runSchedulerTick()
 
 			const incidents = yield* alerts.listIncidents(orgId)
 			const events = yield* alerts.listDeliveryEvents(orgId)
 
-			expect(incidents.incidents).toHaveLength(1)
-			expect(incidents.incidents[0]?.status).toBe("resolved")
-			expect(events.events.map((event: { eventType: string }) => event.eventType)).toEqual([
+			assert.lengthOf(incidents.incidents, 1)
+			assert.strictEqual(incidents.incidents[0]?.status, "resolved")
+			assert.deepStrictEqual(events.events.map((event: { eventType: string }) => event.eventType), [
 				"resolve",
 				"trigger",
 			])
-		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { now: clock.now, fetch: okFetch })))
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: okFetch })))
 	})
 
-	itEffect("sends signed webhook test notifications", () => {
+	it.effect("sends signed webhook test notifications", () => {
 		const testDb = createTestDb(trackedDbs)
 		const requests: Array<{ headers: Headers; body: string }> = []
 		const fetchImpl = (async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -628,11 +595,11 @@ describe("AlertsService", () => {
 			const destination = yield* createWebhookDestination(alerts, orgId, userId)
 			const response = yield* alerts.testDestination(orgId, userId, adminRoles, destination.id)
 
-			expect(response.success).toBe(true)
-			expect(requests).toHaveLength(1)
-			expect(requests[0]?.headers.get("x-maple-event-type")).toBe("test")
-			expect(requests[0]?.headers.get("x-maple-signature")).toBeTruthy()
-			expect(requests[0]?.body).toContain('"eventType":"test"')
+			assert.isTrue(response.success)
+			assert.lengthOf(requests, 1)
+			assert.strictEqual(requests[0]?.headers.get("x-maple-event-type"), "test")
+			assert.isNotEmpty(requests[0]?.headers.get("x-maple-signature") ?? "")
+			assert.include(requests[0]?.body ?? "", '"eventType":"test"')
 		}).pipe(
 			Effect.provide(
 				makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
@@ -642,7 +609,7 @@ describe("AlertsService", () => {
 		)
 	})
 
-	itEffect("keeps processing queued deliveries when a rule evaluation fails", () => {
+	it.effect("keeps processing queued deliveries when a rule evaluation fails", () => {
 		const fixedTime = 1_710_000_000_000
 		const testDb = createTestDb(trackedDbs)
 		const requests: Array<{ headers: Headers }> = []
@@ -650,10 +617,10 @@ describe("AlertsService", () => {
 			requests.push({ headers: new Headers(init?.headers) })
 			return new Response("ok", { status: 200 })
 		}) as typeof fetch
-		// Pin the clock to fixedTime so the pre-seeded delivery (scheduledAt: fixedTime - 1) is due.
-		const clock = makeManualClock(fixedTime)
 
 		return Effect.gen(function* () {
+			// Pin the clock to fixedTime so the pre-seeded delivery (scheduledAt: fixedTime - 1) is due.
+			yield* TestClock.setTime(fixedTime)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_eval_failure")
 			const userId = asUserId("user_eval_failure")
@@ -704,22 +671,21 @@ describe("AlertsService", () => {
 			const tick = yield* alerts.runSchedulerTick()
 			const events = yield* alerts.listDeliveryEvents(orgId)
 
-			expect(tick.evaluationFailureCount).toBe(1)
-			expect(tick.processedCount).toBe(1)
-			expect(tick.deliveryFailureCount).toBe(0)
-			expect(requests).toHaveLength(1)
-			expect(events.events[0]?.status).toBe("success")
+			assert.strictEqual(tick.evaluationFailureCount, 1)
+			assert.strictEqual(tick.processedCount, 1)
+			assert.strictEqual(tick.deliveryFailureCount, 0)
+			assert.lengthOf(requests, 1)
+			assert.strictEqual(events.events[0]?.status, "success")
 		}).pipe(
 			Effect.provide(
 				makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
-					now: clock.now,
 					fetch: fetchImpl,
 				}),
 			),
 		)
 	})
 
-	itEffect("suppresses duplicate delivery sends across concurrent service instances", () => {
+	it.effect("suppresses duplicate delivery sends across concurrent service instances", () => {
 		const fixedTime = 1_710_000_100_000
 		const testDb = createTestDb(trackedDbs)
 		let requestCount = 0
@@ -729,11 +695,11 @@ describe("AlertsService", () => {
 		}) as unknown as typeof fetch
 
 		const stub = makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows })
-		// One shared clock pinned to fixedTime backs every service instance below.
-		const clock = makeManualClock(fixedTime)
-		const overrides = { now: clock.now, fetch: fetchImpl }
+		const overrides = { fetch: fetchImpl }
 
 		return Effect.gen(function* () {
+			// One shared TestClock pinned to fixedTime backs every service instance below.
+			yield* TestClock.setTime(fixedTime)
 			const setup = yield* Effect.gen(function* () {
 				const alerts = yield* AlertsService
 				const orgId = asOrgId("org_dupe_guard")
@@ -803,15 +769,16 @@ describe("AlertsService", () => {
 				return yield* alerts.listDeliveryEvents(setup.orgId)
 			}).pipe(Effect.provide(makeLayer(testDb, stub, overrides)))
 
-			expect(requestCount).toBe(1)
-			expect(tickA.processedCount + tickB.processedCount).toBe(1)
-			expect(events.events.find((event) => event.deliveryKey === "shared-delivery-key")?.status).toBe(
+			assert.strictEqual(requestCount, 1)
+			assert.strictEqual(tickA.processedCount + tickB.processedCount, 1)
+			assert.strictEqual(
+				events.events.find((event) => event.deliveryKey === "shared-delivery-key")?.status,
 				"success",
 			)
 		})
 	})
 
-	itEffect("skips duplicate delivery events and still creates the incident", () => {
+	it.effect("skips duplicate delivery events and still creates the incident", () => {
 		const fixedTime = 1_710_000_200_000
 		const testDb = createTestDb(trackedDbs)
 
@@ -830,9 +797,7 @@ describe("AlertsService", () => {
 				},
 			],
 		}
-		const clock = makeManualClock(fixedTime)
 		const overrides = {
-			now: clock.now,
 			...makeUuidSequence(
 				"00000000-0000-4000-8000-000000000001",
 				"00000000-0000-4000-8000-000000000002",
@@ -845,6 +810,7 @@ describe("AlertsService", () => {
 		const layer = makeLayer(testDb, makeWarehouseStub(state), overrides)
 
 		return Effect.gen(function* () {
+			yield* TestClock.setTime(fixedTime)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_tx_rollback")
 			const userId = asUserId("user_tx_rollback")
@@ -913,19 +879,18 @@ describe("AlertsService", () => {
 			const incidents = yield* alerts.listIncidents(orgId)
 			const events = yield* alerts.listDeliveryEvents(orgId)
 
-			expect(tick.evaluationFailureCount).toBe(0)
-			expect(incidents.incidents).toHaveLength(1)
+			assert.strictEqual(tick.evaluationFailureCount, 0)
+			assert.lengthOf(incidents.incidents, 1)
 			// Only the pre-existing event — the duplicate was silently skipped
-			expect(events.events).toHaveLength(1)
-			expect(events.events[0]?.deliveryKey).toContain(":trigger:")
+			assert.lengthOf(events.events, 1)
+			assert.include(events.events[0]?.deliveryKey ?? "", ":trigger:")
 		}).pipe(Effect.provide(layer))
 	})
 
-	itEffect("times out stuck deliveries and enqueues a retry attempt", () => {
+	it.live("times out stuck deliveries and enqueues a retry attempt", () => {
 		const fixedTime = 1_710_000_300_000
 		const testDb = createTestDb(trackedDbs)
 		const hangingFetch = (() => new Promise(() => {})) as unknown as typeof fetch
-		const clock = makeManualClock(fixedTime)
 
 		return Effect.gen(function* () {
 			const alerts = yield* AlertsService
@@ -976,21 +941,21 @@ describe("AlertsService", () => {
 			const tick = yield* alerts.runSchedulerTick()
 			const events = yield* alerts.listDeliveryEvents(orgId)
 
-			expect(tick.processedCount).toBe(1)
-			expect(tick.deliveryFailureCount).toBe(1)
+			assert.strictEqual(tick.processedCount, 1)
+			assert.strictEqual(tick.deliveryFailureCount, 1)
 			const timeoutEvent = events.events.find(
 				(event) => event.deliveryKey === "timeout-delivery-key" && event.attemptNumber === 1,
 			)
 			const retryEvent = events.events.find(
 				(event) => event.deliveryKey === "timeout-delivery-key" && event.attemptNumber === 2,
 			)
-			expect(timeoutEvent?.status).toBe("failed")
-			expect(timeoutEvent?.errorMessage).toContain("timed out")
-			expect(retryEvent?.status).toBe("queued")
+			assert.strictEqual(timeoutEvent?.status, "failed")
+			assert.include(timeoutEvent?.errorMessage ?? "", "timed out")
+			assert.strictEqual(retryEvent?.status, "queued")
 		}).pipe(
 			Effect.provide(
 				makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
-					now: clock.now,
+					now: Effect.succeed(fixedTime),
 					fetch: hangingFetch,
 					deliveryTimeoutMs: () => 10,
 				}),
@@ -998,7 +963,7 @@ describe("AlertsService", () => {
 		)
 	})
 
-	itEffect("marks corrupted queued payloads as failed without blocking later deliveries", () => {
+	it.effect("marks corrupted queued payloads as failed without blocking later deliveries", () => {
 		const fixedTime = 1_710_000_400_000
 		const testDb = createTestDb(trackedDbs)
 		let requestCount = 0
@@ -1006,9 +971,9 @@ describe("AlertsService", () => {
 			requestCount += 1
 			return new Response("ok", { status: 200 })
 		}) as unknown as typeof fetch
-		const clock = makeManualClock(fixedTime)
 
 		return Effect.gen(function* () {
+			yield* TestClock.setTime(fixedTime)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_payload_isolation")
 			const userId = asUserId("user_payload_isolation")
@@ -1073,30 +1038,31 @@ describe("AlertsService", () => {
 			const tick = yield* alerts.runSchedulerTick()
 			const events = yield* alerts.listDeliveryEvents(orgId)
 
-			expect(tick.processedCount).toBe(2)
-			expect(tick.deliveryFailureCount).toBe(1)
-			expect(requestCount).toBe(1)
-			expect(events.events.find((event) => event.deliveryKey === "bad-payload-key")?.status).toBe(
+			assert.strictEqual(tick.processedCount, 2)
+			assert.strictEqual(tick.deliveryFailureCount, 1)
+			assert.strictEqual(requestCount, 1)
+			assert.strictEqual(
+				events.events.find((event) => event.deliveryKey === "bad-payload-key")?.status,
 				"failed",
 			)
-			expect(events.events.find((event) => event.deliveryKey === "good-payload-key")?.status).toBe(
+			assert.strictEqual(
+				events.events.find((event) => event.deliveryKey === "good-payload-key")?.status,
 				"success",
 			)
 		}).pipe(
 			Effect.provide(
 				makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
-					now: clock.now,
 					fetch: fetchImpl,
 				}),
 			),
 		)
 	})
 
-	it("evaluates logs query alerts in testRule without failing validation", async () => {
+	it.effect("evaluates logs query alerts in testRule without failing validation", () => {
 		const testDb = createTestDb(trackedDbs)
 
-		const result = await Effect.runPromise(
-			Effect.gen(function* () {
+		return Effect.gen(function* () {
+			const result = yield* Effect.gen(function* () {
 				const alerts = yield* AlertsService
 				const orgId = asOrgId("org_logs_test")
 				const userId = asUserId("user_logs_test")
@@ -1137,19 +1103,19 @@ describe("AlertsService", () => {
 						}),
 					),
 				),
-			),
-		)
+			)
 
-		expect(result.status).toBe("breached")
-		expect(result.value).toBe(42)
-		expect(result.sampleCount).toBe(42)
+			assert.strictEqual(result.status, "breached")
+			assert.strictEqual(result.value, 42)
+			assert.strictEqual(result.sampleCount, 42)
+		})
 	})
 
-	it("compiles and evaluates a raw SQL query alert", async () => {
+	it.effect("compiles and evaluates a raw SQL query alert", () => {
 		const testDb = createTestDb(trackedDbs)
 
-		const result = await Effect.runPromise(
-			Effect.gen(function* () {
+		return Effect.gen(function* () {
+			const result = yield* Effect.gen(function* () {
 				const alerts = yield* AlertsService
 				const orgId = asOrgId("org_raw_sql_test")
 				const userId = asUserId("user_raw_sql_test")
@@ -1189,19 +1155,19 @@ describe("AlertsService", () => {
 						}),
 					),
 				),
-			),
-		)
+			)
 
-		expect(result.status).toBe("breached")
-		expect(result.value).toBe(240)
-		expect(result.sampleCount).toBe(20)
+			assert.strictEqual(result.status, "breached")
+			assert.strictEqual(result.value, 240)
+			assert.strictEqual(result.sampleCount, 20)
+		})
 	})
 
-	it("rejects metrics alerts with multiple attr groupBy dimensions", async () => {
+	it.effect("rejects metrics alerts with multiple attr groupBy dimensions", () => {
 		const testDb = createTestDb(trackedDbs)
 
-		const exit = await Effect.runPromiseExit(
-			Effect.gen(function* () {
+		return Effect.gen(function* () {
+			const exit = yield* Effect.gen(function* () {
 				const alerts = yield* AlertsService
 				const orgId = asOrgId("org_metrics_group_validation")
 				const userId = asUserId("user_metrics_group_validation")
@@ -1230,25 +1196,28 @@ describe("AlertsService", () => {
 						destinationIds: [destination.id],
 					}),
 				)
-			}).pipe(
-				Effect.provide(
-					makeLayer(testDb, makeWarehouseStub({ metricsAggregateRows: emptyWarehouseRows })),
-				),
-			),
-		)
+			})
+				.pipe(
+					Effect.provide(
+						makeLayer(testDb, makeWarehouseStub({ metricsAggregateRows: emptyWarehouseRows })),
+					),
+				)
+				.pipe(Effect.exit)
 
-		const failure = getError(exit)
+			const failure = getError(exit)
 
-		expect(Exit.isFailure(exit)).toBe(true)
-		expect(failure).toMatchObject({
-			message: "Metrics alerts support at most one attr.* groupBy dimension",
+			assert.isTrue(Exit.isFailure(exit))
+			assert.strictEqual(
+				(failure as { message: string }).message,
+				"Metrics alerts support at most one attr.* groupBy dimension",
+			)
 		})
 	})
 
 	const VALID_PD_KEY = "e93facc04764012d7bfb002500d5d1a6" // 32 hex chars
 	const REST_API_TOKEN = "u+0123456789abcdefgh" // 20 chars, '+' — the common wrong paste
 
-	it("rejects a PagerDuty key of the wrong shape without calling PagerDuty", async () => {
+	it.effect("rejects a PagerDuty key of the wrong shape without calling PagerDuty", () => {
 		const testDb = createTestDb(trackedDbs)
 		const requests: string[] = []
 		const fetchImpl = (async (input: RequestInfo | URL) => {
@@ -1256,8 +1225,8 @@ describe("AlertsService", () => {
 			return new Response("", { status: 202 })
 		}) as typeof fetch
 
-		const exit = await Effect.runPromiseExit(
-			Effect.gen(function* () {
+		return Effect.gen(function* () {
+			const exit = yield* Effect.gen(function* () {
 				const alerts = yield* AlertsService
 				return yield* alerts.createDestination(
 					asOrgId("org_pd_shape"),
@@ -1265,24 +1234,24 @@ describe("AlertsService", () => {
 					adminRoles,
 					{ type: "pagerduty", name: "Paging", enabled: true, integrationKey: REST_API_TOKEN },
 				)
-			}).pipe(
-				Effect.provide(
-					makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
-						fetch: fetchImpl,
-					}),
-				),
-			),
-		)
+			})
+				.pipe(
+					Effect.provide(
+						makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
+							fetch: fetchImpl,
+						}),
+					),
+				)
+				.pipe(Effect.exit)
 
-		expect(Exit.isFailure(exit)).toBe(true)
-		expect(getError(exit)).toMatchObject({
-			message: expect.stringContaining("32-character Events API v2 routing key"),
+			assert.isTrue(Exit.isFailure(exit))
+			assert.include((getError(exit) as { message: string }).message, "32-character Events API v2 routing key")
+			// Format check short-circuits before any network call.
+			assert.lengthOf(requests, 0)
 		})
-		// Format check short-circuits before any network call.
-		expect(requests).toHaveLength(0)
 	})
 
-	it("rejects a well-formed PagerDuty key that PagerDuty reports invalid", async () => {
+	it.effect("rejects a well-formed PagerDuty key that PagerDuty reports invalid", () => {
 		const testDb = createTestDb(trackedDbs)
 		const requests: Array<{ url: string; body: string }> = []
 		const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1297,8 +1266,8 @@ describe("AlertsService", () => {
 			)
 		}) as typeof fetch
 
-		const exit = await Effect.runPromiseExit(
-			Effect.gen(function* () {
+		return Effect.gen(function* () {
+			const exit = yield* Effect.gen(function* () {
 				const alerts = yield* AlertsService
 				return yield* alerts.createDestination(
 					asOrgId("org_pd_invalid"),
@@ -1306,26 +1275,26 @@ describe("AlertsService", () => {
 					adminRoles,
 					{ type: "pagerduty", name: "Paging", enabled: true, integrationKey: VALID_PD_KEY },
 				)
-			}).pipe(
-				Effect.provide(
-					makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
-						fetch: fetchImpl,
-					}),
-				),
-			),
-		)
+			})
+				.pipe(
+					Effect.provide(
+						makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
+							fetch: fetchImpl,
+						}),
+					),
+				)
+				.pipe(Effect.exit)
 
-		expect(Exit.isFailure(exit)).toBe(true)
-		expect(getError(exit)).toMatchObject({
-			message: expect.stringContaining("Invalid routing key"),
+			assert.isTrue(Exit.isFailure(exit))
+			assert.include((getError(exit) as { message: string }).message, "Invalid routing key")
+			assert.lengthOf(requests, 1)
+			assert.strictEqual(requests[0]?.url, "https://events.pagerduty.com/v2/enqueue")
+			// Validation uses a no-op resolve so it never creates an incident.
+			assert.include(requests[0]?.body ?? "", '"event_action":"resolve"')
 		})
-		expect(requests).toHaveLength(1)
-		expect(requests[0]?.url).toBe("https://events.pagerduty.com/v2/enqueue")
-		// Validation uses a no-op resolve so it never creates an incident.
-		expect(requests[0]?.body).toContain('"event_action":"resolve"')
 	})
 
-	itEffect("accepts a PagerDuty key that PagerDuty confirms", () => {
+	it.effect("accepts a PagerDuty key that PagerDuty confirms", () => {
 		const testDb = createTestDb(trackedDbs)
 		const fetchImpl = (async () => new Response("", { status: 202 })) as typeof fetch
 		return Effect.gen(function* () {
@@ -1336,7 +1305,7 @@ describe("AlertsService", () => {
 				adminRoles,
 				{ type: "pagerduty", name: "Paging", enabled: true, integrationKey: VALID_PD_KEY },
 			)
-			expect(destination.type).toBe("pagerduty")
+			assert.strictEqual(destination.type, "pagerduty")
 		}).pipe(
 			Effect.provide(
 				makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
@@ -1346,7 +1315,7 @@ describe("AlertsService", () => {
 		)
 	})
 
-	itEffect("creates the destination when PagerDuty is unreachable (fails open)", () => {
+	it.effect("creates the destination when PagerDuty is unreachable (fails open)", () => {
 		const testDb = createTestDb(trackedDbs)
 		const fetchImpl = (async () => {
 			throw new Error("network down")
@@ -1359,7 +1328,7 @@ describe("AlertsService", () => {
 				adminRoles,
 				{ type: "pagerduty", name: "Paging", enabled: true, integrationKey: VALID_PD_KEY },
 			)
-			expect(destination.type).toBe("pagerduty")
+			assert.strictEqual(destination.type, "pagerduty")
 		}).pipe(
 			Effect.provide(
 				makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
@@ -1369,7 +1338,7 @@ describe("AlertsService", () => {
 		)
 	})
 
-	itEffect("skips PagerDuty validation on update when the key is left blank", () => {
+	it.effect("skips PagerDuty validation on update when the key is left blank", () => {
 		const testDb = createTestDb(trackedDbs)
 		let calls = 0
 		const fetchImpl = (async () => {
@@ -1386,14 +1355,14 @@ describe("AlertsService", () => {
 				enabled: true,
 				integrationKey: VALID_PD_KEY,
 			})
-			expect(calls).toBe(1) // create validated once
+			assert.strictEqual(calls, 1) // create validated once
 
 			const updated = yield* alerts.updateDestination(orgId, userId, adminRoles, created.id, {
 				type: "pagerduty",
 				name: "Paging renamed",
 			})
-			expect(updated.name).toBe("Paging renamed")
-			expect(calls).toBe(1) // no re-validation when the key is omitted
+			assert.strictEqual(updated.name, "Paging renamed")
+			assert.strictEqual(calls, 1) // no re-validation when the key is omitted
 		}).pipe(
 			Effect.provide(
 				makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
@@ -1403,11 +1372,11 @@ describe("AlertsService", () => {
 		)
 	})
 
-	itEffect("opens per-service incidents for grouped logs query alerts", () => {
+	it.effect("opens per-service incidents for grouped logs query alerts", () => {
 		const testDb = createTestDb(trackedDbs)
-		const clock = makeManualClock()
 
 		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_logs_grouped")
 			const userId = asUserId("user_logs_grouped")
@@ -1450,13 +1419,13 @@ describe("AlertsService", () => {
 			)
 
 			yield* alerts.runSchedulerTick()
-			yield* clock.adjust(Duration.minutes(1))
+			yield* TestClock.adjust(Duration.minutes(1))
 			yield* alerts.runSchedulerTick()
 
 			const incidents = yield* alerts.listIncidents(orgId)
-			expect(incidents.incidents).toHaveLength(1)
-			expect(incidents.incidents[0]?.groupKey).toBe("svc-breach")
-			expect(incidents.incidents[0]?.status).toBe("open")
+			assert.lengthOf(incidents.incidents, 1)
+			assert.strictEqual(incidents.incidents[0]?.groupKey, "svc-breach")
+			assert.strictEqual(incidents.incidents[0]?.status, "open")
 		}).pipe(
 			Effect.provide(
 				makeLayer(
@@ -1467,17 +1436,17 @@ describe("AlertsService", () => {
 							{ bucket: "2026-01-01 00:00:00", groupName: "svc-healthy", count: 3 },
 						],
 					}),
-					{ now: clock.now, fetch: okFetch },
+					{ fetch: okFetch },
 				),
 			),
 		)
 	})
 
-	it("blocks destination deletion when rules still reference it", async () => {
+	it.effect("blocks destination deletion when rules still reference it", () => {
 		const testDb = createTestDb(trackedDbs)
 
-		const exit = await Effect.runPromiseExit(
-			Effect.gen(function* () {
+		return Effect.gen(function* () {
+			const exit = yield* Effect.gen(function* () {
 				const alerts = yield* AlertsService
 				const orgId = asOrgId("org_delete_guard")
 				const userId = asUserId("user_delete_guard")
@@ -1486,27 +1455,27 @@ describe("AlertsService", () => {
 				yield* createErrorRateRule(alerts, orgId, userId, destination.id)
 
 				return yield* alerts.deleteDestination(orgId, adminRoles, destination.id)
-			}).pipe(
-				Effect.provide(
-					makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows })),
-				),
-			),
-		)
+			})
+				.pipe(
+					Effect.provide(
+						makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows })),
+					),
+				)
+				.pipe(Effect.exit)
 
-		const failure = getError(exit)
-		expect(Exit.isFailure(exit)).toBe(true)
-		expect(failure).toBeInstanceOf(AlertDestinationInUseError)
-		expect(failure).toMatchObject({
-			destinationId: expect.any(String),
-			ruleNames: ["Checkout error rate"],
+			const failure = getError(exit)
+			assert.isTrue(Exit.isFailure(exit))
+			assert.instanceOf(failure, AlertDestinationInUseError)
+			assert.isString((failure as { destinationId: unknown }).destinationId)
+			assert.deepStrictEqual((failure as { ruleNames: ReadonlyArray<string> }).ruleNames, ["Checkout error rate"])
 		})
 	})
 
-	it("rejects destination creation for non-admin members", async () => {
+	it.effect("rejects destination creation for non-admin members", () => {
 		const testDb = createTestDb(trackedDbs)
 
-		const exit = await Effect.runPromiseExit(
-			Effect.gen(function* () {
+		return Effect.gen(function* () {
+			const exit = yield* Effect.gen(function* () {
 				const alerts = yield* AlertsService
 				return yield* alerts.createDestination(
 					asOrgId("org_forbidden"),
@@ -1519,20 +1488,22 @@ describe("AlertsService", () => {
 						url: "https://example.com/member",
 					},
 				)
-			}).pipe(
-				Effect.provide(
-					makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows })),
-				),
-			),
-		)
+			})
+				.pipe(
+					Effect.provide(
+						makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows })),
+					),
+				)
+				.pipe(Effect.exit)
 
-		const failure = getError(exit)
+			const failure = getError(exit)
 
-		expect(Exit.isFailure(exit)).toBe(true)
-		expect(failure).toBeInstanceOf(AlertForbiddenError)
+			assert.isTrue(Exit.isFailure(exit))
+			assert.instanceOf(failure, AlertForbiddenError)
+		})
 	})
 
-	itEffect("dedupes destinationIds on create and update, preserving selection order", () => {
+	it.effect("dedupes destinationIds on create and update, preserving selection order", () => {
 		const testDb = createTestDb(trackedDbs)
 
 		return Effect.gen(function* () {
@@ -1575,7 +1546,7 @@ describe("AlertsService", () => {
 					destinationIds: [primary.id, secondary.id, primary.id],
 				}),
 			)
-			expect(created.destinationIds).toEqual([primary.id, secondary.id])
+			assert.deepStrictEqual(created.destinationIds, [primary.id, secondary.id])
 
 			// Updating with duplicates is deduped on the write path too.
 			const updated = yield* alerts.updateRule(
@@ -1588,18 +1559,18 @@ describe("AlertsService", () => {
 					destinationIds: [secondary.id, secondary.id],
 				}),
 			)
-			expect(updated.destinationIds).toEqual([secondary.id])
+			assert.deepStrictEqual(updated.destinationIds, [secondary.id])
 
 			// The persisted row read back is deduped, not just the returned document.
 			const rules = yield* alerts.listRules(orgId)
-			expect(rules.rules).toHaveLength(1)
-			expect(rules.rules[0]?.destinationIds).toEqual([secondary.id])
+			assert.lengthOf(rules.rules, 1)
+			assert.deepStrictEqual(rules.rules[0]?.destinationIds, [secondary.id])
 		}).pipe(
 			Effect.provide(makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }))),
 		)
 	})
 
-	itEffect("round-trips and normalizes rule tags through create/update/list", () => {
+	it.effect("round-trips and normalizes rule tags through create/update/list", () => {
 		const testDb = createTestDb(trackedDbs)
 
 		return Effect.gen(function* () {
@@ -1632,11 +1603,11 @@ describe("AlertsService", () => {
 				adminRoles,
 				new AlertRuleUpsertRequest({ ...baseRule, tags: ["Prod", " payments ", "prod", ""] }),
 			)
-			expect(created.tags).toEqual(["prod", "payments"])
+			assert.deepStrictEqual(created.tags, ["prod", "payments"])
 
 			// The normalized tags survive a round-trip through the persisted row.
 			const afterCreate = yield* alerts.listRules(orgId)
-			expect(afterCreate.rules[0]?.tags).toEqual(["prod", "payments"])
+			assert.deepStrictEqual(afterCreate.rules[0]?.tags, ["prod", "payments"])
 
 			// Clearing tags on update persists an empty list, not the prior value.
 			const updated = yield* alerts.updateRule(
@@ -1646,16 +1617,16 @@ describe("AlertsService", () => {
 				created.id,
 				new AlertRuleUpsertRequest({ ...baseRule, tags: [] }),
 			)
-			expect(updated.tags).toEqual([])
+			assert.deepStrictEqual(updated.tags, [])
 
 			const afterClear = yield* alerts.listRules(orgId)
-			expect(afterClear.rules[0]?.tags).toEqual([])
+			assert.deepStrictEqual(afterClear.rules[0]?.tags, [])
 		}).pipe(
 			Effect.provide(makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }))),
 		)
 	})
 
-	itEffect("opens per-service incidents for multi-service rules", () => {
+	it.effect("opens per-service incidents for multi-service rules", () => {
 		const testDb = createTestDb(trackedDbs)
 		const state = {
 			tracesAggregateRows: [
@@ -1672,9 +1643,9 @@ describe("AlertsService", () => {
 				},
 			],
 		}
-		const clock = makeManualClock()
 
 		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_multi_svc")
 			const userId = asUserId("user_multi_svc")
@@ -1702,18 +1673,18 @@ describe("AlertsService", () => {
 			)
 
 			yield* alerts.runSchedulerTick()
-			yield* clock.adjust(Duration.minutes(1))
+			yield* TestClock.adjust(Duration.minutes(1))
 			yield* alerts.runSchedulerTick()
 
 			const incidents = yield* alerts.listIncidents(orgId)
-			expect(incidents.incidents).toHaveLength(2)
+			assert.lengthOf(incidents.incidents, 2)
 			const groupKeys = incidents.incidents.map((i: { groupKey: string | null }) => i.groupKey).sort()
-			expect(groupKeys).toEqual(["svc-a", "svc-b"])
-			expect(incidents.incidents.every((i: { status: string }) => i.status === "open")).toBe(true)
-		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { now: clock.now, fetch: okFetch })))
+			assert.deepStrictEqual(groupKeys, ["svc-a", "svc-b"])
+			assert.isTrue(incidents.incidents.every((i: { status: string }) => i.status === "open"))
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: okFetch })))
 	})
 
-	itEffect("opens per-service incidents for groupBy=service rules", () => {
+	it.effect("opens per-service incidents for groupBy=service rules", () => {
 		const testDb = createTestDb(trackedDbs)
 
 		const breachingRow = {
@@ -1753,9 +1724,9 @@ describe("AlertsService", () => {
 			compiledQueryFirst: (_tenant, compiled) =>
 				compiled.decodeFirstRow(alertRows).pipe(Effect.orDie) as never,
 		}
-		const clock = makeManualClock()
 
 		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
 			const alerts = yield* AlertsService
 			const orgId = asOrgId("org_grouped")
 			const userId = asUserId("user_grouped")
@@ -1783,13 +1754,13 @@ describe("AlertsService", () => {
 			)
 
 			yield* alerts.runSchedulerTick()
-			yield* clock.adjust(Duration.minutes(1))
+			yield* TestClock.adjust(Duration.minutes(1))
 			yield* alerts.runSchedulerTick()
 
 			const incidents = yield* alerts.listIncidents(orgId)
-			expect(incidents.incidents).toHaveLength(1)
-			expect(incidents.incidents[0]?.groupKey).toBe("svc-breach")
-			expect(incidents.incidents[0]?.status).toBe("open")
-		}).pipe(Effect.provide(makeLayer(testDb, stub, { now: clock.now, fetch: okFetch })))
+			assert.lengthOf(incidents.incidents, 1)
+			assert.strictEqual(incidents.incidents[0]?.groupKey, "svc-breach")
+			assert.strictEqual(incidents.incidents[0]?.status, "open")
+		}).pipe(Effect.provide(makeLayer(testDb, stub, { fetch: okFetch })))
 	})
 })

--- a/apps/api/src/services/AlertsService.ts
+++ b/apps/api/src/services/AlertsService.ts
@@ -3822,37 +3822,37 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 									"@maple/http/errors/WarehouseQuotaExceededError": (error) =>
 										recordEvaluationFailure(row, error, "tinybird_quota", {
 											quotaSetting: error.setting,
-											pipe: error.pipe,
+											pipe: error.pipeName,
 										}),
 									"@maple/http/errors/WarehouseUpstreamError": (error) =>
 										recordEvaluationFailure(row, error, "tinybird_upstream", {
 											upstreamStatus: error.upstreamStatus,
-											pipe: error.pipe,
+											pipe: error.pipeName,
 										}),
 									"@maple/http/errors/WarehouseAuthError": (error) =>
 										recordEvaluationFailure(row, error, "tinybird_auth", {
 											upstreamStatus: error.upstreamStatus,
-											pipe: error.pipe,
+											pipe: error.pipeName,
 										}),
 									"@maple/http/errors/WarehouseConfigError": (error) =>
 										recordEvaluationFailure(row, error, "tinybird_config", {
-											pipe: error.pipe,
+											pipe: error.pipeName,
 										}),
 									"@maple/http/errors/WarehouseClientError": (error) =>
 										recordEvaluationFailure(row, error, "tinybird_client", {
-											pipe: error.pipe,
+											pipe: error.pipeName,
 										}),
 									"@maple/http/errors/WarehouseSchemaDriftError": (error) =>
 										recordEvaluationFailure(row, error, "tinybird_schema_drift", {
-											pipe: error.pipe,
+											pipe: error.pipeName,
 										}),
 									"@maple/http/errors/WarehouseValidationError": (error) =>
 										recordEvaluationFailure(row, error, "tinybird_validation", {
-											pipe: error.pipe,
+											pipe: error.pipeName,
 										}),
 									"@maple/http/errors/WarehouseQueryError": (error) =>
 										recordEvaluationFailure(row, error, "tinybird_query", {
-											pipe: error.pipe,
+											pipe: error.pipeName,
 										}),
 								}),
 							)

--- a/apps/api/src/services/DigestService.ts
+++ b/apps/api/src/services/DigestService.ts
@@ -198,7 +198,7 @@ export class DigestService extends Context.Service<DigestService>()("@maple/api/
 			const [overviewResponse, usageResponse, topErrors] = yield* Effect.all(
 				[
 					warehouse.query(systemTenant, {
-						pipe: "service_overview_compare",
+						pipeName: "service_overview_compare",
 						params: {
 							current_start_time: currentStart,
 							current_end_time: currentEnd,
@@ -207,7 +207,7 @@ export class DigestService extends Context.Service<DigestService>()("@maple/api/
 						},
 					}),
 					warehouse.query(systemTenant, {
-						pipe: "get_service_usage_compare",
+						pipeName: "get_service_usage_compare",
 						params: {
 							current_start_time: currentStart,
 							current_end_time: currentEnd,
@@ -216,7 +216,7 @@ export class DigestService extends Context.Service<DigestService>()("@maple/api/
 						},
 					}),
 					warehouse.query(systemTenant, {
-						pipe: "errors_by_type",
+						pipeName: "errors_by_type",
 						params: {
 							start_time: currentStart,
 							end_time: currentEnd,

--- a/apps/api/src/services/OnboardingEmailService.ts
+++ b/apps/api/src/services/OnboardingEmailService.ts
@@ -77,7 +77,7 @@ export class OnboardingEmailService extends Context.Service<OnboardingEmailServi
 				}
 
 				const response = yield* warehouse.query(systemTenant, {
-					pipe: "service_overview_compare",
+					pipeName: "service_overview_compare",
 					params: {
 						current_start_time: currentStart,
 						current_end_time: currentEnd,
@@ -131,39 +131,42 @@ export class OnboardingEmailService extends Context.Service<OnboardingEmailServi
 
 				const orgs = yield* paginate((params) => clerk.organizations.getOrganizationList(params))
 
-				let ensured = 0
-				for (const org of orgs) {
-					const members = yield* paginate((params) =>
-						clerk.organizations.getOrganizationMembershipList({
-							organizationId: org.id,
-							...params,
-						}),
-					)
-					const firstMember = members.find(
-						(m) => m.publicUserData?.identifier && m.publicUserData?.userId,
-					)
-					if (!firstMember?.publicUserData) continue
+				const ensuredFlags = yield* Effect.forEach(orgs, (org) =>
+					Effect.gen(function* () {
+						const members = yield* paginate((params) =>
+							clerk.organizations.getOrganizationMembershipList({
+								organizationId: org.id,
+								...params,
+							}),
+						)
+						const firstMember = members.find(
+							(m) => m.publicUserData?.identifier && m.publicUserData?.userId,
+						)
+						if (!firstMember?.publicUserData) return false
 
-					const orgId = OrgId.make(org.id)
-					const orgCreatedAt =
-						typeof org.createdAt === "number" ? org.createdAt : yield* Clock.currentTimeMillis
+						const orgId = OrgId.make(org.id)
+						const orgCreatedAt =
+							typeof org.createdAt === "number"
+								? org.createdAt
+								: yield* Clock.currentTimeMillis
 
-					yield* onboarding.ensureRow(
-						orgId,
-						firstMember.publicUserData.userId,
-						firstMember.publicUserData.identifier,
-						{ createdAt: orgCreatedAt },
-					)
+						yield* onboarding.ensureRow(
+							orgId,
+							firstMember.publicUserData.userId,
+							firstMember.publicUserData.identifier,
+							{ createdAt: orgCreatedAt },
+						)
 
-					// Orgs that predate this feature are existing users — never run
-					// the welcome → nudge → activation sequence for them.
-					if (orgCreatedAt < ONBOARDING_LAUNCH_CUTOFF) {
-						yield* onboarding.suppressOnboardingEmails(orgId)
-					}
+						// Orgs that predate this feature are existing users — never run
+						// the welcome → nudge → activation sequence for them.
+						if (orgCreatedAt < ONBOARDING_LAUNCH_CUTOFF) {
+							yield* onboarding.suppressOnboardingEmails(orgId)
+						}
 
-					ensured += 1
-				}
-				return ensured
+						return true
+					}),
+				)
+				return ensuredFlags.filter(Boolean).length
 			})
 
 			const renderEmail = (node: EmailNode) =>

--- a/apps/api/src/services/ScrapeTargetsService.test.ts
+++ b/apps/api/src/services/ScrapeTargetsService.test.ts
@@ -1,5 +1,4 @@
-import { afterEach, describe, it } from "@effect/vitest"
-import { expect } from "vitest"
+import { afterEach, assert, describe, it } from "@effect/vitest"
 import { ConfigProvider, Effect, Exit, Layer, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import { CreateScrapeTargetRequest, OrgId, ScrapeIntervalSeconds, ScrapeTargetId } from "@maple/domain/http"
@@ -76,11 +75,11 @@ describe("ScrapeTargetsService", () => {
 
 			const response = yield* service.scrapeForCollector(target.id)
 
-			expect(response.status).toBe(200)
-			expect(response.body).toBe("up 1\n")
-			expect(response.contentType).toBe("text/plain; version=0.0.4")
-			expect(calls.some((call) => call.url === "https://metrics.example.com/metrics")).toBe(true)
-			expect(calls.every((call) => call.authorization === "Bearer stored-token")).toBe(true)
+			assert.strictEqual(response.status, 200)
+			assert.strictEqual(response.body, "up 1\n")
+			assert.strictEqual(response.contentType, "text/plain; version=0.0.4")
+			assert.isTrue(calls.some((call) => call.url === "https://metrics.example.com/metrics"))
+			assert.isTrue(calls.every((call) => call.authorization === "Bearer stored-token"))
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -102,8 +101,8 @@ describe("ScrapeTargetsService", () => {
 			yield* service.recordScrapeResults([{ targetId: target.id, scrapedAt, error: null }])
 
 			const updated = yield* service.get(orgId, target.id)
-			expect(updated.lastScrapeAt).toBe(new Date(scrapedAt).toISOString())
-			expect(updated.lastScrapeError).toBeNull()
+			assert.strictEqual(updated.lastScrapeAt, new Date(scrapedAt).toISOString())
+			assert.isNull(updated.lastScrapeError)
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -130,16 +129,16 @@ describe("ScrapeTargetsService", () => {
 			])
 
 			const updated = yield* service.get(orgId, target.id)
-			expect(updated.lastScrapeAt).toBe(new Date(goodScrapeAt).toISOString())
-			expect(updated.lastScrapeError).toBe("HTTP 503")
+			assert.strictEqual(updated.lastScrapeAt, new Date(goodScrapeAt).toISOString())
+			assert.strictEqual(updated.lastScrapeError, "HTTP 503")
 
 			// A later success clears the error again.
 			yield* service.recordScrapeResults([
 				{ targetId: target.id, scrapedAt: goodScrapeAt + 30_000, error: null },
 			])
 			const recovered = yield* service.get(orgId, target.id)
-			expect(recovered.lastScrapeAt).toBe(new Date(goodScrapeAt + 30_000).toISOString())
-			expect(recovered.lastScrapeError).toBeNull()
+			assert.strictEqual(recovered.lastScrapeAt, new Date(goodScrapeAt + 30_000).toISOString())
+			assert.isNull(recovered.lastScrapeError)
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -165,7 +164,7 @@ describe("ScrapeTargetsService", () => {
 			])
 
 			const updated = yield* service.get(orgId, target.id)
-			expect(updated.lastScrapeAt).toBe(new Date(scrapedAt).toISOString())
+			assert.strictEqual(updated.lastScrapeAt, new Date(scrapedAt).toISOString())
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -184,13 +183,13 @@ describe("ScrapeTargetsService", () => {
 				}),
 			)
 
-			expect(target.targetType).toBe("planetscale")
-			expect(target.organization).toBe("my-org")
-			expect(target.url).toBe("https://api.planetscale.com/v1/organizations/my-org/metrics")
-			expect(target.authType).toBe("token")
-			expect(target.hasCredentials).toBe(true)
+			assert.strictEqual(target.targetType, "planetscale")
+			assert.strictEqual(target.organization, "my-org")
+			assert.strictEqual(target.url, "https://api.planetscale.com/v1/organizations/my-org/metrics")
+			assert.strictEqual(target.authType, "token")
+			assert.isTrue(target.hasCredentials)
 			// PlanetScale's documented default scrape interval.
-			expect(target.scrapeIntervalSeconds).toBe(30)
+			assert.strictEqual(target.scrapeIntervalSeconds, 30)
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -210,7 +209,7 @@ describe("ScrapeTargetsService", () => {
 					}),
 				)
 				.pipe(Effect.flip)
-			expect(missingOrg.message).toContain("organization is required")
+			assert.include(missingOrg.message, "organization is required")
 
 			const withUrl = yield* service
 				.create(
@@ -224,7 +223,7 @@ describe("ScrapeTargetsService", () => {
 					}),
 				)
 				.pipe(Effect.flip)
-			expect(withUrl.message).toContain("do not provide a url")
+			assert.include(withUrl.message, "do not provide a url")
 
 			const badCredentials = yield* service
 				.create(
@@ -237,12 +236,12 @@ describe("ScrapeTargetsService", () => {
 					}),
 				)
 				.pipe(Effect.flip)
-			expect(badCredentials.message).toContain("tokenId")
+			assert.include(badCredentials.message, "tokenId")
 
 			const missingUrl = yield* service
 				.create(orgId, new CreateScrapeTargetRequest({ name: "Prom" }))
 				.pipe(Effect.flip)
-			expect(missingUrl.message).toContain("url is required")
+			assert.include(missingUrl.message, "url is required")
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -271,14 +270,14 @@ describe("ScrapeTargetsService", () => {
 				},
 			])
 			const failed = yield* service.get(orgId, target.id)
-			expect(failed.lastScrapeError).toBe("[branch:branch-1] HTTP 503")
+			assert.strictEqual(failed.lastScrapeError, "[branch:branch-1] HTTP 503")
 
 			// Any branch success clears the rollup error.
 			yield* service.recordScrapeResults([
 				{ targetId: target.id, scrapedAt: 1750000015000, error: null, subTargetKey: "branch-2" },
 			])
 			const recovered = yield* service.get(orgId, target.id)
-			expect(recovered.lastScrapeError).toBeNull()
+			assert.isNull(recovered.lastScrapeError)
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -317,29 +316,29 @@ describe("ScrapeTargetsService", () => {
 			])
 
 			const checks = yield* service.listChecks(orgId, target.id, {})
-			expect(checks).toHaveLength(2)
-			expect(checks[0]?.checkedAt.getTime()).toBe(scrapedAt + 15_000)
-			expect(checks[0]?.error).toBe("target returned HTTP 503")
-			expect(checks[0]?.subTargetKey).toBe("branch-1")
-			expect(checks[0]?.durationMs).toBe(1100)
-			expect(checks[0]?.samplesScraped).toBeNull()
-			expect(checks[1]?.checkedAt.getTime()).toBe(scrapedAt)
-			expect(checks[1]?.error).toBeNull()
-			expect(checks[1]?.subTargetKey).toBe("")
-			expect(checks[1]?.durationMs).toBe(250)
-			expect(checks[1]?.samplesScraped).toBe(120)
-			expect(checks[1]?.samplesPostRelabel).toBe(118)
+			assert.lengthOf(checks, 2)
+			assert.strictEqual(checks[0]?.checkedAt.getTime(), scrapedAt + 15_000)
+			assert.strictEqual(checks[0]?.error, "target returned HTTP 503")
+			assert.strictEqual(checks[0]?.subTargetKey, "branch-1")
+			assert.strictEqual(checks[0]?.durationMs, 1100)
+			assert.isNull(checks[0]?.samplesScraped)
+			assert.strictEqual(checks[1]?.checkedAt.getTime(), scrapedAt)
+			assert.isNull(checks[1]?.error)
+			assert.strictEqual(checks[1]?.subTargetKey, "")
+			assert.strictEqual(checks[1]?.durationMs, 250)
+			assert.strictEqual(checks[1]?.samplesScraped, 120)
+			assert.strictEqual(checks[1]?.samplesPostRelabel, 118)
 
 			// Time-range + limit filtering.
 			const limited = yield* service.listChecks(orgId, target.id, { limit: 1 })
-			expect(limited).toHaveLength(1)
-			expect(limited[0]?.checkedAt.getTime()).toBe(scrapedAt + 15_000)
+			assert.lengthOf(limited, 1)
+			assert.strictEqual(limited[0]?.checkedAt.getTime(), scrapedAt + 15_000)
 			const windowed = yield* service.listChecks(orgId, target.id, {
 				startTime: scrapedAt - 1,
 				endTime: scrapedAt + 1,
 			})
-			expect(windowed).toHaveLength(1)
-			expect(windowed[0]?.checkedAt.getTime()).toBe(scrapedAt)
+			assert.lengthOf(windowed, 1)
+			assert.strictEqual(windowed[0]?.checkedAt.getTime(), scrapedAt)
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -360,11 +359,11 @@ describe("ScrapeTargetsService", () => {
 
 			yield* TestClock.setTime(1750000000000)
 			const probed = yield* service.probe(orgId, target.id)
-			expect(probed.success).toBe(true)
-			expect(probed.lastScrapeAt).not.toBeNull()
+			assert.isTrue(probed.success)
+			assert.isNotNull(probed.lastScrapeAt)
 
 			const checks = yield* service.listChecks(orgId, target.id, {})
-			expect(checks).toHaveLength(0)
+			assert.lengthOf(checks, 0)
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -390,8 +389,8 @@ describe("ScrapeTargetsService", () => {
 			])
 
 			const checks = yield* service.listChecks(orgId, target.id, {})
-			expect(checks).toHaveLength(1)
-			expect(checks[0]?.checkedAt.getTime()).toBe(now - 60 * 60 * 1000)
+			assert.lengthOf(checks, 1)
+			assert.strictEqual(checks[0]?.checkedAt.getTime(), now - 60 * 60 * 1000)
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -409,7 +408,7 @@ describe("ScrapeTargetsService", () => {
 			)
 
 			const result = yield* service.listChecks(asOrgId("org_2"), target.id, {}).pipe(Effect.exit)
-			expect(Exit.isFailure(result)).toBe(true)
+			assert.isTrue(Exit.isFailure(result))
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 })

--- a/apps/api/src/services/ScrapeTargetsService.ts
+++ b/apps/api/src/services/ScrapeTargetsService.ts
@@ -685,29 +685,35 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 					Math.max(1_000, (row.value.scrapeIntervalSeconds - 1) * 1000),
 				)
 
+				// `safeFetch` is retained for its SSRF protection + per-hop redirect
+				// re-validation (the Effect HttpClient transport has neither). The manual
+				// AbortController/setTimeout is replaced by the interruption-aware signal
+				// from `Effect.tryPromise` plus `Effect.timeout`: on timeout the fiber is
+				// interrupted, which aborts the in-flight fetch via that signal.
 				return yield* Effect.tryPromise({
-					try: async () => {
-						const controller = new AbortController()
-						const timeout = setTimeout(() => controller.abort(), timeoutMs)
-						try {
-							const response = await safeFetch(scrapeUrl, {
-								method: "GET",
-								headers,
-								signal: controller.signal,
-							})
-							return {
-								status: response.status,
-								body: await response.text(),
-								contentType:
-									response.headers.get("content-type") ??
-									"text/plain; version=0.0.4; charset=utf-8",
-							} satisfies ScrapeTargetProxyResponse
-						} finally {
-							clearTimeout(timeout)
-						}
+					try: async (signal) => {
+						const response = await safeFetch(scrapeUrl, {
+							method: "GET",
+							headers,
+							signal,
+						})
+						return {
+							status: response.status,
+							body: await response.text(),
+							contentType:
+								response.headers.get("content-type") ??
+								"text/plain; version=0.0.4; charset=utf-8",
+						} satisfies ScrapeTargetProxyResponse
 					},
 					catch: toPersistenceError,
-				})
+				}).pipe(
+					Effect.timeout(timeoutMs),
+					// A timeout surfaces as the same persistence error a fetch abort
+					// produced before, so callers see no new error type.
+					Effect.catchTag("TimeoutError", () =>
+						Effect.fail(toPersistenceError(new Error("The operation was aborted"))),
+					),
+				)
 			})
 
 			const pruneChecks = Effect.fn("ScrapeTargetsService.pruneChecks")(function* (
@@ -730,33 +736,38 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 
 				// Cap backstop for misconfigured/very short intervals: drop everything
 				// older than the Nth-newest row per target.
-				for (const targetId of targetIds) {
-					const capBoundary = yield* database
-						.execute((db) =>
-							db
-								.select({ checkedAt: scrapeTargetChecks.checkedAt })
-								.from(scrapeTargetChecks)
-								.where(eq(scrapeTargetChecks.targetId, targetId))
-								.orderBy(desc(scrapeTargetChecks.checkedAt))
-								.limit(1)
-								.offset(CHECK_MAX_ROWS_PER_TARGET - 1),
-						)
-						.pipe(Effect.mapError(toPersistenceError))
-					const boundary = capBoundary[0]
-					if (boundary === undefined) continue
-					yield* database
-						.execute((db) =>
-							db
-								.delete(scrapeTargetChecks)
-								.where(
-									and(
-										eq(scrapeTargetChecks.targetId, targetId),
-										lt(scrapeTargetChecks.checkedAt, boundary.checkedAt),
-									),
-								),
-						)
-						.pipe(Effect.mapError(toPersistenceError))
-				}
+				yield* Effect.forEach(
+					targetIds,
+					(targetId) =>
+						Effect.gen(function* () {
+							const capBoundary = yield* database
+								.execute((db) =>
+									db
+										.select({ checkedAt: scrapeTargetChecks.checkedAt })
+										.from(scrapeTargetChecks)
+										.where(eq(scrapeTargetChecks.targetId, targetId))
+										.orderBy(desc(scrapeTargetChecks.checkedAt))
+										.limit(1)
+										.offset(CHECK_MAX_ROWS_PER_TARGET - 1),
+								)
+								.pipe(Effect.mapError(toPersistenceError))
+							const boundary = capBoundary[0]
+							if (boundary === undefined) return
+							yield* database
+								.execute((db) =>
+									db
+										.delete(scrapeTargetChecks)
+										.where(
+											and(
+												eq(scrapeTargetChecks.targetId, targetId),
+												lt(scrapeTargetChecks.checkedAt, boundary.checkedAt),
+											),
+										),
+								)
+								.pipe(Effect.mapError(toPersistenceError))
+						}),
+					{ discard: true },
+				)
 			})
 
 			const recordScrapeResults = Effect.fn("ScrapeTargetsService.recordScrapeResults")(function* (
@@ -771,37 +782,41 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 				}>,
 				options?: { readonly recordChecks?: boolean },
 			) {
-				for (const result of results) {
-					// Rollup for discovered sub-targets: any branch success advances
-					// lastScrapeAt; any branch failure surfaces (branch-prefixed) as
-					// lastScrapeError. Per-branch health stays visible in check history
-					// via the per-branch `instance`.
-					const error =
-						result.error !== null && result.subTargetKey
-							? `[branch:${result.subTargetKey}] ${result.error}`
-							: result.error
-					yield* database
-						.execute((db) =>
-							db
-								.update(scrapeTargets)
-								.set(
-									error === null
-										? {
-												lastScrapeAt: new Date(result.scrapedAt),
-												lastScrapeError: null,
-												updatedAt: new Date(result.scrapedAt),
-											}
-										: // Failure keeps lastScrapeAt at the last good scrape so data
-											// gaps stay visible alongside the error.
-											{
-												lastScrapeError: error,
-												updatedAt: new Date(result.scrapedAt),
-											},
-								)
-								.where(eq(scrapeTargets.id, result.targetId)),
-						)
-						.pipe(Effect.mapError(toPersistenceError))
-				}
+				yield* Effect.forEach(
+					results,
+					(result) => {
+						// Rollup for discovered sub-targets: any branch success advances
+						// lastScrapeAt; any branch failure surfaces (branch-prefixed) as
+						// lastScrapeError. Per-branch health stays visible in check history
+						// via the per-branch `instance`.
+						const error =
+							result.error !== null && result.subTargetKey
+								? `[branch:${result.subTargetKey}] ${result.error}`
+								: result.error
+						return database
+							.execute((db) =>
+								db
+									.update(scrapeTargets)
+									.set(
+										error === null
+											? {
+													lastScrapeAt: new Date(result.scrapedAt),
+													lastScrapeError: null,
+													updatedAt: new Date(result.scrapedAt),
+												}
+											: // Failure keeps lastScrapeAt at the last good scrape so data
+												// gaps stay visible alongside the error.
+												{
+													lastScrapeError: error,
+													updatedAt: new Date(result.scrapedAt),
+												},
+									)
+									.where(eq(scrapeTargets.id, result.targetId)),
+							)
+							.pipe(Effect.mapError(toPersistenceError))
+					},
+					{ discard: true },
+				)
 
 				if (options?.recordChecks === false || results.length === 0) return
 
@@ -882,25 +897,29 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 				const headers = yield* authHeadersForRow(row)
 
 				const now = yield* Clock.currentTimeMillis
+				// `safeFetch` is retained for SSRF protection + redirect re-validation. The
+				// manual AbortController/setTimeout is replaced by the interruption-aware
+				// signal plus a fixed 10s `Effect.timeout`; the timeout lands as a failure
+				// in the captured Exit (→ success: false), matching the old abort path.
 				const requestExit = yield* Effect.tryPromise({
-					try: async () => {
-						const controller = new AbortController()
-						const timeout = setTimeout(() => controller.abort(), 10_000)
-						try {
-							const response = await safeFetch(row.url, {
-								method: "GET",
-								headers,
-								signal: controller.signal,
-							})
-							if (!response.ok) {
-								throw new Error(`HTTP ${response.status} ${response.statusText}`)
-							}
-						} finally {
-							clearTimeout(timeout)
+					try: async (signal) => {
+						const response = await safeFetch(row.url, {
+							method: "GET",
+							headers,
+							signal,
+						})
+						if (!response.ok) {
+							throw new Error(`HTTP ${response.status} ${response.statusText}`)
 						}
 					},
 					catch: (error) => (error instanceof Error ? error : new Error("Connection failed")),
-				}).pipe(Effect.exit)
+				}).pipe(
+					Effect.timeout(10_000),
+					Effect.catchTag("TimeoutError", () =>
+						Effect.fail(new Error("Connection failed")),
+					),
+					Effect.exit,
+				)
 
 				// Manual probes update lastScrapeAt/lastScrapeError but must not
 				// fabricate scheduled-check history rows.

--- a/apps/api/src/services/vcs/VcsCommitService.ts
+++ b/apps/api/src/services/vcs/VcsCommitService.ts
@@ -139,46 +139,78 @@ export class VcsCommitService extends Context.Service<VcsCommitService, VcsCommi
 				sha: GitCommitSha,
 				installations: ReadonlyArray<VcsInstallation>,
 			) {
+				// `reposProbed` accumulates across the whole walk; it's reported in both
+				// the resolved and not-found outcomes. `found` carries the first repo that
+				// resolves and, once set, makes every later iteration a no-op — so no extra
+				// `fetchCommit` runs after a hit and the counter stops advancing, preserving
+				// the original early-`return` semantics exactly (forEach merely walks, but
+				// skips, the remaining items).
 				let reposProbed = 0
-				for (const installation of installations) {
-					const provider = yield* registry
-						.resolve(installation.provider)
-						.pipe(Effect.mapError((e) => new IntegrationsUpstreamError({ message: e.message })))
-					const repos = yield* asPersistence(
-						repo.listRepositoriesByInstallation(installation.id, "active"),
-					)
-					for (const repository of repos) {
-						reposProbed += 1
-						const outcome = yield* Effect.result(
-							provider.fetchCommit(
-								installation,
-								{
-									externalRepoId: repository.externalRepoId,
-									owner: repository.owner,
-									name: repository.name,
-								},
-								sha,
-							),
+				const hit: {
+					current: {
+						readonly normalized: CommitUpsertInput
+						readonly repository: VcsRepo
+						readonly reposProbed: number
+					} | null
+				} = { current: null }
+
+				yield* Effect.forEach(installations, (installation) =>
+					Effect.gen(function* () {
+						if (hit.current !== null) return
+						const provider = yield* registry
+							.resolve(installation.provider)
+							.pipe(
+								Effect.mapError(
+									(e) => new IntegrationsUpstreamError({ message: e.message }),
+								),
+							)
+						const repos = yield* asPersistence(
+							repo.listRepositoriesByInstallation(installation.id, "active"),
 						)
+						yield* Effect.forEach(repos, (repository) =>
+							Effect.gen(function* () {
+								if (hit.current !== null) return
+								reposProbed += 1
+								const outcome = yield* Effect.result(
+									provider.fetchCommit(
+										installation,
+										{
+											externalRepoId: repository.externalRepoId,
+											owner: repository.owner,
+											name: repository.name,
+										},
+										sha,
+									),
+								)
 
-						if (Result.isFailure(outcome)) {
-							// Best-effort: skip repos that error; another may have the commit.
-							continue
-						}
-						if (Option.isNone(outcome.success)) continue
+								if (Result.isFailure(outcome)) {
+									// Best-effort: skip repos that error; another may have the commit.
+									return
+								}
+								if (Option.isNone(outcome.success)) return
 
-						yield* Effect.annotateCurrentSpan({
-							"vcs.commit.repos_probed": reposProbed,
-							"vcs.commit.provider": installation.provider,
-							"vcs.commit.outcome": "resolved",
-							"vcs.repository.id": repository.id,
-						})
-						return {
-							_tag: "resolved" as const,
-							normalized: outcome.success.value,
-							repository,
-							reposProbed,
-						}
+								yield* Effect.annotateCurrentSpan({
+									"vcs.commit.repos_probed": reposProbed,
+									"vcs.commit.provider": installation.provider,
+									"vcs.commit.outcome": "resolved",
+									"vcs.repository.id": repository.id,
+								})
+								hit.current = {
+									normalized: outcome.success.value,
+									repository,
+									reposProbed,
+								}
+							}),
+						)
+					}),
+				)
+
+				if (hit.current !== null) {
+					return {
+						_tag: "resolved" as const,
+						normalized: hit.current.normalized,
+						repository: hit.current.repository,
+						reposProbed: hit.current.reposProbed,
 					}
 				}
 

--- a/apps/api/src/services/vcs/VcsSyncService.ts
+++ b/apps/api/src/services/vcs/VcsSyncService.ts
@@ -94,23 +94,22 @@ export class VcsSyncService extends Context.Service<VcsSyncService, VcsSyncServi
 			// Point the repo at a new tracked branch: wipe its (old-branch) commits and
 			// enqueue a fresh backfill of the new branch. Used by the engine's automatic
 			// fallback to the default when the tracked branch is deleted upstream.
-			const retargetTrackedBranch = (
+			const retargetTrackedBranch = Effect.fn("VcsSyncService.retargetTrackedBranch")(function* (
 				installation: VcsInstallation,
 				repository: VcsRepo,
 				newBranch: string,
-			) =>
-				Effect.gen(function* () {
-					yield* repo.changeTrackedBranch(repository.orgId, repository.id, newBranch)
-					const sinceMs = (yield* Clock.currentTimeMillis) - BACKFILL_WINDOW_MS
-					yield* queue.send(backfillJob(installation, repository, newBranch, sinceMs))
-					yield* Effect.logInfo("[VCS] Tracked branch retargeted to default after deletion").pipe(
-						Effect.annotateLogs({
-							provider: installation.provider,
-							externalRepoId: repository.externalRepoId,
-							newBranch,
-						}),
-					)
-				})
+			) {
+				yield* repo.changeTrackedBranch(repository.orgId, repository.id, newBranch)
+				const sinceMs = (yield* Clock.currentTimeMillis) - BACKFILL_WINDOW_MS
+				yield* queue.send(backfillJob(installation, repository, newBranch, sinceMs))
+				yield* Effect.logInfo("[VCS] Tracked branch retargeted to default after deletion").pipe(
+					Effect.annotateLogs({
+						provider: installation.provider,
+						externalRepoId: repository.externalRepoId,
+						newBranch,
+					}),
+				)
+			})
 
 			const syncCommits = (
 				provider: VcsProviderClient,
@@ -450,46 +449,47 @@ export class VcsSyncService extends Context.Service<VcsSyncService, VcsSyncServi
 
 			// Single gate for "should the engine act on this installation?" — rule lives in
 			// isInstallationProcessable. Suspended/disconnected installations are skipped.
-			const ensureProcessable = (installation: VcsInstallation, kind: VcsSyncJob["kind"]) =>
-				Effect.gen(function* () {
-					const processable = isInstallationProcessable(installation)
-					yield* Effect.annotateCurrentSpan({
-						"vcs.installation.status": installation.status,
-						"vcs.installation.processable": processable,
-					})
-					if (!processable) {
-						yield* Effect.annotateCurrentSpan({
-							"vcs.process.outcome": "skipped",
-							"vcs.process.reason": "installation_not_processable",
-						})
-						yield* Effect.logInfo("[VCS] Skipping VCS job: installation not processable").pipe(
-							Effect.annotateLogs({
-								provider: installation.provider,
-								externalInstallationId: installation.externalInstallationId,
-								status: installation.status,
-								kind,
-							}),
-						)
-					}
-					return processable
+			const ensureProcessable = Effect.fn("VcsSyncService.ensureProcessable")(function* (
+				installation: VcsInstallation,
+				kind: VcsSyncJob["kind"],
+			) {
+				const processable = isInstallationProcessable(installation)
+				yield* Effect.annotateCurrentSpan({
+					"vcs.installation.status": installation.status,
+					"vcs.installation.processable": processable,
 				})
+				if (!processable) {
+					yield* Effect.annotateCurrentSpan({
+						"vcs.process.outcome": "skipped",
+						"vcs.process.reason": "installation_not_processable",
+					})
+					yield* Effect.logInfo("[VCS] Skipping VCS job: installation not processable").pipe(
+						Effect.annotateLogs({
+							provider: installation.provider,
+							externalInstallationId: installation.externalInstallationId,
+							status: installation.status,
+							kind,
+						}),
+					)
+				}
+				return processable
+			})
 
 			// Resolve the repo a data job targets (external repo id → entity), applying the
 			// two drop rules every data job shares — logging + annotating each so the drop is
 			// traceable. A `None` result means "drop this job":
 			//  - unknown repo (no local row): nothing to attach to.
 			//  - soft-removed repo: paused until access is re-granted (which flips it active).
-			const resolveRepositoryForJob = (
+			const resolveRepositoryForJob = Effect.fn("VcsSyncService.resolveRepositoryForJob")(function* (
 				installation: VcsInstallation,
 				job: PushJob | SyncCommitsJob | SyncBranchesJob | BranchEventJob,
-			) =>
-				Effect.gen(function* () {
-					const repositoryOpt = yield* repo.resolveRepository(
-						installation.orgId,
-						job.provider,
-						job.externalRepoId,
-					)
-					if (Option.isNone(repositoryOpt)) {
+			) {
+				const repositoryOpt = yield* repo.resolveRepository(
+					installation.orgId,
+					job.provider,
+					job.externalRepoId,
+				)
+				if (Option.isNone(repositoryOpt)) {
 						yield* Effect.annotateCurrentSpan({
 							"vcs.repository.outcome": "dropped",
 							"vcs.repository.reason": "unknown_repository",
@@ -657,45 +657,47 @@ export class VcsSyncService extends Context.Service<VcsSyncService, VcsSyncServi
 				})
 			})
 
-			const handleSyncCommits = (
+			const handleSyncCommits = Effect.fn("VcsSyncService.handleSyncCommits")(function* (
 				provider: VcsProviderClient,
 				installation: VcsInstallation,
 				job: SyncCommitsJob,
-			) =>
-				Effect.gen(function* () {
-					if (!(yield* ensureProcessable(installation, job.kind))) return
-					const repositoryOpt = yield* resolveRepositoryForJob(installation, job)
-					if (Option.isNone(repositoryOpt)) return
-					yield* syncCommits(provider, installation, repositoryOpt.value, job)
-				})
+			) {
+				if (!(yield* ensureProcessable(installation, job.kind))) return
+				const repositoryOpt = yield* resolveRepositoryForJob(installation, job)
+				if (Option.isNone(repositoryOpt)) return
+				yield* syncCommits(provider, installation, repositoryOpt.value, job)
+			})
 
-			const handleSyncBranches = (
+			const handleSyncBranches = Effect.fn("VcsSyncService.handleSyncBranches")(function* (
 				provider: VcsProviderClient,
 				installation: VcsInstallation,
 				job: SyncBranchesJob,
-			) =>
-				Effect.gen(function* () {
-					if (!(yield* ensureProcessable(installation, job.kind))) return
-					const repositoryOpt = yield* resolveRepositoryForJob(installation, job)
-					if (Option.isNone(repositoryOpt)) return
-					yield* syncBranches(provider, installation, repositoryOpt.value)
-				})
+			) {
+				if (!(yield* ensureProcessable(installation, job.kind))) return
+				const repositoryOpt = yield* resolveRepositoryForJob(installation, job)
+				if (Option.isNone(repositoryOpt)) return
+				yield* syncBranches(provider, installation, repositoryOpt.value)
+			})
 
-			const handlePush = (installation: VcsInstallation, job: PushJob) =>
-				Effect.gen(function* () {
-					if (!(yield* ensureProcessable(installation, job.kind))) return
-					const repositoryOpt = yield* resolveRepositoryForJob(installation, job)
-					if (Option.isNone(repositoryOpt)) return
-					yield* applyPush(installation, repositoryOpt.value, job)
-				})
+			const handlePush = Effect.fn("VcsSyncService.handlePush")(function* (
+				installation: VcsInstallation,
+				job: PushJob,
+			) {
+				if (!(yield* ensureProcessable(installation, job.kind))) return
+				const repositoryOpt = yield* resolveRepositoryForJob(installation, job)
+				if (Option.isNone(repositoryOpt)) return
+				yield* applyPush(installation, repositoryOpt.value, job)
+			})
 
-			const handleBranchEvent = (installation: VcsInstallation, job: BranchEventJob) =>
-				Effect.gen(function* () {
-					if (!(yield* ensureProcessable(installation, job.kind))) return
-					const repositoryOpt = yield* resolveRepositoryForJob(installation, job)
-					if (Option.isNone(repositoryOpt)) return
-					yield* applyBranchEvent(installation, repositoryOpt.value, job)
-				})
+			const handleBranchEvent = Effect.fn("VcsSyncService.handleBranchEvent")(function* (
+				installation: VcsInstallation,
+				job: BranchEventJob,
+			) {
+				if (!(yield* ensureProcessable(installation, job.kind))) return
+				const repositoryOpt = yield* resolveRepositoryForJob(installation, job)
+				if (Option.isNone(repositoryOpt)) return
+				yield* applyBranchEvent(installation, repositoryOpt.value, job)
+			})
 
 			const processMessage = Effect.fn("VcsSyncService.processMessage")(function* (raw: unknown) {
 				const jobOpt = yield* decodeJob(raw).pipe(

--- a/apps/api/src/services/vcs/vendor/github/GithubProvider.ts
+++ b/apps/api/src/services/vcs/vendor/github/GithubProvider.ts
@@ -15,7 +15,7 @@ import {
 	VcsWebhookParseError,
 	VcsWebhookSignatureError,
 } from "@maple/domain/http"
-import { Clock, Context, Effect, Layer, Option, Redacted, Schema } from "effect"
+import { Clock, Context, Effect, Layer, Match, Option, Redacted, Schema } from "effect"
 import { Env } from "../../../../lib/Env"
 import type { VcsProviderClient, VcsWebhookRequest } from "../../VcsProviderClient"
 import { QUEUE_MESSAGE_LIMIT_BYTES } from "../../VcsSyncQueue"
@@ -458,25 +458,22 @@ export class GithubProvider extends Context.Service<GithubProvider, VcsProviderC
 			// `webhookToJobs` span.
 			const mapEvent = (event: string | undefined, parsed: unknown, now: number) =>
 				Effect.gen(function* () {
-					switch (event) {
-						case "push":
-							return yield* mapPush(parsed, now)
-						case "installation":
-							return yield* mapInstallation(parsed)
-						case "installation_repositories":
-							return yield* mapInstallationRepositories(parsed)
-						case "create":
-							return yield* mapRefEvent("created")(parsed)
-						case "delete":
-							return yield* mapRefEvent("deleted")(parsed)
-						default:
+					return yield* Match.value(event).pipe(
+						Match.when("push", () => mapPush(parsed, now)),
+						Match.when("installation", () => mapInstallation(parsed)),
+						Match.when("installation_repositories", () =>
+							mapInstallationRepositories(parsed),
+						),
+						Match.when("create", () => mapRefEvent("created")(parsed)),
+						Match.when("delete", () => mapRefEvent("deleted")(parsed)),
+						Match.orElse(() =>
 							// ping and unhandled events are accepted no-ops.
-							yield* Effect.annotateCurrentSpan({
+							Effect.annotateCurrentSpan({
 								"vcs.webhook.outcome": "skipped",
 								"vcs.webhook.skip_reason": "unhandled_event",
-							})
-							return []
-					}
+							}).pipe(Effect.as([])),
+						),
+					)
 				})
 
 			const webhookToJobs = (input: VcsWebhookRequest) =>

--- a/apps/cli/src/commands/server.ts
+++ b/apps/cli/src/commands/server.ts
@@ -1,7 +1,8 @@
-import { Effect, Option, Schema } from "effect"
+import { Clock, Effect, Option, Schema } from "effect"
 import { FileSystem } from "effect/FileSystem"
 import * as Command from "effect/unstable/cli/Command"
 import * as Flag from "effect/unstable/cli/Flag"
+import { FetchHttpClient, HttpClient } from "effect/unstable/http"
 import { openSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
@@ -132,18 +133,15 @@ const offlineFlag = Flag.boolean("offline").pipe(
 // Log file for `--background` runs, beside the PID file (e.g. ~/.maple/maple.log).
 const logFilePath = (dataDir: string): string => join(dirname(dataDir), "maple.log")
 
-/** Non-fatal `/health` probe used while waiting for a detached server to bind. */
+/** Non-fatal `/health` probe used while waiting for a detached server to bind.
+ *  A transport error or a >300ms timeout collapses to `false` (not yet up). */
 const probeHealth = (addr: string): Effect.Effect<boolean> =>
-	Effect.tryPromise(async () => {
-		const controller = new AbortController()
-		const timer = setTimeout(() => controller.abort(), 300)
-		try {
-			const res = await fetch(`${addr}/health`, { signal: controller.signal })
-			return res.ok
-		} finally {
-			clearTimeout(timer)
-		}
-	}).pipe(Effect.orElseSucceed(() => false))
+	HttpClient.get(`${addr}/health`).pipe(
+		Effect.map((res) => res.status >= 200 && res.status < 300),
+		Effect.timeout("300 millis"),
+		Effect.provide(FetchHttpClient.layer),
+		Effect.orElseSucceed(() => false),
+	)
 
 /**
  * Re-exec `maple start` detached, dropping `--background`/`-d` so the child runs
@@ -334,10 +332,11 @@ export const start = Command.make("start", {
 
 					// Bootstrap succeeded — stamp the store so a later start over an
 					// incompatible binary upgrade is detected instead of crashing.
+					const stampedAtIso = new Date(yield* Clock.currentTimeMillis).toISOString()
 					yield* fs
 						.writeFileString(
 							storeMarkerPath(dataDir),
-							storeMarkerJson(MAPLE_VERSION, new Date().toISOString(), SCHEMA_FINGERPRINT),
+							storeMarkerJson(MAPLE_VERSION, stampedAtIso, SCHEMA_FINGERPRINT),
 						)
 						.pipe(Effect.ignore)
 

--- a/apps/cli/src/core/config.ts
+++ b/apps/cli/src/core/config.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, type PlatformError } from "effect"
+import { Clock, Context, Effect, Layer, type PlatformError, Schema } from "effect"
 import { FileSystem } from "effect/FileSystem"
 import * as os from "node:os"
 import * as path from "node:path"
@@ -20,6 +20,13 @@ interface StoredConfig {
 	latestKnownVersion?: string
 }
 
+/** Malformed on-disk config JSON. Caught immediately by `Effect.orElseSucceed`
+ *  (a bad/unreadable file falls back to an empty config), but typed so the error
+ *  channel isn't a bare `Error`. */
+class ConfigParseError extends Schema.TaggedErrorClass<ConfigParseError>()("@maple/cli/ConfigParseError", {
+	message: Schema.String,
+}) {}
+
 const CONFIG_DIR = path.join(os.homedir(), ".maple")
 const CONFIG_PATH = path.join(CONFIG_DIR, "config.json")
 
@@ -34,7 +41,7 @@ const readStored = (fs: FileSystem): Effect.Effect<StoredConfig> =>
 					const parsed = JSON.parse(raw) as unknown
 					return typeof parsed === "object" && parsed !== null ? (parsed as StoredConfig) : {}
 				},
-				catch: () => new Error("invalid config"),
+				catch: () => new ConfigParseError({ message: "invalid config" }),
 			}),
 		),
 		// Missing/unreadable/invalid file → empty config. The CLI still works in
@@ -110,11 +117,14 @@ export class MapleConfig extends Context.Service<MapleConfig, MapleConfigShape>(
 					return rest
 				}),
 			recordUpdateCheck: (latestTag) =>
-				writeMerged(fs, (cur) => ({
-					...cur,
-					lastUpdateCheck: new Date().toISOString(),
-					...(latestTag ? { latestKnownVersion: latestTag } : {}),
-				})),
+				Effect.gen(function* () {
+					const nowIso = new Date(yield* Clock.currentTimeMillis).toISOString()
+					yield* writeMerged(fs, (cur) => ({
+						...cur,
+						lastUpdateCheck: nowIso,
+						...(latestTag ? { latestKnownVersion: latestTag } : {}),
+					}))
+				}),
 		} satisfies MapleConfigShape
 	}),
 }) {

--- a/apps/cli/src/core/executor.ts
+++ b/apps/cli/src/core/executor.ts
@@ -18,7 +18,7 @@ const LOCAL_ORG_ID = Schema.decodeUnknownSync(OrgId)("local")
 const toWarehouseError = (pipe: string) => (error: unknown) =>
 	new WarehouseQueryError({
 		message: error instanceof Error ? error.message : String(error),
-		pipe,
+		pipeName: pipe,
 	})
 
 // Cap `db.query.text` at 16 KB to match apps/api's WarehouseQueryService span.
@@ -91,7 +91,7 @@ export const makeLocalWarehouseExecutorShape = (baseUrl: string): WarehouseExecu
 						(error) =>
 							new WarehouseSchemaDriftError({
 								message: error.message,
-								pipe: "compiledQuery",
+								pipeName: "compiledQuery",
 								cause: error,
 							}),
 					),
@@ -125,7 +125,7 @@ export const makeLocalWarehouseExecutorShape = (baseUrl: string): WarehouseExecu
 						(error) =>
 							new WarehouseSchemaDriftError({
 								message: error.message,
-								pipe: "compiledQueryFirst",
+								pipeName: "compiledQueryFirst",
 								cause: error,
 							}),
 					),
@@ -149,7 +149,7 @@ export const makeLocalWarehouseExecutorShape = (baseUrl: string): WarehouseExecu
 				if (!compiled) {
 					return yield* new WarehouseValidationError({
 						message: `Unsupported pipe in local mode: ${pipe}`,
-						pipe,
+						pipeName: pipe,
 					})
 				}
 				yield* Effect.annotateCurrentSpan({
@@ -170,7 +170,7 @@ export const makeLocalWarehouseExecutorShape = (baseUrl: string): WarehouseExecu
 						(error) =>
 							new WarehouseSchemaDriftError({
 								message: error.message,
-								pipe,
+								pipeName: pipe,
 								cause: error,
 							}),
 					),

--- a/apps/cli/src/core/remote-executor.ts
+++ b/apps/cli/src/core/remote-executor.ts
@@ -58,7 +58,7 @@ export const makeRemoteWarehouseExecutorShape = (
 				catch: (error) =>
 					new WarehouseQueryError({
 						message: error instanceof Error ? error.message : String(error),
-						pipe,
+						pipeName: pipe,
 					}),
 			}).pipe(
 				Effect.tap((result) => Effect.annotateCurrentSpan({ "result.rowCount": result.data.length })),
@@ -73,15 +73,15 @@ export const makeRemoteWarehouseExecutorShape = (
 			),
 		sqlQuery: <T = Record<string, unknown>>(_sql: string, _options?: ExecutorQueryOptions) =>
 			Effect.fail(
-				new WarehouseClientError({ message: RAW_SQL_REMOTE_MESSAGE, pipe: "sqlQuery" }),
+				new WarehouseClientError({ message: RAW_SQL_REMOTE_MESSAGE, pipeName: "sqlQuery" }),
 			) as Effect.Effect<ReadonlyArray<T>, WarehouseClientError>,
 		compiledQuery: <T>(_compiled: unknown, _options?: ExecutorQueryOptions) =>
 			Effect.fail(
-				new WarehouseClientError({ message: RAW_SQL_REMOTE_MESSAGE, pipe: "compiledQuery" }),
+				new WarehouseClientError({ message: RAW_SQL_REMOTE_MESSAGE, pipeName: "compiledQuery" }),
 			) as Effect.Effect<ReadonlyArray<T>, WarehouseClientError>,
 		compiledQueryFirst: <T>(_compiled: unknown, _options?: ExecutorQueryOptions) =>
 			Effect.fail(
-				new WarehouseClientError({ message: RAW_SQL_REMOTE_MESSAGE, pipe: "compiledQueryFirst" }),
+				new WarehouseClientError({ message: RAW_SQL_REMOTE_MESSAGE, pipeName: "compiledQueryFirst" }),
 			) as Effect.Effect<Option.Option<T>, WarehouseClientError>,
 	}
 }

--- a/apps/cli/src/core/time.ts
+++ b/apps/cli/src/core/time.ts
@@ -1,7 +1,7 @@
 // Time-range resolution for the CLI commands. Emits ClickHouse-style
 // `YYYY-MM-DD HH:mm:ss` UTC strings, matching what the query engine expects.
 
-import { Effect, Option, Schema } from "effect"
+import { Clock, Effect, Option, Schema } from "effect"
 
 export interface Range {
 	readonly startTime: string
@@ -60,9 +60,9 @@ export const resolveRangeChecked = (a: {
 				message: `unrecognized --since "${a.since}" — use Nm, Nh, or Nd (e.g. 30m, 6h, 7d)`,
 			})
 		}
-		const now = new Date()
+		const nowMs = yield* Clock.currentTimeMillis
 		return {
-			startTime: start ?? formatDateTimeUTC(new Date(now.getTime() - ms)),
-			endTime: end ?? formatDateTimeUTC(now),
+			startTime: start ?? formatDateTimeUTC(new Date(nowMs - ms)),
+			endTime: end ?? formatDateTimeUTC(new Date(nowMs)),
 		}
 	})

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -13,7 +13,7 @@
 // rename swaps the directory entry, so the running process keeps its old inode
 // while new invocations pick up the new binary. Keep the triple/URL logic here
 // in sync with install.sh.
-import { Effect, Option, Schema } from "effect"
+import { Clock, Effect, Option, Schema } from "effect"
 import { realpathSync } from "node:fs"
 import { chmod, mkdir, rename, rm } from "node:fs/promises"
 import { dirname, join } from "node:path"
@@ -317,7 +317,7 @@ const printNotice = (current: string, latest: string): void => {
 export const maybeNotifyUpdate: Effect.Effect<void, never, MapleConfig> = Effect.gen(function* () {
 	if (!shouldRunNotify(process.argv)) return
 	const config = yield* MapleConfig
-	const now = Date.now()
+	const now = yield* Clock.currentTimeMillis
 	let latest = config.latestKnownVersion
 
 	if (shouldCheck(config.lastUpdateCheck, now)) {

--- a/apps/cli/src/core/warehouse.ts
+++ b/apps/cli/src/core/warehouse.ts
@@ -37,7 +37,7 @@ export const WarehouseExecutorFromMode = Layer.effect(
 							? makeLocalWarehouseExecutorShape(m.baseUrl)
 							: makeRemoteWarehouseExecutorShape(m.apiUrl, m.token, m.orgId ?? ""),
 				),
-				Effect.mapError((e) => new WarehouseConfigError({ message: e.message, pipe: "mode" })),
+				Effect.mapError((e) => new WarehouseConfigError({ message: e.message, pipeName: "mode" })),
 			),
 		)
 		return WarehouseExecutor.of({

--- a/apps/scraper/src/ApiClient.test.ts
+++ b/apps/scraper/src/ApiClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Redacted } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { ApiClient } from "./ApiClient"
@@ -72,12 +72,12 @@ describe("ApiClient", () => {
 				),
 			)
 
-			expect(recorded[0]?.url).toBe("http://api.test/api/internal/scrape-targets")
-			expect(recorded[0]?.headers.authorization).toBe("Bearer internal-token")
-			expect(targets).toHaveLength(1)
-			expect(targets[0]?.id).toBe(VALID_TARGET.id)
-			expect(targets[0]?.labels).toEqual({ env: "prod" })
-			expect(targets[0]?.ingestKey).toBe("maple_pk_org_1_key")
+			assert.strictEqual(recorded[0]?.url, "http://api.test/api/internal/scrape-targets")
+			assert.strictEqual(recorded[0]?.headers.authorization, "Bearer internal-token")
+			assert.lengthOf(targets, 1)
+			assert.strictEqual(targets[0]?.id, VALID_TARGET.id)
+			assert.deepStrictEqual(targets[0]?.labels, { env: "prod" })
+			assert.strictEqual(targets[0]?.ingestKey, "maple_pk_org_1_key")
 		}).pipe(Effect.provide(TestLayer)),
 	)
 
@@ -91,8 +91,8 @@ describe("ApiClient", () => {
 				),
 				Effect.flip,
 			)
-			expect(result._tag).toBe("@maple/scraper/ApiRequestError")
-			expect(result.status).toBe(401)
+			assert.strictEqual(result._tag, "@maple/scraper/ApiRequestError")
+			assert.strictEqual(result.status, 401)
 		}).pipe(Effect.provide(TestLayer)),
 	)
 
@@ -106,7 +106,7 @@ describe("ApiClient", () => {
 				),
 				Effect.flip,
 			)
-			expect(result.message).toContain("payload mismatch")
+			assert.include(result.message, "payload mismatch")
 		}).pipe(Effect.provide(TestLayer)),
 	)
 
@@ -121,10 +121,10 @@ describe("ApiClient", () => {
 				),
 			)
 
-			expect(recorded[0]?.url).toBe("http://api.test/api/internal/prometheus-scrape?targetId=target-1")
-			expect(recorded[0]?.headers.authorization).toBe("Bearer internal-token")
-			expect(response.status).toBe(200)
-			expect(response.body).toContain("up 1")
+			assert.strictEqual(recorded[0]?.url, "http://api.test/api/internal/prometheus-scrape?targetId=target-1")
+			assert.strictEqual(recorded[0]?.headers.authorization, "Bearer internal-token")
+			assert.strictEqual(response.status, 200)
+			assert.include(response.body, "up 1")
 		}).pipe(Effect.provide(TestLayer)),
 	)
 
@@ -139,7 +139,8 @@ describe("ApiClient", () => {
 				),
 			)
 
-			expect(recorded[0]?.url).toBe(
+			assert.strictEqual(
+				recorded[0]?.url,
 				"http://api.test/api/internal/prometheus-scrape?targetId=target-1&sub=branch%20a%2F1",
 			)
 		}).pipe(Effect.provide(TestLayer)),
@@ -152,7 +153,7 @@ describe("ApiClient", () => {
 			const fetchStub = stubFetch(recorded, () => Response.json({ recorded: 1 }))
 
 			yield* client.reportResults([]).pipe(Effect.provideService(FetchHttpClient.Fetch, fetchStub))
-			expect(recorded).toHaveLength(0)
+			assert.lengthOf(recorded, 0)
 
 			yield* client
 				.reportResults([
@@ -160,10 +161,10 @@ describe("ApiClient", () => {
 				])
 				.pipe(Effect.provideService(FetchHttpClient.Fetch, fetchStub))
 
-			expect(recorded[0]?.url).toBe("http://api.test/api/internal/scrape-results")
-			expect(recorded[0]?.method).toBe("POST")
-			expect(recorded[0]?.headers["content-type"]).toBe("application/json")
-			expect(JSON.parse(recorded[0]?.body ?? "[]")).toEqual([
+			assert.strictEqual(recorded[0]?.url, "http://api.test/api/internal/scrape-results")
+			assert.strictEqual(recorded[0]?.method, "POST")
+			assert.strictEqual(recorded[0]?.headers["content-type"], "application/json")
+			assert.deepStrictEqual(JSON.parse(recorded[0]?.body ?? "[]"), [
 				{ targetId: VALID_TARGET.id, scrapedAt: 1750000000000, error: null },
 			])
 		}).pipe(Effect.provide(TestLayer)),

--- a/apps/scraper/src/OtlpIngest.test.ts
+++ b/apps/scraper/src/OtlpIngest.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Redacted } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { OtlpIngest } from "./OtlpIngest"
@@ -87,11 +87,11 @@ describe("OtlpIngest", () => {
 				),
 			)
 
-			expect(recorded[0]?.url).toBe("http://ingest.test/v1/metrics")
-			expect(recorded[0]?.method).toBe("POST")
-			expect(recorded[0]?.headers.authorization).toBe("Bearer maple_pk_test_key")
-			expect(recorded[0]?.headers["content-type"]).toBe("application/json")
-			expect(JSON.parse(recorded[0]?.body ?? "{}")).toEqual(SAMPLE_REQUEST)
+			assert.strictEqual(recorded[0]?.url, "http://ingest.test/v1/metrics")
+			assert.strictEqual(recorded[0]?.method, "POST")
+			assert.strictEqual(recorded[0]?.headers.authorization, "Bearer maple_pk_test_key")
+			assert.strictEqual(recorded[0]?.headers["content-type"], "application/json")
+			assert.deepStrictEqual(JSON.parse(recorded[0]?.body ?? "{}"), SAMPLE_REQUEST)
 		}).pipe(Effect.provide(TestLayer)),
 	)
 
@@ -105,9 +105,9 @@ describe("OtlpIngest", () => {
 				),
 				Effect.flip,
 			)
-			expect(error._tag).toBe("@maple/scraper/OtlpIngestError")
-			expect(error.status).toBe(402)
-			expect(error.message).toContain("billing limit")
+			assert.strictEqual(error._tag, "@maple/scraper/OtlpIngestError")
+			assert.strictEqual(error.status, 402)
+			assert.include(error.message, "billing limit")
 		}).pipe(Effect.provide(TestLayer)),
 	)
 
@@ -121,7 +121,7 @@ describe("OtlpIngest", () => {
 				),
 				Effect.flip,
 			)
-			expect(error.status).toBe(401)
+			assert.strictEqual(error.status, 401)
 		}).pipe(Effect.provide(TestLayer)),
 	)
 })

--- a/apps/scraper/src/ScrapeScheduler.test.ts
+++ b/apps/scraper/src/ScrapeScheduler.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { Duration, Effect, Layer, Redacted, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import { InternalScrapeTarget, type ScrapeResultReport } from "@maple/domain/http"
@@ -121,9 +121,9 @@ describe("ScrapeScheduler", () => {
 			const aCalls = harness.scrapeCalls.filter((id) => id === TARGET_A).length
 			const bCalls = harness.scrapeCalls.filter((id) => id === TARGET_B).length
 			// 5s interval: scrape at t=0,5,...,55 → 12 within the first minute.
-			expect(aCalls).toBe(12)
+			assert.strictEqual(aCalls, 12)
 			// 300s interval: only the initial scrape.
-			expect(bCalls).toBe(1)
+			assert.strictEqual(bCalls, 1)
 		}),
 	)
 
@@ -135,8 +135,8 @@ describe("ScrapeScheduler", () => {
 			// One scrape happened; flush loop fires at t=10s.
 			yield* TestClock.adjust(Duration.seconds(10))
 
-			expect(harness.ingestCalls).toHaveLength(1)
-			expect(harness.ingestCalls[0]?.ingestKey).toBe("maple_pk_org_a")
+			assert.lengthOf(harness.ingestCalls, 1)
+			assert.strictEqual(harness.ingestCalls[0]?.ingestKey, "maple_pk_org_a")
 
 			const resource = harness.ingestCalls[0]!.request.resourceMetrics[0]!
 			const resourceAttrs = Object.fromEntries(
@@ -144,13 +144,13 @@ describe("ScrapeScheduler", () => {
 			)
 			// Org attribution comes from the ingest key at the gateway — the
 			// scraper must not claim it client-side.
-			expect(resourceAttrs).not.toHaveProperty("maple_org_id")
-			expect(resourceAttrs.maple_scrape_target_id).toBe(TARGET_A)
-			expect(resource.scopeMetrics[0]!.metrics[0]!.name).toBe("up")
+			assert.notProperty(resourceAttrs, "maple_org_id")
+			assert.strictEqual(resourceAttrs.maple_scrape_target_id, TARGET_A)
+			assert.strictEqual(resource.scopeMetrics[0]!.metrics[0]!.name, "up")
 
-			expect(harness.reportedResults).toHaveLength(1)
-			expect(harness.reportedResults[0]?.targetId).toBe(TARGET_A)
-			expect(harness.reportedResults[0]?.error).toBeNull()
+			assert.lengthOf(harness.reportedResults, 1)
+			assert.strictEqual(harness.reportedResults[0]?.targetId, TARGET_A)
+			assert.isNull(harness.reportedResults[0]?.error)
 		}),
 	)
 
@@ -162,9 +162,9 @@ describe("ScrapeScheduler", () => {
 
 			yield* TestClock.adjust(Duration.seconds(10))
 
-			expect(harness.ingestCalls).toEqual([])
+			assert.deepStrictEqual(harness.ingestCalls, [])
 			// The scrape itself succeeded.
-			expect(harness.reportedResults[0]?.error).toBeNull()
+			assert.isNull(harness.reportedResults[0]?.error)
 		}),
 	)
 
@@ -176,9 +176,9 @@ describe("ScrapeScheduler", () => {
 
 			yield* TestClock.adjust(Duration.seconds(10))
 
-			expect(harness.ingestCalls).toEqual([])
-			expect(harness.reportedResults).toHaveLength(1)
-			expect(harness.reportedResults[0]?.error).toContain("HTTP 503")
+			assert.deepStrictEqual(harness.ingestCalls, [])
+			assert.lengthOf(harness.reportedResults, 1)
+			assert.include(harness.reportedResults[0]?.error ?? "", "HTTP 503")
 		}),
 	)
 
@@ -194,13 +194,13 @@ describe("ScrapeScheduler", () => {
 
 			yield* TestClock.adjust(Duration.seconds(10))
 
-			expect(harness.reportedResults).toHaveLength(1)
+			assert.lengthOf(harness.reportedResults, 1)
 			const report = harness.reportedResults[0]!
-			expect(report.error).toBeNull()
-			expect(report.durationMs).toBe(2000)
+			assert.isNull(report.error)
+			assert.strictEqual(report.durationMs, 2000)
 			// GAUGE_BODY exposes a single `up 1` sample → one gauge data point.
-			expect(report.samplesScraped).toBe(1)
-			expect(report.samplesPostMetricRelabeling).toBe(1)
+			assert.strictEqual(report.samplesScraped, 1)
+			assert.strictEqual(report.samplesPostMetricRelabeling, 1)
 		}),
 	)
 
@@ -212,12 +212,12 @@ describe("ScrapeScheduler", () => {
 
 			yield* TestClock.adjust(Duration.seconds(10))
 
-			expect(harness.reportedResults).toHaveLength(1)
+			assert.lengthOf(harness.reportedResults, 1)
 			const report = harness.reportedResults[0]!
-			expect(report.error).toContain("HTTP 503")
-			expect(report.durationMs).toBe(0)
-			expect(report.samplesScraped).toBeUndefined()
-			expect(report.samplesPostMetricRelabeling).toBeUndefined()
+			assert.include(report.error ?? "", "HTTP 503")
+			assert.strictEqual(report.durationMs, 0)
+			assert.strictEqual(report.samplesScraped, undefined)
+			assert.strictEqual(report.samplesPostMetricRelabeling, undefined)
 		}),
 	)
 
@@ -235,8 +235,8 @@ describe("ScrapeScheduler", () => {
 
 			yield* TestClock.adjust(Duration.seconds(10))
 
-			expect(harness.reportedResults).toHaveLength(1)
-			expect(harness.reportedResults[0]?.error).toContain("billing limit")
+			assert.lengthOf(harness.reportedResults, 1)
+			assert.include(harness.reportedResults[0]?.error ?? "", "billing limit")
 		}),
 	)
 
@@ -254,14 +254,14 @@ describe("ScrapeScheduler", () => {
 			const aCalls = harness.scrapeCalls.filter((id) => id === TARGET_A).length
 			const bCalls = harness.scrapeCalls.filter((id) => id === TARGET_B).length
 			// The failing target keeps being retried on its interval…
-			expect(aCalls).toBeGreaterThanOrEqual(3)
+			assert.isAtLeast(aCalls, 3)
 			// …and the healthy target keeps scraping and ingesting.
-			expect(bCalls).toBeGreaterThanOrEqual(3)
-			expect(harness.ingestCalls.length).toBeGreaterThanOrEqual(3)
+			assert.isAtLeast(bCalls, 3)
+			assert.isAtLeast(harness.ingestCalls.length, 3)
 
 			const aResults = harness.reportedResults.filter((r) => r.targetId === TARGET_A)
-			expect(aResults.length).toBeGreaterThan(0)
-			expect(aResults[0]?.error).toContain("boom")
+			assert.isAbove(aResults.length, 0)
+			assert.include(aResults[0]?.error ?? "", "boom")
 		}),
 	)
 
@@ -277,13 +277,13 @@ describe("ScrapeScheduler", () => {
 
 			const branch1 = harness.subCalls.filter((c) => c.subTargetKey === "branch-1").length
 			const branch2 = harness.subCalls.filter((c) => c.subTargetKey === "branch-2").length
-			expect(branch1).toBeGreaterThanOrEqual(3)
-			expect(branch2).toBeGreaterThanOrEqual(3)
+			assert.isAtLeast(branch1, 3)
+			assert.isAtLeast(branch2, 3)
 
 			// Result reports carry the sub-target key for branch-level attribution.
 			const reportedKeys = new Set(harness.reportedResults.map((r) => r.subTargetKey))
-			expect(reportedKeys.has("branch-1")).toBe(true)
-			expect(reportedKeys.has("branch-2")).toBe(true)
+			assert.isTrue(reportedKeys.has("branch-1"))
+			assert.isTrue(reportedKeys.has("branch-2"))
 
 			// Discovery drops branch-2 → only its loop is interrupted.
 			harness.targets = [
@@ -293,10 +293,12 @@ describe("ScrapeScheduler", () => {
 			const branch2AfterRemoval = harness.subCalls.filter((c) => c.subTargetKey === "branch-2").length
 			yield* TestClock.adjust(Duration.seconds(30))
 
-			expect(harness.subCalls.filter((c) => c.subTargetKey === "branch-2").length).toBe(
+			assert.strictEqual(
+				harness.subCalls.filter((c) => c.subTargetKey === "branch-2").length,
 				branch2AfterRemoval,
 			)
-			expect(harness.subCalls.filter((c) => c.subTargetKey === "branch-1").length).toBeGreaterThan(
+			assert.isAbove(
+				harness.subCalls.filter((c) => c.subTargetKey === "branch-1").length,
 				branch1,
 			)
 		}),
@@ -309,7 +311,7 @@ describe("ScrapeScheduler", () => {
 
 			yield* TestClock.adjust(Duration.seconds(30))
 			const aCallsBefore = harness.scrapeCalls.filter((id) => id === TARGET_A).length
-			expect(aCallsBefore).toBeGreaterThanOrEqual(3)
+			assert.isAtLeast(aCallsBefore, 3)
 
 			// Swap A out for B before the next reconcile (every 60s).
 			harness.targets = [mkTarget(TARGET_B, 10)]
@@ -318,14 +320,14 @@ describe("ScrapeScheduler", () => {
 			const aCallsAfterSwap = harness.scrapeCalls.filter((id) => id === TARGET_A).length
 			yield* TestClock.adjust(Duration.seconds(30))
 
-			expect(harness.scrapeCalls.filter((id) => id === TARGET_A).length).toBe(aCallsAfterSwap)
-			expect(harness.scrapeCalls.filter((id) => id === TARGET_B).length).toBeGreaterThanOrEqual(3)
+			assert.strictEqual(harness.scrapeCalls.filter((id) => id === TARGET_A).length, aCallsAfterSwap)
+			assert.isAtLeast(harness.scrapeCalls.filter((id) => id === TARGET_B).length, 3)
 
 			// A rotated ingest key → fingerprint change → loop restarted with the new key.
 			harness.targets = [mkTarget(TARGET_B, 10, { ingestKey: "maple_pk_rotated" })]
 			yield* TestClock.adjust(Duration.seconds(60))
 			yield* TestClock.adjust(Duration.seconds(10))
-			expect(harness.ingestCalls.at(-1)?.ingestKey).toBe("maple_pk_rotated")
+			assert.strictEqual(harness.ingestCalls.at(-1)?.ingestKey, "maple_pk_rotated")
 		}),
 	)
 
@@ -362,12 +364,12 @@ describe("ScrapeScheduler", () => {
 
 			yield* TestClock.adjust(Duration.seconds(10))
 			const before = harness.scrapeCalls.length
-			expect(before).toBeGreaterThanOrEqual(2)
+			assert.isAtLeast(before, 2)
 
 			// Two failed reconciles later, the existing loop is still scraping.
 			yield* TestClock.adjust(Duration.seconds(120))
-			expect(listCalls).toBeGreaterThanOrEqual(3)
-			expect(harness.scrapeCalls.length).toBeGreaterThan(before)
+			assert.isAtLeast(listCalls, 3)
+			assert.isAbove(harness.scrapeCalls.length, before)
 		}),
 	)
 
@@ -404,12 +406,12 @@ describe("ScrapeScheduler", () => {
 
 			// First flush at t=10s fails; the result must be retried later.
 			yield* TestClock.adjust(Duration.seconds(15))
-			expect(harness.reportedResults).toEqual([])
+			assert.deepStrictEqual(harness.reportedResults, [])
 
 			failReports = false
 			yield* TestClock.adjust(Duration.seconds(10))
-			expect(harness.reportedResults).toHaveLength(1)
-			expect(harness.reportedResults[0]?.targetId).toBe(TARGET_A)
+			assert.lengthOf(harness.reportedResults, 1)
+			assert.strictEqual(harness.reportedResults[0]?.targetId, TARGET_A)
 		}),
 	)
 })

--- a/apps/scraper/src/ScrapeScheduler.ts
+++ b/apps/scraper/src/ScrapeScheduler.ts
@@ -203,22 +203,30 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 				const current = yield* Ref.get(fibersRef)
 				const next = new Map<string, TargetEntry>()
 
-				for (const target of targets) {
-					const key = targetKey(target)
-					const fingerprint = targetFingerprint(target)
-					const existing = current.get(key)
-					if (existing && existing.fingerprint === fingerprint) {
-						next.set(key, existing)
-						continue
-					}
-					if (existing) yield* Fiber.interrupt(existing.fiber)
-					const fiber = yield* Effect.forkChild(targetLoop(target))
-					next.set(key, { fingerprint, fiber })
-				}
+				yield* Effect.forEach(
+					targets,
+					(target) =>
+						Effect.gen(function* () {
+							const key = targetKey(target)
+							const fingerprint = targetFingerprint(target)
+							const existing = current.get(key)
+							if (existing && existing.fingerprint === fingerprint) {
+								next.set(key, existing)
+								return
+							}
+							if (existing) yield* Fiber.interrupt(existing.fiber)
+							const fiber = yield* Effect.forkChild(targetLoop(target))
+							next.set(key, { fingerprint, fiber })
+						}),
+					{ discard: true },
+				)
 
-				for (const [id, entry] of current) {
-					if (!next.has(id)) yield* Fiber.interrupt(entry.fiber)
-				}
+				yield* Effect.forEach(
+					current,
+					([id, entry]) =>
+						next.has(id) ? Effect.void : Fiber.interrupt(entry.fiber),
+					{ discard: true },
+				)
 
 				yield* Ref.set(fibersRef, next)
 				yield* Ref.set(lastReconcileRef, yield* Clock.currentTimeMillis)

--- a/apps/web/src/api/warehouse/metrics.ts
+++ b/apps/web/src/api/warehouse/metrics.ts
@@ -168,6 +168,10 @@ const getMetricTimeSeriesEffect = Effect.fn("QueryEngine.getMetricTimeSeries")(f
 			},
 		})
 
+	// The five aggregation queries fan out concurrently; wrap them in their own
+	// span so the per-metric work is traceable and annotated, rather than landing
+	// untracked under the parent. orgId is resolved server-side (not available
+	// here), so we annotate the metric identifiers we do have.
 	const [avgRes, sumRes, minRes, maxRes, countRes] = yield* Effect.all(
 		[
 			executeMetricsQueryEngine(makeRequest("avg")),
@@ -177,6 +181,16 @@ const getMetricTimeSeriesEffect = Effect.fn("QueryEngine.getMetricTimeSeries")(f
 			executeMetricsQueryEngine(makeRequest("count")),
 		],
 		{ concurrency: 5 },
+	).pipe(
+		Effect.withSpan("warehouse.metrics.getMetricTimeSeries", {
+			attributes: {
+				metricName: input.metricName,
+				metricType: input.metricType,
+				...(input.service ? { service: input.service } : {}),
+				aggregations: "avg,sum,min,max,count",
+				bucketSeconds,
+			},
+		}),
 	)
 
 	// Build a map of bucket::service -> { avg, sum, min, max, count }

--- a/apps/web/src/api/warehouse/query-builder-breakdown.ts
+++ b/apps/web/src/api/warehouse/query-builder-breakdown.ts
@@ -2,7 +2,23 @@ import { Effect, Result, Schema } from "effect"
 import { QueryBuilderQueryDraftSchema } from "@maple/domain/http"
 import { QueryEngineExecuteRequest } from "@maple/query-engine"
 import { buildBreakdownQuerySpec } from "@/lib/query-builder/model"
-import { decodeInput, executeQueryEngine, invalidWarehouseInput } from "@/api/warehouse/effect-utils"
+import {
+	type BackendError,
+	type WarehouseQueryError,
+	decodeInput,
+	executeQueryEngine,
+	invalidWarehouseInput,
+} from "@/api/warehouse/effect-utils"
+
+// Discriminate the typed query-engine error channel on `_tag` (both the local
+// `WarehouseQueryError` and the backend `@maple/http/errors/Warehouse*` union
+// carry a `message` field) rather than collapsing it via `instanceof Error`.
+function queryEngineErrorMessage(
+	error: WarehouseQueryError | BackendError,
+	fallback: string,
+): string {
+	return "message" in error && typeof error.message === "string" ? error.message : fallback
+}
 
 const dateTimeString = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/))
 
@@ -63,7 +79,7 @@ const executeBreakdownQuery = Effect.fn("QueryEngine.executeBreakdownQuery")(fun
 			queryId: query.id,
 			queryName: query.name,
 			status: "error",
-			error: error instanceof Error ? error.message : "Breakdown query failed",
+			error: queryEngineErrorMessage(error, "Breakdown query failed"),
 			data: [],
 		} satisfies BreakdownQueryResult
 	}

--- a/apps/web/src/api/warehouse/query-builder-timeseries.ts
+++ b/apps/web/src/api/warehouse/query-builder-timeseries.ts
@@ -21,6 +21,15 @@ import { computeBucketSeconds } from "@/api/warehouse/timeseries-utils"
 
 type ExecuteError = WarehouseApiError | BackendError
 
+// Discriminate the typed error channel on `_tag` (every member is a tagged
+// error — the local `Warehouse*Error` classes and the backend
+// `@maple/http/errors/Warehouse*` union both carry a `message` field) rather
+// than collapsing it via `instanceof Error`, which loses the tag and the
+// statically-known message.
+function executeErrorMessage(error: ExecuteError, fallback: string): string {
+	return "message" in error && typeof error.message === "string" ? error.message : fallback
+}
+
 const dateTimeString = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/))
 
 const COMPARISON_MODES = ["none", "previous_period"] as const
@@ -311,7 +320,7 @@ const executeTimeseriesQueryWithFallbackUsing = Effect.fn("QueryEngine.executeTi
 
 			if (Result.isFailure(outcome)) {
 				const error = outcome.failure
-				const message = error instanceof Error ? error.message : "Query execution failed"
+				const message = executeErrorMessage(error, "Query execution failed")
 
 				attempts.push({
 					startTime: window.startTime,
@@ -610,7 +619,7 @@ const runQueryWindow = Effect.fn("QueryEngine.runQueryWindow")(function* (
 						queryName: query.name,
 						source: query.dataSource,
 						status: "error",
-						error: error instanceof Error ? error.message : "Query execution failed",
+						error: executeErrorMessage(error, "Query execution failed"),
 						warnings: built.warnings,
 						data: [],
 					} satisfies QueryRunResult

--- a/apps/web/src/hooks/use-infinite-logs.ts
+++ b/apps/web/src/hooks/use-infinite-logs.ts
@@ -3,7 +3,10 @@ import { Result } from "@/lib/effect-atom"
 import { Effect } from "effect"
 
 import { listLogs, type Log, type LogsResponse } from "@/api/warehouse/logs"
-import { listLogsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
+import {
+	listLogsResultAtom,
+	type QueryAtomFailure,
+} from "@/lib/services/atoms/warehouse-query-atoms"
 import { useRetainedRefreshableResultValue } from "@/hooks/use-retained-refreshable-result-value"
 import { useTableRefreshTimeRange } from "@/hooks/use-table-refresh-time-range"
 import type { LogsSearchParams } from "@/routes/logs"
@@ -12,7 +15,7 @@ const PAGE_SIZE = 100
 const FETCH_THRESHOLD = 20
 
 export interface UseInfiniteLogsReturn {
-	firstPageResult: Result.Result<LogsResponse, unknown>
+	firstPageResult: Result.Result<LogsResponse, QueryAtomFailure>
 	allData: Log[]
 	isFetchingNextPage: boolean
 	hasNextPage: boolean

--- a/apps/web/src/hooks/use-infinite-traces.ts
+++ b/apps/web/src/hooks/use-infinite-traces.ts
@@ -3,7 +3,10 @@ import { Result } from "@/lib/effect-atom"
 import { Effect } from "effect"
 
 import { listTraces, type Trace, type TracesResponse } from "@/api/warehouse/traces"
-import { listTracesResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
+import {
+	listTracesResultAtom,
+	type QueryAtomFailure,
+} from "@/lib/services/atoms/warehouse-query-atoms"
 import { useRetainedRefreshableResultValue } from "@/hooks/use-retained-refreshable-result-value"
 import { useTableRefreshTimeRange } from "@/hooks/use-table-refresh-time-range"
 import type { TracesSearchParams } from "@/routes/traces"
@@ -12,7 +15,7 @@ const PAGE_SIZE = 100
 const FETCH_THRESHOLD = 20
 
 export interface UseInfiniteTracesReturn {
-	firstPageResult: Result.Result<TracesResponse, unknown>
+	firstPageResult: Result.Result<TracesResponse, QueryAtomFailure>
 	allData: Trace[]
 	isFetchingNextPage: boolean
 	hasNextPage: boolean

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
@@ -94,7 +94,7 @@ class QueryAtomError extends Schema.TaggedErrorClass<QueryAtomError>()("@maple/w
 // The error union surfaced to atom consumers: the structured query errors plus
 // any tagged backend error, all normalized through `QueryAtomError`'s shape for
 // anything that is not already a known tagged error.
-type QueryAtomFailure = QueryError | QueryAtomError
+export type QueryAtomFailure = QueryError | QueryAtomError
 
 const isTaggedBackendError = (error: QueryError): boolean => error._tag.startsWith("@maple/http/errors/")
 

--- a/lib/effect-cloudflare/src/http-server.ts
+++ b/lib/effect-cloudflare/src/http-server.ts
@@ -20,45 +20,51 @@ import { Request as RequestService } from "./request.ts"
  * returns a `Response`. Any uncaught cause is converted into a 500 via
  * `safeHttpEffect`.
  */
-export const serveWebRequest = <Req = never>(
+export const serveWebRequest = Effect.fnUntraced(function* <Req = never>(
 	webRequest: globalThis.Request,
 	handler: HttpEffect<Req>,
 	options: {
 		remoteAddress?: string
 		acceptWebSocket?: (socket: unknown) => void
 	} = {},
-): Effect.Effect<globalThis.Response, never, Exclude<Req, HttpServerRequest.HttpServerRequest | Scope>> =>
-	Effect.gen(function* () {
-		const request = HttpServerRequest.fromWeb(webRequest).modify({
-			remoteAddress: Option.fromUndefinedOr(options.remoteAddress),
-		})
+) {
+	const request = HttpServerRequest.fromWeb(webRequest).modify({
+		remoteAddress: Option.fromUndefinedOr(options.remoteAddress),
+	})
 
-		Object.defineProperty(request, "raw", {
-			get: () =>
-				Object.assign(request.stream, {
-					raw: webRequest.body,
-				}),
-		})
-
-		const response = yield* safeHttpEffect(handler).pipe(
-			Effect.provideService(HttpServerRequest.HttpServerRequest, request),
-			Effect.provideService(RequestService, webRequest),
-			Effect.catchCause((cause) => {
-				const message = Option.match(Cause.findErrorOption(cause), {
-					onNone: () => "Internal Server Error",
-					onSome: (error: unknown) =>
-						error instanceof Error && error.message ? error.message : "Internal Server Error",
-				})
-				return Effect.succeed(
-					HttpServerResponse.text(message, {
-						status: 500,
-						statusText: message,
-					}),
-				)
+	Object.defineProperty(request, "raw", {
+		get: () =>
+			Object.assign(request.stream, {
+				raw: webRequest.body,
 			}),
-		)
+	})
 
-		return HttpServerResponse.toWeb(response, {
-			context: yield* Effect.context(),
-		})
-	}) as Effect.Effect<globalThis.Response, never, Exclude<Req, HttpServerRequest.HttpServerRequest | Scope>>
+	const response = yield* safeHttpEffect(handler).pipe(
+		Effect.provideService(HttpServerRequest.HttpServerRequest, request),
+		Effect.provideService(RequestService, webRequest),
+		Effect.catchCause((cause) => {
+			const message = Option.match(Cause.findErrorOption(cause), {
+				onNone: () => "Internal Server Error",
+				onSome: (error: unknown) =>
+					error instanceof Error && error.message ? error.message : "Internal Server Error",
+			})
+			return Effect.succeed(
+				HttpServerResponse.text(message, {
+					status: 500,
+					statusText: message,
+				}),
+			)
+		}),
+	)
+
+	return HttpServerResponse.toWeb(response, {
+		context: yield* Effect.context(),
+	})
+}) as <Req = never>(
+	webRequest: globalThis.Request,
+	handler: HttpEffect<Req>,
+	options?: {
+		remoteAddress?: string
+		acceptWebSocket?: (socket: unknown) => void
+	},
+) => Effect.Effect<globalThis.Response, never, Exclude<Req, HttpServerRequest.HttpServerRequest | Scope>>

--- a/lib/effect-sdk/src/server/config.ts
+++ b/lib/effect-sdk/src/server/config.ts
@@ -79,10 +79,13 @@ const REPOSITORY_URL_ENV_KEYS = [
 /** Resolve the repository URL via the ConfigProvider (see resolveRepositoryUrl). */
 export const repositoryUrl = Effect.gen(function* () {
 	const values = new Map<string, string>()
-	for (const key of REPOSITORY_URL_ENV_KEYS) {
-		const value = yield* Config.option(Config.string(key))
-		if (Option.isSome(value)) values.set(key, value.value)
-	}
+	yield* Effect.forEach(REPOSITORY_URL_ENV_KEYS, (key) =>
+		Config.option(Config.string(key)).pipe(
+			Effect.map((value) => {
+				if (Option.isSome(value)) values.set(key, value.value)
+			}),
+		),
+	)
 	return resolveRepositoryUrl((key) => values.get(key))
 })
 

--- a/lib/effect-sdk/src/server/resource.ts
+++ b/lib/effect-sdk/src/server/resource.ts
@@ -93,62 +93,61 @@ export interface ResolvedResource {
  * (`Otlp.layerJson`-based) and the Cloudflare preset (custom flushable
  * tracer/logger) so both stamp identical resources on outgoing telemetry.
  */
-export const resolveResource = (config: ResourceConfigInput): Effect.Effect<ResolvedResource> =>
-	Effect.gen(function* () {
-		const envEndpoint = yield* EnvConfig.endpoint
-		const endpoint = config.endpoint ?? Option.getOrUndefined(envEndpoint) ?? DEFAULT_MAPLE_ENDPOINT
+export const resolveResource = Effect.fn("resolveResource")(function* (config: ResourceConfigInput) {
+	const envEndpoint = yield* EnvConfig.endpoint
+	const endpoint = config.endpoint ?? Option.getOrUndefined(envEndpoint) ?? DEFAULT_MAPLE_ENDPOINT
 
-		const envIngestKey = yield* EnvConfig.ingestKey
-		const ingestKey = config.ingestKey
-			? Redacted.make(config.ingestKey)
-			: Option.getOrUndefined(envIngestKey)
+	const envIngestKey = yield* EnvConfig.ingestKey
+	const ingestKey = config.ingestKey
+		? Redacted.make(config.ingestKey)
+		: Option.getOrUndefined(envIngestKey)
 
-		const envServiceVersion = yield* EnvConfig.serviceVersion
-		const serviceVersion = config.serviceVersion ?? Option.getOrUndefined(envServiceVersion)
+	const envServiceVersion = yield* EnvConfig.serviceVersion
+	const serviceVersion = config.serviceVersion ?? Option.getOrUndefined(envServiceVersion)
 
-		const envRepositoryUrl = yield* EnvConfig.repositoryUrl
-		const repositoryUrl = config.repositoryUrl ?? envRepositoryUrl
-		// Prefer the platform-provided commit SHA; fall back to serviceVersion only
-		// when it is itself SHA-shaped. Never shell out to git at runtime.
-		const headRevision =
-			Option.getOrUndefined(envServiceVersion) ??
-			(isCommitSha(serviceVersion) ? serviceVersion : undefined)
+	const envRepositoryUrl = yield* EnvConfig.repositoryUrl
+	const repositoryUrl = config.repositoryUrl ?? envRepositoryUrl
+	// Prefer the platform-provided commit SHA; fall back to serviceVersion only
+	// when it is itself SHA-shaped. Never shell out to git at runtime.
+	const headRevision =
+		Option.getOrUndefined(envServiceVersion) ??
+		(isCommitSha(serviceVersion) ? serviceVersion : undefined)
 
-		const envEnvironment = yield* EnvConfig.environment
-		const environment = config.environment ?? envEnvironment
+	const envEnvironment = yield* EnvConfig.environment
+	const environment = config.environment ?? envEnvironment
 
-		const envOtelServiceName = yield* EnvConfig.otelServiceName
-		const serviceName = config.serviceName ?? Option.getOrUndefined(envOtelServiceName) ?? "unknown"
+	const envOtelServiceName = yield* EnvConfig.otelServiceName
+	const serviceName = config.serviceName ?? Option.getOrUndefined(envOtelServiceName) ?? "unknown"
 
-		const envResourceAttributes = yield* EnvConfig.otelResourceAttributes
+	const envResourceAttributes = yield* EnvConfig.otelResourceAttributes
 
-		const attributes: Record<string, unknown> = {}
-		Object.assign(attributes, getAutoPlatformAttributes())
-		attributes["maple.sdk.type"] = config.sdkType ?? "server"
-		attributes["service.instance.id"] = getServiceInstanceId()
-		if (environment) {
-			// Dual-emit: every Tinybird MV (`service_overview_spans_mv` et al.)
-			// pre-extracts the legacy `deployment.environment` key, but query
-			// consumers in `packages/query-engine/src/ch/queries/infra.ts` already
-			// select on `deployment.environment.name` (the OTel-canonical key).
-			// Emit both until the MVs migrate to `coalesce()`.
-			attributes["deployment.environment"] = environment
-			attributes["deployment.environment.name"] = environment
-		}
-		if (serviceVersion) attributes["deployment.commit_sha"] = serviceVersion
-		if (repositoryUrl) attributes["vcs.repository.url.full"] = repositoryUrl
-		if (headRevision) attributes["vcs.ref.head.revision"] = headRevision
-		if (config.serviceNamespace) attributes["service.namespace"] = config.serviceNamespace
-		Object.assign(attributes, envResourceAttributes)
-		if (config.attributes) Object.assign(attributes, config.attributes)
+	const attributes: Record<string, unknown> = {}
+	Object.assign(attributes, getAutoPlatformAttributes())
+	attributes["maple.sdk.type"] = config.sdkType ?? "server"
+	attributes["service.instance.id"] = getServiceInstanceId()
+	if (environment) {
+		// Dual-emit: every Tinybird MV (`service_overview_spans_mv` et al.)
+		// pre-extracts the legacy `deployment.environment` key, but query
+		// consumers in `packages/query-engine/src/ch/queries/infra.ts` already
+		// select on `deployment.environment.name` (the OTel-canonical key).
+		// Emit both until the MVs migrate to `coalesce()`.
+		attributes["deployment.environment"] = environment
+		attributes["deployment.environment.name"] = environment
+	}
+	if (serviceVersion) attributes["deployment.commit_sha"] = serviceVersion
+	if (repositoryUrl) attributes["vcs.repository.url.full"] = repositoryUrl
+	if (headRevision) attributes["vcs.ref.head.revision"] = headRevision
+	if (config.serviceNamespace) attributes["service.namespace"] = config.serviceNamespace
+	Object.assign(attributes, envResourceAttributes)
+	if (config.attributes) Object.assign(attributes, config.attributes)
 
-		return {
-			endpoint,
-			ingestKey,
-			environment,
-			resource: { serviceName, serviceVersion, attributes },
-		} satisfies ResolvedResource
-	}).pipe(Effect.orDie)
+	return {
+		endpoint,
+		ingestKey,
+		environment,
+		resource: { serviceName, serviceVersion, attributes },
+	} satisfies ResolvedResource
+}, Effect.orDie)
 
 /**
  * Synchronous resource resolver for environments where reading from a

--- a/lib/effect-sdk/src/shared/flushable-tracer.test.ts
+++ b/lib/effect-sdk/src/shared/flushable-tracer.test.ts
@@ -13,38 +13,44 @@ class BenignError extends Data.TaggedError("BenignError")<{}> {
 class ReportableError extends Data.TaggedError("ReportableError")<{}> {}
 
 const runSpan = (buffer: ReturnType<typeof makeSpanBuffer>, effect: Effect.Effect<unknown, unknown>) =>
-	Effect.runPromise(
-		effect.pipe(Effect.withSpan("http.server GET"), Effect.provide(buffer.tracerLayer), Effect.exit),
-	)
+	effect.pipe(Effect.withSpan("http.server GET"), Effect.provide(buffer.tracerLayer), Effect.exit)
 
 describe("makeSpanBuffer ignored-failure drop", () => {
-	it("drops spans whose failure carries [ErrorReporter.ignore]", async () => {
-		const buffer = makeSpanBuffer()
-		await runSpan(buffer, Effect.fail(new BenignError()))
-		assert.strictEqual(buffer.size(), 0)
-	})
+	it.effect("drops spans whose failure carries [ErrorReporter.ignore]", () =>
+		Effect.gen(function* () {
+			const buffer = makeSpanBuffer()
+			yield* runSpan(buffer, Effect.fail(new BenignError()))
+			assert.strictEqual(buffer.size(), 0)
+		}),
+	)
 
-	it("keeps spans that fail with a reportable error", async () => {
-		const buffer = makeSpanBuffer()
-		await runSpan(buffer, Effect.fail(new ReportableError()))
-		assert.strictEqual(buffer.size(), 1)
-	})
+	it.effect("keeps spans that fail with a reportable error", () =>
+		Effect.gen(function* () {
+			const buffer = makeSpanBuffer()
+			yield* runSpan(buffer, Effect.fail(new ReportableError()))
+			assert.strictEqual(buffer.size(), 1)
+		}),
+	)
 
-	it("keeps successful spans", async () => {
-		const buffer = makeSpanBuffer()
-		await runSpan(buffer, Effect.succeed(undefined))
-		assert.strictEqual(buffer.size(), 1)
-	})
+	it.effect("keeps successful spans", () =>
+		Effect.gen(function* () {
+			const buffer = makeSpanBuffer()
+			yield* runSpan(buffer, Effect.succeed(undefined))
+			assert.strictEqual(buffer.size(), 1)
+		}),
+	)
 
 	// Pins the upstream contract: the actual error HttpRouter raises for an
 	// unmatched route must stay [ErrorReporter.ignore]-flagged, so the drop holds.
-	it("drops the real HttpServerError/RouteNotFound", async () => {
-		const buffer = makeSpanBuffer()
-		const request = HttpServerRequest.fromWeb(new Request("http://localhost/nope"))
-		const error = new HttpServerError.HttpServerError({
-			reason: new HttpServerError.RouteNotFound({ request }),
-		})
-		await runSpan(buffer, Effect.fail(error))
-		assert.strictEqual(buffer.size(), 0)
-	})
+	it.effect("drops the real HttpServerError/RouteNotFound", () =>
+		Effect.gen(function* () {
+			const buffer = makeSpanBuffer()
+			const request = HttpServerRequest.fromWeb(new Request("http://localhost/nope"))
+			const error = new HttpServerError.HttpServerError({
+				reason: new HttpServerError.RouteNotFound({ request }),
+			})
+			yield* runSpan(buffer, Effect.fail(error))
+			assert.strictEqual(buffer.size(), 0)
+		}),
+	)
 })

--- a/packages/domain/src/http/api-keys.ts
+++ b/packages/domain/src/http/api-keys.ts
@@ -43,9 +43,9 @@ export class ApiKeysListResponse extends Schema.Class<ApiKeysListResponse>("ApiK
 
 export class CreateApiKeyRequest extends Schema.Class<CreateApiKeyRequest>("CreateApiKeyRequest")({
 	name: Schema.String,
-	description: Schema.optional(Schema.String),
-	expiresInSeconds: Schema.optional(Schema.Number),
-	kind: Schema.optional(ApiKeyKind),
+	description: Schema.optionalKey(Schema.String),
+	expiresInSeconds: Schema.optionalKey(Schema.Number),
+	kind: Schema.optionalKey(ApiKeyKind),
 }) {}
 
 export class ApiKeyPersistenceError extends Schema.TaggedErrorClass<ApiKeyPersistenceError>()(

--- a/packages/domain/src/http/api-keys.ts
+++ b/packages/domain/src/http/api-keys.ts
@@ -43,9 +43,9 @@ export class ApiKeysListResponse extends Schema.Class<ApiKeysListResponse>("ApiK
 
 export class CreateApiKeyRequest extends Schema.Class<CreateApiKeyRequest>("CreateApiKeyRequest")({
 	name: Schema.String,
-	description: Schema.optionalKey(Schema.String),
-	expiresInSeconds: Schema.optionalKey(Schema.Number),
-	kind: Schema.optionalKey(ApiKeyKind),
+	description: Schema.optional(Schema.String),
+	expiresInSeconds: Schema.optional(Schema.Number),
+	kind: Schema.optional(ApiKeyKind),
 }) {}
 
 export class ApiKeyPersistenceError extends Schema.TaggedErrorClass<ApiKeyPersistenceError>()(

--- a/packages/domain/src/http/dashboards.ts
+++ b/packages/domain/src/http/dashboards.ts
@@ -28,34 +28,34 @@ const StringRecord = Schema.Record(Schema.String, Schema.String)
 
 export const WidgetDataSourceSchema = Schema.Struct({
 	endpoint: Schema.String,
-	params: Schema.optional(UnknownRecord),
-	transform: Schema.optional(
+	params: Schema.optionalKey(UnknownRecord),
+	transform: Schema.optionalKey(
 		Schema.Struct({
-			fieldMap: Schema.optional(StringRecord),
-			hideSeries: Schema.optional(
+			fieldMap: Schema.optionalKey(StringRecord),
+			hideSeries: Schema.optionalKey(
 				Schema.Struct({
 					baseNames: Schema.Array(Schema.String),
 				}),
 			),
-			flattenSeries: Schema.optional(
+			flattenSeries: Schema.optionalKey(
 				Schema.Struct({
 					valueField: Schema.String,
 				}),
 			),
-			reduceToValue: Schema.optional(
+			reduceToValue: Schema.optionalKey(
 				Schema.Struct({
 					field: Schema.String,
-					aggregate: Schema.optional(Schema.String),
+					aggregate: Schema.optionalKey(Schema.String),
 				}),
 			),
-			computeRatio: Schema.optional(
+			computeRatio: Schema.optionalKey(
 				Schema.Struct({
 					numeratorName: Schema.String,
 					denominatorNames: Schema.Array(Schema.String),
 				}),
 			),
-			limit: Schema.optional(Schema.Number),
-			sortBy: Schema.optional(
+			limit: Schema.optionalKey(Schema.Number),
+			sortBy: Schema.optionalKey(
 				Schema.Struct({
 					field: Schema.String,
 					direction: Schema.String,
@@ -68,11 +68,11 @@ export const WidgetDataSourceSchema = Schema.Struct({
 const WidgetDisplayColumnSchema = Schema.Struct({
 	field: Schema.String,
 	header: Schema.String,
-	unit: Schema.optional(Schema.String),
-	width: Schema.optional(Schema.Number),
-	align: Schema.optional(Schema.Literals(["left", "center", "right"])),
-	hidden: Schema.optional(Schema.Boolean),
-	thresholds: Schema.optional(
+	unit: Schema.optionalKey(Schema.String),
+	width: Schema.optionalKey(Schema.Number),
+	align: Schema.optionalKey(Schema.Literals(["left", "center", "right"])),
+	hidden: Schema.optionalKey(Schema.Boolean),
+	thresholds: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				value: Schema.Number,
@@ -83,118 +83,118 @@ const WidgetDisplayColumnSchema = Schema.Struct({
 })
 
 export const WidgetDisplayConfigSchema = Schema.Struct({
-	title: Schema.optional(Schema.String),
-	description: Schema.optional(Schema.String),
-	chartId: Schema.optional(Schema.String),
-	chartPresentation: Schema.optional(
+	title: Schema.optionalKey(Schema.String),
+	description: Schema.optionalKey(Schema.String),
+	chartId: Schema.optionalKey(Schema.String),
+	chartPresentation: Schema.optionalKey(
 		Schema.Struct({
-			legend: Schema.optional(Schema.Literals(["visible", "hidden", "right"])),
-			seriesStats: Schema.optional(Schema.Boolean),
-			tooltip: Schema.optional(Schema.Literals(["visible", "hidden"])),
-			showPoints: Schema.optional(Schema.Boolean),
-			fillNulls: Schema.optional(Schema.Union([Schema.Number, Schema.Literal(false)])),
-			compareToPreviousPeriod: Schema.optional(Schema.Boolean),
+			legend: Schema.optionalKey(Schema.Literals(["visible", "hidden", "right"])),
+			seriesStats: Schema.optionalKey(Schema.Boolean),
+			tooltip: Schema.optionalKey(Schema.Literals(["visible", "hidden"])),
+			showPoints: Schema.optionalKey(Schema.Boolean),
+			fillNulls: Schema.optionalKey(Schema.Union([Schema.Number, Schema.Literal(false)])),
+			compareToPreviousPeriod: Schema.optionalKey(Schema.Boolean),
 		}),
 	),
-	xAxis: Schema.optional(
+	xAxis: Schema.optionalKey(
 		Schema.Struct({
-			label: Schema.optional(Schema.String),
-			unit: Schema.optional(Schema.String),
-			visible: Schema.optional(Schema.Boolean),
+			label: Schema.optionalKey(Schema.String),
+			unit: Schema.optionalKey(Schema.String),
+			visible: Schema.optionalKey(Schema.Boolean),
 		}),
 	),
-	yAxis: Schema.optional(
+	yAxis: Schema.optionalKey(
 		Schema.Struct({
-			label: Schema.optional(Schema.String),
-			unit: Schema.optional(Schema.String),
-			min: Schema.optional(Schema.Number),
-			max: Schema.optional(Schema.Number),
-			softMin: Schema.optional(Schema.Number),
-			softMax: Schema.optional(Schema.Number),
-			logScale: Schema.optional(Schema.Boolean),
+			label: Schema.optionalKey(Schema.String),
+			unit: Schema.optionalKey(Schema.String),
+			min: Schema.optionalKey(Schema.Number),
+			max: Schema.optionalKey(Schema.Number),
+			softMin: Schema.optionalKey(Schema.Number),
+			softMax: Schema.optionalKey(Schema.Number),
+			logScale: Schema.optionalKey(Schema.Boolean),
 			// When true, the y-axis lower bound follows the minimum of the
 			// displayed data (with padding) instead of being pinned at zero,
 			// making small fluctuations between series easier to see. Ignored
 			// when `softMin`/`min` or `logScale` are set.
-			fitYAxisToData: Schema.optional(Schema.Boolean),
-			visible: Schema.optional(Schema.Boolean),
+			fitYAxisToData: Schema.optionalKey(Schema.Boolean),
+			visible: Schema.optionalKey(Schema.Boolean),
 		}),
 	),
-	seriesMapping: Schema.optional(StringRecord),
-	colorOverrides: Schema.optional(StringRecord),
-	stacked: Schema.optional(Schema.Boolean),
-	curveType: Schema.optional(Schema.Literals(["linear", "monotone"])),
-	unit: Schema.optional(Schema.String),
-	thresholds: Schema.optional(
+	seriesMapping: Schema.optionalKey(StringRecord),
+	colorOverrides: Schema.optionalKey(StringRecord),
+	stacked: Schema.optionalKey(Schema.Boolean),
+	curveType: Schema.optionalKey(Schema.Literals(["linear", "monotone"])),
+	unit: Schema.optionalKey(Schema.String),
+	thresholds: Schema.optionalKey(
 		Schema.Array(
 			Schema.Struct({
 				value: Schema.Number,
 				color: Schema.String,
-				label: Schema.optional(Schema.String),
+				label: Schema.optionalKey(Schema.String),
 			}),
 		),
 	),
-	prefix: Schema.optional(Schema.String),
-	suffix: Schema.optional(Schema.String),
-	sparkline: Schema.optional(
+	prefix: Schema.optionalKey(Schema.String),
+	suffix: Schema.optionalKey(Schema.String),
+	sparkline: Schema.optionalKey(
 		Schema.Struct({
 			enabled: Schema.Boolean,
-			dataSource: Schema.optional(WidgetDataSourceSchema),
+			dataSource: Schema.optionalKey(WidgetDataSourceSchema),
 		}),
 	),
-	columns: Schema.optional(Schema.Array(WidgetDisplayColumnSchema)),
+	columns: Schema.optionalKey(Schema.Array(WidgetDisplayColumnSchema)),
 
 	// List-specific
-	listDataSource: Schema.optional(Schema.String),
-	listWhereClause: Schema.optional(Schema.String),
-	listLimit: Schema.optional(Schema.Number),
-	listRootOnly: Schema.optional(Schema.Boolean),
+	listDataSource: Schema.optionalKey(Schema.String),
+	listWhereClause: Schema.optionalKey(Schema.String),
+	listLimit: Schema.optionalKey(Schema.Number),
+	listRootOnly: Schema.optionalKey(Schema.Boolean),
 
 	// Pie-specific
-	pie: Schema.optional(
+	pie: Schema.optionalKey(
 		Schema.Struct({
-			donut: Schema.optional(Schema.Boolean),
-			innerRadius: Schema.optional(Schema.Number),
-			showLabels: Schema.optional(Schema.Boolean),
-			showPercent: Schema.optional(Schema.Boolean),
+			donut: Schema.optionalKey(Schema.Boolean),
+			innerRadius: Schema.optionalKey(Schema.Number),
+			showLabels: Schema.optionalKey(Schema.Boolean),
+			showPercent: Schema.optionalKey(Schema.Boolean),
 		}),
 	),
 
 	// Funnel-specific
-	funnel: Schema.optional(
+	funnel: Schema.optionalKey(
 		Schema.Struct({
-			showStepPercent: Schema.optional(Schema.Boolean),
+			showStepPercent: Schema.optionalKey(Schema.Boolean),
 		}),
 	),
 
 	// Histogram-specific
-	histogram: Schema.optional(
+	histogram: Schema.optionalKey(
 		Schema.Struct({
-			bucketCount: Schema.optional(Schema.Number),
-			bucketWidth: Schema.optional(Schema.Number),
-			logScaleY: Schema.optional(Schema.Boolean),
+			bucketCount: Schema.optionalKey(Schema.Number),
+			bucketWidth: Schema.optionalKey(Schema.Number),
+			logScaleY: Schema.optionalKey(Schema.Boolean),
 		}),
 	),
 
 	// Heatmap-specific
-	heatmap: Schema.optional(
+	heatmap: Schema.optionalKey(
 		Schema.Struct({
-			colorScale: Schema.optional(Schema.Literals(["viridis", "magma", "cividis", "blues", "reds"])),
-			scaleType: Schema.optional(Schema.Literals(["linear", "log"])),
+			colorScale: Schema.optionalKey(Schema.Literals(["viridis", "magma", "cividis", "blues", "reds"])),
+			scaleType: Schema.optionalKey(Schema.Literals(["linear", "log"])),
 		}),
 	),
 
 	// Gauge-specific
-	gauge: Schema.optional(
+	gauge: Schema.optionalKey(
 		Schema.Struct({
-			min: Schema.optional(Schema.Number),
-			max: Schema.optional(Schema.Number),
-			style: Schema.optional(Schema.Literals(["radial", "bar"])),
+			min: Schema.optionalKey(Schema.Number),
+			max: Schema.optionalKey(Schema.Number),
+			style: Schema.optionalKey(Schema.Literals(["radial", "bar"])),
 		}),
 	),
 
 	// Markdown-specific
-	markdown: Schema.optional(
+	markdown: Schema.optionalKey(
 		Schema.Struct({
 			content: Schema.String,
 		}),
@@ -206,10 +206,10 @@ export const WidgetLayoutSchema = Schema.Struct({
 	y: Schema.Number,
 	w: Schema.Number,
 	h: Schema.Number,
-	minW: Schema.optional(Schema.Number),
-	minH: Schema.optional(Schema.Number),
-	maxW: Schema.optional(Schema.Number),
-	maxH: Schema.optional(Schema.Number),
+	minW: Schema.optionalKey(Schema.Number),
+	minH: Schema.optionalKey(Schema.Number),
+	maxW: Schema.optionalKey(Schema.Number),
+	maxH: Schema.optionalKey(Schema.Number),
 })
 
 export const DashboardWidgetSchema = Schema.Struct({

--- a/packages/domain/src/http/dashboards.ts
+++ b/packages/domain/src/http/dashboards.ts
@@ -28,34 +28,34 @@ const StringRecord = Schema.Record(Schema.String, Schema.String)
 
 export const WidgetDataSourceSchema = Schema.Struct({
 	endpoint: Schema.String,
-	params: Schema.optionalKey(UnknownRecord),
-	transform: Schema.optionalKey(
+	params: Schema.optional(UnknownRecord),
+	transform: Schema.optional(
 		Schema.Struct({
-			fieldMap: Schema.optionalKey(StringRecord),
-			hideSeries: Schema.optionalKey(
+			fieldMap: Schema.optional(StringRecord),
+			hideSeries: Schema.optional(
 				Schema.Struct({
 					baseNames: Schema.Array(Schema.String),
 				}),
 			),
-			flattenSeries: Schema.optionalKey(
+			flattenSeries: Schema.optional(
 				Schema.Struct({
 					valueField: Schema.String,
 				}),
 			),
-			reduceToValue: Schema.optionalKey(
+			reduceToValue: Schema.optional(
 				Schema.Struct({
 					field: Schema.String,
-					aggregate: Schema.optionalKey(Schema.String),
+					aggregate: Schema.optional(Schema.String),
 				}),
 			),
-			computeRatio: Schema.optionalKey(
+			computeRatio: Schema.optional(
 				Schema.Struct({
 					numeratorName: Schema.String,
 					denominatorNames: Schema.Array(Schema.String),
 				}),
 			),
-			limit: Schema.optionalKey(Schema.Number),
-			sortBy: Schema.optionalKey(
+			limit: Schema.optional(Schema.Number),
+			sortBy: Schema.optional(
 				Schema.Struct({
 					field: Schema.String,
 					direction: Schema.String,
@@ -68,11 +68,11 @@ export const WidgetDataSourceSchema = Schema.Struct({
 const WidgetDisplayColumnSchema = Schema.Struct({
 	field: Schema.String,
 	header: Schema.String,
-	unit: Schema.optionalKey(Schema.String),
-	width: Schema.optionalKey(Schema.Number),
-	align: Schema.optionalKey(Schema.Literals(["left", "center", "right"])),
-	hidden: Schema.optionalKey(Schema.Boolean),
-	thresholds: Schema.optionalKey(
+	unit: Schema.optional(Schema.String),
+	width: Schema.optional(Schema.Number),
+	align: Schema.optional(Schema.Literals(["left", "center", "right"])),
+	hidden: Schema.optional(Schema.Boolean),
+	thresholds: Schema.optional(
 		Schema.Array(
 			Schema.Struct({
 				value: Schema.Number,
@@ -83,118 +83,118 @@ const WidgetDisplayColumnSchema = Schema.Struct({
 })
 
 export const WidgetDisplayConfigSchema = Schema.Struct({
-	title: Schema.optionalKey(Schema.String),
-	description: Schema.optionalKey(Schema.String),
-	chartId: Schema.optionalKey(Schema.String),
-	chartPresentation: Schema.optionalKey(
+	title: Schema.optional(Schema.String),
+	description: Schema.optional(Schema.String),
+	chartId: Schema.optional(Schema.String),
+	chartPresentation: Schema.optional(
 		Schema.Struct({
-			legend: Schema.optionalKey(Schema.Literals(["visible", "hidden", "right"])),
-			seriesStats: Schema.optionalKey(Schema.Boolean),
-			tooltip: Schema.optionalKey(Schema.Literals(["visible", "hidden"])),
-			showPoints: Schema.optionalKey(Schema.Boolean),
-			fillNulls: Schema.optionalKey(Schema.Union([Schema.Number, Schema.Literal(false)])),
-			compareToPreviousPeriod: Schema.optionalKey(Schema.Boolean),
+			legend: Schema.optional(Schema.Literals(["visible", "hidden", "right"])),
+			seriesStats: Schema.optional(Schema.Boolean),
+			tooltip: Schema.optional(Schema.Literals(["visible", "hidden"])),
+			showPoints: Schema.optional(Schema.Boolean),
+			fillNulls: Schema.optional(Schema.Union([Schema.Number, Schema.Literal(false)])),
+			compareToPreviousPeriod: Schema.optional(Schema.Boolean),
 		}),
 	),
-	xAxis: Schema.optionalKey(
+	xAxis: Schema.optional(
 		Schema.Struct({
-			label: Schema.optionalKey(Schema.String),
-			unit: Schema.optionalKey(Schema.String),
-			visible: Schema.optionalKey(Schema.Boolean),
+			label: Schema.optional(Schema.String),
+			unit: Schema.optional(Schema.String),
+			visible: Schema.optional(Schema.Boolean),
 		}),
 	),
-	yAxis: Schema.optionalKey(
+	yAxis: Schema.optional(
 		Schema.Struct({
-			label: Schema.optionalKey(Schema.String),
-			unit: Schema.optionalKey(Schema.String),
-			min: Schema.optionalKey(Schema.Number),
-			max: Schema.optionalKey(Schema.Number),
-			softMin: Schema.optionalKey(Schema.Number),
-			softMax: Schema.optionalKey(Schema.Number),
-			logScale: Schema.optionalKey(Schema.Boolean),
+			label: Schema.optional(Schema.String),
+			unit: Schema.optional(Schema.String),
+			min: Schema.optional(Schema.Number),
+			max: Schema.optional(Schema.Number),
+			softMin: Schema.optional(Schema.Number),
+			softMax: Schema.optional(Schema.Number),
+			logScale: Schema.optional(Schema.Boolean),
 			// When true, the y-axis lower bound follows the minimum of the
 			// displayed data (with padding) instead of being pinned at zero,
 			// making small fluctuations between series easier to see. Ignored
 			// when `softMin`/`min` or `logScale` are set.
-			fitYAxisToData: Schema.optionalKey(Schema.Boolean),
-			visible: Schema.optionalKey(Schema.Boolean),
+			fitYAxisToData: Schema.optional(Schema.Boolean),
+			visible: Schema.optional(Schema.Boolean),
 		}),
 	),
-	seriesMapping: Schema.optionalKey(StringRecord),
-	colorOverrides: Schema.optionalKey(StringRecord),
-	stacked: Schema.optionalKey(Schema.Boolean),
-	curveType: Schema.optionalKey(Schema.Literals(["linear", "monotone"])),
-	unit: Schema.optionalKey(Schema.String),
-	thresholds: Schema.optionalKey(
+	seriesMapping: Schema.optional(StringRecord),
+	colorOverrides: Schema.optional(StringRecord),
+	stacked: Schema.optional(Schema.Boolean),
+	curveType: Schema.optional(Schema.Literals(["linear", "monotone"])),
+	unit: Schema.optional(Schema.String),
+	thresholds: Schema.optional(
 		Schema.Array(
 			Schema.Struct({
 				value: Schema.Number,
 				color: Schema.String,
-				label: Schema.optionalKey(Schema.String),
+				label: Schema.optional(Schema.String),
 			}),
 		),
 	),
-	prefix: Schema.optionalKey(Schema.String),
-	suffix: Schema.optionalKey(Schema.String),
-	sparkline: Schema.optionalKey(
+	prefix: Schema.optional(Schema.String),
+	suffix: Schema.optional(Schema.String),
+	sparkline: Schema.optional(
 		Schema.Struct({
 			enabled: Schema.Boolean,
-			dataSource: Schema.optionalKey(WidgetDataSourceSchema),
+			dataSource: Schema.optional(WidgetDataSourceSchema),
 		}),
 	),
-	columns: Schema.optionalKey(Schema.Array(WidgetDisplayColumnSchema)),
+	columns: Schema.optional(Schema.Array(WidgetDisplayColumnSchema)),
 
 	// List-specific
-	listDataSource: Schema.optionalKey(Schema.String),
-	listWhereClause: Schema.optionalKey(Schema.String),
-	listLimit: Schema.optionalKey(Schema.Number),
-	listRootOnly: Schema.optionalKey(Schema.Boolean),
+	listDataSource: Schema.optional(Schema.String),
+	listWhereClause: Schema.optional(Schema.String),
+	listLimit: Schema.optional(Schema.Number),
+	listRootOnly: Schema.optional(Schema.Boolean),
 
 	// Pie-specific
-	pie: Schema.optionalKey(
+	pie: Schema.optional(
 		Schema.Struct({
-			donut: Schema.optionalKey(Schema.Boolean),
-			innerRadius: Schema.optionalKey(Schema.Number),
-			showLabels: Schema.optionalKey(Schema.Boolean),
-			showPercent: Schema.optionalKey(Schema.Boolean),
+			donut: Schema.optional(Schema.Boolean),
+			innerRadius: Schema.optional(Schema.Number),
+			showLabels: Schema.optional(Schema.Boolean),
+			showPercent: Schema.optional(Schema.Boolean),
 		}),
 	),
 
 	// Funnel-specific
-	funnel: Schema.optionalKey(
+	funnel: Schema.optional(
 		Schema.Struct({
-			showStepPercent: Schema.optionalKey(Schema.Boolean),
+			showStepPercent: Schema.optional(Schema.Boolean),
 		}),
 	),
 
 	// Histogram-specific
-	histogram: Schema.optionalKey(
+	histogram: Schema.optional(
 		Schema.Struct({
-			bucketCount: Schema.optionalKey(Schema.Number),
-			bucketWidth: Schema.optionalKey(Schema.Number),
-			logScaleY: Schema.optionalKey(Schema.Boolean),
+			bucketCount: Schema.optional(Schema.Number),
+			bucketWidth: Schema.optional(Schema.Number),
+			logScaleY: Schema.optional(Schema.Boolean),
 		}),
 	),
 
 	// Heatmap-specific
-	heatmap: Schema.optionalKey(
+	heatmap: Schema.optional(
 		Schema.Struct({
-			colorScale: Schema.optionalKey(Schema.Literals(["viridis", "magma", "cividis", "blues", "reds"])),
-			scaleType: Schema.optionalKey(Schema.Literals(["linear", "log"])),
+			colorScale: Schema.optional(Schema.Literals(["viridis", "magma", "cividis", "blues", "reds"])),
+			scaleType: Schema.optional(Schema.Literals(["linear", "log"])),
 		}),
 	),
 
 	// Gauge-specific
-	gauge: Schema.optionalKey(
+	gauge: Schema.optional(
 		Schema.Struct({
-			min: Schema.optionalKey(Schema.Number),
-			max: Schema.optionalKey(Schema.Number),
-			style: Schema.optionalKey(Schema.Literals(["radial", "bar"])),
+			min: Schema.optional(Schema.Number),
+			max: Schema.optional(Schema.Number),
+			style: Schema.optional(Schema.Literals(["radial", "bar"])),
 		}),
 	),
 
 	// Markdown-specific
-	markdown: Schema.optionalKey(
+	markdown: Schema.optional(
 		Schema.Struct({
 			content: Schema.String,
 		}),
@@ -206,10 +206,10 @@ export const WidgetLayoutSchema = Schema.Struct({
 	y: Schema.Number,
 	w: Schema.Number,
 	h: Schema.Number,
-	minW: Schema.optionalKey(Schema.Number),
-	minH: Schema.optionalKey(Schema.Number),
-	maxW: Schema.optionalKey(Schema.Number),
-	maxH: Schema.optionalKey(Schema.Number),
+	minW: Schema.optional(Schema.Number),
+	minH: Schema.optional(Schema.Number),
+	maxW: Schema.optional(Schema.Number),
+	maxH: Schema.optional(Schema.Number),
 })
 
 export const DashboardWidgetSchema = Schema.Struct({

--- a/packages/domain/src/http/demo.ts
+++ b/packages/domain/src/http/demo.ts
@@ -3,7 +3,7 @@ import { Schema } from "effect"
 import { Authorization } from "./current-tenant"
 
 export class DemoSeedRequest extends Schema.Class<DemoSeedRequest>("DemoSeedRequest")({
-	hours: Schema.optional(Schema.Number),
+	hours: Schema.optionalKey(Schema.Number),
 }) {}
 
 export class DemoSeedResponse extends Schema.Class<DemoSeedResponse>("DemoSeedResponse")({

--- a/packages/domain/src/http/demo.ts
+++ b/packages/domain/src/http/demo.ts
@@ -3,7 +3,7 @@ import { Schema } from "effect"
 import { Authorization } from "./current-tenant"
 
 export class DemoSeedRequest extends Schema.Class<DemoSeedRequest>("DemoSeedRequest")({
-	hours: Schema.optionalKey(Schema.Number),
+	hours: Schema.optional(Schema.Number),
 }) {}
 
 export class DemoSeedResponse extends Schema.Class<DemoSeedResponse>("DemoSeedResponse")({

--- a/packages/domain/src/http/observability.ts
+++ b/packages/domain/src/http/observability.ts
@@ -218,7 +218,7 @@ export class ObservabilityApiError extends Schema.TaggedErrorClass<Observability
 	"@maple/http/errors/ObservabilityApiError",
 	{
 		message: Schema.String,
-		pipe: Schema.optionalKey(Schema.String),
+		pipeName: Schema.optionalKey(Schema.String),
 		cause: Schema.optionalKey(Schema.Defect()),
 	},
 	{ httpApiStatus: 500 },

--- a/packages/domain/src/http/query-engine.ts
+++ b/packages/domain/src/http/query-engine.ts
@@ -1182,7 +1182,7 @@ export class QueryEngineExecutionError extends Schema.TaggedErrorClass<QueryEngi
 	{
 		message: Schema.String,
 		causeMessage: Schema.optional(Schema.String),
-		pipe: Schema.optional(Schema.String),
+		pipeName: Schema.optional(Schema.String),
 	},
 	{ httpApiStatus: 502 },
 ) {}

--- a/packages/domain/src/http/warehouse-errors.ts
+++ b/packages/domain/src/http/warehouse-errors.ts
@@ -21,7 +21,7 @@ import { Schema } from "effect"
 // defect; `clickhouse*` carry CH diagnostics extracted by `mapWarehouseError`.
 const warehouseErrorBaseFields = {
 	message: Schema.String,
-	pipe: Schema.String,
+	pipeName: Schema.String,
 	cause: Schema.optionalKey(Schema.Defect()),
 	clickhouseCode: Schema.optional(Schema.String),
 	clickhouseType: Schema.optional(Schema.String),

--- a/packages/domain/src/http/warehouse.ts
+++ b/packages/domain/src/http/warehouse.ts
@@ -17,7 +17,7 @@ const WarehouseQueryNameSchema = Schema.Literals(warehouseQueries)
 const UnknownRecord = Schema.Record(Schema.String, Schema.Unknown)
 
 export class WarehouseQueryRequest extends Schema.Class<WarehouseQueryRequest>("WarehouseQueryRequest")({
-	pipe: WarehouseQueryNameSchema,
+	pipeName: WarehouseQueryNameSchema,
 	params: Schema.optionalKey(UnknownRecord),
 }) {}
 

--- a/packages/domain/src/tinybird/project-sync.ts
+++ b/packages/domain/src/tinybird/project-sync.ts
@@ -113,11 +113,11 @@ export interface TinybirdInstanceHealth {
 }
 
 const SqlResponseSchema = Schema.Struct({
-	data: Schema.optional(Schema.Array(Schema.Record(Schema.String, Schema.Unknown))),
+	data: Schema.optionalKey(Schema.Array(Schema.Record(Schema.String, Schema.Unknown))),
 })
 
 const WorkspaceProbeSchema = Schema.Struct({
-	name: Schema.optional(Schema.String),
+	name: Schema.optionalKey(Schema.String),
 })
 
 export class TinybirdSyncRejectedError extends Schema.TaggedErrorClass<TinybirdSyncRejectedError>()(
@@ -696,7 +696,7 @@ export class TinybirdProjectSync extends Context.Service<TinybirdProjectSync, Ti
 				cleanupOwnedDeployment,
 				fetchInstanceHealth,
 				getCurrentProjectRevision,
-			}
+			} satisfies TinybirdProjectSyncShape
 		}),
 	},
 ) {

--- a/packages/domain/src/tinybird/project-sync.ts
+++ b/packages/domain/src/tinybird/project-sync.ts
@@ -113,11 +113,11 @@ export interface TinybirdInstanceHealth {
 }
 
 const SqlResponseSchema = Schema.Struct({
-	data: Schema.optionalKey(Schema.Array(Schema.Record(Schema.String, Schema.Unknown))),
+	data: Schema.optional(Schema.Array(Schema.Record(Schema.String, Schema.Unknown))),
 })
 
 const WorkspaceProbeSchema = Schema.Struct({
-	name: Schema.optionalKey(Schema.String),
+	name: Schema.optional(Schema.String),
 })
 
 export class TinybirdSyncRejectedError extends Schema.TaggedErrorClass<TinybirdSyncRejectedError>()(

--- a/packages/query-engine/src/caching/edge-cache.ts
+++ b/packages/query-engine/src/caching/edge-cache.ts
@@ -217,40 +217,38 @@ export const makeEdgeCacheService = (backend: EdgeCacheBackend): EdgeCacheServic
 		)
 	})
 
-	const rawGet = <A>(bucket: string, key: string): Effect.Effect<Option.Option<A>, EdgeCacheIOError> =>
-		Effect.gen(function* () {
-			const nowMs = yield* Clock.currentTimeMillis
-			return yield* Effect.tryPromise({
-				try: () => backend.get(bucket, key, nowMs),
-				catch: (cause) =>
-					new EdgeCacheIOError({
-						op: "get",
-						bucket,
-						key,
-						cause: cause instanceof Error ? cause.message : String(cause),
-					}),
-			}).pipe(Effect.map((value) => (value === undefined ? Option.none<A>() : Option.some(value as A))))
-		})
+	const rawGet = Effect.fn("EdgeCache.rawGet")(function* <A>(bucket: string, key: string) {
+		const nowMs = yield* Clock.currentTimeMillis
+		return yield* Effect.tryPromise({
+			try: () => backend.get(bucket, key, nowMs),
+			catch: (cause) =>
+				new EdgeCacheIOError({
+					op: "get",
+					bucket,
+					key,
+					cause: cause instanceof Error ? cause.message : String(cause),
+				}),
+		}).pipe(Effect.map((value) => (value === undefined ? Option.none<A>() : Option.some(value as A))))
+	})
 
-	const rawPut = (
+	const rawPut = Effect.fn("EdgeCache.rawPut")(function* (
 		bucket: string,
 		key: string,
 		value: unknown,
 		ttlSeconds: number,
-	): Effect.Effect<void, EdgeCacheIOError> =>
-		Effect.gen(function* () {
-			const nowMs = yield* Clock.currentTimeMillis
-			return yield* Effect.tryPromise({
-				try: () => backend.put(bucket, key, value, ttlSeconds, nowMs),
-				catch: (cause) =>
-					new EdgeCacheIOError({
-						op: "put",
-						bucket,
-						key,
-						cause: cause instanceof Error ? cause.message : String(cause),
-					}),
-			})
+	) {
+		const nowMs = yield* Clock.currentTimeMillis
+		return yield* Effect.tryPromise({
+			try: () => backend.put(bucket, key, value, ttlSeconds, nowMs),
+			catch: (cause) =>
+				new EdgeCacheIOError({
+					op: "put",
+					bucket,
+					key,
+					cause: cause instanceof Error ? cause.message : String(cause),
+				}),
 		})
+	})
 
 	return { getOrCompute, invalidate, rawGet, rawPut } satisfies EdgeCacheServiceShape
 }

--- a/packages/query-engine/src/execution/errors.test.ts
+++ b/packages/query-engine/src/execution/errors.test.ts
@@ -15,7 +15,7 @@ describe("mapWarehouseError", () => {
 		it("maps the execution-time code to a quota error", () => {
 			const mapped = mapWarehouseError("testPipe", { message: "took too long", code: "159" })
 			expect(mapped).toBeInstanceOf(WarehouseQuotaExceededError)
-			expect(mapped).toMatchObject({ setting: "max_execution_time", pipe: "testPipe" })
+			expect(mapped).toMatchObject({ setting: "max_execution_time", pipeName: "testPipe" })
 		})
 
 		it("maps the memory code to a quota error", () => {
@@ -148,7 +148,7 @@ describe("toWarehouseQueryError", () => {
 		const mapped = toWarehouseQueryError("testPipe", cause)
 		expect(mapped).toBeInstanceOf(WarehouseQueryError)
 		expect(mapped.message).toBe("DB::Exception: boom")
-		expect(mapped.pipe).toBe("testPipe")
+		expect(mapped.pipeName).toBe("testPipe")
 		expect(mapped.cause).toBe(cause)
 	})
 })

--- a/packages/query-engine/src/execution/errors.ts
+++ b/packages/query-engine/src/execution/errors.ts
@@ -74,7 +74,7 @@ const extractUpstreamStatus = (message: string): number | undefined => {
 
 /** Fields shared by every warehouse error, built once per classification. */
 type ClassifiedBase = {
-	readonly pipe: string
+	readonly pipeName: string
 	readonly message: string
 	readonly cause: unknown
 	readonly clickhouseCode: string | undefined
@@ -151,7 +151,7 @@ const CLASSIFICATION_RULES: ReadonlyArray<ClassificationRule> = [
 export const toWarehouseQueryError = (pipe: string, error: unknown) =>
 	new WarehouseQueryError({
 		message: cleanErrorMessage(unknownToMessage(error, "Warehouse query failed")),
-		pipe,
+		pipeName: pipe,
 		cause: error,
 	})
 
@@ -159,7 +159,7 @@ export const mapWarehouseError = (pipe: string, error: unknown): WarehouseSqlErr
 	const { message: rawMessage, code, type } = getClickHouseErrorDetails(error)
 	const message = cleanErrorMessage(rawMessage)
 	const base: ClassifiedBase = {
-		pipe,
+		pipeName: pipe,
 		message,
 		cause: error,
 		clickhouseCode: code,

--- a/packages/query-engine/src/execution/executor.ts
+++ b/packages/query-engine/src/execution/executor.ts
@@ -190,34 +190,34 @@ export const makeWarehouseExecutor = (deps: WarehouseExecutorDeps): WarehouseQue
 		payload: WarehouseQueryRequest,
 		options?: SqlQueryOptions,
 	) {
-		yield* Effect.annotateCurrentSpan("pipe", payload.pipe)
+		yield* Effect.annotateCurrentSpan("pipe", payload.pipeName)
 		yield* Effect.annotateCurrentSpan("orgId", tenant.orgId)
 
 		if (!tenant.orgId || tenant.orgId.trim() === "") {
 			return yield* new WarehouseValidationError({
-				pipe: payload.pipe,
+				pipeName: payload.pipeName,
 				message: "org_id must not be empty",
 			})
 		}
 
-		const compiled = compilePipeQuery(payload.pipe, {
+		const compiled = compilePipeQuery(payload.pipeName, {
 			...payload.params,
 			org_id: tenant.orgId,
 		})
 
 		if (!compiled) {
 			return yield* new WarehouseValidationError({
-				message: `Unsupported pipe: ${payload.pipe}`,
-				pipe: payload.pipe,
+				message: `Unsupported pipe: ${payload.pipeName}`,
+				pipeName: payload.pipeName,
 			})
 		}
 
-		const rows = yield* executeSql(tenant, compiled.sql, payload.pipe, options)
+		const rows = yield* executeSql(tenant, compiled.sql, payload.pipeName, options)
 		const decodedRows = yield* compiled.decodeRows(rows).pipe(
 			Effect.mapError(
 				(error) =>
 					new WarehouseSchemaDriftError({
-						pipe: payload.pipe,
+						pipeName: payload.pipeName,
 						message: error.message,
 						cause: error,
 					}),
@@ -236,13 +236,13 @@ export const makeWarehouseExecutor = (deps: WarehouseExecutorDeps): WarehouseQue
 	) {
 		if (!tenant.orgId || tenant.orgId.trim() === "") {
 			return yield* new WarehouseValidationError({
-				pipe: "sqlQuery",
+				pipeName: "sqlQuery",
 				message: "org_id must not be empty (sqlQuery)",
 			})
 		}
 		if (!sql.includes("OrgId")) {
 			return yield* new WarehouseValidationError({
-				pipe: "sqlQuery",
+				pipeName: "sqlQuery",
 				message: "SQL query must contain OrgId filter (sqlQuery)",
 			})
 		}
@@ -259,7 +259,7 @@ export const makeWarehouseExecutor = (deps: WarehouseExecutorDeps): WarehouseQue
 			Effect.mapError(
 				(error) =>
 					new WarehouseSchemaDriftError({
-						pipe: "compiledQuery",
+						pipeName: "compiledQuery",
 						message: error.message,
 						cause: error,
 					}),
@@ -277,7 +277,7 @@ export const makeWarehouseExecutor = (deps: WarehouseExecutorDeps): WarehouseQue
 			Effect.mapError(
 				(error) =>
 					new WarehouseSchemaDriftError({
-						pipe: "compiledQueryFirst",
+						pipeName: "compiledQueryFirst",
 						message: error.message,
 						cause: error,
 					}),
@@ -335,7 +335,7 @@ export const makeWarehouseExecutor = (deps: WarehouseExecutorDeps): WarehouseQue
 			params: Record<string, unknown>,
 			options?: ExecutorQueryOptions,
 		) =>
-			query(tenant, { pipe, params }, { ...options, context: `pipe:${pipe}` }).pipe(
+			query(tenant, { pipeName: pipe, params }, { ...options, context: `pipe:${pipe}` }).pipe(
 				Effect.map((response) => ({ data: response.data as unknown as ReadonlyArray<T> })),
 				Effect.withSpan("WarehouseExecutor.query", {
 					attributes: { pipe, orgId: tenant.orgId, "query.profile": options?.profile },

--- a/packages/query-engine/src/observability/find-slow-traces.test.ts
+++ b/packages/query-engine/src/observability/find-slow-traces.test.ts
@@ -134,7 +134,7 @@ describe("findSlowTraces", () => {
 				query: () =>
 					Effect.fail(
 						new WarehouseUpstreamError({
-							pipe: "find_slow_traces",
+							pipeName: "find_slow_traces",
 							message: "ClickHouse exploded",
 							upstreamStatus: 503,
 						}),

--- a/packages/query-engine/src/observability/search-traces.ts
+++ b/packages/query-engine/src/observability/search-traces.ts
@@ -49,7 +49,7 @@ export const searchTraces = Effect.fn("Observability.searchTraces")(function* (i
 	const rootMode = !(input.spanName && !input.rootOnly)
 	if (rootMode && (input.attributeFilters?.length ?? 0) > 1) {
 		return yield* new WarehouseValidationError({
-			pipe: "search_traces",
+			pipeName: "search_traces",
 			message:
 				"Root-level trace search supports at most one attribute filter. Provide spanName for span-level search to use multiple filters.",
 		})

--- a/packages/query-engine/src/observability/session-replays.test.ts
+++ b/packages/query-engine/src/observability/session-replays.test.ts
@@ -111,7 +111,7 @@ describe("getSessionTraces", () => {
 				sqlQuery: () =>
 					Effect.fail(
 						new WarehouseUpstreamError({
-							pipe: "session_traces",
+							pipeName: "session_traces",
 							message: "ClickHouse exploded",
 							upstreamStatus: 503,
 						}),
@@ -119,7 +119,7 @@ describe("getSessionTraces", () => {
 				compiledQuery: () =>
 					Effect.fail(
 						new WarehouseUpstreamError({
-							pipe: "session_traces",
+							pipeName: "session_traces",
 							message: "ClickHouse exploded",
 							upstreamStatus: 503,
 						}),
@@ -127,7 +127,7 @@ describe("getSessionTraces", () => {
 				compiledQueryFirst: () =>
 					Effect.fail(
 						new WarehouseUpstreamError({
-							pipe: "session_traces",
+							pipeName: "session_traces",
 							message: "ClickHouse exploded",
 							upstreamStatus: 503,
 						}),

--- a/packages/query-engine/src/runtime/query-engine.ts
+++ b/packages/query-engine/src/runtime/query-engine.ts
@@ -1472,18 +1472,12 @@ export const makeQueryEngineExecute = <T extends QueryTenant>(warehouse: QueryEn
 
 		// ---- Attribute Values ----
 		if (request.query.kind === "attributeValues") {
-			const queryFn = (() => {
-				switch (request.query.scope) {
-					case "resource":
-						return CH.resourceAttributeValuesQuery
-					case "log":
-						return CH.logAttributeValuesQuery
-					case "metric":
-						return CH.metricAttributeValuesQuery
-					default:
-						return CH.spanAttributeValuesQuery
-				}
-			})()
+			const queryFn = Match.value(request.query.scope).pipe(
+				Match.when("resource", () => CH.resourceAttributeValuesQuery),
+				Match.when("log", () => CH.logAttributeValuesQuery),
+				Match.when("metric", () => CH.metricAttributeValuesQuery),
+				Match.orElse(() => CH.spanAttributeValuesQuery),
+			)
 			const rows = yield* executeCHQuery(
 				warehouse,
 				tenant,


### PR DESCRIPTION
Addresses every **Critical** and **Warning** from a whole-repo Effect v4 best-practices review (481 files).

## Verification
- ✅ `bun typecheck` — **23/23 packages clean**
- ✅ **~1,984 unit tests pass** (query-engine 624 · api 607 · web 467 · domain 149 · scraper 43 · effect-sdk 60 · cli 34)
- No behavior changes except where explicitly noted below.
- Pre-existing test-typecheck debt in `vcs.test.ts` / `GithubConnectService.test.ts` (`branch`/`fetchCommit`) is **untouched** — verified identical at the base commit.

## Criticals (7/7)
- **`pipe` → `pipeName` field rename** (3 criticals + 1 warning). An own `pipe` property shadowed Effect's prototype `.pipe()` method on `Warehouse*Error`, `QueryEngineExecutionError`, and `WarehouseQueryRequest` — same latent bug also fixed on the sibling `McpQueryError` / `ObservabilityApiError`. Propagated compiler-guided across **~90 construction/read sites** in domain/api/web/cli. A query-engine unit test was reading the shadowed *method* as a value; it now reads `pipeName` and actually proves the fix. The `pipe` query-param/variable name and `"pipe"` telemetry keys are **unchanged**.
- **`try/catch` in an Effect generator** → `Effect.try`/`Result` (`mcp/replace-dashboard-widgets`).
- **4 CLI wall-clock reads** (`new Date()`/`Date.now()`) → `Clock.currentTimeMillis` (`cli config/server/update/time`).

## Warnings
- **effect-fn:** `for…of`-over-Effect → `Effect.forEach`; bare `Effect.gen` returns → `Effect.fn`/`fnUntraced`; `switch` → `Match`; `Data.TaggedError` → `Schema.TaggedErrorClass`; manual Option unwraps → `Option.match`; `Effect.all(arr.map())` → `Effect.forEach`; `decodeUnknownSync` → `decodeUnknownEffect`.
- **errors-cause:** `catchTag`/`catchTags` replacing broad `unknown` + `_tag` sniffing; concrete error unions replacing `unknown`/`instanceof` in web warehouse hooks; tagged errors replacing `new Error`/sentinel classes.
- **observability:** spans + `annotateLogs` added (alerts.http, web metrics, session-store); CLI health probe routed through `HttpClient`.
- **tests:** bare `it` + `Effect.runPromise` → `it.effect`; vitest `expect` → `@effect/vitest` `assert`; hand-rolled clock → `TestClock`.

## ⚠️ Schema `optional` → `optionalKey` flips were REVERTED
The review flagged `Schema.optional` → `Schema.optionalKey` on HTTP payload models (api-keys, demo, ~78 dashboard widget fields, project-sync). **These were reverted** (commit `revert(schema): …`). `optionalKey` rejects an explicit `undefined` value where `optional` accepts it, and **TypeScript doesn't catch the difference** — so the failure only shows up at runtime when JS code constructs/encodes a payload with a field set to `undefined`. The dashboard widget structs are built throughout the dashboard builder, MCP widget mutations, templates, and persistence round-trips, where undefined optional fields are routine → real runtime-break risk for a convention-only warning. The only kept change in that area is project-sync's `satisfies TinybirdProjectSyncShape` (compile-time only).

## Reviewer notes — deliberately *not* converted
These would have changed behavior or hit a real constraint:
- **CAS-retry / poll-until-hit / stateful-accumulator loops** kept as loops — effect-smol has no `Effect.iterate`/`loop`, and `Effect.forEach` can't express *return-early-with-value* or *accumulate-then-fail* (`DashboardPersistenceService.mutate`, bench-queries poll, `replace-dashboard-widgets` accumulator).
- **`ScrapeTargetsService` keeps `safeFetch`** — it carries SSRF + per-redirect re-validation on arbitrary user URLs; swapping for raw `HttpClient` would be a security regression. The hand-rolled `AbortController` was still replaced with `Effect.timeout`.
- **3 `Service.of()` findings resolved via `satisfies <Shape>`** — `.of()` inside an inline `make` triggers the `TS2506` self-reference footgun; `satisfies` is the repo's correct v4 idiom and achieves the finding's intent.
- **`compare-periods.ts`** needed no change — time already flows through `lib/time.ts`, no wall-clock reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)