### PR TITLE
fix(web): stop dashboard flash during signup (MAP-45)

### DIFF
--- a/apps/web/src/atoms/selected-plan-atoms.ts
+++ b/apps/web/src/atoms/selected-plan-atoms.ts
@@ -1,0 +1,32 @@
+import { Atom } from "@/lib/effect-atom"
+import { Schema } from "effect"
+import { localStorageRuntime } from "@/lib/services/common/storage-runtime"
+
+/**
+ * Per-org memory of "this org was last seen holding an active selected plan",
+ * used by the `__root` gate to optimistically render the dashboard while the
+ * Autumn customer query is still loading. Keyed by orgId so a brand-new org
+ * (fresh signup) starts with no record — taking the no-flash "wait for the plan
+ * to settle" path — while a returning paid org skips straight to the dashboard.
+ * Cleared the moment an org is seen planless (e.g. after unsubscribing), so that
+ * case flashes the dashboard at most once and then reverts to the wait path.
+ * See MAP-45.
+ */
+const selectedPlanKnownAtomFamily = Atom.family((orgId: string) =>
+	Atom.kvs({
+		runtime: localStorageRuntime,
+		key: `maple.billing.selected-plan.${orgId}`,
+		schema: Schema.Boolean,
+		defaultValue: () => false,
+	}),
+)
+
+// Inert, in-memory fallback for renders without an active org (an org-less or
+// still-settling auth session). Lets the consuming `useAtom` call stay
+// unconditional without minting a bogus "default" org bucket in localStorage —
+// an org-less session never reads or persists the flag anyway.
+const noOrgSelectedPlanAtom = Atom.make(false)
+
+/** The per-org selected-plan flag, or an inert in-memory atom when there's no org. */
+export const selectedPlanKnownAtomFor = (orgId: string | null | undefined) =>
+	orgId ? selectedPlanKnownAtomFamily(orgId) : noOrgSelectedPlanAtom

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -9,9 +9,12 @@ import {
 	useRouterState,
 } from "@tanstack/react-router"
 import { toast } from "sonner"
+import { selectedPlanKnownAtomFor } from "@/atoms/selected-plan-atoms"
+import { useAtom } from "@/lib/effect-atom"
 import { hasSelectedPlan, isUsableCustomer } from "@/lib/billing/plan-gating"
 import { parseRedirectUrl } from "@/lib/redirect-utils"
 import { Toaster } from "@maple/ui/components/ui/sonner"
+import { Spinner } from "@maple/ui/components/ui/spinner"
 import { AttributesProvider } from "@maple/ui/components/attributes"
 import { renderAttributeValue } from "@/components/attributes/commit-sha-attribute"
 import { highlightCode } from "@/lib/sugar-high"
@@ -21,6 +24,10 @@ import { captureChatReferrer } from "@/components/chat/auto-contexts"
 import { GlobalShortcuts } from "@/components/command-palette/global-shortcuts"
 
 const PUBLIC_PATHS = new Set(["/sign-in", "/sign-up", "/org-required", "/service-map-bench"])
+
+// Routes that render their own onboarding/billing UI and so must never be
+// gated on plan selection (neither redirected away nor blocked while loading).
+const ALLOWED_WITHOUT_PLAN = ["/select-plan", "/quick-start"]
 
 // Stable references so the AttributesProvider context value never changes
 // identity across renders (avoids re-rendering every CopyableValue consumer).
@@ -48,6 +55,18 @@ export const Route = createRootRouteWithContext<{ auth: RouterAuthContext }>()({
 	},
 	component: RootComponent,
 })
+
+// Full-screen loading state for the brief window where we're waiting on the
+// customer query before we know whether to render the dashboard or bounce to
+// onboarding (first load in a browser / right after unsubscribing). Beats a
+// blank screen. See MAP-45.
+function RootLoading() {
+	return (
+		<main className="flex min-h-screen items-center justify-center bg-background">
+			<Spinner className="size-6 text-muted-foreground" />
+		</main>
+	)
+}
 
 function AppFrame() {
 	const pathname = useRouterState({ select: (s) => s.location.pathname })
@@ -102,6 +121,31 @@ function ClerkReverseRedirects() {
 	const redirectUrl = pathname + (searchStr ?? "")
 	const selectedPlan = hasSelectedPlan(customer)
 
+	// Per-org, localStorage-backed memory (effect-atom KVS) of whether this org
+	// was last seen on an active selected plan. Drives the optimistic "render the
+	// dashboard while the plan is still loading" fast path below. Falls back to an
+	// inert in-memory atom while there's no org (org-less / still-settling auth).
+	const [knownSelectedPlan, setKnownSelectedPlan] = useAtom(selectedPlanKnownAtomFor(orgId))
+
+	// Once the customer query settles to a usable payload, record whether this
+	// org holds an active selected plan, so the flag only ever reflects a
+	// genuinely-known plan state — skip while loading or on an error/unusable
+	// payload so a transient blip can't flip it. A planless settle (e.g.
+	// unsubscribe) clears it here, ending the optimistic flash. See MAP-45.
+	useEffect(() => {
+		if (!isSignedIn || !orgId || isCustomerLoading) return
+		if (customerError || !isUsableCustomer(customer)) return
+		setKnownSelectedPlan(selectedPlan)
+	}, [
+		isSignedIn,
+		orgId,
+		isCustomerLoading,
+		customerError,
+		customer,
+		selectedPlan,
+		setKnownSelectedPlan,
+	])
+
 	if (isSignedIn && pathname === "/sign-in") {
 		const target = getRedirectTarget(searchStr)
 		return <Navigate to={target.pathname} search={target.search} replace />
@@ -132,20 +176,27 @@ function ClerkReverseRedirects() {
 			import.meta.env.DEV &&
 			typeof window !== "undefined" &&
 			window.location.search.includes("quota_preview")
-		// Apply plan-gating only once the customer query has settled. While it's
-		// still loading/retrying, fall through and render the dashboard instead of
-		// blanking the screen (`return null`) — the redirect, if any, fires on the
-		// next render once we actually know the plan, so we never bounce a paying
-		// user to /quick-start before their plan is known.
-		if (!isCustomerLoading || quotaPreview) {
-			const ALLOWED_WITHOUT_PLAN = ["/select-plan", "/quick-start"]
-			if (!selectedPlan && !quotaPreview && !ALLOWED_WITHOUT_PLAN.includes(pathname)) {
-				return <Navigate to="/quick-start" search={{ redirect_url: redirectUrl }} replace />
+		// Plan not yet known (query still loading/retrying). Allowed-without-plan
+		// routes render their own onboarding UI, so let them through. For every
+		// other route, only optimistically render the dashboard when this browser
+		// already knows the org holds a selected plan — otherwise show a loading
+		// screen until the query settles, so we never flash the dashboard before
+		// bouncing a planless user to /quick-start. The flag is cleared on
+		// unsubscribe, so that case flashes once and then takes the wait path.
+		if (isCustomerLoading && !quotaPreview) {
+			if (ALLOWED_WITHOUT_PLAN.includes(pathname) || knownSelectedPlan) {
+				return <AppFrame />
 			}
-			if (selectedPlan && pathname === "/select-plan") {
-				const target = getRedirectTarget(searchStr)
-				return <Navigate to={target.pathname} search={target.search} replace />
-			}
+			return <RootLoading />
+		}
+
+		// Plan known (or dev quota preview): apply the gate.
+		if (!selectedPlan && !quotaPreview && !ALLOWED_WITHOUT_PLAN.includes(pathname)) {
+			return <Navigate to="/quick-start" search={{ redirect_url: redirectUrl }} replace />
+		}
+		if (selectedPlan && pathname === "/select-plan") {
+			const target = getRedirectTarget(searchStr)
+			return <Navigate to={target.pathname} search={target.search} replace />
 		}
 	}
 


### PR DESCRIPTION
Closes MAP-45.

## Problem

The `__root.tsx` plan gate renders the dashboard *while the Autumn customer query is still loading* — a deliberate fast path so paying customers don't wait on the billing query — then redirects to `/quick-start` once it settles as planless. For a fresh signup that means the dashboard **flashes** for a moment before the bounce.

## Fix

Gate that optimistic "render while loading" behind a **per-org flag** recording whether this browser has previously seen an active selected plan. Persisted via **effect-atom's KVS** (`Atom.kvs` + `localStorageRuntime`) in [`selected-plan-atoms.ts`](apps/web/src/atoms/selected-plan-atoms.ts), matching the existing `dashboardFacetsHintAtomFamily` / `quickStartAtomFamily` convention rather than touching `window.localStorage` directly:

- **First load / fresh signup** (no flag): wait for the query to settle instead of rendering the dashboard → no flash before the `/quick-start` redirect.
- **Returning paid org** (flag set): render the dashboard immediately — the fast path is unchanged.
- **Planless on settle** (e.g. unsubscribe): clear the flag, so that case flashes exactly **once** and then reverts to the wait path.

The flag is written in an effect only on a settled, *usable* customer payload, so a transient loading/error blip can't flip it. The gate still never redirects while the query is loading, so a paying user is never bounced before their plan is known.

| Scenario | Before | After |
|---|---|---|
| Fresh signup (no plan) | dashboard **flashes** → `/quick-start` | waits → `/quick-start`, no flash |
| Returning paid org | instant dashboard | instant dashboard (unchanged) |
| First load of a paid org in a new browser | instant dashboard | brief wait, then dashboard |
| Unsubscribe | flashes every load | flashes **once**, then waits |

## Notes

- Independent of #123 (the post-checkout lockout fix) — disjoint files; branched off `main`.
- The atom is read synchronously during render (sync-mode `Atom.kvs`), and the app shell renders client-only (`ReactDOM.createRoot`, not `hydrateRoot`), so the optimistic read carries no SSR/hydration risk.

## Verification

- `bun typecheck --filter=@maple/web` — green (9/9)
- Web `plan-gating` (19) + `atoms`/`routes` suites green. The atom family is declarative config and, like the other `Atom.kvs` families, carries no dedicated unit test (the previous direct-`localStorage` helper + its 8 tests were removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
