### PR TITLE
chore: adopt mise-en-place for toolchain + CI parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - run: bun install --frozen-lockfile
 
@@ -32,7 +32,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - run: bun install --frozen-lockfile
 
@@ -60,7 +60,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - run: bun install --frozen-lockfile
 

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -41,8 +41,8 @@ jobs:
             - name: Checkout
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - name: Setup Bun
-              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            - name: Setup mise (toolchain)
+              uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - name: Load deployment secrets from Doppler
               uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -28,8 +28,8 @@ jobs:
             - name: Checkout
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - name: Setup Bun
-              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            - name: Setup mise (toolchain)
+              uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - name: Load deployment secrets from Doppler
               uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -28,8 +28,8 @@ jobs:
             - name: Checkout
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - name: Setup Bun
-              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            - name: Setup mise (toolchain)
+              uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - name: Load deployment secrets from Doppler
               uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -43,7 +43,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - run: bun install --frozen-lockfile
 

--- a/.github/workflows/ingest-load-tests.yml
+++ b/.github/workflows/ingest-load-tests.yml
@@ -41,7 +41,10 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+            # Installs the rust version pinned in the root mise.toml (was a floating
+            # `stable`). Keep rust-cache below — mise caches the toolchain, not the
+            # cargo registry / target dir.
+            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
               with:

--- a/.github/workflows/ingest-rust-tests.yml
+++ b/.github/workflows/ingest-rust-tests.yml
@@ -44,7 +44,10 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+            # Installs the rust version pinned in the root mise.toml (was a floating
+            # `stable`). Keep rust-cache below — mise caches the toolchain, not the
+            # cargo registry / target dir.
+            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
               with:

--- a/.github/workflows/local-binary-release.yml
+++ b/.github/workflows/local-binary-release.yml
@@ -60,7 +60,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - name: Install JS dependencies
               run: bun install --frozen-lockfile

--- a/.github/workflows/tinybird-cd.yml
+++ b/.github/workflows/tinybird-cd.yml
@@ -38,7 +38,7 @@ jobs:
         environment: ${{ matrix.target.environment }}
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
             - name: Install dependencies
               # Run install before any secrets are scoped to the deploy step.
               run: bun install --frozen-lockfile

--- a/.github/workflows/token-cost.yml
+++ b/.github/workflows/token-cost.yml
@@ -28,7 +28,7 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
             - run: bun install --frozen-lockfile
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 .env.local
 *.local
 
+# mise per-developer overrides (machine-specific tool/env tweaks); mise.toml is committed
+mise.local.toml
+
 node_modules
 .DS_Store
 dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,25 @@ Sign in at `https://web.localhost` with the Clerk test account:
 
 Use this when you need an authenticated browser session to verify UI flows end-to-end.
 
+## Toolchain (mise)
+
+Tool versions (bun, node, rust, python) are pinned in the root [`mise.toml`](mise.toml) via
+[mise-en-place](https://mise.en.dev) — one source of truth shared by local dev and CI (CI installs
+them with `jdx/mise-action`). mise also auto-loads `.env.local` into your shell.
+
+First-time setup:
+
+```bash
+curl https://mise.run | sh                        # install mise
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc     # activate (bash/fish supported too); restart shell
+mise trust                                         # trust this repo's config (it defines env + tasks)
+mise run setup                                     # install tools + JS deps + .env.local + portless CA
+```
+
+mise is optional — `bun dev` / `bun test` / etc. still work without it (you just don't get pinned
+versions or env auto-load). When upgrading a runtime, bump it in `mise.toml` (keep `bun` in sync with
+`packageManager` in `package.json`); CI follows automatically.
+
 ## Commands
 
 ```bash

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,59 @@
+# mise-en-place — single source of truth for this repo's toolchain.
+# Docs: https://mise.en.dev
+#
+# First-time local setup:
+#   curl https://mise.run | sh                          # install mise
+#   echo 'eval "$(mise activate zsh)"' >> ~/.zshrc       # activate in your shell (bash/fish too)
+#   mise trust                                           # trust this config (it defines env + tasks)
+#   mise run setup                                       # install tools + deps + local CA
+#
+# CI installs these exact versions via jdx/mise-action (see .github/workflows/*),
+# so local dev and CI run identical toolchains.
+
+[tools]
+bun = "1.3.11"    # keep in sync with `packageManager` in package.json
+node = "24"       # some scripts (e.g. apps/mobile) shell out to `node`
+rust = "1.94.1"   # apps/ingest (Rust gateway); was floating `stable` in CI
+python = "3.12"   # Tinybird tooling + .github/scripts/format-ingest-benchmark-comment.py
+# go = "1.x"      # otel-collector exporter pins via go.mod; add here only if we want it unified
+
+[env]
+# Auto-load the gitignored local secrets/overrides so ad-hoc `bun run …` commands
+# pick them up without an explicit --env-file flag. This is ADDITIVE: the apps
+# still load .env.local explicitly (portless --env-file, apps/ingest `source`,
+# scraper `bun --env-file`), so non-mise users and CI are unaffected. In CI there
+# is no .env.local, so this is a no-op there (Doppler/secret injection is untouched).
+_.file = ".env.local"
+
+[tasks.setup]
+description = "Bootstrap a fresh checkout: tools, JS deps, env file, local CA"
+run = [
+  "mise install",
+  "bun install",
+  "test -f .env.local || cp .env.example .env.local",
+  "npx portless trust",
+]
+
+[tasks.dev]
+description = "Run all apps via turbo + portless (https://*.localhost)"
+run = "bun dev"
+
+[tasks.build]
+description = "Build all packages/apps via turbo"
+run = "bun build"
+
+[tasks.test]
+description = "Run the test suite via turbo"
+run = "bun test"
+
+[tasks.typecheck]
+description = "Type-check all packages/apps via turbo"
+run = "bun typecheck"
+
+[tasks."db:up"]
+description = "Start the dev Postgres (docker, port 5499)"
+run = "bun db:up"
+
+[tasks."db:migrate"]
+description = "Apply drizzle migrations to the dev Postgres"
+run = "bun db:migrate:local"

--- a/mise.toml
+++ b/mise.toml
@@ -10,12 +10,15 @@
 # CI installs these exact versions via jdx/mise-action (see .github/workflows/*),
 # so local dev and CI run identical toolchains.
 
+# All four are pinned to EXACT patch versions (no fuzzy "24"/"3.12") so a
+# `mise install` resolves byte-identical toolchains locally and in CI — that's
+# the whole point of this file. Bump a patch here and CI follows automatically.
 [tools]
-bun = "1.3.11"    # keep in sync with `packageManager` in package.json
-node = "24"       # some scripts (e.g. apps/mobile) shell out to `node`
-rust = "1.94.1"   # apps/ingest (Rust gateway); was floating `stable` in CI
-python = "3.12"   # Tinybird tooling + .github/scripts/format-ingest-benchmark-comment.py
-# go = "1.x"      # otel-collector exporter pins via go.mod; add here only if we want it unified
+bun = "1.3.11"     # keep in sync with `packageManager` in package.json
+node = "24.18.0"   # some scripts (e.g. apps/mobile) shell out to `node`
+rust = "1.94.1"    # apps/ingest (Rust gateway); was a floating `stable` in CI
+python = "3.12.13" # Tinybird tooling + .github/scripts/format-ingest-benchmark-comment.py
+# go = "1.x.y"     # otel-collector exporter pins via go.mod; add here only if we want it unified
 
 [env]
 # Auto-load the gitignored local secrets/overrides so ad-hoc `bun run …` commands


### PR DESCRIPTION
## What

Adopt [mise-en-place](https://mise.en.dev) as the single source of truth for this repo's toolchain, and wire it into CI so **local dev and CI run identical tool versions**.

Today there's no version manager: the only pin is `packageManager: bun@1.3.11` (already drifting — dev machines run 1.3.14), Rust floats on `stable`, node is unpinned, and Python falls back to system 3.9.6. CI installs each runtime through a different action with no shared pins.

## Changes

- **`mise.toml`** (new) pins `bun 1.3.11` (matches `packageManager`), `node 24`, `rust 1.94.1` (apps/ingest; was a floating `stable`), `python 3.12` (Tinybird tooling + the CI benchmark script; up from 3.9.6).
- **`[env]`** auto-loads `.env.local` into the shell. **Additive** — apps still load it explicitly (portless `--env-file`, ingest `source`, scraper `--env-file`), so non-mise users and CI are unaffected; a missing file is a no-op (verified).
- **`[tasks]`** adds a `setup` bootstrap (tools + deps + env file + portless CA) plus thin `dev`/`build`/`test`/`typecheck`/`db:*` aliases that delegate to the existing `bun`/`turbo` scripts — `package.json` stays the source of truth.
- **CI**: replaced 12 per-tool setup steps across 10 workflows with `jdx/mise-action` (SHA-pinned `v2.4.4`) — `setup-bun` in 8 bun workflows, `dtolnay/rust-toolchain@stable` in the 2 ingest Rust workflows (kept `Swatinem/rust-cache`).
- **`.gitignore`**: ignore `mise.local.toml` (per-dev overrides).
- **`CLAUDE.md`**: document the mise quick-start.

## For reviewers

- **mise is optional locally** — `bun dev` / `bun test` / etc. still work without it. You only get pinned versions + env auto-load if you `mise activate` in your shell.
- **`bun` must stay in sync with `packageManager`** in `package.json` (noted in `mise.toml` + CLAUDE.md).
- **CI trade-off**: with one root config, bun-only jobs also install rust/python — modest, and cached by `mise-action` after the first run. If JS-job time becomes a concern, rust can move to `apps/ingest/mise.toml` later.

## Verification

- `mise install` → bun **1.3.11**, node **24.18.0**, rustc **1.94.1**, python **3.12.13**
- `mise run typecheck` → **23/23** turbo tasks pass via the mise-resolved bun
- `cd apps/ingest && mise exec -- cargo check` → clean under pinned rust
- `.env.local` auto-load confirmed; missing-file case is a graceful no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)