### PR TITLE
fix(mcp): metric label breakdown/enumeration + raw SQL visibility

### DIFF
--- a/apps/api/src/mcp/lib/inspect-widget.ts
+++ b/apps/api/src/mcp/lib/inspect-widget.ts
@@ -24,6 +24,7 @@ import {
 } from "./chart-statistics"
 import { resolveDashboardTimeRange, type DashboardTimeRangeInput } from "./resolve-dashboard-time-range"
 import { resolveTimeRange } from "./time"
+import { autoBucketSeconds, runRawSql } from "./run-raw-sql"
 import type { DashboardDocument, DashboardWidgetSchema } from "@maple/domain/http"
 import type {
 	InspectChartDataData,
@@ -38,7 +39,11 @@ import type { TenantContext } from "@/lib/tenant-context"
 
 const TIMESERIES_ENDPOINT = "custom_query_builder_timeseries"
 const BREAKDOWN_ENDPOINT = "custom_query_builder_breakdown"
+const RAW_SQL_ENDPOINT = "raw_sql_chart"
 const MAX_QUERIES = 5
+// Rows captured for a raw-SQL widget inspection — enough to spot-check, capped
+// so a wide/long result doesn't bloat the response.
+const RAW_SQL_INSPECT_ROWS = 50
 
 export type DashboardWidget = typeof DashboardWidgetSchema.Type
 
@@ -269,8 +274,25 @@ export interface InspectWidgetTimeRange {
 	source: "override" | "dashboard" | "fallback"
 }
 
+/** Result of executing a raw_sql_chart widget's stored SQL during inspection. */
+export interface RawSqlInspectionData {
+	endpoint: string
+	sql: string
+	/** Macro-expanded SQL actually executed; absent when expansion/validation failed. */
+	expandedSql?: string
+	status: "ok" | "error"
+	/** Validation/execution error message when status is "error". */
+	error?: string
+	rowCount: number
+	columns: ReadonlyArray<string>
+	rows: ReadonlyArray<Record<string, unknown>>
+	truncated: boolean
+	timeRange: InspectWidgetTimeRange
+}
+
 export type InspectionOutcome =
 	| { kind: "supported"; data: InspectChartDataData }
+	| { kind: "raw_sql"; data: RawSqlInspectionData }
 	| { kind: "unsupported"; endpoint: string }
 	| {
 			kind: "skipped"
@@ -287,6 +309,91 @@ export interface InspectWidgetInput {
 }
 
 /**
+ * Inspect a raw_sql_chart widget by running its stored SQL through the exact
+ * same macro-expansion + safety pass + warehouse execution as the dashboard UI,
+ * returning a rows preview. Never fails the caller — validation/execution
+ * errors are encoded as `status: "error"` in the returned data.
+ */
+const inspectRawSqlWidget = Effect.fn("inspectRawSqlWidget")(function* (
+	tenant: TenantContext,
+	widget: DashboardWidget,
+	timeRange: InspectWidgetTimeRange,
+) {
+	const rawParams = widget.dataSource.params as Record<string, unknown> | undefined
+	const sql = typeof rawParams?.sql === "string" ? rawParams.sql : undefined
+
+	if (!sql) {
+		return {
+			kind: "skipped",
+			reason: "no_params",
+			detail: "raw_sql_chart widget has no `params.sql` to inspect.",
+		} satisfies InspectionOutcome
+	}
+
+	const granularitySeconds =
+		typeof rawParams?.granularitySeconds === "number"
+			? rawParams.granularitySeconds
+			: autoBucketSeconds(timeRange.startTime, timeRange.endTime)
+
+	const result = yield* runRawSql({
+		tenant,
+		sql,
+		startTime: timeRange.startTime,
+		endTime: timeRange.endTime,
+		granularitySeconds,
+	}).pipe(
+		Effect.map((value) => ({ ok: true as const, value })),
+		Effect.catchTag("@maple/http/errors/RawSqlValidationError", (error) =>
+			Effect.succeed({ ok: false as const, error: `${error.code}: ${error.message}` }),
+		),
+		Effect.catchTags({
+			"@maple/http/errors/WarehouseQueryError": (e) => Effect.succeed({ ok: false as const, error: e.message }),
+			"@maple/http/errors/WarehouseUpstreamError": (e) => Effect.succeed({ ok: false as const, error: e.message }),
+			"@maple/http/errors/WarehouseAuthError": (e) => Effect.succeed({ ok: false as const, error: e.message }),
+			"@maple/http/errors/WarehouseConfigError": (e) => Effect.succeed({ ok: false as const, error: e.message }),
+			"@maple/http/errors/WarehouseClientError": (e) => Effect.succeed({ ok: false as const, error: e.message }),
+			"@maple/http/errors/WarehouseSchemaDriftError": (e) => Effect.succeed({ ok: false as const, error: e.message }),
+			"@maple/http/errors/WarehouseQuotaExceededError": (e) =>
+				Effect.succeed({ ok: false as const, error: e.message }),
+			"@maple/http/errors/WarehouseValidationError": (e) => Effect.succeed({ ok: false as const, error: e.message }),
+		}),
+	)
+
+	if (!result.ok) {
+		return {
+			kind: "raw_sql",
+			data: {
+				endpoint: RAW_SQL_ENDPOINT,
+				sql,
+				status: "error",
+				error: result.error,
+				rowCount: 0,
+				columns: [],
+				rows: [],
+				truncated: false,
+				timeRange,
+			},
+		} satisfies InspectionOutcome
+	}
+
+	const rendered = result.value.rows.slice(0, RAW_SQL_INSPECT_ROWS)
+	return {
+		kind: "raw_sql",
+		data: {
+			endpoint: RAW_SQL_ENDPOINT,
+			sql,
+			expandedSql: result.value.expandedSql,
+			status: "ok",
+			rowCount: result.value.rowCount,
+			columns: result.value.columns,
+			rows: rendered,
+			truncated: result.value.rowCount > rendered.length,
+			timeRange,
+		},
+	} satisfies InspectionOutcome
+})
+
+/**
  * Run the validation pipeline for a single widget. Never fails the caller —
  * problems are encoded in the returned `InspectionOutcome` so post-mutation
  * callers can always finish their response.
@@ -298,6 +405,10 @@ export const inspectWidget = Effect.fn("inspectWidget")(
 		const endpoint = widget.dataSource.endpoint
 		const isTimeseries = endpoint === TIMESERIES_ENDPOINT
 		const isBreakdown = endpoint === BREAKDOWN_ENDPOINT
+
+		if (endpoint === RAW_SQL_ENDPOINT) {
+			return yield* inspectRawSqlWidget(tenant, widget, timeRange)
+		}
 
 		if (!isTimeseries && !isBreakdown) {
 			return { kind: "unsupported", endpoint } satisfies InspectionOutcome
@@ -638,6 +749,24 @@ function summarizeOutcome(widget: DashboardWidget, outcome: InspectionOutcome): 
 			verdict: "unsupported",
 			flags: [],
 			note: `Predefined endpoint (${outcome.endpoint}); inspect with query_data if needed.`,
+		}
+	}
+	if (outcome.kind === "raw_sql") {
+		const verdict: WidgetInspectionVerdict =
+			outcome.data.status === "error" ? "broken" : outcome.data.rowCount === 0 ? "suspicious" : "looks_healthy"
+		const note =
+			outcome.data.status === "error"
+				? `Raw SQL failed: ${outcome.data.error ?? "unknown error"}`
+				: outcome.data.rowCount === 0
+					? "Raw SQL returned no rows for this window."
+					: `Raw SQL returned ${outcome.data.rowCount} row(s).`
+		return {
+			widgetId: widget.id,
+			...(widget.display.title !== undefined && { title: widget.display.title }),
+			visualization: widget.visualization,
+			verdict,
+			flags: [],
+			note,
 		}
 	}
 	if (outcome.kind === "skipped") {

--- a/apps/api/src/mcp/lib/run-raw-sql.test.ts
+++ b/apps/api/src/mcp/lib/run-raw-sql.test.ts
@@ -1,0 +1,84 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+import { runRawSql, autoBucketSeconds } from "./run-raw-sql"
+import { WarehouseQueryService, type WarehouseQueryServiceShape } from "@/lib/WarehouseQueryService"
+import type { TenantContext } from "@/lib/tenant-context"
+
+const tenant = { orgId: "org_test" } as TenantContext
+
+const makeStub = (
+	rows: ReadonlyArray<Record<string, unknown>>,
+	captured?: { sql?: string },
+): WarehouseQueryServiceShape =>
+	({
+		sqlQuery: (_t: unknown, sql: string) => {
+			if (captured) captured.sql = sql
+			return Effect.succeed(rows)
+		},
+	}) as unknown as WarehouseQueryServiceShape
+
+const provide = (stub: WarehouseQueryServiceShape) => Layer.succeed(WarehouseQueryService, stub)
+
+const range = { startTime: "2026-04-01 00:00:00", endTime: "2026-04-01 01:00:00" }
+
+describe("runRawSql", () => {
+	it.effect("expands macros and returns rows + column metadata", () =>
+		Effect.gen(function* () {
+			const captured: { sql?: string } = {}
+			const result = yield* runRawSql({
+				tenant,
+				sql: "SELECT ServiceName, count() AS c FROM traces WHERE $__orgFilter GROUP BY ServiceName",
+				...range,
+				granularitySeconds: 60,
+			}).pipe(Effect.provide(provide(makeStub([{ ServiceName: "api", c: 3 }], captured))))
+
+			// $__orgFilter expanded to the scoped predicate before execution.
+			assert.include(captured.sql ?? "", "OrgId = 'org_test'")
+			assert.strictEqual(result.rowCount, 1)
+			assert.deepStrictEqual([...result.columns], ["ServiceName", "c"])
+		}),
+	)
+
+	it.effect("fails with RawSqlValidationError when $__orgFilter is missing", () =>
+		Effect.gen(function* () {
+			const exit = yield* runRawSql({
+				tenant,
+				sql: "SELECT count() FROM traces",
+				...range,
+				granularitySeconds: 60,
+			}).pipe(Effect.provide(provide(makeStub([]))), Effect.exit)
+
+			assert.isTrue(exit._tag === "Failure")
+			if (exit._tag === "Failure") {
+				const err = exit.cause
+				assert.include(JSON.stringify(err), "MissingOrgFilter")
+			}
+		}),
+	)
+
+	it.effect("rejects DDL/DML keywords", () =>
+		Effect.gen(function* () {
+			const exit = yield* runRawSql({
+				tenant,
+				sql: "DROP TABLE traces WHERE $__orgFilter",
+				...range,
+				granularitySeconds: 60,
+			}).pipe(Effect.provide(provide(makeStub([]))), Effect.exit)
+
+			assert.isTrue(exit._tag === "Failure")
+		}),
+	)
+})
+
+describe("autoBucketSeconds", () => {
+	it("picks a sub-minute bucket for short windows and a coarse one for long windows", () => {
+		const short = autoBucketSeconds("2026-04-01 00:00:00", "2026-04-01 00:05:00")
+		const long = autoBucketSeconds("2026-04-01 00:00:00", "2026-04-08 00:00:00")
+		assert.isTrue(short < long)
+		assert.isTrue(short >= 1)
+	})
+
+	it("falls back to 300 for invalid ranges", () => {
+		assert.strictEqual(autoBucketSeconds("nonsense", "also-bad"), 300)
+	})
+})

--- a/apps/api/src/mcp/lib/run-raw-sql.ts
+++ b/apps/api/src/mcp/lib/run-raw-sql.ts
@@ -1,0 +1,75 @@
+import { Effect } from "effect"
+import { makeExpandMacros } from "@maple/query-engine/runtime"
+import { WarehouseQueryService } from "@/lib/WarehouseQueryService"
+import type { TenantContext } from "@/lib/tenant-context"
+
+// Auto-bucket ladder mirrors the web/HTTP raw-SQL path so `$__interval_s`
+// resolves to a sensible value when the caller doesn't pin granularity.
+const TARGET_POINTS = 120
+const AUTO_BUCKET_LADDER = [1, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 21600, 43200, 86400]
+
+/** Pick a bucket width that yields ~TARGET_POINTS points over the window. */
+export function autoBucketSeconds(startTime: string, endTime: string): number {
+	const toEpochMs = (value: string) => new Date(value.replace(" ", "T") + "Z").getTime()
+	const startMs = toEpochMs(startTime)
+	const endMs = toEpochMs(endTime)
+	if (Number.isNaN(startMs) || Number.isNaN(endMs) || endMs <= startMs) return 300
+	const rangeSeconds = Math.max((endMs - startMs) / 1000, 1)
+	const raw = Math.ceil(rangeSeconds / TARGET_POINTS)
+	return AUTO_BUCKET_LADDER.reduce(
+		(best, candidate) => (Math.abs(candidate - raw) < Math.abs(best - raw) ? candidate : best),
+		AUTO_BUCKET_LADDER[0],
+	)
+}
+
+export interface RunRawSqlInput {
+	readonly tenant: TenantContext
+	readonly sql: string
+	readonly startTime: string
+	readonly endTime: string
+	readonly granularitySeconds: number
+}
+
+export interface RunRawSqlResult {
+	readonly rows: ReadonlyArray<Record<string, unknown>>
+	readonly columns: ReadonlyArray<string>
+	readonly rowCount: number
+	readonly expandedSql: string
+	readonly granularitySeconds: number
+}
+
+/**
+ * Expand the raw-SQL macros (`$__orgFilter`, `$__timeFilter(col)`, …) with the
+ * full safety pass (required org filter, DDL/DML deny-list, single-statement,
+ * auto-LIMIT) and run the result through `WarehouseQueryService.sqlQuery`,
+ * returning the rows plus column/row metadata. Shared by the `run_sql` MCP tool
+ * and `inspect_chart_data`'s raw_sql_chart branch so both honor the identical
+ * guardrails. Fails with `RawSqlValidationError` (macro/safety) or a
+ * `WarehouseError` (execution); callers surface these to the agent.
+ */
+export const runRawSql = Effect.fn("runRawSql")(function* (input: RunRawSqlInput) {
+	const expanded = yield* makeExpandMacros({
+		sql: input.sql,
+		orgId: input.tenant.orgId,
+		startTime: input.startTime,
+		endTime: input.endTime,
+		granularitySeconds: input.granularitySeconds,
+	})
+
+	const warehouse = yield* WarehouseQueryService
+	const rows = yield* warehouse.sqlQuery(input.tenant, expanded.sql, {
+		profile: "list",
+		context: "mcp.run_sql",
+	})
+
+	const records = rows as ReadonlyArray<Record<string, unknown>>
+	const columns = records.length > 0 ? Object.keys(records[0]) : []
+
+	return {
+		rows: records,
+		columns,
+		rowCount: records.length,
+		expandedSql: expanded.sql,
+		granularitySeconds: expanded.granularitySeconds,
+	} satisfies RunRawSqlResult
+})

--- a/apps/api/src/mcp/tools/explore-attributes.ts
+++ b/apps/api/src/mcp/tools/explore-attributes.ts
@@ -58,9 +58,11 @@ export function registerExploreAttributesTool(server: McpToolRegistrar) {
 					Effect.mapError(mapError),
 				)
 
+				// Metric labels are their own scope; span/resource scoping only applies to traces.
+				const sourceLabel = params.source === "metrics" ? "metrics" : `${params.source} (${scope})`
 				const lines: string[] = [
 					`## Attribute Values: ${params.key}`,
-					`Source: ${params.source} (${scope})`,
+					`Source: ${sourceLabel}`,
 					`Time range: ${st} — ${et}${formatClampNote(range)}`,
 					``,
 				]
@@ -77,9 +79,15 @@ export function registerExploreAttributesTool(server: McpToolRegistrar) {
 				}
 
 				lines.push(
-					formatNextSteps([
-						`\`query_data source="traces" kind="timeseries" attribute_key="${params.key}" attribute_value="<value>"\` — chart traces filtered by this attribute`,
-					]),
+					formatNextSteps(
+						params.source === "metrics"
+							? [
+									`\`query_data source="metrics" kind="breakdown" group_by="attribute" attribute_key="${params.key}"\` — break a metric down by this label`,
+								]
+							: [
+									`\`query_data source="traces" kind="timeseries" attribute_key="${params.key}" attribute_value="<value>"\` — chart traces filtered by this attribute`,
+								],
+					),
 				)
 
 				return {

--- a/apps/api/src/mcp/tools/inspect-chart-data.ts
+++ b/apps/api/src/mcp/tools/inspect-chart-data.ts
@@ -9,7 +9,8 @@ import { Effect, Schema } from "effect"
 import { resolveTenant } from "@/mcp/lib/query-warehouse"
 import { DashboardPersistenceService } from "@/services/DashboardPersistenceService"
 import { createDualContent } from "../lib/structured-output"
-import { inspectWidget, type InspectWidgetTimeRange } from "../lib/inspect-widget"
+import { inspectWidget, type InspectWidgetTimeRange, type RawSqlInspectionData } from "../lib/inspect-widget"
+import { formatTable, truncate } from "../lib/format"
 import { resolveDashboardTimeRange, type DashboardTimeRangeInput } from "../lib/resolve-dashboard-time-range"
 import { resolveTimeRange } from "../lib/time"
 import type { InspectChartDataData, InspectChartQueryResult } from "@maple/domain"
@@ -94,6 +95,53 @@ function unsupportedEndpointResult(
 	return { content: [{ type: "text" as const, text }] }
 }
 
+function rawSqlCell(value: unknown): string {
+	if (value === null || value === undefined) return "null"
+	if (typeof value === "object") return truncate(JSON.stringify(value), 60)
+	return truncate(String(value), 60)
+}
+
+function renderRawSqlInspection(
+	data: RawSqlInspectionData,
+	widget: { id: string; visualization: string; display: { title?: string } },
+	dashboardName: string,
+): string {
+	const lines: string[] = [
+		`## Widget inspection: ${widget.display.title ?? widget.id}`,
+		`Dashboard: ${dashboardName}`,
+		`Visualization: ${widget.visualization} | Endpoint: ${data.endpoint}`,
+		`Time range: ${data.timeRange.startTime} → ${data.timeRange.endTime} (source: ${data.timeRange.source})`,
+		``,
+	]
+
+	if (data.status === "error") {
+		lines.push(`### Verdict: BROKEN`)
+		lines.push(`Error: ${data.error ?? "unknown error"}`)
+		lines.push(``)
+		lines.push(`Fix the SQL via update_dashboard_widget and re-run inspect_chart_data to verify.`)
+		return lines.join("\n")
+	}
+
+	lines.push(`### Verdict: ${data.rowCount === 0 ? "SUSPICIOUS (no rows)" : "OK"}`)
+	lines.push(
+		`Rows: ${data.rowCount}${data.truncated ? ` (showing first ${data.rows.length})` : ""} | Columns: ${data.columns.length}`,
+	)
+	lines.push(``)
+
+	if (data.rowCount === 0) {
+		lines.push("Query executed successfully but returned no rows. Check filters and the time range.")
+	} else {
+		lines.push(
+			formatTable(
+				[...data.columns],
+				data.rows.map((row) => data.columns.map((col) => rawSqlCell(row[col]))),
+			),
+		)
+		if (data.truncated) lines.push(``, `… +${data.rowCount - data.rows.length} more rows`)
+	}
+	return lines.join("\n")
+}
+
 function renderInspectionMarkdown(data: InspectChartDataData, dashboardName: string): string {
 	const lines: string[] = []
 	lines.push(`## Widget inspection: ${data.widget.title ?? data.widget.id}`)
@@ -134,8 +182,9 @@ const inspectChartDataDescription =
 	"Use this tool to re-verify a widget after fixing it, or to inspect any existing widget on demand. " +
 	"Returns row counts, series statistics, sample data points, and sanity flags (EMPTY, ALL_ZEROS, FLAT_LINE, UNIT_MISMATCH, NEGATIVE_VALUES, UNREALISTIC_MAGNITUDE, SINGLE_SERIES_DOMINATES, CARDINALITY_EXPLOSION, SUSPICIOUS_GAP, BROKEN_BREAKDOWN, SINGLE_POINT, ALL_NULLS, BUILDER_WARNINGS). " +
 	"The verdict is one of `looks_healthy`, `suspicious`, or `broken`. **If the verdict is not `looks_healthy`, fix the widget via update_dashboard_widget and re-inspect.** " +
-	"Limitations: only supports custom_query_builder_timeseries and custom_query_builder_breakdown widgets; formula expressions in `formulas[]` are NOT evaluated server-side — only the base queries are inspected; " +
-	"checks only the requested window without the dashboard UI's auto-fallback. For predefined-endpoint widgets (service_overview, errors_summary, etc.), this tool returns guidance to use `query_data` directly with the widget's params."
+	"Supports custom_query_builder_timeseries, custom_query_builder_breakdown, and raw_sql_chart widgets (raw SQL is executed and its rows returned). " +
+	"Limitations: formula expressions in `formulas[]` are NOT evaluated server-side — only the base queries are inspected; " +
+	"checks only the requested window without the dashboard UI's auto-fallback. For other predefined-endpoint widgets (service_overview, errors_summary, etc.), this tool returns guidance to use `query_data` directly with the widget's params."
 
 export function registerInspectChartDataTool(server: McpToolRegistrar) {
 	server.tool(
@@ -238,6 +287,38 @@ export function registerInspectChartDataTool(server: McpToolRegistrar) {
 					},
 					dashboard.name,
 				)
+			}
+
+			if (outcome.kind === "raw_sql") {
+				return {
+					content: createDualContent(
+						renderRawSqlInspection(
+							outcome.data,
+							{
+								id: widget.id,
+								visualization: widget.visualization,
+								display: {
+									...(widget.display.title !== undefined && { title: widget.display.title }),
+								},
+							},
+							dashboard.name,
+						),
+						{
+							tool: "run_sql",
+							data: {
+								expandedSql: outcome.data.expandedSql ?? outcome.data.sql,
+								rowCount: outcome.data.rowCount,
+								columns: outcome.data.columns,
+								rows: outcome.data.rows,
+								truncated: outcome.data.truncated,
+								timeRange: {
+									start: outcome.data.timeRange.startTime,
+									end: outcome.data.timeRange.endTime,
+								},
+							},
+						},
+					),
+				}
 			}
 
 			if (outcome.kind === "skipped") {

--- a/apps/api/src/mcp/tools/query-data.ts
+++ b/apps/api/src/mcp/tools/query-data.ts
@@ -316,12 +316,13 @@ export function registerQueryDataTool(server: McpToolRegistrar) {
 						} satisfies MetricsTimeseriesQuery
 					}
 					const metricsMetric = (params.metric ?? "avg") as MetricsBreakdownQuery["metric"]
-					if (!params.group_by) decisions.push(`group_by: defaulted to "service"`)
+					if (!params.group_by)
+						decisions.push(`group_by: defaulted to "service" (available: service, attribute)`)
 					return {
 						kind: "breakdown",
 						source: "metrics",
 						metric: metricsMetric,
-						groupBy: "service",
+						groupBy: params.group_by === "attribute" ? "attribute" : "service",
 						filters,
 						...(params.limit && { limit: params.limit }),
 					} satisfies MetricsBreakdownQuery

--- a/apps/api/src/mcp/tools/registry.ts
+++ b/apps/api/src/mcp/tools/registry.ts
@@ -38,6 +38,7 @@ import { registerListDashboardsTool } from "./list-dashboards"
 import { registerListMetricsTool } from "./list-metrics"
 import { registerListServicesTool } from "./list-services"
 import { registerQueryDataTool } from "./query-data"
+import { registerRunSqlTool } from "./run-sql"
 import { registerRemoveDashboardWidgetTool } from "./remove-dashboard-widget"
 import { registerReplaceDashboardWidgetsTool } from "./replace-dashboard-widgets"
 import { registerReorderDashboardWidgetsTool } from "./reorder-dashboard-widgets"
@@ -99,6 +100,7 @@ const collectMapleToolDefinitions = (): ReadonlyArray<MapleToolDefinition> => {
 	registerErrorDetailTool(registrar)
 	registerListMetricsTool(registrar)
 	registerQueryDataTool(registrar)
+	registerRunSqlTool(registrar)
 	registerServiceMapTool(registrar)
 	registerListAlertRulesTool(registrar)
 	registerGetAlertRuleTool(registrar)

--- a/apps/api/src/mcp/tools/run-sql.ts
+++ b/apps/api/src/mcp/tools/run-sql.ts
@@ -1,0 +1,129 @@
+import {
+	optionalNumberParam,
+	optionalStringParam,
+	requiredStringParam,
+	type McpToolRegistrar,
+	type McpToolResult,
+} from "./types"
+import { Effect, Schema } from "effect"
+import { resolveTenant } from "@/mcp/lib/query-warehouse"
+import { resolveTimeRange } from "../lib/time"
+import { autoBucketSeconds, runRawSql } from "../lib/run-raw-sql"
+import { createDualContent } from "../lib/structured-output"
+import { formatTable, truncate } from "../lib/format"
+import { warehouseToMcpHandlers } from "../lib/map-warehouse-error"
+
+// Rows returned to the model are capped so a wide/long result doesn't blow the
+// context. The full count is always reported via meta.rowCount.
+const MAX_RENDERED_ROWS = 100
+
+const runSqlSchema = Schema.Struct({
+	sql: requiredStringParam(
+		"Raw ClickHouse SQL to run read-only. MUST reference the `$__orgFilter` macro " +
+			"(expands to `OrgId = '<your-org>'`) so the query is scoped to your org — queries without it are rejected. " +
+			"Optional macros: `$__timeFilter(Column)` (expands to `Column >= <start> AND Column <= <end>`), " +
+			"`$__startTime`, `$__endTime`, `$__interval_s` (bucket width in seconds for toStartOfInterval). " +
+			"Only a single SELECT is allowed; DDL/DML keywords (INSERT, DROP, ALTER, …) are rejected. " +
+			"A `LIMIT 10000` is appended automatically if you omit one. " +
+			"Use describe_warehouse_tables to discover table/column names.",
+	),
+	start_time: optionalStringParam("Start time (YYYY-MM-DD HH:mm:ss UTC). Defaults to 1 hour ago."),
+	end_time: optionalStringParam("End time (YYYY-MM-DD HH:mm:ss UTC). Defaults to now."),
+	granularity_seconds: optionalNumberParam(
+		"Value substituted for the `$__interval_s` macro. Auto-computed from the time range if omitted.",
+	),
+})
+
+const runSqlDescription =
+	"Run read-only ClickHouse SQL against your org's warehouse and return the rows. " +
+	"Use this to verify a raw query before saving it as a raw_sql_chart widget, to spot-check data, " +
+	"or to answer questions the structured tools (query_data, explore_attributes) can't express. " +
+	"Org isolation is automatic and required via the `$__orgFilter` macro. Read-only: writes/DDL are rejected and an auto-LIMIT is applied. " +
+	"For dashboard widgets prefer add_dashboard_widget; for trends/top-N prefer query_data."
+
+function cellToString(value: unknown): string {
+	if (value === null || value === undefined) return "null"
+	if (typeof value === "object") return truncate(JSON.stringify(value), 60)
+	return truncate(String(value), 60)
+}
+
+export function registerRunSqlTool(server: McpToolRegistrar) {
+	server.tool(
+		"run_sql",
+		runSqlDescription,
+		runSqlSchema,
+		Effect.fn("McpTool.runSql")(function* (params) {
+			const tenant = yield* resolveTenant
+			const { st, et } = resolveTimeRange(params.start_time, params.end_time)
+			const granularitySeconds = params.granularity_seconds ?? autoBucketSeconds(st, et)
+
+			const outcome = yield* runRawSql({
+				tenant,
+				sql: params.sql,
+				startTime: st,
+				endTime: et,
+				granularitySeconds,
+			}).pipe(
+				Effect.map((value) => ({ ok: true as const, value })),
+				// Macro/safety failures are caller-fixable: echo the reason + an example.
+				Effect.catchTag("@maple/http/errors/RawSqlValidationError", (error) =>
+					Effect.succeed({
+						ok: false as const,
+						result: {
+							isError: true,
+							content: [
+								{
+									type: "text" as const,
+									text:
+										`SQL rejected (${error.code}): ${error.message}\n\n` +
+										`Example:\n  SELECT count() AS c FROM traces WHERE $__orgFilter AND $__timeFilter(Timestamp)`,
+								},
+							],
+						} satisfies McpToolResult,
+					}),
+				),
+				// Execution failures (CH syntax/schema/quota) surface the warehouse message so the agent can fix the SQL.
+				Effect.catchTags(warehouseToMcpHandlers("run_sql")),
+			)
+
+			if (!outcome.ok) return outcome.result
+
+			const { rows, columns, rowCount, expandedSql } = outcome.value
+			const rendered = rows.slice(0, MAX_RENDERED_ROWS)
+			const truncated = rowCount > rendered.length
+
+			const lines: string[] = [
+				`## SQL result`,
+				`Rows: ${rowCount}${truncated ? ` (showing first ${rendered.length})` : ""} | Columns: ${columns.length}`,
+				`Time range: ${st} — ${et}`,
+				``,
+			]
+
+			if (rowCount === 0) {
+				lines.push("No rows returned.")
+			} else {
+				lines.push(
+					formatTable(
+						[...columns],
+						rendered.map((row) => columns.map((col) => cellToString(row[col]))),
+					),
+				)
+				if (truncated) lines.push(``, `… +${rowCount - rendered.length} more rows (refine with LIMIT or filters)`)
+			}
+
+			return {
+				content: createDualContent(lines.join("\n"), {
+					tool: "run_sql",
+					data: {
+						expandedSql,
+						rowCount,
+						columns,
+						rows: rendered,
+						truncated,
+						timeRange: { start: st, end: et },
+					},
+				}),
+			}
+		}),
+	)
+}

--- a/packages/domain/src/mcp-structured-types.ts
+++ b/packages/domain/src/mcp-structured-types.ts
@@ -874,7 +874,20 @@ export interface GetInstrumentationRecommendationsData {
 	total: number
 }
 
+export interface RunSqlData {
+	/** The fully macro-expanded SQL that was executed (org filter + time bounds inlined). */
+	expandedSql: string
+	rowCount: number
+	columns: ReadonlyArray<string>
+	/** Returned rows, capped for the response. */
+	rows: ReadonlyArray<Record<string, unknown>>
+	/** True when `rows` was truncated below the full result set for display. */
+	truncated: boolean
+	timeRange: { start: string; end: string }
+}
+
 export type StructuredToolOutput =
+	| { tool: "run_sql"; data: RunSqlData }
 	| { tool: "search_sessions"; data: SearchSessionsData }
 	| { tool: "get_session_transcript"; data: GetSessionTranscriptData }
 	| { tool: "get_session_traces"; data: GetSessionTracesData }

--- a/packages/domain/src/query-engine.ts
+++ b/packages/domain/src/query-engine.ts
@@ -180,7 +180,7 @@ export const MetricsBreakdownQuery = Schema.Struct({
 	kind: Schema.Literal("breakdown"),
 	source: Schema.Literal("metrics"),
 	metric: Schema.Literals(["avg", "sum", "count"]),
-	groupBy: Schema.Literal("service"),
+	groupBy: Schema.Literals(["service", "attribute"]),
 	filters: MetricsFilters,
 	limit: Schema.optional(
 		Schema.Number.check(Schema.isInt(), Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(100)),

--- a/packages/domain/src/warehouse-queries.ts
+++ b/packages/domain/src/warehouse-queries.ts
@@ -46,6 +46,7 @@ export const warehouseQueries = [
 	"span_attribute_values",
 	"resource_attribute_keys",
 	"resource_attribute_values",
+	"metric_attribute_values",
 ] as const
 
 export type WarehouseQueryName = (typeof warehouseQueries)[number]

--- a/packages/query-engine/src/ch/pipe-dispatch.test.ts
+++ b/packages/query-engine/src/ch/pipe-dispatch.test.ts
@@ -40,6 +40,7 @@ describe("compilePipeQuery", () => {
 			"metric_attribute_keys",
 			"span_attribute_values",
 			"resource_attribute_values",
+			"metric_attribute_values",
 			"custom_traces_timeseries",
 			"custom_traces_breakdown",
 			"top_operations",
@@ -68,6 +69,18 @@ describe("compilePipeQuery", () => {
 	it("returns undefined for unknown pipes", () => {
 		const result = compilePipeQuery("nonexistent_pipe", baseParams())
 		expect(result).toBeUndefined()
+	})
+
+	it("metric_attribute_values reads metric-scoped values for the given key", () => {
+		const result = compilePipeQuery("metric_attribute_values", {
+			...baseParams(),
+			attribute_key: "group",
+			limit: 50,
+		})
+		expect(result).toBeDefined()
+		expect(result!.sql).toContain("attribute_values_hourly")
+		expect(result!.sql).toContain("'metric'")
+		expect(result!.sql).toContain("group")
 	})
 
 	describe("logs free-text search param", () => {

--- a/packages/query-engine/src/ch/pipe-dispatch.ts
+++ b/packages/query-engine/src/ch/pipe-dispatch.ts
@@ -506,6 +506,17 @@ export function compilePipeQuery(pipe: string, params: PipeParams): PipeCompiled
 					),
 				),
 			),
+			Match.when("metric_attribute_values", () =>
+				eraseType(
+					CH.compile(
+						CH.metricAttributeValuesQuery({
+							attributeKey: String(params.attribute_key),
+							limit: int("limit", 50),
+						}),
+						{ orgId, startTime, endTime },
+					),
+				),
+			),
 			// ----- Custom charts -----
 			Match.when("custom_traces_timeseries", () => {
 				const tsOpts = pipeParamsToTracesTimeseriesOpts(params)

--- a/packages/query-engine/src/ch/queries/metrics.test.ts
+++ b/packages/query-engine/src/ch/queries/metrics.test.ts
@@ -240,6 +240,17 @@ describe("metricsBreakdownQuery", () => {
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("LIMIT 25")
 	})
+
+	it("breaks down by attribute label instead of service when groupByAttributeKey is set", () => {
+		const q = metricsBreakdownQuery({ metricType: "sum", groupByAttributeKey: "region" })
+		const { sql } = compileCH(q, baseParams)
+		// Groups by the label value, not ServiceName...
+		expect(sql).toContain("Attributes['region'] AS name")
+		expect(sql).not.toContain("ServiceName AS name")
+		// ...and drops datapoints missing the label so an empty bucket can't dominate.
+		expect(sql).toContain("Attributes['region'] != ''")
+		expect(sql).toContain("GROUP BY name")
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/query-engine/src/ch/queries/metrics.ts
+++ b/packages/query-engine/src/ch/queries/metrics.ts
@@ -340,6 +340,7 @@ export function metricsTimeseriesRateQuery(
 
 export interface MetricsBreakdownOpts {
 	metricType: MetricType
+	groupByAttributeKey?: string
 	limit?: number
 }
 
@@ -353,12 +354,14 @@ export interface MetricsBreakdownOutput {
 export function metricsBreakdownQuery(opts: MetricsBreakdownOpts) {
 	const { tbl, isHistogram } = resolveMetricTable(opts.metricType)
 	const limit = opts.limit ?? 10
+	const groupKey = opts.groupByAttributeKey
 
 	return from(tbl as typeof MetricsSum)
 		.select(($) => {
 			const exprs = metricsSelectExprs($, isHistogram)
 			return {
-				name: $.ServiceName,
+				// Break down by a metric label value when requested, otherwise by service.
+				name: groupKey ? $.Attributes.get(groupKey) : $.ServiceName,
 				avgValue: exprs.avgValue,
 				sumValue: exprs.sumValue,
 				count: exprs.dataPointCount,
@@ -369,6 +372,8 @@ export function metricsBreakdownQuery(opts: MetricsBreakdownOpts) {
 			$.OrgId.eq(param.string("orgId")),
 			$.TimeUnix.gte(param.dateTime("startTime")),
 			$.TimeUnix.lte(param.dateTime("endTime")),
+			// Drop datapoints missing the label so an empty bucket doesn't dominate.
+			CH.when(groupKey, (k: string) => $.Attributes.get(k).neq("")),
 		])
 		.groupBy("name")
 		.orderBy(["count", "desc"])

--- a/packages/query-engine/src/observability/explore-attributes.test.ts
+++ b/packages/query-engine/src/observability/explore-attributes.test.ts
@@ -1,0 +1,82 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+import { exploreAttributeKeys, exploreAttributeValues } from "./explore-attributes"
+import { WarehouseExecutor } from "./WarehouseExecutor"
+import type { WarehouseExecutorShape } from "./WarehouseExecutor"
+
+interface CapturedCalls {
+	pipeCalls: Array<{ pipe: string; params: Record<string, unknown> }>
+}
+
+const makeMockExecutor = (captured: CapturedCalls): WarehouseExecutorShape => ({
+	orgId: "org_test",
+	sqlQuery: () => Effect.succeed([] as ReadonlyArray<never>),
+	compiledQuery: (compiled) => compiled.decodeRows([]).pipe(Effect.orDie),
+	compiledQueryFirst: (compiled) => compiled.decodeFirstRow([]).pipe(Effect.orDie),
+	query: (pipe: string, params: Record<string, unknown>) => {
+		captured.pipeCalls.push({ pipe, params })
+		return Effect.succeed({ data: [] as ReadonlyArray<never> })
+	},
+})
+
+const makeLayer = (executor: WarehouseExecutorShape) => Layer.succeed(WarehouseExecutor, executor)
+
+const timeRange = { startTime: "2026-04-01 00:00:00", endTime: "2026-04-02 00:00:00" }
+
+describe("exploreAttributeValues", () => {
+	it.effect("routes source=metrics to the metric_attribute_values pipe (not span)", () =>
+		Effect.gen(function* () {
+			const captured: CapturedCalls = { pipeCalls: [] }
+
+			yield* exploreAttributeValues({ source: "metrics", timeRange, key: "group" }).pipe(
+				Effect.provide(makeLayer(makeMockExecutor(captured))),
+			)
+
+			const call = captured.pipeCalls[0]
+			assert.isDefined(call)
+			assert.strictEqual(call.pipe, "metric_attribute_values")
+			assert.strictEqual(call.params.attribute_key, "group")
+		}),
+	)
+
+	it.effect("routes traces+resource scope to resource_attribute_values", () =>
+		Effect.gen(function* () {
+			const captured: CapturedCalls = { pipeCalls: [] }
+
+			yield* exploreAttributeValues({
+				source: "traces",
+				scope: "resource",
+				timeRange,
+				key: "service.name",
+			}).pipe(Effect.provide(makeLayer(makeMockExecutor(captured))))
+
+			assert.strictEqual(captured.pipeCalls[0]?.pipe, "resource_attribute_values")
+		}),
+	)
+
+	it.effect("defaults traces span scope to span_attribute_values", () =>
+		Effect.gen(function* () {
+			const captured: CapturedCalls = { pipeCalls: [] }
+
+			yield* exploreAttributeValues({ source: "traces", timeRange, key: "http.method" }).pipe(
+				Effect.provide(makeLayer(makeMockExecutor(captured))),
+			)
+
+			assert.strictEqual(captured.pipeCalls[0]?.pipe, "span_attribute_values")
+		}),
+	)
+})
+
+describe("exploreAttributeKeys", () => {
+	it.effect("routes source=metrics to the metric_attribute_keys pipe", () =>
+		Effect.gen(function* () {
+			const captured: CapturedCalls = { pipeCalls: [] }
+
+			yield* exploreAttributeKeys({ source: "metrics", timeRange }).pipe(
+				Effect.provide(makeLayer(makeMockExecutor(captured))),
+			)
+
+			assert.strictEqual(captured.pipeCalls[0]?.pipe, "metric_attribute_keys")
+		}),
+	)
+})

--- a/packages/query-engine/src/observability/explore-attributes.ts
+++ b/packages/query-engine/src/observability/explore-attributes.ts
@@ -75,11 +75,14 @@ export const exploreAttributeValues = Effect.fn("Observability.exploreAttributeV
 	const executor = yield* WarehouseExecutor
 
 	const pipeName =
-		input.scope === "resource"
-			? ("resource_attribute_values" as const)
-			: ("span_attribute_values" as const)
+		input.source === "metrics"
+			? ("metric_attribute_values" as const)
+			: input.scope === "resource"
+				? ("resource_attribute_values" as const)
+				: ("span_attribute_values" as const)
 
 	yield* Effect.annotateCurrentSpan({
+		source: input.source,
 		scope: input.scope ?? "span",
 		key: input.key,
 		service: input.service ?? "all",

--- a/packages/query-engine/src/runtime/query-engine.ts
+++ b/packages/query-engine/src/runtime/query-engine.ts
@@ -355,6 +355,25 @@ const validateTraceAttributeFilters = Effect.fn("QueryEngineService.validateTrac
 	},
 )
 
+const validateMetricsAttributeFilters = Effect.fn(
+	"QueryEngineService.validateMetricsAttributeFilters",
+)(function* (query: QuerySpec): Effect.fn.Return<void, QueryEngineValidationError> {
+	if (query.source !== "metrics") return
+	if (query.kind !== "timeseries" && query.kind !== "breakdown") return
+
+	// `groupBy` is an array for timeseries, a single literal for breakdown.
+	const groupBy = query.groupBy
+	const wantsAttribute = Array.isArray(groupBy) ? groupBy.includes("attribute") : groupBy === "attribute"
+	if (wantsAttribute && !query.filters.groupByAttributeKey) {
+		// Mirror the traces guard: never silently downgrade an attribute grouping
+		// to a service grouping — the agent asked for a label breakdown.
+		return yield* new QueryEngineValidationError({
+			message: "Invalid metrics attribute grouping",
+			details: ["groupBy=attribute requires filters.groupByAttributeKey"],
+		})
+	}
+})
+
 const validatePointBudget = Effect.fn("QueryEngineService.validatePointBudget")(function* (
 	request: QueryEngineExecuteRequest,
 	range: TimeRangeBounds,
@@ -599,6 +618,7 @@ const validateExecute = Effect.fn("QueryEngineService.validateExecute")(function
 ): Effect.fn.Return<TimeRangeBounds, QueryEngineValidationError> {
 	const range = yield* validateTimeRange(request)
 	yield* validateTraceAttributeFilters(request.query)
+	yield* validateMetricsAttributeFilters(request.query)
 	yield* validatePointBudget(request, range)
 	yield* validateListQuery(request, range)
 	yield* validateBreakdownQuery(request, range)
@@ -610,6 +630,7 @@ export const validateEvaluate = Effect.fn("QueryEngineService.validateEvaluate")
 ): Effect.fn.Return<TimeRangeBounds, QueryEngineValidationError> {
 	const range = yield* validateTimeRange(request)
 	yield* validateTraceAttributeFilters(request.query)
+	yield* validateMetricsAttributeFilters(request.query)
 	return range
 })
 

--- a/packages/query-engine/src/runtime/query-engine.ts
+++ b/packages/query-engine/src/runtime/query-engine.ts
@@ -1216,6 +1216,10 @@ export const makeQueryEngineExecute = <T extends QueryTenant>(warehouse: QueryEn
 				tenant,
 				CH.metricsBreakdownQuery({
 					metricType: request.query.filters.metricType,
+					...(request.query.groupBy === "attribute" &&
+						request.query.filters.groupByAttributeKey && {
+							groupByAttributeKey: request.query.filters.groupByAttributeKey,
+						}),
 					limit: request.query.limit,
 				}),
 				{

--- a/packages/query-engine/src/runtime/validate-metrics-attribute.test.ts
+++ b/packages/query-engine/src/runtime/validate-metrics-attribute.test.ts
@@ -1,0 +1,65 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import { MetricName } from "@maple/domain"
+import { QueryEngineEvaluateRequest, type MetricsTimeseriesQuery } from "../query-engine"
+import { validateEvaluate } from "./query-engine"
+
+const makeRequest = (query: MetricsTimeseriesQuery) =>
+	new QueryEngineEvaluateRequest({
+		startTime: "2026-04-01 00:00:00",
+		endTime: "2026-04-01 01:00:00",
+		query,
+		reducer: "avg",
+		sampleCountStrategy: "metric_data_points",
+	})
+
+const baseFilters = { metricName: Schema.decodeUnknownSync(MetricName)("cpu.usage"), metricType: "gauge" as const }
+
+describe("validateMetricsAttributeFilters", () => {
+	it.effect("rejects groupBy=attribute when groupByAttributeKey is missing", () =>
+		Effect.gen(function* () {
+			const exit = yield* validateEvaluate(
+				makeRequest({
+					kind: "timeseries",
+					source: "metrics",
+					metric: "avg",
+					groupBy: ["attribute"],
+					filters: baseFilters,
+				}),
+			).pipe(Effect.exit)
+
+			assert.isTrue(exit._tag === "Failure")
+			assert.include(JSON.stringify(exit), "groupBy=attribute requires filters.groupByAttributeKey")
+		}),
+	)
+
+	it.effect("accepts groupBy=attribute when groupByAttributeKey is present", () =>
+		Effect.gen(function* () {
+			const range = yield* validateEvaluate(
+				makeRequest({
+					kind: "timeseries",
+					source: "metrics",
+					metric: "avg",
+					groupBy: ["attribute"],
+					filters: { ...baseFilters, groupByAttributeKey: "region" },
+				}),
+			)
+			assert.isDefined(range)
+		}),
+	)
+
+	it.effect("accepts groupBy=service without a key", () =>
+		Effect.gen(function* () {
+			const range = yield* validateEvaluate(
+				makeRequest({
+					kind: "timeseries",
+					source: "metrics",
+					metric: "avg",
+					groupBy: ["service"],
+					filters: baseFilters,
+				}),
+			)
+			assert.isDefined(range)
+		}),
+	)
+})


### PR DESCRIPTION
## Why

An agent building dashboards against `metrics_gauge` via the Maple MCP server hit three dead-ends — all real tooling gaps, not user error:

1. **`query_data` metrics breakdown-by-label was silently wrong.** `kind=breakdown group_by=attribute attribute_key=group` always collapsed to a single row named after the service, never the label's values.
2. **Metric label values couldn't be enumerated.** `explore_attributes source=metrics key=group` returned "No values found" and mislabeled itself `Source: metrics (span)` — it was reading span-scoped attribute values.
3. **Raw SQL was write-only to the agent.** `add_dashboard_widget(sql=...)` creates a `raw_sql_chart` widget that renders in the UI, but `inspect_chart_data` rejected it (`UNSUPPORTED`) and there was no tool to run raw SQL and return rows — the agent could write a query it could never see the output of.

## What changed

**Metrics breakdown by attribute label**
- Widened `MetricsBreakdownQuery.groupBy` to `["service", "attribute"]` (`packages/domain/src/query-engine.ts`)
- `metricsBreakdownQuery` now selects/groups by `Attributes['<key>']` and drops empty-label datapoints when `groupByAttributeKey` is set (`packages/query-engine/src/ch/queries/metrics.ts`) — mirrors the timeseries path
- Runtime threads `groupByAttributeKey` through; `query_data` stops hardcoding `groupBy: "service"`

**`explore_attributes source=metrics` (pure wiring — the CH query and MV data already existed)**
- Registered `metric_attribute_values` in the wire contract and dispatched it to the pre-existing `metricAttributeValuesQuery` (reads `attribute_values_hourly` at `'metric'` scope)
- `exploreAttributeValues` routes by `source` (metrics → metric pipe) before scope
- Fixed the misleading `metrics (span)` header and made the next-step hint metrics-aware

**Raw SQL visible to the agent**
- New shared `runRawSql` helper: the existing macro safety pass (`makeExpandMacros` — required `$__orgFilter`, DDL/DML deny-list, single-statement, auto-LIMIT) → `warehouse.sqlQuery`, returns rows + meta
- New read-only `run_sql` MCP tool (registered in the tool registry) with a `RunSqlData` structured-output type
- `inspect_chart_data` now executes `raw_sql_chart` widgets and returns a rows preview (verdict: error→broken, 0-rows→suspicious); post-mutation validation summary handles the new outcome too

## Tests / verification
- `bun typecheck` — 23/23
- New vitest coverage: metrics breakdown attribute grouping compiles to `Attributes['region']` (not `ServiceName`); `metric_attribute_values` dispatch; `exploreAttributeValues` source routing; `runRawSql` wiring + macro validation
- Full suites green: query-engine (632), api MCP (105), domain (152)

## Reviewer notes
- The `run_sql` org isolation rests on the existing `$__orgFilter` requirement + `WarehouseQueryService.sqlQuery`'s `OrgId` substring guard + the DDL/DML deny-list; it's read-only.
- Warehouse errors surface to the agent as readable `isError` text (via `server.ts`'s `McpQueryError` handler), so ClickHouse syntax/schema errors are actionable.
- Live `mcp__maple__*` verification only works post-deploy (those tools hit the deployed server), so pre-deploy confidence is typecheck + vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)