### PR TITLE
fix(scraper): cut PlanetScale 429s via branch filtering + scrape jitter

### DIFF
--- a/apps/api/src/services/PlanetScaleDiscoveryService.test.ts
+++ b/apps/api/src/services/PlanetScaleDiscoveryService.test.ts
@@ -82,7 +82,10 @@ const stubFetch =
 		return respond()
 	}
 
-const createPlanetScaleTargetRow = (organization: string) =>
+const createPlanetScaleTargetRow = (
+	organization: string,
+	branchFilters?: { includeBranches?: string[]; excludeBranches?: string[] },
+) =>
 	Effect.gen(function* () {
 		const service = yield* ScrapeTargetsService
 		const created = yield* service.create(
@@ -92,6 +95,8 @@ const createPlanetScaleTargetRow = (organization: string) =>
 				targetType: "planetscale",
 				organization,
 				authCredentials: JSON.stringify({ tokenId: "tok_id", tokenSecret: "tok_secret" }),
+				...(branchFilters?.includeBranches ? { includeBranches: branchFilters.includeBranches } : {}),
+				...(branchFilters?.excludeBranches ? { excludeBranches: branchFilters.excludeBranches } : {}),
 			}),
 		)
 		const rows = yield* service.listAllEnabled()
@@ -99,6 +104,15 @@ const createPlanetScaleTargetRow = (organization: string) =>
 		if (!row) return yield* Effect.die("created row not found")
 		return row
 	})
+
+const BRANCHES_SD_PAYLOAD = ["main", "stg", "pr-12", "pr-13"].map((branch) => ({
+	targets: [`${branch}.metrics.psdb.cloud:443`],
+	labels: {
+		__metrics_path__: "/metrics",
+		planetscale_database_branch_id: branch,
+		planetscale_database: "mydb",
+	},
+}))
 
 describe("PlanetScaleDiscoveryService", () => {
 	it.effect("discovers sub-targets with the token auth scheme and strips meta labels", () => {
@@ -191,6 +205,42 @@ describe("PlanetScaleDiscoveryService", () => {
 			)
 
 			expect(error.message).toContain("read_metrics_endpoints")
+		}).pipe(Effect.provide(makeLayer(testDb)))
+	})
+
+	it.effect("excludes branches matching an exclude glob (e.g. pr-*)", () => {
+		const testDb = createTestDb(trackedDbs)
+		const recorded: Array<RecordedRequest> = []
+		return Effect.gen(function* () {
+			const discovery = yield* PlanetScaleDiscoveryService
+			const row = yield* createPlanetScaleTargetRow("my-org", { excludeBranches: ["pr-*"] })
+
+			const entries = yield* discovery.discover(row).pipe(
+				Effect.provideService(
+					FetchHttpClient.Fetch,
+					stubFetch(recorded, () => Response.json(BRANCHES_SD_PAYLOAD)),
+				),
+			)
+
+			expect(entries.map((entry) => entry.subTargetKey)).toEqual(["main", "stg"])
+		}).pipe(Effect.provide(makeLayer(testDb)))
+	})
+
+	it.effect("keeps only branches matching an include glob", () => {
+		const testDb = createTestDb(trackedDbs)
+		const recorded: Array<RecordedRequest> = []
+		return Effect.gen(function* () {
+			const discovery = yield* PlanetScaleDiscoveryService
+			const row = yield* createPlanetScaleTargetRow("my-org", { includeBranches: ["main", "stg"] })
+
+			const entries = yield* discovery.discover(row).pipe(
+				Effect.provideService(
+					FetchHttpClient.Fetch,
+					stubFetch(recorded, () => Response.json(BRANCHES_SD_PAYLOAD)),
+				),
+			)
+
+			expect(entries.map((entry) => entry.subTargetKey)).toEqual(["main", "stg"])
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 

--- a/apps/api/src/services/PlanetScaleDiscoveryService.ts
+++ b/apps/api/src/services/PlanetScaleDiscoveryService.ts
@@ -86,6 +86,48 @@ const subTargetsFromGroup = (group: {
 	return { ok, dropped }
 }
 
+/**
+ * Branch name a filter pattern matches against: PlanetScale's http_sd exposes
+ * the human branch name as `planetscale_branch`; older payloads only carry
+ * `planetscale_database_branch_id`. Fall back to the sub-target key so a filter
+ * never silently matches nothing.
+ */
+const branchNameForFilter = (entry: PlanetScaleSubTarget): string =>
+	entry.labels.planetscale_branch ?? entry.labels.planetscale_database_branch_id ?? entry.subTargetKey
+
+/** Glob → anchored RegExp supporting `*` (any run) and `?` (one char). */
+const globToRegExp = (pattern: string): RegExp => {
+	const escaped = pattern
+		.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+		.replace(/\*/g, ".*")
+		.replace(/\?/g, ".")
+	return new RegExp(`^${escaped}$`)
+}
+
+interface BranchFilters {
+	readonly include: ReadonlyArray<string>
+	readonly exclude: ReadonlyArray<string>
+}
+
+/** Read include/exclude branch globs off the row's `discovery_config_json`. */
+const parseBranchFilters = (discoveryConfigJson: unknown): BranchFilters => {
+	const cfg = discoveryConfigJson as
+		| { includeBranches?: unknown; excludeBranches?: unknown }
+		| null
+		| undefined
+	const toList = (value: unknown): string[] =>
+		Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []
+	return { include: toList(cfg?.includeBranches), exclude: toList(cfg?.excludeBranches) }
+}
+
+/** exclude wins over include; an empty include list means "all branches". */
+const branchPassesFilters = (name: string, filters: BranchFilters): boolean => {
+	if (filters.exclude.some((pattern) => globToRegExp(pattern).test(name))) return false
+	if (filters.include.length > 0 && !filters.include.some((pattern) => globToRegExp(pattern).test(name)))
+		return false
+	return true
+}
+
 export interface PlanetScaleDiscoveryServiceShape {
 	/**
 	 * Resolve a planetscale target row into its discovered sub-targets,
@@ -169,7 +211,27 @@ export class PlanetScaleDiscoveryService extends Context.Service<
 					"Dropped PlanetScale discovered targets failing URL validation",
 				).pipe(Effect.annotateLogs({ scrapeTargetId: row.id, dropped: dropped.join(", ") }))
 			}
-			return entries as ReadonlyArray<PlanetScaleSubTarget>
+
+			// Apply the org's branch include/exclude globs so PR-preview branches
+			// (et al.) aren't scraped — the main lever against PlanetScale 429s from
+			// fanning out across every branch in the org.
+			const filters = parseBranchFilters(row.discoveryConfigJson)
+			if (filters.include.length === 0 && filters.exclude.length === 0) {
+				return entries as ReadonlyArray<PlanetScaleSubTarget>
+			}
+			const kept = entries.filter((entry) =>
+				branchPassesFilters(branchNameForFilter(entry), filters),
+			)
+			if (kept.length < entries.length) {
+				yield* Effect.logInfo("Filtered PlanetScale branches by include/exclude globs").pipe(
+					Effect.annotateLogs({
+						scrapeTargetId: row.id,
+						kept: kept.length,
+						filtered: entries.length - kept.length,
+					}),
+				)
+			}
+			return kept as ReadonlyArray<PlanetScaleSubTarget>
 		})
 
 		const discover = Effect.fn("PlanetScaleDiscoveryService.discover")(function* (row: ScrapeTargetRow) {

--- a/apps/api/src/services/ScrapeTargetsService.ts
+++ b/apps/api/src/services/ScrapeTargetsService.ts
@@ -146,7 +146,24 @@ const decodeScrapeTargetTypeSync = Schema.decodeUnknownSync(ScrapeTargetType)
 const ScrapeLabelsSchema = Schema.Record(Schema.String, Schema.String)
 const DiscoveryConfigSchema = Schema.Struct({
 	organization: Schema.String,
+	includeBranches: Schema.optionalKey(Schema.Array(Schema.String)),
+	excludeBranches: Schema.optionalKey(Schema.Array(Schema.String)),
 })
+
+/** Cap pattern lists so a target config stays small and bounded. */
+const MAX_BRANCH_PATTERNS = 50
+const MAX_BRANCH_PATTERN_LENGTH = 200
+
+/** Trim, drop blanks, and de-duplicate a branch glob list from a request. */
+const normalizeBranchPatterns = (patterns: ReadonlyArray<string> | undefined): string[] => {
+	if (!patterns) return []
+	const seen = new Set<string>()
+	for (const raw of patterns) {
+		const pattern = raw.trim()
+		if (pattern.length > 0) seen.add(pattern)
+	}
+	return [...seen]
+}
 
 const parseEncryptionKey = (raw: string): Effect.Effect<Buffer, ScrapeTargetEncryptionError> =>
 	parseBase64Aes256GcmKey(raw, (message) =>
@@ -229,6 +246,8 @@ const rowToResponse = (row: ScrapeTargetRow): ScrapeTargetResponse =>
 		url: row.url,
 		targetType: decodeScrapeTargetTypeSync(row.targetType),
 		organization: decodeDiscoveryConfig(row.discoveryConfigJson)?.organization ?? null,
+		includeBranches: decodeDiscoveryConfig(row.discoveryConfigJson)?.includeBranches ?? [],
+		excludeBranches: decodeDiscoveryConfig(row.discoveryConfigJson)?.excludeBranches ?? [],
 		scrapeIntervalSeconds: decodeScrapeIntervalSecondsSync(row.scrapeIntervalSeconds),
 		labelsJson: row.labelsJson == null ? null : JSON.stringify(row.labelsJson),
 		authType: decodeScrapeAuthTypeSync(row.authType),
@@ -304,6 +323,44 @@ const validateLabelsJson = (labelsJson: string | null | undefined) => {
 		}),
 	)
 }
+
+/**
+ * Normalize + bound a branch glob list. Returns the cleaned patterns, or fails
+ * if the list or an individual pattern exceeds the configured caps.
+ */
+const validateBranchPatterns = (
+	patterns: ReadonlyArray<string> | undefined,
+	field: "includeBranches" | "excludeBranches",
+): Effect.Effect<string[], ScrapeTargetValidationError> => {
+	const normalized = normalizeBranchPatterns(patterns)
+	if (normalized.length > MAX_BRANCH_PATTERNS) {
+		return Effect.fail(
+			new ScrapeTargetValidationError({
+				message: `${field} accepts at most ${MAX_BRANCH_PATTERNS} patterns`,
+			}),
+		)
+	}
+	const tooLong = normalized.find((pattern) => pattern.length > MAX_BRANCH_PATTERN_LENGTH)
+	if (tooLong !== undefined) {
+		return Effect.fail(
+			new ScrapeTargetValidationError({
+				message: `${field} patterns must be at most ${MAX_BRANCH_PATTERN_LENGTH} characters`,
+			}),
+		)
+	}
+	return Effect.succeed(normalized)
+}
+
+/** Assemble the `discovery_config_json` value, omitting empty pattern lists. */
+const buildDiscoveryConfig = (
+	organization: string,
+	includeBranches: ReadonlyArray<string>,
+	excludeBranches: ReadonlyArray<string>,
+): { organization: string; includeBranches?: string[]; excludeBranches?: string[] } => ({
+	organization,
+	...(includeBranches.length > 0 ? { includeBranches: [...includeBranches] } : {}),
+	...(excludeBranches.length > 0 ? { excludeBranches: [...excludeBranches] } : {}),
+})
 
 export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, ScrapeTargetsServiceShape>()(
 	"@maple/api/services/ScrapeTargetsService",
@@ -387,7 +444,9 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 				const targetType = request.targetType ?? "prometheus"
 
 				let url: string
-				let discoveryConfigJson: { organization: string } | null = null
+				let discoveryConfigJson:
+					| { organization: string; includeBranches?: string[]; excludeBranches?: string[] }
+					| null = null
 				let authType: string
 
 				if (targetType === "planetscale") {
@@ -415,10 +474,25 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 							}),
 						)
 					}
+					const includeBranches = yield* validateBranchPatterns(
+						request.includeBranches,
+						"includeBranches",
+					)
+					const excludeBranches = yield* validateBranchPatterns(
+						request.excludeBranches,
+						"excludeBranches",
+					)
 					url = planetScaleDiscoveryUrl(organization)
-					discoveryConfigJson = { organization }
+					discoveryConfigJson = buildDiscoveryConfig(organization, includeBranches, excludeBranches)
 					authType = "token"
 				} else {
+					if (request.includeBranches !== undefined || request.excludeBranches !== undefined) {
+						return yield* Effect.fail(
+							new ScrapeTargetValidationError({
+								message: "includeBranches/excludeBranches are only valid for PlanetScale targets",
+							}),
+						)
+					}
 					if (!request.url) {
 						return yield* Effect.fail(
 							new ScrapeTargetValidationError({ message: "url is required" }),
@@ -523,6 +597,16 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 						}),
 					)
 				}
+				if (
+					!isPlanetScale &&
+					(request.includeBranches !== undefined || request.excludeBranches !== undefined)
+				) {
+					return yield* Effect.fail(
+						new ScrapeTargetValidationError({
+							message: "includeBranches/excludeBranches are only valid for PlanetScale targets",
+						}),
+					)
+				}
 
 				if (request.url !== undefined && request.url !== null) {
 					yield* validateUrl(request.url)
@@ -536,8 +620,17 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 				if (request.name !== undefined) updates.name = request.name.trim()
 				if (request.url !== undefined && request.url !== null) updates.url = request.url.trim()
 
-				if (isPlanetScale && request.organization !== undefined) {
-					const organization = request.organization?.trim()
+				if (
+					isPlanetScale &&
+					(request.organization !== undefined ||
+						request.includeBranches !== undefined ||
+						request.excludeBranches !== undefined)
+				) {
+					const existingConfig = decodeDiscoveryConfig(existing.discoveryConfigJson)
+					const organization =
+						request.organization !== undefined
+							? request.organization?.trim()
+							: existingConfig?.organization
 					if (!organization) {
 						return yield* Effect.fail(
 							new ScrapeTargetValidationError({
@@ -545,8 +638,21 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 							}),
 						)
 					}
+					// Provided lists replace (empty array clears); omitted lists are preserved.
+					const includeBranches =
+						request.includeBranches !== undefined
+							? yield* validateBranchPatterns(request.includeBranches, "includeBranches")
+							: (existingConfig?.includeBranches ?? [])
+					const excludeBranches =
+						request.excludeBranches !== undefined
+							? yield* validateBranchPatterns(request.excludeBranches, "excludeBranches")
+							: (existingConfig?.excludeBranches ?? [])
 					updates.url = planetScaleDiscoveryUrl(organization)
-					updates.discoveryConfigJson = { organization }
+					updates.discoveryConfigJson = buildDiscoveryConfig(
+						organization,
+						includeBranches,
+						excludeBranches,
+					)
 				}
 				if (request.scrapeIntervalSeconds !== undefined) {
 					updates.scrapeIntervalSeconds = request.scrapeIntervalSeconds

--- a/apps/api/src/services/ScrapeTargetsService.ts
+++ b/apps/api/src/services/ScrapeTargetsService.ts
@@ -238,16 +238,17 @@ const decodeDiscoveryConfig = (discoveryConfigJson: unknown) => {
 	}
 }
 
-const rowToResponse = (row: ScrapeTargetRow): ScrapeTargetResponse =>
-	new ScrapeTargetResponse({
+const rowToResponse = (row: ScrapeTargetRow): ScrapeTargetResponse => {
+	const discoveryConfig = decodeDiscoveryConfig(row.discoveryConfigJson)
+	return new ScrapeTargetResponse({
 		id: decodeTargetIdSync(row.id),
 		name: row.name,
 		serviceName: row.serviceName ?? null,
 		url: row.url,
 		targetType: decodeScrapeTargetTypeSync(row.targetType),
-		organization: decodeDiscoveryConfig(row.discoveryConfigJson)?.organization ?? null,
-		includeBranches: decodeDiscoveryConfig(row.discoveryConfigJson)?.includeBranches ?? [],
-		excludeBranches: decodeDiscoveryConfig(row.discoveryConfigJson)?.excludeBranches ?? [],
+		organization: discoveryConfig?.organization ?? null,
+		includeBranches: discoveryConfig?.includeBranches ?? [],
+		excludeBranches: discoveryConfig?.excludeBranches ?? [],
 		scrapeIntervalSeconds: decodeScrapeIntervalSecondsSync(row.scrapeIntervalSeconds),
 		labelsJson: row.labelsJson == null ? null : JSON.stringify(row.labelsJson),
 		authType: decodeScrapeAuthTypeSync(row.authType),
@@ -260,6 +261,7 @@ const rowToResponse = (row: ScrapeTargetRow): ScrapeTargetResponse =>
 		createdAt: decodeIsoDateTimeStringSync(row.createdAt.toISOString()),
 		updatedAt: decodeIsoDateTimeStringSync(row.updatedAt.toISOString()),
 	})
+}
 
 const MIN_SCRAPE_INTERVAL = 5
 const MAX_SCRAPE_INTERVAL = 300

--- a/apps/scraper/src/ScrapeScheduler.test.ts
+++ b/apps/scraper/src/ScrapeScheduler.test.ts
@@ -4,7 +4,12 @@ import { TestClock } from "effect/testing"
 import { InternalScrapeTarget, type ScrapeResultReport } from "@maple/domain/http"
 import { ApiClient, ApiRequestError, type ApiClientShape, type ScrapeProxyResponse } from "./ApiClient"
 import { OtlpIngest, OtlpIngestError, type OtlpIngestShape } from "./OtlpIngest"
-import { nextScrapeDelayMs, ScrapeScheduler, type ScrapeOutcome } from "./ScrapeScheduler"
+import {
+	initialJitterMs,
+	nextScrapeDelayMs,
+	ScrapeScheduler,
+	type ScrapeOutcome,
+} from "./ScrapeScheduler"
 import { ScraperEnv, type ScraperEnvShape } from "./Env"
 import type { OtlpExportRequest } from "./prometheus/otlp"
 
@@ -534,5 +539,30 @@ describe("nextScrapeDelayMs", () => {
 			nextScrapeDelayMs({ baseMs: 10_000, outcome: limited(5_000), consecutiveRateLimits: 2 }),
 			40_000,
 		)
+	})
+})
+
+describe("initialJitterMs", () => {
+	it("stays within [0, baseMs) and is deterministic for a key", () => {
+		const baseMs = 30_000
+		const a = initialJitterMs("target_a:branch-1", baseMs)
+		assert.isAtLeast(a, 0)
+		assert.isBelow(a, baseMs)
+		// Same key → same jitter (survives reconciles without a random source).
+		assert.strictEqual(initialJitterMs("target_a:branch-1", baseMs), a)
+	})
+
+	it("de-synchronizes branches of one target so they don't start on the same tick", () => {
+		const baseMs = 30_000
+		const branch1 = initialJitterMs("target_a:branch-1", baseMs)
+		const branch2 = initialJitterMs("target_a:branch-2", baseMs)
+		const branch3 = initialJitterMs("target_a:branch-3", baseMs)
+		assert.notStrictEqual(branch1, branch2)
+		assert.notStrictEqual(branch2, branch3)
+		assert.notStrictEqual(branch1, branch3)
+	})
+
+	it("returns 0 when the interval is non-positive", () => {
+		assert.strictEqual(initialJitterMs("target_a:branch-1", 0), 0)
 	})
 })

--- a/apps/scraper/src/ScrapeScheduler.ts
+++ b/apps/scraper/src/ScrapeScheduler.ts
@@ -63,6 +63,23 @@ export const nextScrapeDelayMs = ({
 	return Math.min(MAX_BACKOFF_MS, Math.max(exponential, retryAfter))
 }
 
+/**
+ * Deterministic per-target start delay in `[0, baseMs)`. Discovered sub-targets
+ * (PlanetScale branches) share one id and the same interval, so without this
+ * they all scrape on the same tick — a synchronized burst that trips
+ * PlanetScale's per-org rate limit (429). Derived from a stable key (FNV-1a) so
+ * it survives reconciles and needs no random source (keeps tests deterministic).
+ */
+export const initialJitterMs = (key: string, baseMs: number): number => {
+	if (baseMs <= 0) return 0
+	let hash = 0x811c9dc5
+	for (let i = 0; i < key.length; i++) {
+		hash ^= key.charCodeAt(i)
+		hash = Math.imul(hash, 0x01000193)
+	}
+	return (hash >>> 0) % baseMs
+}
+
 const hostFromUrl = (url: string): string => {
 	try {
 		return new URL(url).host
@@ -270,7 +287,12 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 						yield* Effect.sleep(Duration.millis(sleepMs))
 						return yield* loop(outcome.rateLimited ? consecutiveRateLimits + 1 : 0)
 					})
-				return loop(0)
+				// Plain targets have nothing to de-sync against; only stagger the
+				// branches of a discovered (PlanetScale) target so they spread across
+				// the interval instead of bursting together.
+				if (target.subTargetKey == null) return loop(0)
+				const jitterMs = initialJitterMs(targetKey(target), baseMs)
+				return Effect.flatMap(Effect.sleep(Duration.millis(jitterMs)), () => loop(0))
 			}
 
 			const reconcile = Effect.gen(function* () {

--- a/apps/web/src/components/settings/scrape-targets-section.tsx
+++ b/apps/web/src/components/settings/scrape-targets-section.tsx
@@ -223,6 +223,8 @@ export function ScrapeTargetsSection({
 	const [formOrganization, setFormOrganization] = useState("")
 	const [formTokenId, setFormTokenId] = useState("")
 	const [formTokenSecret, setFormTokenSecret] = useState("")
+	const [formIncludeBranches, setFormIncludeBranches] = useState("")
+	const [formExcludeBranches, setFormExcludeBranches] = useState("")
 	const [formInterval, setFormInterval] = useState("15")
 	const [formAuthType, setFormAuthType] = useState<ScrapeAuthType>("none")
 	const [formAuthToken, setFormAuthToken] = useState("")
@@ -282,6 +284,8 @@ export function ScrapeTargetsSection({
 		setFormOrganization("")
 		setFormTokenId("")
 		setFormTokenSecret("")
+		setFormIncludeBranches("")
+		setFormExcludeBranches("")
 		setFormInterval(targetType === "planetscale" ? "30" : "15")
 		setFormAuthType("none")
 		setFormAuthToken("")
@@ -299,6 +303,8 @@ export function ScrapeTargetsSection({
 		setFormOrganization(target.organization ?? "")
 		setFormTokenId("")
 		setFormTokenSecret("")
+		setFormIncludeBranches(target.includeBranches.join(", "))
+		setFormExcludeBranches(target.excludeBranches.join(", "))
 		setFormInterval(String(target.scrapeIntervalSeconds))
 		setFormAuthType(target.authType)
 		setFormAuthToken("")
@@ -332,6 +338,13 @@ export function ScrapeTargetsSection({
 			})
 		}
 		return null
+	}
+
+	function parseBranchList(value: string): string[] {
+		return value
+			.split(",")
+			.map((entry) => entry.trim())
+			.filter((entry) => entry.length > 0)
 	}
 
 	async function handleSave() {
@@ -370,6 +383,8 @@ export function ScrapeTargetsSection({
 						? {
 								organization: formOrganization.trim(),
 								authType: "token" as const,
+								includeBranches: parseBranchList(formIncludeBranches),
+								excludeBranches: parseBranchList(formExcludeBranches),
 							}
 						: {
 								url: formUrl.trim(),
@@ -396,6 +411,8 @@ export function ScrapeTargetsSection({
 								targetType: "planetscale" as const,
 								organization: formOrganization.trim(),
 								authType: "token" as const,
+								includeBranches: parseBranchList(formIncludeBranches),
+								excludeBranches: parseBranchList(formExcludeBranches),
 							}
 						: {
 								url: formUrl.trim(),
@@ -635,6 +652,33 @@ export function ScrapeTargetsSection({
 										Create a service token with the{" "}
 										<span className="font-mono">read_metrics_endpoints</span> organization
 										permission.
+									</p>
+								</div>
+								<div className="space-y-2">
+									<Label htmlFor="scrape-include-branches">Include branches (optional)</Label>
+									<Input
+										id="scrape-include-branches"
+										placeholder="e.g. main, stg"
+										value={formIncludeBranches}
+										onChange={(e) => setFormIncludeBranches(e.target.value)}
+									/>
+									<p className="text-muted-foreground text-xs">
+										Comma-separated branch globs. When set, only matching branches are
+										scraped. Leave blank to scrape all branches.
+									</p>
+								</div>
+								<div className="space-y-2">
+									<Label htmlFor="scrape-exclude-branches">Exclude branches (optional)</Label>
+									<Input
+										id="scrape-exclude-branches"
+										placeholder="e.g. pr-*"
+										value={formExcludeBranches}
+										onChange={(e) => setFormExcludeBranches(e.target.value)}
+									/>
+									<p className="text-muted-foreground text-xs">
+										Comma-separated branch globs to skip — e.g.{" "}
+										<span className="font-mono">pr-*</span> to avoid scraping PR-preview
+										branches (a common source of PlanetScale rate-limit 429s).
 									</p>
 								</div>
 							</>
@@ -1077,7 +1121,21 @@ function ScrapeTargetDetails({
 					<div className="divide-y rounded-md border bg-background/35 text-xs">
 						<DetailRow label="Service" value={target.serviceName ?? target.name} />
 						{target.targetType === "planetscale" ? (
-							<DetailRow label="Organization" value={target.organization ?? "-"} />
+							<>
+								<DetailRow label="Organization" value={target.organization ?? "-"} />
+								{target.includeBranches.length > 0 && (
+									<DetailRow
+										label="Include branches"
+										value={<span className="font-mono">{target.includeBranches.join(", ")}</span>}
+									/>
+								)}
+								{target.excludeBranches.length > 0 && (
+									<DetailRow
+										label="Exclude branches"
+										value={<span className="font-mono">{target.excludeBranches.join(", ")}</span>}
+									/>
+								)}
+							</>
 						) : (
 							<DetailRow label="Instance" value={hostnameFromUrl(target.url)} />
 						)}

--- a/packages/domain/src/http/scrape-targets.ts
+++ b/packages/domain/src/http/scrape-targets.ts
@@ -17,6 +17,10 @@ export class ScrapeTargetResponse extends Schema.Class<ScrapeTargetResponse>("Sc
 	targetType: ScrapeTargetType,
 	/** PlanetScale organization name; `null` for plain Prometheus targets. */
 	organization: Schema.NullOr(Schema.String),
+	/** PlanetScale only — glob patterns; only matching branches are scraped (empty = all). */
+	includeBranches: Schema.Array(Schema.String),
+	/** PlanetScale only — glob patterns; matching branches are skipped (e.g. `pr-*`). */
+	excludeBranches: Schema.Array(Schema.String),
 	scrapeIntervalSeconds: ScrapeIntervalSeconds,
 	labelsJson: Schema.NullOr(Schema.String),
 	authType: ScrapeAuthType,
@@ -43,6 +47,10 @@ export class CreateScrapeTargetRequest extends Schema.Class<CreateScrapeTargetRe
 	targetType: Schema.optionalKey(ScrapeTargetType),
 	/** Required for `planetscale` targets. */
 	organization: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	/** PlanetScale only — branch glob allowlist (omit/empty = scrape all branches). */
+	includeBranches: Schema.optionalKey(Schema.Array(Schema.String)),
+	/** PlanetScale only — branch glob denylist (e.g. `pr-*` to skip PR previews). */
+	excludeBranches: Schema.optionalKey(Schema.Array(Schema.String)),
 	scrapeIntervalSeconds: Schema.optionalKey(ScrapeIntervalSeconds),
 	labelsJson: Schema.optionalKey(Schema.NullOr(Schema.String)),
 	authType: Schema.optionalKey(ScrapeAuthType),
@@ -58,6 +66,10 @@ export class UpdateScrapeTargetRequest extends Schema.Class<UpdateScrapeTargetRe
 	url: Schema.optionalKey(Schema.String),
 	/** PlanetScale targets only — updates the organization and re-derives the SD url. */
 	organization: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	/** PlanetScale only — branch glob allowlist (empty array clears it; omit = unchanged). */
+	includeBranches: Schema.optionalKey(Schema.Array(Schema.String)),
+	/** PlanetScale only — branch glob denylist (empty array clears it; omit = unchanged). */
+	excludeBranches: Schema.optionalKey(Schema.Array(Schema.String)),
 	scrapeIntervalSeconds: Schema.optionalKey(ScrapeIntervalSeconds),
 	labelsJson: Schema.optionalKey(Schema.NullOr(Schema.String)),
 	authType: Schema.optionalKey(ScrapeAuthType),


### PR DESCRIPTION
## Problem

PlanetScale scrape targets in the connectors dashboard sat stuck at **HTTP 429**, even after #128 added per-target backoff and with the scrape interval maxed at the UI's 300s ceiling. Raising the interval didn't help.

Diagnosed from the code: the 429 is PlanetScale rate-limiting the **per-branch metric scrapes** (`*.metrics.psdb.cloud`), driven by request *volume + bursting*, not frequency:

1. **No branch filter.** Discovery returns a metrics target for *every* branch in the org. Our own PR-preview workflow creates a `pr-<n>` PlanetScale branch per PR, so the org carries `main` + `stg` + a pile of `pr-*` branches — all scraped.
2. **Synchronized bursts.** All branch loops are forked together on reconcile, scrape immediately, then sleep the *same* interval with no jitter → phase-aligned bursts through one global `SCRAPER_CONCURRENCY` semaphore. Raising the interval doesn't de-sync the burst.
3. **Per-branch backoff vs per-org limit.** #128's backoff is keyed per sub-target, but PlanetScale's budget is per-org, so branches keep colliding.

## Changes

**1. Branch include/exclude filtering** (primary fix)
- `includeBranches` / `excludeBranches` glob patterns (`*`, `?`) on PlanetScale targets — e.g. exclude `pr-*` to skip PR previews.
- Applied in `PlanetScaleDiscoveryService.fetchSubTargets` (matches `planetscale_branch` → `planetscale_database_branch_id` → sub-target key; exclude wins over include; empty = all branches).
- Stored in the existing `discovery_config_json` jsonb column — **no DB migration**.
- Validation: capped at 50 patterns / 200 chars each; rejected for non-PlanetScale targets; merge-on-update (empty array clears, omitted preserves).
- Surfaced in the PlanetScale settings form (two optional comma-separated inputs, placeholder `pr-*`) + detail-panel rows.

**2. Per-branch scrape jitter** (burst mitigation)
- Deterministic `initialJitterMs` (FNV-1a, `[0, baseMs)`) staggers each branch's first scrape so an org's branches spread across the interval. Applied **only** to discovered sub-targets; plain Prometheus targets are unchanged (keeps their start-at-t0 cadence).

Org-coordinated backoff is intentionally **out of scope** — noted as a follow-up if 429s persist after this.

## Testing

- **Discovery** (7 pass): new cases assert `exclude: pr-*` and `include: [main, stg]` keep only `main`/`stg` from a `main/stg/pr-12/pr-13` payload.
- **Scheduler** (24 pass): new `initialJitterMs` cases (range, determinism, branch de-sync) + existing timing tests still green.
- `ScrapeTargetsService` (11) + `scraper-internal` (9) tests pass.
- `bun typecheck`: 23/23 packages clean.

## Reviewer notes

- No browser verification: both preview ports were held by another active dev session. UI changes are additive and use existing `Input`/`Label`/`DetailRow` primitives.
- Full E2E needs a real PlanetScale org token. Post-deploy: set a target to exclude `pr-*`, confirm the sub-target count drops in the detail panel and the 429/Down state clears in `scrape_target_checks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
