### PR TITLE
feat(replays): active/idle time on session overview, MCP + sidebar filters

### DIFF
--- a/apps/api/src/mcp/tools/get-session-traces.ts
+++ b/apps/api/src/mcp/tools/get-session-traces.ts
@@ -51,11 +51,15 @@ export function registerGetSessionTracesTool(server: McpToolRegistrar) {
 			// Tinybird path returns numbers (see the facets handler in
 			// session-replay.http.ts); coerce every numeric at the edge.
 			const errorCount = Number(session.errorCount)
+			const activeTimeMs = session.activeTimeMs != null ? Number(session.activeTimeMs) : null
+			const idleTimeMs = session.idleTimeMs != null ? Number(session.idleTimeMs) : null
 			const metaParts = [
 				device || "unknown client",
 				session.country || null,
 				errorCount > 0 ? `${errorCount} errors` : "no errors",
-				session.durationMs != null ? `${Math.round(Number(session.durationMs))}ms` : null,
+				session.durationMs != null ? `${Math.round(Number(session.durationMs))}ms total` : null,
+				activeTimeMs != null ? `${Math.round(activeTimeMs)}ms active` : null,
+				idleTimeMs != null ? `${Math.round(idleTimeMs)}ms idle` : null,
 			].filter((p): p is string => Boolean(p))
 
 			const lines: string[] = [`## Session ${session.sessionId}`, metaParts.join(" · ")]
@@ -118,6 +122,8 @@ export function registerGetSessionTracesTool(server: McpToolRegistrar) {
 							pageViews: Number(session.pageViews),
 							clickCount: Number(session.clickCount),
 							errorCount,
+							activeTimeMs,
+							idleTimeMs,
 						},
 						totalTraceCount,
 						traces: pipe(

--- a/apps/api/src/routes/session-replay.http.ts
+++ b/apps/api/src/routes/session-replay.http.ts
@@ -40,6 +40,10 @@ export const HttpSessionReplaysLive = HttpApiBuilder.group(MapleApi, "sessionRep
 							hasErrors: payload.hasErrors,
 							search: payload.search,
 							cursor: payload.cursor,
+							durationMinMs: payload.durationMinMs,
+							durationMaxMs: payload.durationMaxMs,
+							activeTimeMinMs: payload.activeTimeMinMs,
+							activeTimeMaxMs: payload.activeTimeMaxMs,
 							limit: payload.limit,
 							offset: payload.offset,
 						}),
@@ -115,20 +119,48 @@ export const HttpSessionReplaysLive = HttpApiBuilder.group(MapleApi, "sessionRep
 							sessionId: payload.sessionId,
 						},
 					)
-					const maybeData = yield* warehouse.compiledQueryFirst(tenant, compiled, {
-						profile: "discovery",
-						context: "getReplay",
-					})
+					// Active/idle breakdown from session_events gaps. Both reads are
+					// single-session sort-key seeks (`(OrgId, SessionId)` prefix) sharing
+					// the partition-pruning window, so they're cheap and independent — run
+					// them concurrently to keep the detail page to one round-trip of
+					// latency rather than two.
+					const activityCompiled = CH.compile(
+						CH.sessionActivityQuery({
+							startTime: payload.windowStart,
+							endTime: payload.windowEnd,
+						}),
+						{ orgId: tenant.orgId, sessionId: payload.sessionId },
+					)
+					const [maybeData, maybeActivity] = yield* Effect.all(
+						[
+							warehouse.compiledQueryFirst(tenant, compiled, {
+								profile: "discovery",
+								context: "getReplay",
+							}),
+							warehouse.compiledQueryFirst(tenant, activityCompiled, {
+								profile: "discovery",
+								context: "getReplayActivity",
+							}),
+						],
+						{ concurrency: 2 },
+					)
 					const data = Option.getOrNull(maybeData)
+					if (!data) {
+						return new GetReplayResponse({ data: null })
+					}
+					const activity = Option.getOrNull(maybeActivity)
+
 					return new GetReplayResponse({
-						data: data
-							? {
-									...data,
-									sessionId: decodeSessionId(data.sessionId),
-									userId: data.userId ? decodeUserId(data.userId) : null,
-									traceIds: data.traceIds.map((traceId) => decodeTraceId(traceId)),
-								}
-							: null,
+						data: {
+							...data,
+							sessionId: decodeSessionId(data.sessionId),
+							userId: data.userId ? decodeUserId(data.userId) : null,
+							traceIds: data.traceIds.map((traceId) => decodeTraceId(traceId)),
+							// ClickHouse JSON-quotes 64-bit ints as strings; coerce before
+							// Schema.Number validates (see the facets handler).
+							activeTimeMs: activity ? Number(activity.activeTimeMs) : null,
+							idleTimeMs: activity ? Number(activity.idleTimeMs) : null,
+						},
 					})
 				}),
 			)

--- a/apps/web/src/api/warehouse/replays.ts
+++ b/apps/web/src/api/warehouse/replays.ts
@@ -28,6 +28,12 @@ const ListReplaysInput = Schema.Struct({
 	hasErrors: Schema.optional(Schema.Boolean),
 	search: Schema.optional(Schema.String),
 	cursor: Schema.optional(Schema.String),
+	// Session-time range filters (ms) — duration is the stored wall-clock time,
+	// activeTime is computed server-side from session_events gaps.
+	durationMinMs: Schema.optional(Schema.Number),
+	durationMaxMs: Schema.optional(Schema.Number),
+	activeTimeMinMs: Schema.optional(Schema.Number),
+	activeTimeMaxMs: Schema.optional(Schema.Number),
 	limit: Schema.optional(Schema.Number),
 	offset: Schema.optional(Schema.Number),
 })
@@ -60,6 +66,10 @@ export const listReplays = Effect.fn("SessionReplays.listReplays")(function* ({
 					hasErrors: input.hasErrors,
 					search: input.search,
 					cursor: input.cursor,
+					durationMinMs: input.durationMinMs,
+					durationMaxMs: input.durationMaxMs,
+					activeTimeMinMs: input.activeTimeMinMs,
+					activeTimeMaxMs: input.activeTimeMaxMs,
 					limit: input.limit ?? 50,
 					offset: input.offset ?? 0,
 				}),

--- a/apps/web/src/components/replays/preview-fixtures.ts
+++ b/apps/web/src/components/replays/preview-fixtures.ts
@@ -159,6 +159,8 @@ export const PREVIEW_SESSION = {
 	userId: "jordan@acme.dev",
 	urlInitial: INITIAL_URL,
 	durationMs: 30_000,
+	activeTimeMs: 21_500,
+	idleTimeMs: 8_500,
 	browserName: "Chrome 138",
 	osName: "macOS 15",
 	deviceType: "desktop",

--- a/apps/web/src/components/replays/replay-studio.tsx
+++ b/apps/web/src/components/replays/replay-studio.tsx
@@ -30,6 +30,11 @@ interface ReplayStudioSession {
 	readonly urlInitial: string
 	readonly startTime: string
 	readonly durationMs: number | null
+	/** Engaged time (ms), computed server-side from session_events gaps. Omitted
+	 *  on the preview fixture; null when the session has no distilled events. */
+	readonly activeTimeMs?: number | null
+	/** Idle time (ms) — the long-gap complement of active time. */
+	readonly idleTimeMs?: number | null
 	readonly clickCount: number
 	readonly pageViews?: number | null
 	readonly errorCount: number
@@ -123,11 +128,21 @@ export function ReplayStudio({
 	)
 }
 
-/** Unified vitals strip for the header — Duration / Clicks / Pages / Errors,
- *  divided into one cohesive cluster. Only an error count > 0 takes colour. */
+/** Unified vitals strip for the header — Duration / Active / Idle / Clicks /
+ *  Pages / Errors, divided into one cohesive cluster. Active + Idle split the
+ *  wall-clock duration into engaged vs idle time (shown only when the warehouse
+ *  supplied them). Only an error count > 0 takes colour. */
 function StatStrip({ session }: { session: ReplayStudioSession }) {
 	const items = [
 		{ label: "Duration", value: formatDuration(session.durationMs) },
+		// `activeTimeMs === undefined` only on the preview fixture; a real session
+		// with no distilled events sends `null`, which renders as "—".
+		...(session.activeTimeMs !== undefined
+			? [{ label: "Active", value: formatDuration(session.activeTimeMs) }]
+			: []),
+		...(session.idleTimeMs !== undefined
+			? [{ label: "Idle", value: formatDuration(session.idleTimeMs) }]
+			: []),
 		{ label: "Clicks", value: String(session.clickCount) },
 		{ label: "Pages", value: String(session.pageViews || 1) },
 		{ label: "Errors", value: String(session.errorCount), error: session.errorCount > 0 },

--- a/apps/web/src/components/replays/replays-filter-sidebar.tsx
+++ b/apps/web/src/components/replays/replays-filter-sidebar.tsx
@@ -77,6 +77,15 @@ export function ReplaysFilterSidebar({ facetsResult }: ReplaysFilterSidebarProps
 		navigate({ search: (prev) => ({ ...prev, userId: value }) })
 	}
 
+	// Session-time ranges (seconds in the URL; mapped to ms before the query).
+	const setDurationRange = (min: number | undefined, max: number | undefined) => {
+		navigate({ search: (prev) => ({ ...prev, durationMin: min, durationMax: max }) })
+	}
+
+	const setActiveRange = (min: number | undefined, max: number | undefined) => {
+		navigate({ search: (prev) => ({ ...prev, activeMin: min, activeMax: max }) })
+	}
+
 	const clearAllFilters = () => {
 		navigate({
 			search: {
@@ -94,7 +103,11 @@ export function ReplaysFilterSidebar({ facetsResult }: ReplaysFilterSidebarProps
 		!!search.country ||
 		!!search.deviceType ||
 		!!search.userId ||
-		search.hasErrors === true
+		search.hasErrors === true ||
+		search.durationMin != null ||
+		search.durationMax != null ||
+		search.activeMin != null ||
+		search.activeMax != null
 
 	return Result.builder(facetsResult)
 		.onInitial(() => <FilterSidebarLoading sectionCount={5} />)
@@ -125,6 +138,26 @@ export function ReplaysFilterSidebar({ facetsResult }: ReplaysFilterSidebarProps
 							checked={search.hasErrors === true}
 							onChange={toggleHasErrors}
 							count={facets.errorCount}
+						/>
+
+						<Separator className="my-2" />
+
+						<RangeFilter
+							title="Session time"
+							hint="Total length, in seconds"
+							min={search.durationMin}
+							max={search.durationMax}
+							onApply={setDurationRange}
+						/>
+
+						<Separator className="my-2" />
+
+						<RangeFilter
+							title="Active time"
+							hint="Engaged (non-idle) time, in seconds"
+							min={search.activeMin}
+							max={search.activeMax}
+							onApply={setActiveRange}
 						/>
 
 						{services.length > 0 && (
@@ -239,6 +272,80 @@ function UserIdFilter({ value, onApply }: UserIdFilterProps) {
 					</InputGroupAddon>
 				)}
 			</InputGroup>
+		</form>
+	)
+}
+
+// A min/max numeric range (seconds). Like UserIdFilter, it commits on submit (so
+// partial typing doesn't refetch per keystroke) and syncs back when the applied
+// value changes elsewhere (Clear all). Blank bound = unbounded on that side.
+interface RangeFilterProps {
+	title: string
+	hint: string
+	min: number | undefined
+	max: number | undefined
+	onApply: (min: number | undefined, max: number | undefined) => void
+}
+
+function RangeFilter({ title, hint, min, max, onApply }: RangeFilterProps) {
+	const [minText, setMinText] = useState(min != null ? String(min) : "")
+	const [maxText, setMaxText] = useState(max != null ? String(max) : "")
+
+	useEffect(() => {
+		setMinText(min != null ? String(min) : "")
+	}, [min])
+	useEffect(() => {
+		setMaxText(max != null ? String(max) : "")
+	}, [max])
+
+	// Parse a non-negative number, or undefined for blank/invalid (= unbounded).
+	const parse = (raw: string): number | undefined => {
+		const trimmed = raw.trim()
+		if (trimmed === "") return undefined
+		const n = Number(trimmed)
+		return Number.isFinite(n) && n >= 0 ? n : undefined
+	}
+
+	return (
+		<form
+			className="py-2"
+			onSubmit={(e) => {
+				e.preventDefault()
+				onApply(parse(minText), parse(maxText))
+			}}
+		>
+			<Label className="mb-1 block text-sm font-medium text-muted-foreground">{title}</Label>
+			<p className="mb-2 text-xs text-muted-foreground/70">{hint}</p>
+			<div className="flex items-center gap-2">
+				<InputGroup>
+					<InputGroupInput
+						size="sm"
+						inputMode="numeric"
+						value={minText}
+						onChange={(e) => setMinText(e.target.value)}
+						placeholder="Min"
+						aria-label={`${title} minimum (seconds)`}
+					/>
+					<InputGroupAddon align="inline-end">s</InputGroupAddon>
+				</InputGroup>
+				<span className="text-muted-foreground">–</span>
+				<InputGroup>
+					<InputGroupInput
+						size="sm"
+						inputMode="numeric"
+						value={maxText}
+						onChange={(e) => setMaxText(e.target.value)}
+						placeholder="Max"
+						aria-label={`${title} maximum (seconds)`}
+					/>
+					<InputGroupAddon align="inline-end">s</InputGroupAddon>
+				</InputGroup>
+			</div>
+			{/* Submit is keyboard-driven (Enter); a hidden submit keeps the form
+			    submittable without a visible button cluttering the sidebar. */}
+			<button type="submit" className="sr-only">
+				Apply {title}
+			</button>
 		</form>
 	)
 }

--- a/apps/web/src/hooks/use-infinite-replays.ts
+++ b/apps/web/src/hooks/use-infinite-replays.ts
@@ -23,6 +23,10 @@ export interface ReplaysFilterInputs {
 	userId?: string
 	hasErrors?: boolean
 	search?: string
+	durationMinMs?: number
+	durationMaxMs?: number
+	activeTimeMinMs?: number
+	activeTimeMaxMs?: number
 }
 
 interface ReplaysPage {

--- a/apps/web/src/lib/search-params.ts
+++ b/apps/web/src/lib/search-params.ts
@@ -11,6 +11,13 @@ const StringArrayFromJsonString = Schema.mutable(Schema.fromJsonString(Schema.Ar
 export const BooleanFromStringParam = Schema.fromJsonString(Schema.Boolean)
 
 /**
+ * URL search param number field. TanStack Router's parseSearch yields a string
+ * (`?n=30` → `"30"`); this decodes it to a number. Pair with `Schema.Number` in
+ * a Union so a value set JS-side by `navigate` (a real number) round-trips too.
+ */
+export const NumberFromStringParam = Schema.fromJsonString(Schema.Number)
+
+/**
  * Use this for URL search param array fields. Accepts both a real array
  * and a JSON-encoded string, preventing crashes from malformed URLs.
  */

--- a/apps/web/src/routes/replays/index.tsx
+++ b/apps/web/src/routes/replays/index.tsx
@@ -8,7 +8,7 @@ import { SessionsList } from "@/components/replays/sessions-list"
 import { ActiveUserFilter } from "@/components/replays/active-user-filter"
 import { ReplaysFilterSidebar } from "@/components/replays/replays-filter-sidebar"
 import { ReplaysToolbar } from "@/components/replays/replays-toolbar"
-import { BooleanFromStringParam } from "@/lib/search-params"
+import { BooleanFromStringParam, NumberFromStringParam } from "@/lib/search-params"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useInfiniteReplays } from "@/hooks/use-infinite-replays"
 import { Result, useAtomValue } from "@/lib/effect-atom"
@@ -30,6 +30,13 @@ const replaysSearchSchema = Schema.Struct({
 	deviceType: Schema.optional(Schema.String),
 	userId: Schema.optional(Schema.String),
 	hasErrors: Schema.optional(Schema.Union([Schema.Boolean, BooleanFromStringParam])),
+	// Session-time range filters, in whole seconds (human-friendly URLs). Mapped
+	// to ms before hitting the warehouse. Union accepts a JS-set number or a
+	// URL-parsed string, mirroring hasErrors.
+	durationMin: Schema.optional(Schema.Union([Schema.Number, NumberFromStringParam])),
+	durationMax: Schema.optional(Schema.Union([Schema.Number, NumberFromStringParam])),
+	activeMin: Schema.optional(Schema.Union([Schema.Number, NumberFromStringParam])),
+	activeMax: Schema.optional(Schema.Union([Schema.Number, NumberFromStringParam])),
 	q: Schema.optional(Schema.String),
 })
 
@@ -58,6 +65,11 @@ function ReplaysPage() {
 			userId: search.userId,
 			hasErrors: search.hasErrors,
 			search: search.q,
+			// URL params are whole seconds; the warehouse filters in ms.
+			durationMinMs: search.durationMin != null ? search.durationMin * 1000 : undefined,
+			durationMaxMs: search.durationMax != null ? search.durationMax * 1000 : undefined,
+			activeTimeMinMs: search.activeMin != null ? search.activeMin * 1000 : undefined,
+			activeTimeMaxMs: search.activeMax != null ? search.activeMax * 1000 : undefined,
 		}),
 		[
 			startTime,
@@ -69,6 +81,10 @@ function ReplaysPage() {
 			search.userId,
 			search.hasErrors,
 			search.q,
+			search.durationMin,
+			search.durationMax,
+			search.activeMin,
+			search.activeMax,
 		],
 	)
 

--- a/packages/domain/src/http/session-replay.ts
+++ b/packages/domain/src/http/session-replay.ts
@@ -34,6 +34,14 @@ export class ListReplaysRequest extends Schema.Class<ListReplaysRequest>("ListRe
 	hasErrors: Schema.optional(Schema.Boolean),
 	search: Schema.optional(Schema.String),
 	cursor: Schema.optional(Schema.String),
+	// Session-time range filters (ms). `durationMin/Max` filter the stored
+	// wall-clock duration; `activeTimeMin/Max` filter active (non-idle) time
+	// computed from session_events gaps (server-side: setting either active bound
+	// joins the activity aggregate). All four are JS-constructed → Schema.optional.
+	durationMinMs: Schema.optional(Schema.Number),
+	durationMaxMs: Schema.optional(Schema.Number),
+	activeTimeMinMs: Schema.optional(Schema.Number),
+	activeTimeMaxMs: Schema.optional(Schema.Number),
 	limit: Schema.optional(Schema.Number),
 	offset: Schema.optional(Schema.Number),
 }) {}
@@ -124,6 +132,10 @@ export class GetReplayResponse extends Schema.Class<GetReplayResponse>("GetRepla
 			errorCount: Schema.Number,
 			traceIds: Schema.Array(TraceId),
 			resourceAttributes: Schema.String,
+			// Active/idle breakdown from session_events gaps (null when the session
+			// has no distilled events). active + idle ≈ event span ≤ durationMs.
+			activeTimeMs: Schema.NullOr(Schema.Number),
+			idleTimeMs: Schema.NullOr(Schema.Number),
 		}),
 	),
 }) {}

--- a/packages/domain/src/mcp-structured-types.ts
+++ b/packages/domain/src/mcp-structured-types.ts
@@ -826,6 +826,10 @@ export interface GetSessionTracesData {
 		pageViews: number
 		clickCount: number
 		errorCount: number
+		/** Engaged time (ms) from session_events gaps; null if no distilled events. */
+		activeTimeMs: number | null
+		/** Idle time (ms) — the long-gap complement of active time. */
+		idleTimeMs: number | null
 	}
 	totalTraceCount: number
 	traces: ReadonlyArray<{

--- a/packages/query-engine/src/ch/index.ts
+++ b/packages/query-engine/src/ch/index.ts
@@ -119,9 +119,14 @@ export {
 export {
 	sessionTranscriptQuery,
 	searchSessionsByEventQuery,
+	sessionActivityQuery,
+	sessionActivityAggregateQuery,
+	IDLE_GAP_THRESHOLD_MS,
 	type SessionTranscriptOutput,
 	type SearchSessionsByEventOpts,
 	type SearchSessionsByEventOutput,
+	type SessionActivityOpts,
+	type SessionActivityOutput,
 } from "./queries/session-events"
 
 // Queries — Services

--- a/packages/query-engine/src/ch/queries/session-events.test.ts
+++ b/packages/query-engine/src/ch/queries/session-events.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+import { compileCH } from "@maple-dev/clickhouse-builder"
+import { sessionActivityQuery, IDLE_GAP_THRESHOLD_MS } from "./session-events"
+
+const sessionParams = { orgId: "org_1", sessionId: "sess_1" }
+const WINDOW = { startTime: "2026-06-24 04:00:00", endTime: "2026-06-25 06:00:00" }
+
+// ---------------------------------------------------------------------------
+// sessionActivityQuery
+//
+// Active/idle time from gaps between distilled events: a lagInFrame window
+// measures each event's gap to its predecessor, then sumIf splits the gaps at
+// the idle threshold. One row per session.
+// ---------------------------------------------------------------------------
+
+describe("sessionActivityQuery", () => {
+	it("computes per-event gaps with a lagInFrame window ordered by Timestamp, Seq", () => {
+		const { sql } = compileCH(sessionActivityQuery(), sessionParams)
+		expect(sql).toContain("FROM session_events")
+		expect(sql).toContain(
+			"lagInFrame(Timestamp, 1, Timestamp) OVER (PARTITION BY SessionId ORDER BY Timestamp ASC, Seq ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)",
+		)
+		// Nanosecond subtraction → milliseconds.
+		expect(sql).toContain("toUnixTimestamp64Nano(Timestamp)")
+		expect(sql).toContain("/ 1000000 AS gapMs")
+	})
+
+	it("splits gaps into active / idle at the idle threshold", () => {
+		const { sql } = compileCH(sessionActivityQuery(), sessionParams)
+		expect(sql).toContain(
+			`sumIf(gapMs, (gapMs > 0 AND gapMs <= ${IDLE_GAP_THRESHOLD_MS})) AS activeTimeMs`,
+		)
+		expect(sql).toContain(`sumIf(gapMs, gapMs > ${IDLE_GAP_THRESHOLD_MS}) AS idleTimeMs`)
+		expect(sql).toContain("GROUP BY sessionId")
+	})
+
+	it("scopes to the org + session and returns a single row", () => {
+		const { sql } = compileCH(sessionActivityQuery(), sessionParams)
+		expect(sql).toContain("OrgId = 'org_1'")
+		expect(sql).toContain("SessionId = 'sess_1'")
+		expect(sql).toContain("LIMIT 1")
+		expect(sql).toContain("FORMAT JSON")
+	})
+
+	it("adds the session time window as a partition-pruning predicate when provided", () => {
+		const { sql } = compileCH(sessionActivityQuery(WINDOW), sessionParams)
+		expect(sql).toContain("Timestamp >= '2026-06-24 04:00:00'")
+		expect(sql).toContain("Timestamp <= '2026-06-25 06:00:00'")
+	})
+
+	it("omits the time window when absent (deep-link path, full scan)", () => {
+		const { sql } = compileCH(sessionActivityQuery(), sessionParams)
+		expect(sql).not.toContain("Timestamp >=")
+		expect(sql).not.toContain("Timestamp <=")
+	})
+})

--- a/packages/query-engine/src/ch/queries/session-events.ts
+++ b/packages/query-engine/src/ch/queries/session-events.ts
@@ -12,7 +12,7 @@
 import * as CH from "@maple-dev/clickhouse-builder/expr"
 import { compileFnCall } from "@maple-dev/clickhouse-builder"
 import { param } from "@maple-dev/clickhouse-builder"
-import { from } from "@maple-dev/clickhouse-builder"
+import { from, fromQuery, type ColumnAccessor } from "@maple-dev/clickhouse-builder"
 import { SessionEvents } from "../tables"
 
 function count(): CH.Expr<number> {
@@ -172,4 +172,112 @@ export function searchSessionsByEventQuery(opts: SearchSessionsByEventOpts) {
 		.limit(limit)
 		.offset(opts.offset ?? 0)
 		.format("JSON")
+}
+
+// ---------------------------------------------------------------------------
+// Active / idle time, computed from gaps between distilled events
+//
+// A session's wall-clock duration overstates engagement: a 30s interaction left
+// open in a background tab for 45 minutes reports 45:00. We approximate *active*
+// time from `session_events` — the distilled semantic stream (click / nav /
+// input / console / network / error) — by walking consecutive events per
+// session (ordered by Timestamp, Seq) and measuring the gap to the previous one:
+//
+//   activeTimeMs = Σ gap where 0 < gap ≤ IDLE_GAP_THRESHOLD_MS  (engaged)
+//   idleTimeMs   = Σ gap where gap > IDLE_GAP_THRESHOLD_MS       (idle stretch)
+//
+// (active + idle ≈ last − first event timestamp; both ≤ wall-clock DurationMs.)
+//
+// The first event of each session has no predecessor — `lagInFrame`'s default is
+// the row's own Timestamp, so its gap is 0 and counts as neither active nor idle.
+//
+// IDLE_GAP_THRESHOLD_MS is deliberately larger than the rrweb player's 2s idle
+// threshold (replay-timeline.ts): `session_events` are sparse semantic events
+// (no continuous mouse-move samples), so a 2s threshold would flag nearly every
+// gap as idle. 15s is a heuristic — tune if it proves too coarse/fine.
+// ---------------------------------------------------------------------------
+
+/** Gaps longer than this (ms) between distilled events count as idle, not active. */
+export const IDLE_GAP_THRESHOLD_MS = 15_000
+
+export interface SessionActivityOutput {
+	readonly sessionId: string
+	readonly activeTimeMs: number
+	readonly idleTimeMs: number
+	readonly eventCount: number
+}
+
+export interface SessionActivityOpts {
+	/** Optional session time window — prunes daily partitions. Omit to scan all. */
+	startTime?: string
+	endTime?: string
+}
+
+// Per-event gap (ms) to the previous distilled event in the same session.
+// dateTime64(9) subtraction via nanos, matching the metrics rate query's
+// lagInFrame pattern. Shared by the single-session and aggregate variants.
+function sessionGapSelect($: ColumnAccessor<typeof SessionEvents.columns>) {
+	const onePrecedingFrame = CH.windowSpec({
+		partitionBy: [$.SessionId],
+		orderBy: [
+			[$.Timestamp, "asc"],
+			[$.Seq, "asc"],
+		],
+		frame: CH.rowsBetween(CH.preceding(1), CH.currentRow),
+	})
+	const previousTimestamp = CH.over(CH.lagInFrame($.Timestamp, 1, $.Timestamp), onePrecedingFrame)
+	return {
+		sessionId: $.SessionId,
+		gapMs: CH.toFloat64(
+			CH.toUnixTimestamp64Nano($.Timestamp).sub(CH.toUnixTimestamp64Nano(previousTimestamp)),
+		).div(1_000_000),
+	}
+}
+
+// Aggregate per-session gaps into active / idle totals. Generic over the inner
+// gap subquery so both variants share the threshold split.
+function activeIdleAggregate(inner: ReturnType<typeof sessionActivityGaps>) {
+	return fromQuery(inner, "g")
+		.select(($) => ({
+			sessionId: $.sessionId,
+			activeTimeMs: CH.sumIf($.gapMs, $.gapMs.gt(0).and($.gapMs.lte(IDLE_GAP_THRESHOLD_MS))),
+			idleTimeMs: CH.sumIf($.gapMs, $.gapMs.gt(IDLE_GAP_THRESHOLD_MS)),
+			eventCount: count(),
+		}))
+		.groupBy("sessionId")
+}
+
+function sessionActivityGaps(opts: { single: boolean } & SessionActivityOpts) {
+	return from(SessionEvents)
+		.select(sessionGapSelect)
+		.where(($) =>
+			opts.single
+				? [
+						$.OrgId.eq(param.string("orgId")),
+						$.SessionId.eq(param.string("sessionId")),
+						CH.when(opts.startTime, (v: string) => $.Timestamp.gte(v)),
+						CH.when(opts.endTime, (v: string) => $.Timestamp.lte(v)),
+					]
+				: [
+						$.OrgId.eq(param.string("orgId")),
+						$.Timestamp.gte(param.dateTime("startTime")),
+						$.Timestamp.lte(param.dateTime("endTime")),
+					],
+		)
+}
+
+// Single session (detail page + MCP get_session_traces). Binds `sessionId` as a
+// param; optional startTime/endTime hints prune daily partitions.
+export function sessionActivityQuery(opts: SessionActivityOpts = {}) {
+	return activeIdleAggregate(sessionActivityGaps({ single: true, ...opts }))
+		.limit(1)
+		.format("JSON")
+}
+
+// Every session in the org + time window, keyed by sessionId. Returned as an
+// unformatted builder so the replays list query can LEFT JOIN it to filter by
+// active time. Binds the same `startTime`/`endTime` params as the list query, so
+// they resolve to the same window when compiled together.
+export function sessionActivityAggregateQuery() {
+	return activeIdleAggregate(sessionActivityGaps({ single: false }))
 }

--- a/packages/query-engine/src/ch/queries/session-replays.test.ts
+++ b/packages/query-engine/src/ch/queries/session-replays.test.ts
@@ -128,3 +128,58 @@ describe("getSessionReplayQuery", () => {
 		expect(sql).not.toContain("StartTime >=")
 	})
 })
+
+// ---------------------------------------------------------------------------
+// Session-time filters — duration (stored) + active time (session_events gaps)
+//
+// Guardrail: the default list and the duration-only filter must never touch
+// session_events. Active-time filtering joins the per-session activity aggregate
+// (the only path that scans the events table).
+// ---------------------------------------------------------------------------
+
+describe("sessionReplaysListQuery session-time filters", () => {
+	it("keeps the fast path (no subquery, no session_events) when unfiltered", () => {
+		const { sql } = compileCH(sessionReplaysListQuery({}), { ...baseParams, ...WINDOW })
+		expect(sql).not.toContain("session_events")
+		// No wrapping subquery: the FROM is the table directly.
+		expect(sql).toContain("FROM session_replays")
+		expect(sql).not.toContain("FROM (SELECT")
+	})
+
+	it("wraps in a subquery to filter on the aggregated duration, without session_events", () => {
+		const { sql } = compileCH(sessionReplaysListQuery({ durationMinMs: 5000, durationMaxMs: 60000 }), {
+			...baseParams,
+			...WINDOW,
+		})
+		expect(sql).not.toContain("session_events")
+		expect(sql).toContain("FROM (SELECT")
+		expect(sql).toContain(") AS s")
+		expect(sql).toContain("durationMs >= 5000")
+		expect(sql).toContain("durationMs <= 60000")
+	})
+
+	it("LEFT JOINs the session_events activity aggregate to filter on active time", () => {
+		const { sql } = compileCH(
+			sessionReplaysListQuery({ activeTimeMinMs: 10000, activeTimeMaxMs: 60000 }),
+			{ ...baseParams, ...WINDOW },
+		)
+		expect(sql).toContain("LEFT JOIN")
+		expect(sql).toContain("FROM session_events")
+		expect(sql).toContain("ON s.sessionId = a.sessionId")
+		expect(sql).toContain("a.activeTimeMs >= 10000")
+		expect(sql).toContain("a.activeTimeMs <= 60000")
+		// The activity aggregate scopes session_events to the same org + window.
+		expect(sql).toContain("sumIf(gapMs, (gapMs > 0 AND gapMs <= 15000))")
+	})
+
+	it("scopes the activity aggregate's session_events scan to the list window", () => {
+		const { sql } = compileCH(sessionReplaysListQuery({ activeTimeMinMs: 1000 }), {
+			...baseParams,
+			...WINDOW,
+		})
+		// session_replays filters StartTime; session_events filters Timestamp — both
+		// to the same bound, so the join's scan is partition-pruned identically.
+		expect(sql).toContain("StartTime >= '2026-06-24 04:00:00'")
+		expect(sql).toContain("Timestamp >= '2026-06-24 04:00:00'")
+	})
+})

--- a/packages/query-engine/src/ch/queries/session-replays.test.ts
+++ b/packages/query-engine/src/ch/queries/session-replays.test.ts
@@ -166,10 +166,30 @@ describe("sessionReplaysListQuery session-time filters", () => {
 		expect(sql).toContain("LEFT JOIN")
 		expect(sql).toContain("FROM session_events")
 		expect(sql).toContain("ON s.sessionId = a.sessionId")
-		expect(sql).toContain("a.activeTimeMs >= 10000")
-		expect(sql).toContain("a.activeTimeMs <= 60000")
+		// Coalesce to 0 so the LEFT JOIN's NULL (sessions with no distilled events)
+		// is treated as zero activity rather than silently dropped.
+		expect(sql).toContain("coalesce(a.activeTimeMs, 0) >= 10000")
+		expect(sql).toContain("coalesce(a.activeTimeMs, 0) <= 60000")
 		// The activity aggregate scopes session_events to the same org + window.
 		expect(sql).toContain("sumIf(gapMs, (gapMs > 0 AND gapMs <= 15000))")
+	})
+
+	it("keeps zero-activity (no-event) sessions under a max-only or zero bound", () => {
+		// A LEFT-JOIN NULL must satisfy `<= max` and `>= 0`; coalesce(…, 0) makes
+		// `0 <= max` / `0 >= 0` true so rrweb-only sessions aren't dropped. A
+		// min > 0 still excludes them (0 < min), which is intended.
+		const maxOnly = compileCH(sessionReplaysListQuery({ activeTimeMaxMs: 30000 }), {
+			...baseParams,
+			...WINDOW,
+		}).sql
+		expect(maxOnly).toContain("coalesce(a.activeTimeMs, 0) <= 30000")
+
+		const zeroMin = compileCH(sessionReplaysListQuery({ activeTimeMinMs: 0 }), {
+			...baseParams,
+			...WINDOW,
+		}).sql
+		// An explicit 0 bound is still emitted (not skipped as a falsy value).
+		expect(zeroMin).toContain("coalesce(a.activeTimeMs, 0) >= 0")
 	})
 
 	it("scopes the activity aggregate's session_events scan to the list window", () => {

--- a/packages/query-engine/src/ch/queries/session-replays.ts
+++ b/packages/query-engine/src/ch/queries/session-replays.ts
@@ -175,12 +175,22 @@ export function sessionReplaysListQuery(
 				errorCount: $.errorCount,
 				traceCount: $.traceCount,
 			}))
-			.where(($) => [
-				CH.when(opts.durationMinMs, (v: number) => $.durationMs.gte(v)),
-				CH.when(opts.durationMaxMs, (v: number) => $.durationMs.lte(v)),
-				CH.when(opts.activeTimeMinMs, (v: number) => $.a.activeTimeMs.gte(v)),
-				CH.when(opts.activeTimeMaxMs, (v: number) => $.a.activeTimeMs.lte(v)),
-			])
+			.where(($) => {
+				// The LEFT JOIN yields NULL activeTimeMs for sessions with no
+				// distilled session_events (the rrweb-only case the detail/MCP path
+				// reports as null). Coalesce to 0 so a max bound — or a min of 0 —
+				// includes those zero-activity sessions instead of silently dropping
+				// them: a NULL comparison is itself NULL, which WHERE excludes. A min
+				// > 0 still (correctly) excludes them, since 0 < min. `!= null` rather
+				// than the truthy CH.when so an explicit 0 bound is still applied.
+				const activeMs = CH.coalesce($.a.activeTimeMs, CH.lit(0))
+				return [
+					opts.durationMinMs != null ? $.durationMs.gte(opts.durationMinMs) : undefined,
+					opts.durationMaxMs != null ? $.durationMs.lte(opts.durationMaxMs) : undefined,
+					opts.activeTimeMinMs != null ? activeMs.gte(opts.activeTimeMinMs) : undefined,
+					opts.activeTimeMaxMs != null ? activeMs.lte(opts.activeTimeMaxMs) : undefined,
+				]
+			})
 			.orderBy(["startTime", "desc"])
 			.limit(limit)
 			.offset(opts.offset ?? 0)
@@ -207,8 +217,12 @@ export function sessionReplaysListQuery(
 			traceCount: $.traceCount,
 		}))
 		.where(($) => [
-			CH.when(opts.durationMinMs, (v: number) => $.durationMs.gte(v)),
-			CH.when(opts.durationMaxMs, (v: number) => $.durationMs.lte(v)),
+			// durationMs is NULL for in-progress (Version=1-only) sessions; leaving
+			// it NULL deliberately excludes them from a duration filter (an unknown
+			// duration can't be said to fall within a bound). `!= null` rather than
+			// the truthy CH.when so an explicit 0 bound is still applied.
+			opts.durationMinMs != null ? $.durationMs.gte(opts.durationMinMs) : undefined,
+			opts.durationMaxMs != null ? $.durationMs.lte(opts.durationMaxMs) : undefined,
 		])
 		.orderBy(["startTime", "desc"])
 		.limit(limit)

--- a/packages/query-engine/src/ch/queries/session-replays.ts
+++ b/packages/query-engine/src/ch/queries/session-replays.ts
@@ -21,9 +21,10 @@
 import * as CH from "@maple-dev/clickhouse-builder/expr"
 import { compileFnCall, compileFnCallCond } from "@maple-dev/clickhouse-builder"
 import { param } from "@maple-dev/clickhouse-builder"
-import { from, type ColumnAccessor } from "@maple-dev/clickhouse-builder"
+import { from, fromQuery, type ColumnAccessor, type CHQuery } from "@maple-dev/clickhouse-builder"
 import { unionAll, type CHUnionQuery } from "@maple-dev/clickhouse-builder"
 import { SessionReplays, SessionReplayEvents, TraceDetailSpans } from "../tables"
+import { sessionActivityAggregateQuery } from "./session-events"
 
 // argMax(value, ordering) — finalize a ReplacingMergeTree column to its latest
 // version. Generic per call site, so declared here rather than via defineFn.
@@ -59,6 +60,16 @@ export interface SessionReplaysListOpts {
 	search?: string
 	/** Keyset cursor: only sessions with StartTime strictly before this. */
 	cursor?: string
+	/** Min/max wall-clock duration (ms). Filters on the stored DurationMs; only
+	 *  completed (Version=2) sessions carry it, so in-progress sessions are
+	 *  excluded when either bound is set. */
+	durationMinMs?: number
+	durationMaxMs?: number
+	/** Min/max active time (ms), computed from session_events gaps. Setting either
+	 *  bound LEFT JOINs the per-session activity aggregate (the only path that
+	 *  scans session_events — the default list never does). */
+	activeTimeMinMs?: number
+	activeTimeMaxMs?: number
 	limit?: number
 	offset?: number
 }
@@ -82,10 +93,19 @@ export interface SessionReplaysListOutput {
 	readonly traceCount: number
 }
 
-export function sessionReplaysListQuery(opts: SessionReplaysListOpts) {
+// Return type is annotated (not inferred) because the duration/active filters
+// branch into structurally-different sources (the base table vs a wrapping
+// subquery, optionally joined) — all three produce the same row shape, but TS
+// otherwise infers a union that won't unify at the compileCH call site. Mirrors
+// metricsTimeseriesRateQuery's annotation.
+export function sessionReplaysListQuery(
+	opts: SessionReplaysListOpts,
+): CHQuery<any, SessionReplaysListOutput, {}> {
 	const limit = opts.limit ?? 50
+	const needsDurationFilter = opts.durationMinMs != null || opts.durationMaxMs != null
+	const needsActiveFilter = opts.activeTimeMinMs != null || opts.activeTimeMaxMs != null
 
-	return from(SessionReplays)
+	const base = from(SessionReplays)
 		.select(($) => ({
 			sessionId: $.SessionId,
 			startTime: argMax($.StartTime, $.Version),
@@ -122,6 +142,74 @@ export function sessionReplaysListQuery(opts: SessionReplaysListOpts) {
 			CH.when(opts.cursor, (v: string) => $.StartTime.lt(v)),
 		])
 		.groupBy("sessionId")
+
+	// Fast path: no post-aggregate filters → the original grouped query, untouched
+	// (never reads session_events).
+	if (!needsDurationFilter && !needsActiveFilter) {
+		return base.orderBy(["startTime", "desc"]).limit(limit).offset(opts.offset ?? 0).format("JSON")
+	}
+
+	// Duration and active-time bounds are post-aggregate predicates (argMax /
+	// joined column), which the DSL can't put in WHERE/HAVING directly — wrap the
+	// grouped query in a subquery and filter there. The active-time filter LEFT
+	// JOINs the per-session session_events activity aggregate; the duration-only
+	// path skips the join (and the session_events scan) entirely.
+	if (needsActiveFilter) {
+		return fromQuery(base, "s")
+			.leftJoinQuery(sessionActivityAggregateQuery(), "a", (s, a) => s.sessionId.eq(a.sessionId))
+			.select(($) => ({
+				sessionId: $.sessionId,
+				startTime: $.startTime,
+				endTime: $.endTime,
+				durationMs: $.durationMs,
+				status: $.status,
+				userId: $.userId,
+				urlInitial: $.urlInitial,
+				browserName: $.browserName,
+				osName: $.osName,
+				deviceType: $.deviceType,
+				country: $.country,
+				serviceName: $.serviceName,
+				pageViews: $.pageViews,
+				clickCount: $.clickCount,
+				errorCount: $.errorCount,
+				traceCount: $.traceCount,
+			}))
+			.where(($) => [
+				CH.when(opts.durationMinMs, (v: number) => $.durationMs.gte(v)),
+				CH.when(opts.durationMaxMs, (v: number) => $.durationMs.lte(v)),
+				CH.when(opts.activeTimeMinMs, (v: number) => $.a.activeTimeMs.gte(v)),
+				CH.when(opts.activeTimeMaxMs, (v: number) => $.a.activeTimeMs.lte(v)),
+			])
+			.orderBy(["startTime", "desc"])
+			.limit(limit)
+			.offset(opts.offset ?? 0)
+			.format("JSON")
+	}
+
+	return fromQuery(base, "s")
+		.select(($) => ({
+			sessionId: $.sessionId,
+			startTime: $.startTime,
+			endTime: $.endTime,
+			durationMs: $.durationMs,
+			status: $.status,
+			userId: $.userId,
+			urlInitial: $.urlInitial,
+			browserName: $.browserName,
+			osName: $.osName,
+			deviceType: $.deviceType,
+			country: $.country,
+			serviceName: $.serviceName,
+			pageViews: $.pageViews,
+			clickCount: $.clickCount,
+			errorCount: $.errorCount,
+			traceCount: $.traceCount,
+		}))
+		.where(($) => [
+			CH.when(opts.durationMinMs, (v: number) => $.durationMs.gte(v)),
+			CH.when(opts.durationMaxMs, (v: number) => $.durationMs.lte(v)),
+		])
 		.orderBy(["startTime", "desc"])
 		.limit(limit)
 		.offset(opts.offset ?? 0)

--- a/packages/query-engine/src/observability/session-replays.test.ts
+++ b/packages/query-engine/src/observability/session-replays.test.ts
@@ -9,50 +9,62 @@ interface Captured {
 	sqls: string[]
 }
 
+interface MockResponses {
+	detail?: ReadonlyArray<Record<string, unknown>>
+	activity?: ReadonlyArray<Record<string, unknown>>
+	summaries?: ReadonlyArray<Record<string, unknown>>
+}
+
 /**
- * Mock executor whose `sqlQuery` records each SQL string. The wrapper always
- * runs the session-detail query first, so the Nth call's rows come from the
- * Nth element of `responses` (detail row(s), then trace-summary row(s)).
+ * Mock executor that records each SQL string and dispatches rows by which query
+ * is running, matched on its source table. This stays correct regardless of the
+ * execution order of the concurrent detail (`session_replays`) and activity
+ * (`session_events`) reads; the trace summaries read `trace_detail_spans`.
  */
-const makeExecutor = (
-	captured: Captured,
-	responses: ReadonlyArray<ReadonlyArray<Record<string, unknown>>>,
-): WarehouseExecutorShape => ({
-	orgId: "org_test",
-	query: () => Effect.succeed({ data: [] as ReadonlyArray<never> }),
-	sqlQuery: ((sql: string) => {
-		const rows = responses[captured.sqls.length] ?? []
-		captured.sqls.push(sql)
-		return Effect.succeed(rows as ReadonlyArray<never>)
-	}) as WarehouseExecutorShape["sqlQuery"],
-	compiledQuery: ((compiled) => {
-		const rows = responses[captured.sqls.length] ?? []
-		captured.sqls.push(compiled.sql)
-		return compiled.decodeRows(rows).pipe(Effect.orDie)
-	}) as WarehouseExecutorShape["compiledQuery"],
-	compiledQueryFirst: ((compiled) => {
-		const rows = responses[captured.sqls.length] ?? []
-		captured.sqls.push(compiled.sql)
-		return compiled.decodeFirstRow(rows).pipe(Effect.orDie)
-	}) as WarehouseExecutorShape["compiledQueryFirst"],
-})
+const makeExecutor = (captured: Captured, responses: MockResponses): WarehouseExecutorShape => {
+	const rowsFor = (sql: string): ReadonlyArray<Record<string, unknown>> => {
+		if (sql.includes("session_events")) return responses.activity ?? []
+		if (sql.includes("trace_detail_spans")) return responses.summaries ?? []
+		return responses.detail ?? []
+	}
+	return {
+		orgId: "org_test",
+		query: () => Effect.succeed({ data: [] as ReadonlyArray<never> }),
+		sqlQuery: ((sql: string) => {
+			captured.sqls.push(sql)
+			return Effect.succeed(rowsFor(sql) as ReadonlyArray<never>)
+		}) as WarehouseExecutorShape["sqlQuery"],
+		compiledQuery: ((compiled) => {
+			captured.sqls.push(compiled.sql)
+			return compiled.decodeRows(rowsFor(compiled.sql)).pipe(Effect.orDie)
+		}) as WarehouseExecutorShape["compiledQuery"],
+		compiledQueryFirst: ((compiled) => {
+			captured.sqls.push(compiled.sql)
+			return compiled.decodeFirstRow(rowsFor(compiled.sql)).pipe(Effect.orDie)
+		}) as WarehouseExecutorShape["compiledQueryFirst"],
+	}
+}
 
 const makeLayer = (executor: WarehouseExecutorShape) => Layer.succeed(WarehouseExecutor, executor)
 
 const traceIds = (n: number) => Array.from({ length: n }, (_, i) => `trace-${i}`)
 
+/** The recorded SQL for the query that reads `table`, if it ran. */
+const sqlFor = (captured: Captured, table: string) => captured.sqls.find((s) => s.includes(table))
+
 describe("getSessionTraces", () => {
-	it.effect("returns null session and runs only the detail query when none found", () =>
+	it.effect("returns null and runs no summaries query when the session is missing", () =>
 		Effect.gen(function* () {
 			const captured: Captured = { sqls: [] }
 			const out = yield* getSessionTraces({ sessionId: "missing" }).pipe(
-				Effect.provide(makeLayer(makeExecutor(captured, [[]]))),
+				Effect.provide(makeLayer(makeExecutor(captured, { detail: [] }))),
 			)
 
 			assert.isNull(out.session)
 			assert.deepStrictEqual(out.traces, [])
 			assert.strictEqual(out.totalTraceCount, 0)
-			assert.strictEqual(captured.sqls.length, 1)
+			// Detail + activity run concurrently; the summaries query never does.
+			assert.isUndefined(sqlFor(captured, "trace_detail_spans"))
 		}),
 	)
 
@@ -60,14 +72,36 @@ describe("getSessionTraces", () => {
 		Effect.gen(function* () {
 			const captured: Captured = { sqls: [] }
 			const out = yield* getSessionTraces({ sessionId: "s1" }).pipe(
-				Effect.provide(makeLayer(makeExecutor(captured, [[{ sessionId: "s1", traceIds: [] }]]))),
+				Effect.provide(
+					makeLayer(makeExecutor(captured, { detail: [{ sessionId: "s1", traceIds: [] }] })),
+				),
 			)
 
 			assert.isNotNull(out.session)
 			assert.deepStrictEqual(out.traces, [])
 			assert.strictEqual(out.totalTraceCount, 0)
-			// Only the detail query ran — `TraceId IN ()` is never compiled.
-			assert.strictEqual(captured.sqls.length, 1)
+			// `TraceId IN ()` is never compiled.
+			assert.isUndefined(sqlFor(captured, "trace_detail_spans"))
+		}),
+	)
+
+	it.effect("merges the active/idle breakdown into the session metadata", () =>
+		Effect.gen(function* () {
+			const captured: Captured = { sqls: [] }
+			const out = yield* getSessionTraces({ sessionId: "s1" }).pipe(
+				Effect.provide(
+					makeLayer(
+						makeExecutor(captured, {
+							detail: [{ sessionId: "s1", traceIds: [] }],
+							activity: [{ sessionId: "s1", activeTimeMs: 21500, idleTimeMs: 8500 }],
+						}),
+					),
+				),
+			)
+
+			assert.isNotNull(out.session)
+			assert.strictEqual(out.session?.activeTimeMs, 21500)
+			assert.strictEqual(out.session?.idleTimeMs, 8500)
 		}),
 	)
 
@@ -76,13 +110,14 @@ describe("getSessionTraces", () => {
 			const captured: Captured = { sqls: [] }
 			const out = yield* getSessionTraces({ sessionId: "s1" }).pipe(
 				Effect.provide(
-					makeLayer(makeExecutor(captured, [[{ sessionId: "s1", traceIds: traceIds(150) }], []])),
+					makeLayer(
+						makeExecutor(captured, { detail: [{ sessionId: "s1", traceIds: traceIds(150) }] }),
+					),
 				),
 			)
 
 			assert.strictEqual(out.totalTraceCount, 150)
-			assert.strictEqual(captured.sqls.length, 2)
-			const summarySql = captured.sqls[1]!
+			const summarySql = sqlFor(captured, "trace_detail_spans")!
 			assert.include(summarySql, "trace-49")
 			assert.notInclude(summarySql, "trace-50")
 		}),
@@ -93,11 +128,13 @@ describe("getSessionTraces", () => {
 			const captured: Captured = { sqls: [] }
 			yield* getSessionTraces({ sessionId: "s1", limit: 999 }).pipe(
 				Effect.provide(
-					makeLayer(makeExecutor(captured, [[{ sessionId: "s1", traceIds: traceIds(150) }], []])),
+					makeLayer(
+						makeExecutor(captured, { detail: [{ sessionId: "s1", traceIds: traceIds(150) }] }),
+					),
 				),
 			)
 
-			const summarySql = captured.sqls[1]!
+			const summarySql = sqlFor(captured, "trace_detail_spans")!
 			assert.include(summarySql, "trace-99")
 			assert.notInclude(summarySql, "trace-100")
 		}),

--- a/packages/query-engine/src/observability/session-replays.ts
+++ b/packages/query-engine/src/observability/session-replays.ts
@@ -26,9 +26,18 @@ export interface SessionTracesInput {
 	readonly limit?: number
 }
 
+/** Session metadata plus the active/idle breakdown merged in from a second
+ *  pass over `session_events` (null when the session has no distilled events). */
+export interface SessionWithActivity extends SessionReplayDetailOutput {
+	/** Engaged time (ms): Σ gaps ≤ idle threshold between distilled events. */
+	readonly activeTimeMs: number | null
+	/** Idle time (ms): Σ gaps > idle threshold between distilled events. */
+	readonly idleTimeMs: number | null
+}
+
 export interface SessionTracesOutput {
 	/** The browser session's metadata, or null when no such session exists. */
-	readonly session: SessionReplayDetailOutput | null
+	readonly session: SessionWithActivity | null
 	/** Per-trace summaries for the (clamped) correlated trace ids. */
 	readonly traces: ReadonlyArray<SessionTraceSummaryOutput>
 	/** Full count of trace ids on the session, before the `limit` clamp. */
@@ -52,15 +61,36 @@ export const getSessionTraces = Effect.fn("Observability.getSessionTraces")(func
 	const executor = yield* WarehouseExecutor
 	yield* Effect.annotateCurrentSpan({ orgId: executor.orgId, sessionId: input.sessionId })
 
-	// 1) Session metadata + the full TraceIds array.
+	// 1) Session metadata (+ full TraceIds array) and the active/idle breakdown
+	// from a second pass over session_events. Both are single-session sort-key
+	// seeks (`(OrgId, SessionId)` prefix) and independent, so run them
+	// concurrently — one round-trip of latency, not two.
 	const detailCompiled = CH.compile(CH.getSessionReplayQuery(), {
 		orgId: executor.orgId,
 		sessionId: input.sessionId,
 	})
-	const maybeSession = yield* executor.compiledQueryFirst(detailCompiled, { profile: "discovery" })
-	const session = Option.getOrNull(maybeSession)
-	if (!session) {
+	const activityCompiled = CH.compile(CH.sessionActivityQuery(), {
+		orgId: executor.orgId,
+		sessionId: input.sessionId,
+	})
+	const [maybeSession, maybeActivity] = yield* Effect.all(
+		[
+			executor.compiledQueryFirst(detailCompiled, { profile: "discovery" }),
+			executor.compiledQueryFirst(activityCompiled, { profile: "discovery" }),
+		],
+		{ concurrency: 2 },
+	)
+	const sessionRow = Option.getOrNull(maybeSession)
+	if (!sessionRow) {
 		return { session: null, traces: [], totalTraceCount: 0 } satisfies SessionTracesOutput
+	}
+
+	// `null` active/idle if the session has no distilled events (e.g. rrweb-only).
+	const activity = Option.getOrNull(maybeActivity)
+	const session: SessionWithActivity = {
+		...sessionRow,
+		activeTimeMs: activity ? Number(activity.activeTimeMs) : null,
+		idleTimeMs: activity ? Number(activity.idleTimeMs) : null,
 	}
 
 	const totalTraceCount = session.traceIds.length


### PR DESCRIPTION
## What & why

Session replays only exposed **total wall-clock duration**, which overstates engagement — a 30-second interaction left open in a background tab reports `45:00`. The web player already collapses idle gaps at playback, but that lives client-side only, so it couldn't feed MCP or a list filter.

This adds an **active / idle time** breakdown, computed **at query time** from gaps in the distilled `session_events` stream. No SDK / ingest / schema changes, so it works on all existing sessions immediately.

**Definition:** per session, the gap to the previous distilled event is measured via a `lagInFrame` window; gaps `> IDLE_GAP_THRESHOLD_MS` (15s) count as idle, the rest as active. `active + idle ≈ last − first event ≤ wall-clock duration`. The 15s threshold is deliberately larger than the player's 2s rrweb threshold because distilled events are sparse.

## Where it shows up

- **Overview** — `StatStrip` now reads Duration / **Active** / **Idle** / Clicks / Pages / Errors.
- **MCP** — `get_session_traces` returns `activeTimeMs` / `idleTimeMs`.
- **Sidebar** — two new range filters: **Session time** (duration) and **Active time**.

## Changes by layer

- **query-engine** (`session-events.ts`): `sessionActivityQuery` (single session) + `sessionActivityAggregateQuery` (join source) + `IDLE_GAP_THRESHOLD_MS`.
- **list filter** (`session-replays.ts`): `sessionReplaysListQuery` gains duration + active-time bounds via a wrapping subquery (no `HAVING` in the DSL).
- **observability + MCP + HTTP + domain**: active/idle threaded through `getSessionTraces`, `get_session_traces`, `getReplay`, and the request/response schemas.
- **web**: StatStrip stats, sidebar `RangeFilter`, `NumberFromStringParam` search params, filter-input plumbing.

## Performance (guardrails)

- **Gated:** the `session_events` join is added **only** when an active-time bound is set. The default list and the duration-only filter never scan `session_events`.
- **Fail-fast caps:** single-session reads run under the `discovery` profile (5s / 512MB); the list active-time scan runs under `list` (15s / 1.5GB) — a whale org errors gracefully instead of hanging the dashboard.
- **Cheap reads:** single-session queries are `(OrgId, SessionId)` sort-key seeks; the list window matches the table sort key `(OrgId, SessionId, Timestamp, Seq)` → read-in-order + aggregation-in-order.
- **No added latency:** the overview's detail + activity reads run **concurrently** (one round-trip, not two).

## Testing

- `bun typecheck` — green across all 24 packages.
- `vitest` — 645/645 in query-engine, incl. compile-snapshot tests asserting the join only appears with an active filter, plus reworked order-independent concurrency tests.
- **Real-data validation** via `run_sql` over 30 days: `active + idle == event span` exactly, and `≤ durationMs` for every completed session. (One session showed 10s active / ~14h idle — the "tab left open" case this feature exists to surface.)
- UI overview verified rendering in the fixture preview route (`30s / 22s / 9s`).

## Reviewer notes

- The 15s idle threshold is a documented heuristic (`IDLE_GAP_THRESHOLD_MS`); tune if it reads too coarse/fine.
- Duration filter excludes in-progress sessions (no stored `DurationMs` until session end) — by design.
- Sidebar `RangeFilter` couldn't be browser-driven end-to-end (its branch needs a reachable API; preview ports were held by another session) — it's type-checked and mirrors the existing `UserIdFilter` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)