### PR TITLE
feat(alerts): page-level time window on rule detail + UX cleanups

### DIFF
--- a/apps/web/src/components/time-range-picker/time-range-picker.tsx
+++ b/apps/web/src/components/time-range-picker/time-range-picker.tsx
@@ -120,7 +120,16 @@ export function TimeRangePicker({
 					</Button>
 				}
 			/>
-			<PopoverContent align="end" className={tab === "custom" ? "w-auto p-4" : "w-[520px] p-0"}>
+			<PopoverContent
+				align="end"
+				className={
+					// Cap to the viewport so the popover never runs off-screen on
+					// phones (the 520px relative pane is wider than a mobile viewport).
+					tab === "custom"
+						? "w-auto max-w-[calc(100vw-1.5rem)] p-4"
+						: "w-[520px] max-w-[calc(100vw-1.5rem)] p-0"
+				}
+			>
 				{tab === "custom" ? (
 					<CustomRangePicker
 						startTime={startTime}
@@ -140,8 +149,10 @@ export function TimeRangePicker({
 								/>
 							</div>
 
-							{/* Right pane: shorthand input + quick select + recent */}
-							<div className="flex-1 space-y-5 p-4">
+							{/* Right pane: shorthand input + quick select + recent.
+							    min-w-0 lets it shrink below content width on narrow
+							    viewports so the quick-select grid doesn't overflow. */}
+							<div className="min-w-0 flex-1 space-y-5 p-4">
 								<ShorthandInput onApply={handleShorthandApply} />
 								<QuickSelectGrid onSelect={handleQuickSelect} />
 								{recentTimes.length > 0 && (

--- a/apps/web/src/hooks/use-alert-rule-chart.ts
+++ b/apps/web/src/hooks/use-alert-rule-chart.ts
@@ -35,8 +35,15 @@ export interface AlertRuleChartState {
  * aggregations, group-bys). Built-in signals keep the canned custom-chart
  * path. Raw SQL has no structured preview (the hero shows a hint instead).
  */
-export function useAlertRuleChart(form: RuleFormState): AlertRuleChartState {
-	const { startTime, endTime } = useEffectiveTimeRange(undefined, undefined, "24h")
+export function useAlertRuleChart(
+	form: RuleFormState,
+	range?: { startTime: string; endTime: string },
+): AlertRuleChartState {
+	// Callers that own a page-level time window (the rule detail page) pass it in;
+	// the create form + live hero pass nothing and keep the canned last-24h window.
+	const fallback = useEffectiveTimeRange(undefined, undefined, "24h")
+	const startTime = range?.startTime ?? fallback.startTime
+	const endTime = range?.endTime ?? fallback.endTime
 
 	/* ------------------------- builder_query path ------------------------- */
 

--- a/apps/web/src/routes/alerts/$ruleId.tsx
+++ b/apps/web/src/routes/alerts/$ruleId.tsx
@@ -7,6 +7,12 @@ import { useMemo, useState } from "react"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import { formatRelativeTime } from "@/lib/format"
+import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
+import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
+import { applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { presetLabel, formatTimeRangeDisplay } from "@/lib/time-utils"
+import { normalizeTimestampInput } from "@/lib/timezone-format"
 import { AlertPreviewChart } from "@/components/alerts/alert-preview-chart"
 import { CheckHistorySparkline } from "@/components/alerts/check-history-sparkline"
 import { AlertStatusBadge } from "@/components/alerts/alert-status-badge"
@@ -23,7 +29,12 @@ import {
 	formatAlertDuration,
 	computeIncidentStats,
 } from "@/lib/alerts/form-utils"
-import { AlertRuleId, type AlertCheckDocument, type AlertRuleDocument } from "@maple/domain/http"
+import {
+	AlertRuleId,
+	IsoDateTimeString,
+	type AlertCheckDocument,
+	type AlertRuleDocument,
+} from "@maple/domain/http"
 import { CheckIcon, PencilIcon, DotsVerticalIcon, CircleWarningIcon } from "@/components/icons"
 import { cn } from "@maple/ui/utils"
 import { Badge } from "@maple/ui/components/ui/badge"
@@ -46,6 +57,9 @@ type RuleDetailTab = (typeof tabValues)[number]
 
 const RuleDetailSearch = Schema.Struct({
 	tab: Schema.optional(Schema.String),
+	startTime: Schema.optional(Schema.String),
+	endTime: Schema.optional(Schema.String),
+	timePreset: Schema.optional(Schema.String),
 })
 
 export const Route = effectRoute(createFileRoute("/alerts/$ruleId"))({
@@ -54,9 +68,36 @@ export const Route = effectRoute(createFileRoute("/alerts/$ruleId"))({
 })
 
 function RuleDetailPage() {
+	const search = Route.useSearch()
+	return (
+		<PageRefreshProvider timePreset={search.timePreset ?? "24h"}>
+			<RuleDetailContent />
+		</PageRefreshProvider>
+	)
+}
+
+function RuleDetailContent() {
 	const { ruleId } = Route.useParams()
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
+
+	// Page-level time window (24h default), shared by the chart, checks, and the
+	// header timeline strip — the standard services/errors wiring.
+	const { startTime, endTime } = useEffectiveTimeRange(
+		search.startTime,
+		search.endTime,
+		search.timePreset ?? "24h",
+	)
+	// listRuleChecks takes ISO `since`/`until`; the effective range is Tinybird
+	// format ("YYYY-MM-DD HH:mm:ss"), so normalize before converting.
+	const since = useMemo(
+		() => IsoDateTimeString.make(new Date(normalizeTimestampInput(startTime)).toISOString()),
+		[startTime],
+	)
+	const until = useMemo(
+		() => IsoDateTimeString.make(new Date(normalizeTimestampInput(endTime)).toISOString()),
+		[endTime],
+	)
 
 	const rulesQueryAtom = MapleApiAtomClient.query("alerts", "listRules", {
 		reactivityKeys: ["alertRules"],
@@ -70,8 +111,8 @@ function RuleDetailPage() {
 	const refreshIncidents = useAtomRefresh(incidentsQueryAtom)
 	const checksQueryAtom = MapleApiAtomClient.query("alerts", "listRuleChecks", {
 		params: { ruleId: ruleId as AlertRuleId },
-		query: {},
-		reactivityKeys: ["alertChecks", ruleId],
+		query: { since, until },
+		reactivityKeys: ["alertChecks", ruleId, since, until],
 	})
 	const checksResult = useAtomValue(checksQueryAtom)
 	const refreshChecks = useAtomRefresh(checksQueryAtom)
@@ -132,15 +173,25 @@ function RuleDetailPage() {
 		}))
 	}, [ruleIncidents])
 
-	const timelineRange = useMemo(() => {
-		if (timelineSegments.length === 0) return { min: Date.now() - 86_400_000 * 3, max: Date.now() }
-		const starts = timelineSegments.map((s) => s.start)
-		const ends = timelineSegments.map((s) => s.end)
-		return { min: Math.min(...starts), max: Math.max(...ends, Date.now()) }
-	}, [timelineSegments])
+	// The strip frames the selected window so "today" vs "last week" reshapes the
+	// at-a-glance answer; incident segments still paint wherever they fall within it.
+	const timelineRange = useMemo(
+		() => ({
+			min: new Date(normalizeTimestampInput(startTime)).getTime(),
+			max: new Date(normalizeTimestampInput(endTime)).getTime(),
+		}),
+		[startTime, endTime],
+	)
 
 	const formState = useMemo(() => (rule ? ruleToFormState(rule) : defaultRuleForm()), [rule])
-	const { chartData, chartLoading, chartError } = useAlertRuleChart(formState)
+	const { chartData, chartLoading, chartError } = useAlertRuleChart(formState, { startTime, endTime })
+
+	// Mirror the picker's default: a custom range formats its bounds, otherwise the
+	// preset label (falling back to the same "24h" the header + data window use).
+	const rangeLabel =
+		search.startTime && search.endTime
+			? formatTimeRangeDisplay(search.startTime, search.endTime)
+			: presetLabel(search.timePreset ?? "24h")
 
 	if (Result.isInitial(rulesResult)) {
 		return (
@@ -299,14 +350,25 @@ function RuleDetailPage() {
 				</div>
 			}
 			headerActions={
-				<Button
-					variant="outline"
-					size="sm"
-					render={<Link to="/alerts/create" search={{ ruleId: rule.id }} />}
-				>
-					<PencilIcon size={14} />
-					Edit rule
-				</Button>
+				<div className="flex items-center gap-2">
+					<TimeRangeHeaderControls
+						startTime={search.startTime}
+						endTime={search.endTime}
+						presetValue={search.timePreset ?? "24h"}
+						defaultPreset="24h"
+						onTimeChange={(range) =>
+							navigate({ search: (prev) => applyTimeRangeSearch(prev, range) })
+						}
+					/>
+					<Button
+						variant="outline"
+						size="sm"
+						render={<Link to="/alerts/create" search={{ ruleId: rule.id }} />}
+					>
+						<PencilIcon size={14} />
+						Edit rule
+					</Button>
+				</div>
 			}
 			stickyContent={stickyContent}
 		>
@@ -330,7 +392,7 @@ function RuleDetailPage() {
 					)}
 					<div className="space-y-2">
 						<h2 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-							{signalLabels[rule.signalType]}: Last 24h
+							{signalLabels[rule.signalType]}: {rangeLabel}
 						</h2>
 						{chartError != null ? (
 							<div className="flex h-[300px] w-full items-center justify-center rounded-md border border-dashed border-destructive/40 bg-destructive/5 px-6 text-center">
@@ -340,6 +402,12 @@ function RuleDetailPage() {
 									</p>
 									<p className="line-clamp-3 text-muted-foreground text-xs">{chartError}</p>
 								</div>
+							</div>
+						) : !chartLoading && chartData.length === 0 ? (
+							<div className="flex h-[300px] w-full items-center justify-center rounded-md border border-dashed border-border/60 px-6 text-center">
+								<p className="max-w-md text-muted-foreground text-sm">
+									No data in this window. Try widening the range.
+								</p>
 							</div>
 						) : (
 							<AlertPreviewChart
@@ -780,9 +848,10 @@ function ChecksPanel({
 					<EmptyMedia variant="icon">
 						<CheckIcon size={18} />
 					</EmptyMedia>
-					<EmptyTitle>No checks recorded yet</EmptyTitle>
+					<EmptyTitle>No checks in this window</EmptyTitle>
 					<EmptyDescription>
-						Once this rule is evaluated the scheduler will record one check per minute here.
+						No evaluations were recorded for the selected time range. Try widening the
+						range, or wait for the scheduler to record the next check.
 					</EmptyDescription>
 				</EmptyHeader>
 			</Empty>

--- a/apps/web/src/routes/alerts/$ruleId.tsx
+++ b/apps/web/src/routes/alerts/$ruleId.tsx
@@ -35,7 +35,13 @@ import {
 	type AlertCheckDocument,
 	type AlertRuleDocument,
 } from "@maple/domain/http"
-import { CheckIcon, PencilIcon, DotsVerticalIcon, CircleWarningIcon } from "@/components/icons"
+import {
+	CheckIcon,
+	PencilIcon,
+	DotsVerticalIcon,
+	CircleWarningIcon,
+	SquareTerminalIcon,
+} from "@/components/icons"
 import { cn } from "@maple/ui/utils"
 import { Badge } from "@maple/ui/components/ui/badge"
 import { Button } from "@maple/ui/components/ui/button"
@@ -394,7 +400,24 @@ function RuleDetailContent() {
 						<h2 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
 							{signalLabels[rule.signalType]}: {rangeLabel}
 						</h2>
-						{chartError != null ? (
+						{rule.signalType === "raw_query" ? (
+							// Raw SQL has no structured preview regardless of window, so the
+							// generic "widen the range" empty-state would mislead — mirror
+							// RuleLiveChartHero and show a raw-SQL hint instead.
+							<div className="flex h-[300px] w-full items-center justify-center rounded-md border border-dashed bg-muted/20 px-6 text-center">
+								<div className="max-w-sm space-y-2">
+									<div className="mx-auto flex size-9 items-center justify-center rounded-md bg-muted text-muted-foreground">
+										<SquareTerminalIcon size={16} />
+									</div>
+									<p className="font-medium text-sm">
+										Live preview unavailable for raw SQL
+									</p>
+									<p className="text-muted-foreground text-xs">
+										Raw SQL rules don't have a structured chart preview.
+									</p>
+								</div>
+							</div>
+						) : chartError != null ? (
 							<div className="flex h-[300px] w-full items-center justify-center rounded-md border border-dashed border-destructive/40 bg-destructive/5 px-6 text-center">
 								<div className="max-w-md space-y-1">
 									<p className="font-medium text-destructive text-sm">

--- a/apps/web/src/routes/alerts/index.tsx
+++ b/apps/web/src/routes/alerts/index.tsx
@@ -11,6 +11,7 @@ import { ProviderLogo } from "@/components/alerts/destination-provider"
 import { AlertStatusBadge } from "@/components/alerts/alert-status-badge"
 import { AlertSeverityBadge } from "@/components/alerts/alert-severity-badge"
 import { AlertStatStrip, AlertFiringHero } from "@/components/alerts/alert-stat-card"
+import { AlertSegmentedSelect } from "@/components/alerts/alert-segmented-select"
 import { AlertTagControls } from "@/components/alerts/alert-tag-controls"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
@@ -244,14 +245,21 @@ function MonitorTab({
 	const warningCount = openIncidents.filter((i) => i.severity === "warning").length
 	const enabledRules = rules.filter((r) => r.enabled).length
 
-	// Triggered in the last 24h = incidents whose firstTriggeredAt is within 24h
-	const triggered24h = useMemo(() => {
-		const cutoff = Date.now() - 24 * 60 * 60 * 1000
+	// Triggered window — a quick lens over how recently rules have been firing.
+	const [triggeredWindow, setTriggeredWindow] = useState<"24h" | "7d" | "30d">("24h")
+	const triggeredInWindow = useMemo(() => {
+		const windowMs =
+			triggeredWindow === "24h"
+				? 24 * 60 * 60 * 1000
+				: triggeredWindow === "7d"
+					? 7 * 24 * 60 * 60 * 1000
+					: 30 * 24 * 60 * 60 * 1000
+		const cutoff = Date.now() - windowMs
 		return incidents.filter((i) => {
 			if (!i.firstTriggeredAt) return false
 			return new Date(i.firstTriggeredAt).getTime() >= cutoff
 		}).length
-	}, [incidents])
+	}, [incidents, triggeredWindow])
 
 	const mttr = useMemo(() => {
 		const resolved = incidents.filter((i) => i.resolvedAt && i.firstTriggeredAt)
@@ -420,17 +428,32 @@ function MonitorTab({
 			)}
 
 			{/* Slim summary strip — a secondary glance, sits beneath the incident list */}
-			<AlertStatStrip
-				items={[
-					{
-						label: "Triggered (24h)",
-						value: triggered24h,
-						hint: triggered24h === 1 ? "incident" : "incidents",
-					},
-					{ label: "Avg MTTR", value: mttr, hint: "across resolved" },
-					{ label: "Rules enabled", value: enabledRules, hint: `of ${rules.length} total` },
-				]}
-			/>
+			<div className="space-y-2">
+				<div className="flex justify-end">
+					<AlertSegmentedSelect<"24h" | "7d" | "30d">
+						options={[
+							{ value: "24h", label: "24h" },
+							{ value: "7d", label: "7d" },
+							{ value: "30d", label: "30d" },
+						]}
+						value={triggeredWindow}
+						onChange={setTriggeredWindow}
+						size="sm"
+						aria-label="Triggered window"
+					/>
+				</div>
+				<AlertStatStrip
+					items={[
+						{
+							label: `Triggered (${triggeredWindow})`,
+							value: triggeredInWindow,
+							hint: triggeredInWindow === 1 ? "incident" : "incidents",
+						},
+						{ label: "Avg MTTR", value: mttr, hint: "across resolved" },
+						{ label: "Rules enabled", value: enabledRules, hint: `of ${rules.length} total` },
+					]}
+				/>
+			</div>
 
 			{/* No-activity hint — only when nothing has happened at all */}
 			{openIncidents.length === 0 && deliveryEvents.length === 0 && (


### PR DESCRIPTION
## What & why

The alert **rule detail** page (`/alerts/$ruleId`) was the one detail view in the app without a time-range control. Its Overview chart was hardcoded to "Last 24h" and the Checks tab fetched with **no window at all** (`query: {}`), so you couldn't answer the basic operational question: *did this actually change today, or over the last week?* Every other detail/list view (services, errors, logs, replays, metrics) already has the standard header time-range picker — this wires the alert detail page up to the same pattern.

The backend already supported this: `listRuleChecks` accepts `since`/`until`/`limit` and `alert_checks` retains 90 days. This is frontend wiring, not new query work.

## Changes

**Detail page** — `apps/web/src/routes/alerts/$ruleId.tsx`
- Adds `startTime`/`endTime`/`timePreset` search params + the standard `TimeRangeHeaderControls` (presets, custom range, `D` hotkey, reload) in the header, wrapped in `PageRefreshProvider` — verbatim the services/errors wiring.
- The selected window (24h default) now drives the **Overview chart**, the **Checks query** (`since`/`until`, refetches on change), and the **header timeline strip** (reframed to the window instead of incident min/max).
- Dynamic chart heading (`presetLabel`/`formatTimeRangeDisplay`) replacing hardcoded "Last 24h", plus "no data / no checks in this window" empty states.

**Chart hook** — `apps/web/src/hooks/use-alert-rule-chart.ts`
- Optional `range` param; falls back to the internal 24h default, so the create form and live hero are unchanged.

**Monitor tab** — `apps/web/src/routes/alerts/index.tsx`
- A compact 24h/7d/30d segmented control that drives the "Triggered (Xh)" stat value + label (client-side, no new query).

## Verification

- `bun typecheck` passes.
- Browser-verified end-to-end against local web+api: selecting **Last 1 week** drives the URL (`?timePreset=1w`), picker label, chart heading, and timeline strip (reframed to Jun 20 → Jun 27) in sync; Overview chart renders real data. Monitor selector flips **Triggered (24h) → Triggered (7d)**. Create page live chart still shows "Live · last 24h" (no regression).
- Caught & fixed a heading-default mismatch during verification (heading said "Last 12 hours" while the picker/data used 24h).

> Note: the Checks tab *data* couldn't be exercised locally (`alert_checks` is a Tinybird/warehouse datasource and local Tinybird isn't serving it → the tab renders its existing error state cleanly). The empty-state copy lives in that already-exercised branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)