### PR TITLE
feat(alerts): AI diagnosis readout + integrated chat for firing alerts

### DIFF
--- a/apps/api/src/services/AiTriageService.alert.test.ts
+++ b/apps/api/src/services/AiTriageService.alert.test.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from "node:crypto"
+import { afterEach, describe, expect, it } from "@effect/vitest"
+import { AiTriageRunCreateRequest, OrgId } from "@maple/domain/http"
+import { Effect, Layer, Schema } from "effect"
+import { AiTriageService } from "./AiTriageService"
+import {
+	cleanupTestDbs,
+	createTestDb,
+	executeSql,
+	queryFirstRow,
+	type TestDb,
+} from "../lib/test-pglite"
+
+const createdDbs: TestDb[] = []
+
+afterEach(async () => {
+	await cleanupTestDbs(createdDbs)
+})
+
+const ORG = Schema.decodeUnknownSync(OrgId)("org_alert_triage_test")
+const RULE_NAME = "Checkout error rate"
+
+/**
+ * Seed one alert rule + one open incident and return the incident id. Mirrors the
+ * NOT NULL columns of `alert_rules` / `alert_incidents` (defaults fill the rest).
+ */
+const seedAlertIncident = async (db: TestDb): Promise<string> => {
+	const ruleId = randomUUID()
+	const incidentId = randomUUID()
+	const now = new Date().toISOString()
+	await executeSql(
+		db,
+		`INSERT INTO alert_rules
+			(id, org_id, name, enabled, severity, service_names_json, signal_type, comparator,
+			 threshold, window_minutes, minimum_sample_count, consecutive_breaches_required,
+			 consecutive_healthy_required, renotify_interval_minutes, destination_ids_json,
+			 reducer, no_data_behavior, created_at, updated_at, created_by, updated_by)
+		 VALUES ($1,$2,$3,true,'critical',$4::jsonb,'error_rate','gt',0.05,15,5,2,2,30,
+			 '[]'::jsonb,'avg','skip',$5,$5,'user_seed','user_seed')`,
+		[ruleId, ORG, RULE_NAME, JSON.stringify(["checkout-api"]), now],
+	)
+	await executeSql(
+		db,
+		`INSERT INTO alert_incidents
+			(id, org_id, rule_id, incident_key, rule_name, group_key, signal_type, severity,
+			 status, comparator, threshold, first_triggered_at, last_triggered_at,
+			 last_observed_value, last_sample_count, dedupe_key, error_issue_id, created_at, updated_at)
+		 VALUES ($1,$2,$3,$4,$5,'checkout-api','error_rate','critical','open','gt',0.05,$6,$6,
+			 0.12,200,$7,NULL,$6,$6)`,
+		[incidentId, ORG, ruleId, `ikey-${incidentId}`, RULE_NAME, now, `${ORG}:${ruleId}:checkout-api`],
+	)
+	return incidentId
+}
+
+describe("AiTriageService alert incidentKind", () => {
+	it.effect("createRun builds alert context instead of failing NotFound", () => {
+		const db = createTestDb(createdDbs)
+		return Effect.gen(function* () {
+			// Acquiring the service forces the Database layer (and its migrations) to
+			// build before we seed via raw SQL.
+			const service = yield* AiTriageService
+			const incidentId = yield* Effect.promise(() => seedAlertIncident(db))
+
+			// No WorkerEnvironment in tests → the run is enqueued then marked failed
+			// (binding unavailable), but the row + contextJson are written first. The
+			// regression we guard: this used to throw AiTriageNotFoundError.
+			const doc = yield* service.createRun(
+				ORG,
+				new AiTriageRunCreateRequest({ incidentKind: "alert", incidentId }),
+			)
+
+			expect(doc.incidentKind).toBe("alert")
+			expect(doc.incidentId).toBe(incidentId)
+
+			const row = yield* Effect.promise(() =>
+				queryFirstRow<{ incident_kind: string; context_json: Record<string, unknown> }>(
+					db,
+					`SELECT incident_kind, context_json FROM ai_triage_runs WHERE incident_id = $1`,
+					[incidentId],
+				),
+			)
+			expect(row?.incident_kind).toBe("alert")
+			expect(row?.context_json?.kind).toBe("alert")
+			expect(row?.context_json?.ruleName).toBe(RULE_NAME)
+			expect(row?.context_json?.signalType).toBe("error_rate")
+		}).pipe(Effect.provide(Layer.provide(AiTriageService.layer, db.layer)))
+	})
+
+	it.effect("createRun fails NotFound for an unknown alert incident", () => {
+		const db = createTestDb(createdDbs)
+		return Effect.gen(function* () {
+			const service = yield* AiTriageService
+			const exit = yield* service
+				.createRun(
+					ORG,
+					new AiTriageRunCreateRequest({ incidentKind: "alert", incidentId: randomUUID() }),
+				)
+				.pipe(Effect.exit)
+			expect(exit._tag).toBe("Failure")
+		}).pipe(Effect.provide(Layer.provide(AiTriageService.layer, db.layer)))
+	})
+})

--- a/apps/api/src/services/AiTriageService.ts
+++ b/apps/api/src/services/AiTriageService.ts
@@ -9,6 +9,7 @@ import {
 	AiTriageSettingsDocument,
 	type AiTriageSettingsUpdateRequest,
 	AiTriageValidationError,
+	AlertIncidentId,
 	AnomalyIncidentId,
 	ErrorIncidentId,
 	type ErrorIssueId,
@@ -20,6 +21,8 @@ import {
 	type AiTriageRunRow,
 	aiTriageSettings,
 	type AiTriageSettingsRow,
+	alertIncidents,
+	alertRules,
 	anomalyIncidents,
 	errorIncidents,
 	errorIssues,
@@ -38,6 +41,7 @@ const decodeIsoSync = Schema.decodeUnknownSync(AiTriageRunDocument.fields.create
 const decodeResultSync = Schema.decodeUnknownSync(AiTriageResult)
 const decodeAnomalyIncidentId = Schema.decodeUnknownOption(AnomalyIncidentId)
 const decodeErrorIncidentId = Schema.decodeUnknownOption(ErrorIncidentId)
+const decodeAlertIncidentId = Schema.decodeUnknownOption(AlertIncidentId)
 
 const describeCause = (cause: unknown): string | undefined => {
 	if (cause == null) return undefined
@@ -244,6 +248,57 @@ export class AiTriageService extends Context.Service<AiTriageService, AiTriageSe
 							firstTriggeredAt: incident.firstTriggeredAt.toISOString(),
 							lastTriggeredAt: incident.lastTriggeredAt.toISOString(),
 							status: incident.status,
+						},
+					}
+				}
+
+				if (request.incidentKind === "alert") {
+					const incidentId = Option.getOrUndefined(decodeAlertIncidentId(request.incidentId))
+					const rows = incidentId
+						? yield* dbExecute((db) =>
+								db
+									.select()
+									.from(alertIncidents)
+									.where(
+										and(eq(alertIncidents.orgId, orgId), eq(alertIncidents.id, incidentId)),
+									)
+									.limit(1),
+							)
+						: []
+					const incident = rows[0]
+					if (!incident) {
+						return yield* Effect.fail(
+							new AiTriageNotFoundError({
+								message: `No such alert incident: '${request.incidentId}'`,
+							}),
+						)
+					}
+					const ruleRows = yield* dbExecute((db) =>
+						db
+							.select()
+							.from(alertRules)
+							.where(and(eq(alertRules.orgId, orgId), eq(alertRules.id, incident.ruleId)))
+							.limit(1),
+					)
+					const rule = ruleRows[0]
+					return {
+						issueId: incident.errorIssueId ?? undefined,
+						context: {
+							kind: "alert",
+							ruleName: incident.ruleName,
+							signalType: incident.signalType,
+							comparator: incident.comparator,
+							threshold: incident.threshold,
+							thresholdUpper: incident.thresholdUpper,
+							groupKey: incident.groupKey,
+							observedValue: incident.lastObservedValue,
+							sampleCount: incident.lastSampleCount,
+							windowMinutes: rule?.windowMinutes,
+							serviceNames: rule?.serviceNamesJson?.join(", "),
+							severity: incident.severity,
+							status: incident.status,
+							firstTriggeredAt: incident.firstTriggeredAt.toISOString(),
+							lastTriggeredAt: incident.lastTriggeredAt.toISOString(),
 						},
 					}
 				}

--- a/apps/web/src/components/ai-triage/ai-triage-card.tsx
+++ b/apps/web/src/components/ai-triage/ai-triage-card.tsx
@@ -6,30 +6,69 @@ import { toast } from "sonner"
 
 import { useIntervalRefresh } from "@/hooks/use-interval-refresh"
 
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "@maple/ui/components/ui/alert"
 import { Badge } from "@maple/ui/components/ui/badge"
 import { Button } from "@maple/ui/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@maple/ui/components/ui/card"
+import { Card } from "@maple/ui/components/ui/card"
+import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@maple/ui/components/ui/empty"
+import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { Spinner } from "@maple/ui/components/ui/spinner"
 import { cn } from "@maple/ui/lib/utils"
+import { Shimmer } from "@/components/ai-elements/shimmer"
+import {
+	ArrowPathIcon,
+	ArrowRightIcon,
+	ChatBubbleSparkleIcon,
+	CircleWarningIcon,
+	PulseIcon,
+} from "@/components/icons"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import { formatRelativeTime } from "@/lib/format"
 import {
 	AiTriageRunCreateRequest,
 	type AiTriageIncidentKind,
+	type AiTriageResult,
 	type AiTriageRunDocument,
 	type ErrorIssueId,
 } from "@maple/domain/http"
-import { SEVERITY_TONE } from "@/components/errors/severity-badge"
-
-const CONFIDENCE_TONE: Record<string, string> = {
-	high: "bg-success/10 text-success",
-	medium: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
-	low: "bg-muted text-muted-foreground",
-}
+import { SEVERITY_ACCENT, SEVERITY_LABEL, SEVERITY_TONE } from "@/components/errors/severity-badge"
 
 const FAILURE_HINTS: Record<string, string> = {
 	no_structured_result: "The agent did not produce a structured result within its budget.",
 	workflow_binding_unavailable: "The triage workflow is not available in this environment.",
+}
+
+const EYEBROW = "text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground"
+
+const INCIDENT_NOUN: Record<AiTriageIncidentKind, string> = {
+	alert: "alert",
+	error: "error",
+	anomaly: "anomaly",
+}
+
+const CONFIDENCE_FILL: Record<string, { count: number; bar: string; text: string }> = {
+	high: { count: 3, bar: "bg-success", text: "text-success" },
+	medium: { count: 2, bar: "bg-warning", text: "text-warning" },
+	low: { count: 1, bar: "bg-muted-foreground/60", text: "text-muted-foreground" },
+}
+
+/** Three-segment certainty meter — encodes the AI's own confidence as a real signal. */
+function ConfidenceMeter({ confidence }: { confidence: string }) {
+	const tone = CONFIDENCE_FILL[confidence] ?? CONFIDENCE_FILL.low
+	return (
+		<div className="flex items-center gap-2" aria-label={`Confidence: ${confidence}`}>
+			<span className={EYEBROW}>Confidence</span>
+			<div className="flex items-center gap-0.5" aria-hidden>
+				{[0, 1, 2].map((i) => (
+					<span
+						key={i}
+						className={cn("h-2.5 w-1.5 rounded-[1px]", i < tone.count ? tone.bar : "bg-border")}
+					/>
+				))}
+			</div>
+			<span className={cn("text-xs font-medium capitalize", tone.text)}>{confidence}</span>
+		</div>
+	)
 }
 
 export interface AiTriageCardProps {
@@ -37,9 +76,15 @@ export interface AiTriageCardProps {
 	/** Incident to (re-)run triage against; null disables the run button. */
 	incidentId: string | null
 	issueId?: ErrorIssueId
+	/**
+	 * When provided, render a quiet "Ask a follow-up" action that opens an
+	 * integrated chat seeded with this incident's context. Receives the latest
+	 * completed triage result (if any) so the caller can fold it into the preamble.
+	 */
+	onOpenChat?: (result: AiTriageRunDocument["result"]) => void
 }
 
-export function AiTriageCard({ incidentKind, incidentId, issueId }: AiTriageCardProps) {
+export function AiTriageCard({ incidentKind, incidentId, issueId, onOpenChat }: AiTriageCardProps) {
 	const reactivityKeys = ["aiTriageRuns", `aiTriage:${incidentKind}:${incidentId ?? issueId ?? ""}`]
 	const runsQueryAtom = MapleApiAtomClient.query("aiTriage", "listRuns", {
 		query:
@@ -82,138 +127,263 @@ export function AiTriageCard({ incidentKind, incidentId, issueId }: AiTriageCard
 		})
 		setIsStarting(false)
 		if (Exit.isSuccess(result)) {
-			toast.success("AI triage started")
+			toast.success("Diagnosis started")
 		} else {
-			toast.error("Failed to start AI triage")
+			toast.error("Couldn't start the diagnosis")
 		}
 	}
 
-	return (
-		<Card>
-			<CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
-				<div className="space-y-1">
-					<CardTitle className="flex items-center gap-2 text-sm">
-						AI triage
-						{runsLoading || runActive ? <Spinner className="size-3.5" /> : null}
-						{run?.status === "completed" && run.result ? (
-							<>
-								<Badge
-									variant="outline"
-									className={cn(SEVERITY_TONE[run.result.severityAssessment])}
-								>
-									{run.result.severityAssessment}
-								</Badge>
-								<Badge
-									variant="outline"
-									className={cn(CONFIDENCE_TONE[run.result.confidence])}
-								>
-									{run.result.confidence} confidence
-								</Badge>
-							</>
-						) : null}
-					</CardTitle>
-					<CardDescription>
-						{runsFailed
-							? "Couldn't load triage runs for this incident."
-							: runsLoading
-								? "Loading triage runs…"
-								: run === null
-									? "No investigation has run for this incident yet."
-									: runActive
-										? "The agent is investigating this incident…"
-										: run.status === "failed"
-											? (FAILURE_HINTS[run.error ?? ""] ??
-												`Triage failed: ${run.error ?? "unknown error"}`)
-											: `Investigated ${formatRelativeTime(run.completedAt ?? run.createdAt)}${run.model ? ` · ${run.model}` : ""}`}
-					</CardDescription>
-				</div>
-				{runsFailed ? (
+	// --- Loading the run list ------------------------------------------------
+	if (runsLoading) {
+		return (
+			<Card className="space-y-3 p-5">
+				<Skeleton className="h-4 w-40" />
+				<Skeleton className="h-3 w-full" />
+				<Skeleton className="h-3 w-2/3" />
+			</Card>
+		)
+	}
+
+	if (runsFailed) {
+		return (
+			<Alert variant="warning">
+				<CircleWarningIcon />
+				<AlertTitle>Couldn't load the diagnosis</AlertTitle>
+				<AlertDescription>Try again in a moment.</AlertDescription>
+				<AlertAction>
 					<Button size="sm" variant="outline" onClick={() => refreshRuns()}>
 						Retry
 					</Button>
-				) : (
-					<Button
-						size="sm"
-						variant="outline"
-						onClick={startRun}
-						disabled={incidentId === null || runsLoading || runActive || isStarting}
-					>
-						{run === null ? "Run triage" : "Re-run"}
+				</AlertAction>
+			</Alert>
+		)
+	}
+
+	// --- No run yet: focused CTA --------------------------------------------
+	if (run === null) {
+		return (
+			<Card>
+				<Empty className="py-8">
+					<EmptyHeader>
+						<EmptyMedia variant="icon">
+							<PulseIcon size={18} />
+						</EmptyMedia>
+						<EmptyTitle>No diagnosis yet</EmptyTitle>
+						<EmptyDescription>
+							See what's driving this {INCIDENT_NOUN[incidentKind]} — Maple reads the
+							traces, errors, and logs to find the likely cause.
+						</EmptyDescription>
+					</EmptyHeader>
+					<EmptyContent>
+						<Button
+							size="sm"
+							onClick={startRun}
+							disabled={incidentId === null || isStarting}
+						>
+							<PulseIcon className="size-3.5" />
+							Diagnose this {INCIDENT_NOUN[incidentKind]}
+						</Button>
+						{incidentId === null ? (
+							<p className="text-xs text-muted-foreground">No incident to diagnose yet.</p>
+						) : null}
+					</EmptyContent>
+				</Empty>
+			</Card>
+		)
+	}
+
+	// --- Investigating -------------------------------------------------------
+	if (runActive) {
+		return (
+			<Card className="space-y-3 p-5">
+				<div className="flex items-center gap-2">
+					<Spinner className="size-4 text-muted-foreground" />
+					<Shimmer className="text-sm font-medium">
+						Investigating — reading traces, errors, and logs
+					</Shimmer>
+				</div>
+				<div className="space-y-2">
+					<Skeleton className="h-3 w-3/4" />
+					<Skeleton className="h-3 w-1/2" />
+				</div>
+			</Card>
+		)
+	}
+
+	// --- Failed --------------------------------------------------------------
+	if (run.status === "failed") {
+		return (
+			<Alert variant="error">
+				<CircleWarningIcon />
+				<AlertTitle>Diagnosis failed</AlertTitle>
+				<AlertDescription>
+					{FAILURE_HINTS[run.error ?? ""] ?? `Triage failed: ${run.error ?? "unknown error"}`}
+				</AlertDescription>
+				<AlertAction>
+					<Button size="sm" variant="outline" onClick={startRun} disabled={isStarting}>
+						Retry
 					</Button>
-				)}
-			</CardHeader>
-			{run?.status === "completed" && run.result ? (
-				<CardContent className="space-y-4 text-sm">
-					<p className="text-foreground">{run.result.summary}</p>
+				</AlertAction>
+			</Alert>
+		)
+	}
 
-					<div className="space-y-1">
-						<div className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-							Suspected cause
-						</div>
-						<p className="text-muted-foreground">{run.result.suspectedCause}</p>
+	const result = run.result
+	if (!result) {
+		// Completed without a structured result — shouldn't happen, but degrade gracefully.
+		return (
+			<Alert variant="warning">
+				<CircleWarningIcon />
+				<AlertTitle>No diagnosis produced</AlertTitle>
+				<AlertDescription>The investigation finished without a structured result.</AlertDescription>
+				<AlertAction>
+					<Button size="sm" variant="outline" onClick={startRun} disabled={isStarting}>
+						Re-run
+					</Button>
+				</AlertAction>
+			</Alert>
+		)
+	}
+
+	return <DiagnosisReadout run={run} result={result} onOpenChat={onOpenChat} onRerun={startRun} rerunning={isStarting} />
+}
+
+function DiagnosisReadout({
+	run,
+	result,
+	onOpenChat,
+	onRerun,
+	rerunning,
+}: {
+	run: AiTriageRunDocument
+	result: AiTriageResult
+	onOpenChat?: (result: AiTriageRunDocument["result"]) => void
+	onRerun: () => void
+	rerunning: boolean
+}) {
+	const severity = result.severityAssessment
+	// Aggregate the services named across all evidence into one blast-radius row.
+	const services = [...new Set(result.evidence.flatMap((e) => e.relatedServices))]
+	const traceEvidence = result.evidence.filter((e) => e.note || e.traceIds.length || e.logPatterns.length)
+
+	return (
+		<Card className="relative gap-0 overflow-hidden p-0">
+			<span aria-hidden className={cn("absolute inset-y-0 left-0 z-10 w-1", SEVERITY_ACCENT[severity])} />
+
+			{/* Banner — what's wrong, front and center */}
+			<div className="space-y-3 p-5 pl-6">
+				<div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+					<span className="flex items-center gap-1.5">
+						<PulseIcon className="size-3.5 text-muted-foreground" />
+						<span className={EYEBROW}>AI Diagnosis</span>
+					</span>
+					<Badge variant="outline" className={cn("capitalize", SEVERITY_TONE[severity])}>
+						{SEVERITY_LABEL[severity]}
+					</Badge>
+					<span className="text-muted-foreground/40">·</span>
+					<span className="text-xs text-muted-foreground">
+						investigated {formatRelativeTime(run.completedAt ?? run.createdAt)}
+						{run.model ? ` · ${run.model}` : ""}
+					</span>
+				</div>
+				<p className="text-[15px] font-medium leading-snug text-foreground">{result.suspectedCause}</p>
+				<p className="text-sm leading-relaxed text-muted-foreground">{result.summary}</p>
+				<ConfidenceMeter confidence={result.confidence} />
+			</div>
+
+			{/* Blast radius */}
+			<div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-t border-border px-5 py-3 pl-6">
+				<span className={EYEBROW}>Blast radius</span>
+				<span className="text-sm text-foreground">{result.affectedScope}</span>
+				{services.length > 0 ? (
+					<div className="flex flex-wrap gap-1">
+						{services.map((service) => (
+							<Badge key={service} variant="outline" className="text-[11px]">
+								{service}
+							</Badge>
+						))}
 					</div>
+				) : null}
+			</div>
 
-					<div className="space-y-1">
-						<div className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-							Affected scope
-						</div>
-						<p className="text-muted-foreground">{run.result.affectedScope}</p>
-					</div>
-
-					{run.result.evidence.length > 0 ? (
-						<div className="space-y-2">
-							<div className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-								Evidence
-							</div>
-							{run.result.evidence.map((item, index) => (
-								<div key={index} className="rounded-md border border-border/60 p-3">
-									{item.note ? (
-										<p className="mb-2 text-muted-foreground">{item.note}</p>
-									) : null}
-									<div className="flex flex-wrap gap-1.5">
+			{/* Evidence */}
+			{traceEvidence.length > 0 ? (
+				<div className="space-y-2.5 border-t border-border px-5 py-4 pl-6">
+					<span className={EYEBROW}>Evidence</span>
+					<ul className="space-y-3">
+						{traceEvidence.map((item, index) => (
+							<li key={index} className="space-y-1.5">
+								{item.note ? <p className="text-sm text-muted-foreground">{item.note}</p> : null}
+								{item.traceIds.length || item.logPatterns.length ? (
+									<div className="flex flex-wrap items-center gap-1.5">
 										{item.traceIds.map((traceId) => (
 											<Link
 												key={traceId}
 												to="/traces/$traceId"
 												params={{ traceId }}
-												className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground hover:bg-muted/70"
+												className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground transition-colors hover:bg-muted/70"
 											>
-												{traceId.slice(0, 16)}…
+												{traceId.slice(0, 12)}…
 											</Link>
 										))}
 										{item.logPatterns.map((pattern) => (
 											<span
 												key={pattern}
-												className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+												className="rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
 											>
 												{pattern}
 											</span>
 										))}
-										{item.relatedServices.map((service) => (
-											<Badge key={service} variant="outline" className="text-[11px]">
-												{service}
-											</Badge>
-										))}
 									</div>
-								</div>
-							))}
-						</div>
-					) : null}
-
-					{run.result.suggestedActions.length > 0 ? (
-						<div className="space-y-1">
-							<div className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-								Suggested actions
-							</div>
-							<ol className="list-decimal space-y-1 pl-5 text-muted-foreground">
-								{run.result.suggestedActions.map((action) => (
-									<li key={action}>{action}</li>
-								))}
-							</ol>
-						</div>
-					) : null}
-				</CardContent>
+								) : null}
+							</li>
+						))}
+					</ul>
+				</div>
 			) : null}
+
+			{/* Runbook */}
+			{result.suggestedActions.length > 0 ? (
+				<div className="space-y-2.5 border-t border-border px-5 py-4 pl-6">
+					<span className={EYEBROW}>What to do</span>
+					<ol className="space-y-2">
+						{result.suggestedActions.map((action, index) => (
+							<li key={action} className="flex gap-2.5 text-sm text-foreground">
+								<span className="mt-px flex size-5 shrink-0 items-center justify-center rounded-md bg-muted font-mono text-[11px] tabular-nums text-muted-foreground">
+									{index + 1}
+								</span>
+								<span className="leading-snug">{action}</span>
+							</li>
+						))}
+					</ol>
+				</div>
+			) : null}
+
+			{/* Quiet footer */}
+			<div className="flex items-center justify-between gap-2 border-t border-border px-3 py-2 pl-5">
+				<Button
+					size="sm"
+					variant="ghost"
+					onClick={onRerun}
+					disabled={rerunning}
+					className="text-muted-foreground"
+				>
+					<ArrowPathIcon className="size-3.5" />
+					Re-run
+				</Button>
+				{onOpenChat ? (
+					<Button
+						size="sm"
+						variant="ghost"
+						onClick={() => onOpenChat(result)}
+						className="text-muted-foreground"
+					>
+						<ChatBubbleSparkleIcon className="size-3.5" />
+						Ask a follow-up
+						<ArrowRightIcon className="size-3" />
+					</Button>
+				) : null}
+			</div>
 		</Card>
 	)
 }

--- a/apps/web/src/components/alerts/alert-chat-sheet.tsx
+++ b/apps/web/src/components/alerts/alert-chat-sheet.tsx
@@ -1,0 +1,83 @@
+import { Link } from "@tanstack/react-router"
+
+import { Button } from "@maple/ui/components/ui/button"
+import {
+	Sheet,
+	SheetDescription,
+	SheetHeader,
+	SheetPopup,
+	SheetTitle,
+} from "@maple/ui/components/ui/sheet"
+import { ExternalLinkIcon } from "@/components/icons"
+
+import { ChatConversation } from "@/components/chat/chat-conversation"
+import { FlueClientProvider } from "@/components/chat/flue-client-provider"
+import {
+	alertTabId,
+	encodeAlertContextToSearchParam,
+	signalLabel,
+	type AlertContext,
+} from "@/components/chat/alert-context"
+
+export interface AlertChatSheetProps {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	/** Null while no incident/context is selected — the sheet renders nothing. */
+	alertContext: AlertContext | null
+}
+
+/**
+ * Right-side slide-over that hosts the full Maple chat (`<ChatConversation>` in
+ * `mode="alert"`) seeded with a firing alert's context — so an on-call engineer
+ * can keep asking follow-up questions without leaving the alert detail page.
+ *
+ * The conversation is addressed by the stable `alert-<incidentId>` tab id, so
+ * this panel and the full `/chat?mode=alert` page are the same thread. We mount
+ * our own {@link FlueClientProvider} (the chat page mounts one too) so the panel
+ * works standalone.
+ */
+export function AlertChatSheet({ open, onOpenChange, alertContext }: AlertChatSheetProps) {
+	return (
+		<Sheet open={open && alertContext !== null} onOpenChange={onOpenChange}>
+			{alertContext ? (
+				<SheetPopup
+					side="right"
+					className="w-[calc(100%-(--spacing(12)))] sm:max-w-2xl"
+					closeProps={{ className: "absolute end-12 top-4 z-10" }}
+				>
+					<SheetHeader className="flex flex-row items-start justify-between gap-3 border-b pb-4">
+						<div className="min-w-0 space-y-1">
+							<SheetTitle className="truncate text-base">{alertContext.ruleName}</SheetTitle>
+							<SheetDescription>
+								Discuss this {signalLabel(alertContext.signalType)} alert with Maple AI.
+							</SheetDescription>
+						</div>
+						<Button size="sm" variant="ghost" render={
+							<Link
+								to="/chat"
+								search={{
+									mode: "alert",
+									alert: encodeAlertContextToSearchParam(alertContext),
+									tab: alertTabId(alertContext),
+								}}
+							/>
+						}>
+							Open full page
+							<ExternalLinkIcon className="size-3.5" />
+						</Button>
+					</SheetHeader>
+					<div className="flex min-h-0 flex-1 flex-col">
+						<FlueClientProvider>
+							<ChatConversation
+								tabId={alertTabId(alertContext)}
+								isActive={open}
+								mode="alert"
+								alertContext={alertContext}
+							/>
+						</FlueClientProvider>
+					</div>
+				</SheetPopup>
+			) : null}
+		</Sheet>
+	)
+}

--- a/apps/web/src/components/chat/alert-context.ts
+++ b/apps/web/src/components/chat/alert-context.ts
@@ -1,3 +1,5 @@
+import { fromBase64Url, toBase64Url } from "@/lib/base64url"
+
 export interface AlertContext {
 	ruleId: string
 	ruleName: string
@@ -14,20 +16,6 @@ export interface AlertContext {
 	/** Prior AI-triage findings, folded into the chat preamble so the agent starts from them. */
 	aiSummary?: string
 	aiSuspectedCause?: string
-}
-
-const fromBase64Url = (input: string): string => {
-	const padded = input.replace(/-/g, "+").replace(/_/g, "/")
-	const pad = padded.length % 4
-	const full = pad === 0 ? padded : padded + "=".repeat(4 - pad)
-	if (typeof atob !== "undefined") {
-		try {
-			return decodeURIComponent(escape(atob(full)))
-		} catch {
-			return atob(full)
-		}
-	}
-	return Buffer.from(full, "base64").toString("utf8")
 }
 
 const isAlertContext = (value: unknown): value is AlertContext => {
@@ -50,19 +38,8 @@ const isAlertContext = (value: unknown): value is AlertContext => {
 	return true
 }
 
-export const encodeAlertContextToSearchParam = (ctx: AlertContext): string => {
-	const json = JSON.stringify(ctx)
-	if (typeof btoa !== "undefined") {
-		let raw: string
-		try {
-			raw = btoa(unescape(encodeURIComponent(json)))
-		} catch {
-			raw = btoa(json)
-		}
-		return raw.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
-	}
-	return Buffer.from(json, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
-}
+export const encodeAlertContextToSearchParam = (ctx: AlertContext): string =>
+	toBase64Url(JSON.stringify(ctx))
 
 export const decodeAlertContextFromSearchParam = (raw: string): AlertContext | undefined => {
 	try {

--- a/apps/web/src/components/chat/alert-context.ts
+++ b/apps/web/src/components/chat/alert-context.ts
@@ -11,6 +11,9 @@ export interface AlertContext {
 	windowMinutes: number
 	groupKey: string | null
 	sampleCount: number | null
+	/** Prior AI-triage findings, folded into the chat preamble so the agent starts from them. */
+	aiSummary?: string
+	aiSuspectedCause?: string
 }
 
 const fromBase64Url = (input: string): string => {
@@ -42,7 +45,23 @@ const isAlertContext = (value: unknown): value is AlertContext => {
 	if (typeof v.windowMinutes !== "number") return false
 	if (v.groupKey !== null && typeof v.groupKey !== "string") return false
 	if (v.sampleCount !== null && typeof v.sampleCount !== "number") return false
+	if (v.aiSummary !== undefined && typeof v.aiSummary !== "string") return false
+	if (v.aiSuspectedCause !== undefined && typeof v.aiSuspectedCause !== "string") return false
 	return true
+}
+
+export const encodeAlertContextToSearchParam = (ctx: AlertContext): string => {
+	const json = JSON.stringify(ctx)
+	if (typeof btoa !== "undefined") {
+		let raw: string
+		try {
+			raw = btoa(unescape(encodeURIComponent(json)))
+		} catch {
+			raw = btoa(json)
+		}
+		return raw.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+	}
+	return Buffer.from(json, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
 }
 
 export const decodeAlertContextFromSearchParam = (raw: string): AlertContext | undefined => {

--- a/apps/web/src/components/chat/context-preamble.ts
+++ b/apps/web/src/components/chat/context-preamble.ts
@@ -191,5 +191,16 @@ const formatAlertContextBlock = (alert: AlertContext): string => {
 		"- When you recommend dashboards or links, prefer existing Maple routes (services, traces, errors, alerts). Use `get_alert_rule`/`list_alert_incidents` if you need deeper rule history.",
 		"- If the event is `resolve`, focus on root-cause and prevention rather than immediate mitigation.",
 	]
+
+	if (alert.aiSummary || alert.aiSuspectedCause) {
+		lines.push(
+			"",
+			"### Prior AI triage",
+			"An automated triage pass already ran on this incident. Build on it — verify, deepen, or correct it rather than starting from scratch.",
+		)
+		if (alert.aiSummary) lines.push(`- summary: ${alert.aiSummary}`)
+		if (alert.aiSuspectedCause) lines.push(`- suspected_cause: ${alert.aiSuspectedCause}`)
+	}
+
 	return lines.join("\n")
 }

--- a/apps/web/src/components/errors/severity-badge.tsx
+++ b/apps/web/src/components/errors/severity-badge.tsx
@@ -9,6 +9,14 @@ export const SEVERITY_TONE: Record<IssueSeverity, string> = {
 	low: "bg-muted text-muted-foreground",
 }
 
+/** Solid severity accent for left bars, dots, and meters (mirrors anomaly-format). */
+export const SEVERITY_ACCENT: Record<IssueSeverity, string> = {
+	critical: "bg-destructive",
+	high: "bg-orange-500",
+	medium: "bg-amber-500",
+	low: "bg-border/60",
+}
+
 export const SEVERITY_LABEL: Record<IssueSeverity, string> = {
 	critical: "Critical",
 	high: "High",

--- a/apps/web/src/routes/alerts/$ruleId.tsx
+++ b/apps/web/src/routes/alerts/$ruleId.tsx
@@ -817,11 +817,13 @@ function RuleDetailContent() {
 																<DropdownMenuContent align="end">
 																	<DropdownMenuItem
 																		onClick={() =>
-																			setExpandedIncidentId(incident.id)
+																			setExpandedIncidentId(
+																				isExpanded ? null : incident.id,
+																			)
 																		}
 																	>
 																		<ChatBubbleSparkleIcon size={14} />
-																		AI summary
+																		{isExpanded ? "Hide AI summary" : "AI summary"}
 																	</DropdownMenuItem>
 																	<DropdownMenuItem
 																		onClick={() =>

--- a/apps/web/src/routes/alerts/$ruleId.tsx
+++ b/apps/web/src/routes/alerts/$ruleId.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import { Result, useAtomRefresh, useAtomValue } from "@/lib/effect-atom"
 import { effectRoute } from "@effect-router/core"
 import { Schema } from "effect"
-import { useMemo, useState } from "react"
+import { Fragment, useMemo, useState } from "react"
 
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
@@ -32,15 +32,22 @@ import {
 import {
 	AlertRuleId,
 	IsoDateTimeString,
+	type AiTriageResult,
 	type AlertCheckDocument,
+	type AlertIncidentDocument,
 	type AlertRuleDocument,
 } from "@maple/domain/http"
+import { AiTriageCard } from "@/components/ai-triage/ai-triage-card"
+import { AlertChatSheet } from "@/components/alerts/alert-chat-sheet"
+import type { AlertContext } from "@/components/chat/alert-context"
 import {
 	CheckIcon,
 	PencilIcon,
 	DotsVerticalIcon,
 	CircleWarningIcon,
 	SquareTerminalIcon,
+	ChevronDownIcon,
+	ChatBubbleSparkleIcon,
 } from "@/components/icons"
 import { cn } from "@maple/ui/utils"
 import { Badge } from "@maple/ui/components/ui/badge"
@@ -160,6 +167,24 @@ function RuleDetailContent() {
 		if (stateFilter === "all") return ruleIncidents
 		return ruleIncidents.filter((i) => i.status === stateFilter)
 	}, [ruleIncidents, stateFilter])
+
+	// Incident the Overview AI-summary card binds to: the open one, else most recent.
+	const overviewIncident = useMemo(
+		() => ruleIncidents.find((i) => i.status === "open") ?? ruleIncidents[0] ?? null,
+		[ruleIncidents],
+	)
+
+	// Integrated alert chat slide-over, seeded with an incident's context.
+	const [chatContext, setChatContext] = useState<AlertContext | null>(null)
+	const [chatOpen, setChatOpen] = useState(false)
+	// History rows lazily mount their own triage card only when expanded.
+	const [expandedIncidentId, setExpandedIncidentId] = useState<string | null>(null)
+
+	const openAlertChat = (incident: AlertIncidentDocument, result?: AiTriageResult | null) => {
+		if (!rule) return
+		setChatContext(toAlertContext(rule, incident, result))
+		setChatOpen(true)
+	}
 
 	const stats = useMemo(() => computeIncidentStats(ruleIncidents), [ruleIncidents])
 	const maxContributorCount = stats.topContributors.length > 0 ? stats.topContributors[0][1] : 1
@@ -443,6 +468,15 @@ function RuleDetailContent() {
 						)}
 					</div>
 
+					{overviewIncident ? (
+						<AiTriageCard
+							incidentKind="alert"
+							incidentId={overviewIncident.id}
+							issueId={overviewIncident.errorIssueId ?? undefined}
+							onOpenChat={(result) => openAlertChat(overviewIncident, result)}
+						/>
+					) : null}
+
 					<div className="space-y-3">
 						<h2 className="text-lg font-semibold">Configuration</h2>
 						<Card>
@@ -682,8 +716,10 @@ function RuleDetailContent() {
 									<TableBody>
 										{filteredIncidents.map((incident) => {
 											const isOpen = incident.status === "open"
+											const isExpanded = expandedIncidentId === incident.id
 											return (
-												<TableRow key={incident.id}>
+												<Fragment key={incident.id}>
+												<TableRow>
 													<TableCell>
 														<AlertStatusBadge
 															state={isOpen ? "firing" : "resolved"}
@@ -750,29 +786,73 @@ function RuleDetailContent() {
 														)}
 													</TableCell>
 													<TableCell>
-														<DropdownMenu>
-															<DropdownMenuTrigger
-																render={
-																	<Button variant="ghost" size="icon-sm" />
+														<div className="flex items-center justify-end gap-1">
+															<Button
+																variant="ghost"
+																size="icon-sm"
+																aria-label={isExpanded ? "Hide AI summary" : "Show AI summary"}
+																aria-expanded={isExpanded}
+																onClick={() =>
+																	setExpandedIncidentId(
+																		isExpanded ? null : incident.id,
+																	)
 																}
 															>
-																<DotsVerticalIcon size={14} />
-															</DropdownMenuTrigger>
-															<DropdownMenuContent align="end">
-																<DropdownMenuItem
-																	onClick={() =>
-																		navigate({
-																			to: "/alerts",
-																			search: { tab: "monitor" },
-																		})
+																<ChevronDownIcon
+																	size={14}
+																	className={cn(
+																		"transition-transform",
+																		isExpanded && "rotate-180",
+																	)}
+																/>
+															</Button>
+															<DropdownMenu>
+																<DropdownMenuTrigger
+																	render={
+																		<Button variant="ghost" size="icon-sm" />
 																	}
 																>
-																	View all incidents
-																</DropdownMenuItem>
-															</DropdownMenuContent>
-														</DropdownMenu>
+																	<DotsVerticalIcon size={14} />
+																</DropdownMenuTrigger>
+																<DropdownMenuContent align="end">
+																	<DropdownMenuItem
+																		onClick={() =>
+																			setExpandedIncidentId(incident.id)
+																		}
+																	>
+																		<ChatBubbleSparkleIcon size={14} />
+																		AI summary
+																	</DropdownMenuItem>
+																	<DropdownMenuItem
+																		onClick={() =>
+																			navigate({
+																				to: "/alerts",
+																				search: { tab: "monitor" },
+																			})
+																		}
+																	>
+																		View all incidents
+																	</DropdownMenuItem>
+																</DropdownMenuContent>
+															</DropdownMenu>
+														</div>
 													</TableCell>
 												</TableRow>
+												{isExpanded ? (
+													<TableRow className="bg-muted/30 hover:bg-muted/30">
+														<TableCell colSpan={7} className="p-4">
+															<AiTriageCard
+																incidentKind="alert"
+																incidentId={incident.id}
+																issueId={incident.errorIssueId ?? undefined}
+																onOpenChat={(result) =>
+																	openAlertChat(incident, result)
+																}
+															/>
+														</TableCell>
+													</TableRow>
+												) : null}
+												</Fragment>
 											)
 										})}
 									</TableBody>
@@ -809,8 +889,38 @@ function RuleDetailContent() {
 							setStatusFilter={setCheckStatusFilter}
 						/>
 					))}
+
+			<AlertChatSheet open={chatOpen} onOpenChange={setChatOpen} alertContext={chatContext} />
 		</DashboardLayout>
 	)
+}
+
+/**
+ * Build the chat `AlertContext` from a rule + the incident the engineer is
+ * investigating, optionally folding in a prior triage result so the chat opens
+ * already aware of the AI's findings.
+ */
+function toAlertContext(
+	rule: AlertRuleDocument,
+	incident: AlertIncidentDocument,
+	result?: AiTriageResult | null,
+): AlertContext {
+	return {
+		ruleId: rule.id,
+		ruleName: rule.name,
+		incidentId: incident.id,
+		eventType: incident.status === "open" ? "trigger" : "resolve",
+		signalType: rule.signalType,
+		severity: incident.severity,
+		comparator: rule.comparator,
+		threshold: incident.threshold,
+		value: incident.lastObservedValue,
+		windowMinutes: rule.windowMinutes,
+		groupKey: incident.groupKey,
+		sampleCount: incident.lastSampleCount,
+		...(result?.summary ? { aiSummary: result.summary } : {}),
+		...(result?.suspectedCause ? { aiSuspectedCause: result.suspectedCause } : {}),
+	}
 }
 
 function ConfigRow({ label, children, wide }: { label: string; children: React.ReactNode; wide?: boolean }) {

--- a/packages/db/scripts/seed-alert-diagnosis.ts
+++ b/packages/db/scripts/seed-alert-diagnosis.ts
@@ -1,0 +1,95 @@
+/**
+ * Local-only helper to preview the alert AI-diagnosis readout without the
+ * deployed CHAT_FLUE / Workers-AI binding.
+ *
+ * It seeds an OPEN alert incident + a COMPLETED `ai_triage_runs` row (with a
+ * realistic structured result) for the most recent alert rule in your dev
+ * Postgres, then prints the URL to open.
+ *
+ *   bun run --cwd packages/db scripts/seed-alert-diagnosis.ts           # newest rule
+ *   bun run --cwd packages/db scripts/seed-alert-diagnosis.ts <ruleId>  # a specific rule
+ *
+ * Cleanup:
+ *   bun run --cwd packages/db scripts/seed-alert-diagnosis.ts --clean
+ *
+ * Requires the dev Postgres (`bun db:up && bun db:migrate:local`).
+ */
+import { randomUUID } from "node:crypto"
+import postgres from "postgres"
+
+const DSN = process.env.MAPLE_DEV_PG ?? "postgres://maple:maple@localhost:5499/maple"
+const TAG = "seed-alert-diagnosis" // dedupeKey marker so --clean only removes our rows
+const sql = postgres(DSN)
+
+const result = {
+	summary:
+		"Checkout error rate jumped to 18% right after payment-service v2.3.1 rolled out at 16:02. The spike is isolated to the /checkout/confirm path; upstream traffic is healthy.",
+	suspectedCause:
+		"Regression in payment-service v2.3.1 — the new Stripe client times out on idempotency-key retries, surfacing as 502s on checkout-api/confirm.",
+	severityAssessment: "high",
+	affectedScope: "checkout-api · /checkout/confirm · ~18% of confirm requests, ~240 users in the last 5m",
+	evidence: [
+		{
+			traceIds: ["0af7651916cd43dd8448eb211c80319c", "4bf92f3577b34da6a3ce929d0e0e4736"],
+			logPatterns: ["upstream timeout after 30000ms"],
+			relatedServices: ["payment-service", "checkout-api"],
+			note: "Both representative traces fail in payment-service.StripeClient.charge with a 30s timeout, then checkout-api returns 502.",
+		},
+		{
+			traceIds: [],
+			logPatterns: ["idempotency key replay rejected"],
+			relatedServices: ["payment-service"],
+			note: "payment-service logs show idempotency-key replays being rejected since the 16:02 deploy — absent in the prior build.",
+		},
+	],
+	suggestedActions: [
+		"Roll back payment-service to v2.3.0 to stop the bleeding.",
+		"Check the Stripe client timeout/retry config introduced in v2.3.1.",
+		"Confirm checkout-api/confirm error rate returns below 5% after rollback.",
+	],
+	confidence: "high",
+}
+
+async function clean() {
+	const inc = await sql`delete from alert_incidents where dedupe_key like ${"%:" + TAG} returning id`
+	if (inc.length) {
+		await sql`delete from ai_triage_runs where incident_id in ${sql(inc.map((r) => r.id))}`
+	}
+	console.log(`Removed ${inc.length} seeded incident(s) and their diagnosis runs.`)
+}
+
+async function seed(ruleId?: string) {
+	const rule = (
+		ruleId
+			? await sql`select id, org_id, name, signal_type, comparator, threshold, severity from alert_rules where id = ${ruleId}`
+			: await sql`select id, org_id, name, signal_type, comparator, threshold, severity from alert_rules order by created_at desc limit 1`
+	)[0]
+	if (!rule) {
+		console.error("No alert rule found. Create one at /alerts first, or pass a rule id.")
+		process.exit(1)
+	}
+
+	const incidentId = randomUUID()
+	const now = new Date()
+	await sql`insert into alert_incidents
+		(id, org_id, rule_id, incident_key, rule_name, group_key, signal_type, severity, status,
+		 comparator, threshold, first_triggered_at, last_triggered_at, last_observed_value,
+		 last_sample_count, dedupe_key, error_issue_id, created_at, updated_at)
+		values (${incidentId}, ${rule.org_id}, ${rule.id}, ${"ikey-" + incidentId}, ${rule.name},
+		 ${"checkout-api"}, ${rule.signal_type}, ${rule.severity}, ${"open"}, ${rule.comparator},
+		 ${rule.threshold}, ${now}, ${now}, ${0.18}, ${240}, ${rule.org_id + ":" + TAG}, ${null}, ${now}, ${now})`
+
+	await sql`insert into ai_triage_runs
+		(id, org_id, incident_kind, incident_id, issue_id, status, context_json, result_json, model,
+		 input_tokens, output_tokens, created_at, started_at, completed_at, updated_at)
+		values (${randomUUID()}, ${rule.org_id}, ${"alert"}, ${incidentId}, ${null}, ${"completed"},
+		 ${sql.json({ kind: "alert" })}, ${sql.json(result)}, ${"@cf/moonshotai/kimi-k2.6"}, ${1840},
+		 ${320}, ${now}, ${now}, ${now}, ${now})`
+
+	console.log(`Seeded a completed diagnosis on rule "${rule.name}".`)
+	console.log(`Open:  /alerts/${rule.id}   (Overview tab)`)
+}
+
+const arg = process.argv[2]
+await (arg === "--clean" ? clean() : seed(arg))
+await sql.end()


### PR DESCRIPTION
## What

Adds an on-demand **AI diagnosis** to alert incidents that explains *why* an alert is firing — presented **UI-first** as a scannable readout (not a text dump), with chat demoted to a secondary follow-up.

### Backend
- Wire the missing `"alert"` branch into `AiTriageService.buildContext` so a triage run can be created for an alert incident: it loads the incident + parent rule, builds the prompt context, and links the run to the incident's `errorIssueId`.
- This also **repairs a pre-existing bug**: the errors hub already rendered the triage button for alert-backed issues, but it failed with `AiTriageNotFoundError` because the alert kind was never handled.
- Unit tests (PGlite) cover the alert-context build and the not-found path.
- No schema/migration/endpoint changes — the Flue `triage` workflow + prompt already accept the `"alert"` kind.

### Frontend — diagnosis readout
Rebuilt the shared `AiTriageCard` from flat stacked text into a severity-accented **diagnosis readout**:
- Left accent bar in the severity color; the **suspected cause is the headline** (what's wrong), summary as supporting text.
- 3-segment **confidence meter**, a **blast-radius** strip (scope + service chips), **evidence** as clickable trace / log-pattern / service chips, and a numbered **runbook** of next steps.
- Focused empty-state CTA ("Diagnose this _alert/error/anomaly_"), shimmer running state, inline failed state.
- Chat demoted to a quiet footer link.
- It's the shared card, so the **error-issue and anomaly pages get the same upgrade**. Adds a shared `SEVERITY_ACCENT` map next to `SEVERITY_TONE`.

### Frontend — integrated chat
- New `AlertChatSheet`: a right-side slide-over that mounts the existing `ChatConversation` in alert mode, seeded with the incident context **and** the triage summary (new optional `aiSummary`/`aiSuspectedCause` on `AlertContext`, folded into the chat preamble). Opened from the diagnosis card; shares the `alert-<incidentId>` thread with the full `/chat` page.
- The card is rendered on the alert rule **Overview** tab (latest incident) and per-incident in expandable **History** rows.

## Why
When an alert fires, the operator wants to see the likely cause and next steps at a glance — and be able to keep investigating. The first iteration shipped the data path but presented it as a chat-forward text dump; this reworks it into a proper diagnostic surface.

## Testing
- `bun typecheck` — all packages green.
- `vitest` — new `AiTriageService.alert.test.ts` (alert context built; not-found for unknown incident) + existing triage/preamble suites pass.
- Browser E2E (desktop): seeded an incident + completed run and screenshotted the full readout (severity accent, confidence meter, evidence trace chips, runbook, footer); verified the empty-state CTA; regression-checked the error-issue page (shared card renders, no chat footer link). No render errors.

## Reviewer notes
- The live triage *generation* and chat *streaming* need the deployed `CHAT_FLUE` binding / `VITE_FLUE_CHAT_URL`, so they run in preview/prod rather than locally — the create/persist path and all UI states were verified by seeding run rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)