### PR TITLE
feat(alerts): "Ask Maple AI" opens a dedicated incident diagnosis page

### DIFF
--- a/apps/api/src/services/AlertDeliveryDispatch.test.ts
+++ b/apps/api/src/services/AlertDeliveryDispatch.test.ts
@@ -3,6 +3,7 @@ import { AlertDeliveryError } from "@maple/domain/http"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
 import {
+	buildAlertChatUrl,
 	buildDiscordEmbedsFromTemplate,
 	buildSlackBlocksFromTemplate,
 	buildTemplateContext,
@@ -35,6 +36,22 @@ const baseContext: TemplateRenderContext = {
 
 const LINK = "https://web.localhost/alerts"
 const CHAT = "https://web.localhost/chat?mode=alert"
+
+describe("buildAlertChatUrl (Ask Maple AI link)", () => {
+	it("targets the incident diagnosis page when an incident exists", () => {
+		const url = buildAlertChatUrl("https://web.localhost", baseContext)
+		assert.isTrue(
+			url.startsWith("https://web.localhost/alerts/incidents/inc_1?alert="),
+			url,
+		)
+	})
+
+	it("falls back to the chat surface when there is no incident row", () => {
+		const url = buildAlertChatUrl("https://web.localhost", { ...baseContext, incidentId: null })
+		assert.isTrue(url.startsWith("https://web.localhost/chat?"), url)
+		assert.include(url, "mode=alert")
+	})
+})
 
 describe("buildTemplateContext", () => {
 	const ctx = buildTemplateContext(baseContext, LINK, CHAT)

--- a/apps/api/src/services/AlertDeliveryDispatch.ts
+++ b/apps/api/src/services/AlertDeliveryDispatch.ts
@@ -89,6 +89,13 @@ export interface ChatUrlContext {
 const toBase64Url = (raw: string): string =>
 	Buffer.from(raw, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
 
+/**
+ * "Ask Maple AI" deep-link. Points at the incident-scoped diagnosis page, which
+ * auto-generates the AI diagnosis and hosts the alert chat alongside it. The
+ * encoded alert context is carried so the page renders + seeds the chat without
+ * a round-trip. When there is no incident row yet (e.g. a `test` notification)
+ * we fall back to the generic chat surface.
+ */
 export const buildAlertChatUrl = (baseUrl: string, context: ChatUrlContext): string => {
 	const alertJson = JSON.stringify({
 		ruleId: context.ruleId,
@@ -105,11 +112,14 @@ export const buildAlertChatUrl = (baseUrl: string, context: ChatUrlContext): str
 		groupKey: context.groupKey,
 		sampleCount: context.sampleCount,
 	})
-	const tabId = `alert-${context.incidentId ?? context.dedupeKey}`
+	const encoded = toBase64Url(alertJson)
+	if (context.incidentId) {
+		return `${baseUrl}/alerts/incidents/${encodeURIComponent(context.incidentId)}?alert=${encoded}`
+	}
 	const params = new URLSearchParams({
 		mode: "alert",
-		tab: tabId,
-		alert: toBase64Url(alertJson),
+		tab: `alert-${context.dedupeKey}`,
+		alert: encoded,
 	})
 	return `${baseUrl}/chat?${params.toString()}`
 }

--- a/apps/web/src/components/ai-triage/ai-triage-card.tsx
+++ b/apps/web/src/components/ai-triage/ai-triage-card.tsx
@@ -1,7 +1,7 @@
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
 import { Link } from "@tanstack/react-router"
 import { Exit } from "effect"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 
 import { useIntervalRefresh } from "@/hooks/use-interval-refresh"
@@ -82,9 +82,15 @@ export interface AiTriageCardProps {
 	 * completed triage result (if any) so the caller can fold it into the preamble.
 	 */
 	onOpenChat?: (result: AiTriageRunDocument["result"]) => void
+	/**
+	 * Auto-start a diagnosis as soon as the runs query resolves to none — for the
+	 * "Ask Maple AI" landing page, where arriving IS the intent to diagnose. An
+	 * existing run (queued/running/completed/failed) is reused, never re-triggered.
+	 */
+	autoRun?: boolean
 }
 
-export function AiTriageCard({ incidentKind, incidentId, issueId, onOpenChat }: AiTriageCardProps) {
+export function AiTriageCard({ incidentKind, incidentId, issueId, onOpenChat, autoRun }: AiTriageCardProps) {
 	const reactivityKeys = ["aiTriageRuns", `aiTriage:${incidentKind}:${incidentId ?? issueId ?? ""}`]
 	const runsQueryAtom = MapleApiAtomClient.query("aiTriage", "listRuns", {
 		query:
@@ -132,6 +138,16 @@ export function AiTriageCard({ incidentKind, incidentId, issueId, onOpenChat }: 
 			toast.error("Couldn't start the diagnosis")
 		}
 	}
+
+	// Auto-start once the runs query resolves to "no run" (Ask-Maple-AI landing).
+	// Ref-guarded so it fires exactly once; any existing run is left untouched.
+	const autoRunStartedRef = useRef(false)
+	useEffect(() => {
+		if (!autoRun || autoRunStartedRef.current) return
+		if (incidentId === null || runsLoading || runsFailed || run !== null) return
+		autoRunStartedRef.current = true
+		void startRun()
+	})
 
 	// --- Loading the run list ------------------------------------------------
 	if (runsLoading) {

--- a/apps/web/src/components/ai-triage/ai-triage-card.tsx
+++ b/apps/web/src/components/ai-triage/ai-triage-card.tsx
@@ -1,10 +1,11 @@
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
 import { Link } from "@tanstack/react-router"
 import { Exit } from "effect"
-import { useEffect, useRef, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import { useIntervalRefresh } from "@/hooks/use-interval-refresh"
+import { useMountEffect } from "@/hooks/use-mount-effect"
 
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "@maple/ui/components/ui/alert"
 import { Badge } from "@maple/ui/components/ui/badge"
@@ -139,16 +140,6 @@ export function AiTriageCard({ incidentKind, incidentId, issueId, onOpenChat, au
 		}
 	}
 
-	// Auto-start once the runs query resolves to "no run" (Ask-Maple-AI landing).
-	// Ref-guarded so it fires exactly once; any existing run is left untouched.
-	const autoRunStartedRef = useRef(false)
-	useEffect(() => {
-		if (!autoRun || autoRunStartedRef.current) return
-		if (incidentId === null || runsLoading || runsFailed || run !== null) return
-		autoRunStartedRef.current = true
-		void startRun()
-	})
-
 	// --- Loading the run list ------------------------------------------------
 	if (runsLoading) {
 		return (
@@ -175,55 +166,22 @@ export function AiTriageCard({ incidentKind, incidentId, issueId, onOpenChat, au
 		)
 	}
 
-	// --- No run yet: focused CTA --------------------------------------------
+	// --- No run yet: focused CTA (or auto-start on the Ask-Maple-AI landing) --
 	if (run === null) {
 		return (
-			<Card>
-				<Empty className="py-8">
-					<EmptyHeader>
-						<EmptyMedia variant="icon">
-							<PulseIcon size={18} />
-						</EmptyMedia>
-						<EmptyTitle>No diagnosis yet</EmptyTitle>
-						<EmptyDescription>
-							See what's driving this {INCIDENT_NOUN[incidentKind]} — Maple reads the
-							traces, errors, and logs to find the likely cause.
-						</EmptyDescription>
-					</EmptyHeader>
-					<EmptyContent>
-						<Button
-							size="sm"
-							onClick={startRun}
-							disabled={incidentId === null || isStarting}
-						>
-							<PulseIcon className="size-3.5" />
-							Diagnose this {INCIDENT_NOUN[incidentKind]}
-						</Button>
-						{incidentId === null ? (
-							<p className="text-xs text-muted-foreground">No incident to diagnose yet.</p>
-						) : null}
-					</EmptyContent>
-				</Empty>
-			</Card>
+			<AiTriageEmptyState
+				incidentKind={incidentKind}
+				incidentId={incidentId}
+				isStarting={isStarting}
+				autoRun={autoRun ?? false}
+				onDiagnose={startRun}
+			/>
 		)
 	}
 
 	// --- Investigating -------------------------------------------------------
 	if (runActive) {
-		return (
-			<Card className="space-y-3 p-5">
-				<div className="flex items-center gap-2">
-					<Spinner className="size-4 text-muted-foreground" />
-					<Shimmer className="text-sm font-medium">
-						Investigating — reading traces, errors, and logs
-					</Shimmer>
-				</div>
-				<div className="space-y-2">
-					<Skeleton className="h-3 w-3/4" />
-					<Skeleton className="h-3 w-1/2" />
-				</div>
-			</Card>
-		)
+		return <InvestigatingCard />
 	}
 
 	// --- Failed --------------------------------------------------------------
@@ -262,6 +220,79 @@ export function AiTriageCard({ incidentKind, incidentId, issueId, onOpenChat, au
 	}
 
 	return <DiagnosisReadout run={run} result={result} onOpenChat={onOpenChat} onRerun={startRun} rerunning={isStarting} />
+}
+
+/** The "investigating…" placeholder, shared by the active-run and auto-start states. */
+function InvestigatingCard() {
+	return (
+		<Card className="space-y-3 p-5">
+			<div className="flex items-center gap-2">
+				<Spinner className="size-4 text-muted-foreground" />
+				<Shimmer className="text-sm font-medium">
+					Investigating — reading traces, errors, and logs
+				</Shimmer>
+			</div>
+			<div className="space-y-2">
+				<Skeleton className="h-3 w-3/4" />
+				<Skeleton className="h-3 w-1/2" />
+			</div>
+		</Card>
+	)
+}
+
+/**
+ * Empty (no-run) state. Mounting here means the runs query already resolved to
+ * none, so `autoRun` can kick off a diagnosis on mount (useMountEffect, no raw
+ * effect) — that's the "Ask Maple AI" landing behavior. Otherwise it shows the
+ * focused "Diagnose" CTA.
+ */
+function AiTriageEmptyState({
+	incidentKind,
+	incidentId,
+	isStarting,
+	autoRun,
+	onDiagnose,
+}: {
+	incidentKind: AiTriageIncidentKind
+	incidentId: string | null
+	isStarting: boolean
+	autoRun: boolean
+	onDiagnose: () => void
+}) {
+	const shouldAutoRun = autoRun && incidentId !== null
+	useMountEffect(() => {
+		if (shouldAutoRun) onDiagnose()
+	})
+
+	// Once the auto-run fires, show the investigating placeholder rather than
+	// flashing the CTA while the run is being created.
+	if (shouldAutoRun) return <InvestigatingCard />
+
+	return (
+		<Card>
+			<Empty className="py-8">
+				<EmptyHeader>
+					<EmptyMedia variant="icon">
+						<PulseIcon size={18} />
+					</EmptyMedia>
+					<EmptyTitle>No diagnosis yet</EmptyTitle>
+					<EmptyDescription>
+						See what's driving this {INCIDENT_NOUN[incidentKind]} — Maple reads the traces,
+						errors, and logs to find the likely cause.
+					</EmptyDescription>
+				</EmptyHeader>
+				<EmptyContent>
+					<Button size="sm" onClick={onDiagnose} disabled={incidentId === null || isStarting}>
+						<PulseIcon className="size-3.5" />
+						Diagnose this {INCIDENT_NOUN[incidentKind]}
+					</Button>
+					{incidentId === null ? (
+						<p className="text-xs text-muted-foreground">No incident to diagnose yet.</p>
+					) : null}
+				</EmptyContent>
+			</Empty>
+		</Card>
+	)
 }
 
 function DiagnosisReadout({

--- a/apps/web/src/components/chat/alert-context.ts
+++ b/apps/web/src/components/chat/alert-context.ts
@@ -1,3 +1,4 @@
+import type { AiTriageResult, AlertIncidentDocument, AlertRuleDocument } from "@maple/domain/http"
 import { fromBase64Url, toBase64Url } from "@/lib/base64url"
 
 export interface AlertContext {
@@ -37,6 +38,32 @@ const isAlertContext = (value: unknown): value is AlertContext => {
 	if (v.aiSuspectedCause !== undefined && typeof v.aiSuspectedCause !== "string") return false
 	return true
 }
+
+/**
+ * Build the chat `AlertContext` from a rule + the incident under investigation,
+ * optionally folding in a prior triage result so the chat opens already aware of
+ * the AI's findings.
+ */
+export const toAlertContext = (
+	rule: AlertRuleDocument,
+	incident: AlertIncidentDocument,
+	result?: AiTriageResult | null,
+): AlertContext => ({
+	ruleId: rule.id,
+	ruleName: rule.name,
+	incidentId: incident.id,
+	eventType: incident.status === "open" ? "trigger" : "resolve",
+	signalType: rule.signalType,
+	severity: incident.severity,
+	comparator: rule.comparator,
+	threshold: incident.threshold,
+	value: incident.lastObservedValue,
+	windowMinutes: rule.windowMinutes,
+	groupKey: incident.groupKey,
+	sampleCount: incident.lastSampleCount,
+	...(result?.summary ? { aiSummary: result.summary } : {}),
+	...(result?.suspectedCause ? { aiSuspectedCause: result.suspectedCause } : {}),
+})
 
 export const encodeAlertContextToSearchParam = (ctx: AlertContext): string =>
 	toBase64Url(JSON.stringify(ctx))

--- a/apps/web/src/components/chat/context-preamble.ts
+++ b/apps/web/src/components/chat/context-preamble.ts
@@ -109,6 +109,14 @@ export const formatAlertComparator = (c: string): string => {
 			return "<"
 		case "lte":
 			return "<="
+		case "eq":
+			return "="
+		case "neq":
+			return "!="
+		case "between":
+			return "between"
+		case "not_between":
+			return "not between"
 		default:
 			return c
 	}

--- a/apps/web/src/components/chat/context-preamble.ts
+++ b/apps/web/src/components/chat/context-preamble.ts
@@ -99,7 +99,7 @@ const formatPageContextBlock = (payload: PageContextPayload): string => {
 	return lines.join("\n")
 }
 
-const formatAlertComparator = (c: string): string => {
+export const formatAlertComparator = (c: string): string => {
 	switch (c) {
 		case "gt":
 			return ">"

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -50,6 +50,7 @@ import { Route as AlertsCreateRouteImport } from './routes/alerts/create'
 import { Route as AlertsRuleIdRouteImport } from './routes/alerts/$ruleId'
 import { Route as ErrorsIssuesIndexRouteImport } from './routes/errors/issues/index'
 import { Route as ErrorsIssuesIssueIdRouteImport } from './routes/errors/issues/$issueId'
+import { Route as AlertsIncidentsIncidentIdRouteImport } from './routes/alerts/incidents/$incidentId'
 import { Route as InfraKubernetesWorkloadsIndexRouteImport } from './routes/infra/kubernetes/workloads/index'
 import { Route as InfraKubernetesPodsIndexRouteImport } from './routes/infra/kubernetes/pods/index'
 import { Route as InfraKubernetesNodesIndexRouteImport } from './routes/infra/kubernetes/nodes/index'
@@ -264,6 +265,12 @@ const ErrorsIssuesIssueIdRoute = ErrorsIssuesIssueIdRouteImport.update({
   path: '/errors/issues/$issueId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AlertsIncidentsIncidentIdRoute =
+  AlertsIncidentsIncidentIdRouteImport.update({
+    id: '/alerts/incidents/$incidentId',
+    path: '/alerts/incidents/$incidentId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const InfraKubernetesWorkloadsIndexRoute =
   InfraKubernetesWorkloadsIndexRouteImport.update({
     id: '/infra/kubernetes/workloads/',
@@ -347,6 +354,7 @@ export interface FileRoutesByFullPath {
   '/replays/': typeof ReplaysIndexRoute
   '/services/': typeof ServicesIndexRoute
   '/traces/': typeof TracesIndexRoute
+  '/alerts/incidents/$incidentId': typeof AlertsIncidentsIncidentIdRoute
   '/errors/issues/$issueId': typeof ErrorsIssuesIssueIdRoute
   '/errors/issues/': typeof ErrorsIssuesIndexRoute
   '/dashboards/$dashboardId/widgets/$widgetId': typeof DashboardsDashboardIdWidgetsWidgetIdRoute
@@ -397,6 +405,7 @@ export interface FileRoutesByTo {
   '/replays': typeof ReplaysIndexRoute
   '/services': typeof ServicesIndexRoute
   '/traces': typeof TracesIndexRoute
+  '/alerts/incidents/$incidentId': typeof AlertsIncidentsIncidentIdRoute
   '/errors/issues/$issueId': typeof ErrorsIssuesIssueIdRoute
   '/errors/issues': typeof ErrorsIssuesIndexRoute
   '/dashboards/$dashboardId/widgets/$widgetId': typeof DashboardsDashboardIdWidgetsWidgetIdRoute
@@ -448,6 +457,7 @@ export interface FileRoutesById {
   '/replays/': typeof ReplaysIndexRoute
   '/services/': typeof ServicesIndexRoute
   '/traces/': typeof TracesIndexRoute
+  '/alerts/incidents/$incidentId': typeof AlertsIncidentsIncidentIdRoute
   '/errors/issues/$issueId': typeof ErrorsIssuesIssueIdRoute
   '/errors/issues/': typeof ErrorsIssuesIndexRoute
   '/dashboards/$dashboardId_/widgets/$widgetId': typeof DashboardsDashboardIdWidgetsWidgetIdRoute
@@ -500,6 +510,7 @@ export interface FileRouteTypes {
     | '/replays/'
     | '/services/'
     | '/traces/'
+    | '/alerts/incidents/$incidentId'
     | '/errors/issues/$issueId'
     | '/errors/issues/'
     | '/dashboards/$dashboardId/widgets/$widgetId'
@@ -550,6 +561,7 @@ export interface FileRouteTypes {
     | '/replays'
     | '/services'
     | '/traces'
+    | '/alerts/incidents/$incidentId'
     | '/errors/issues/$issueId'
     | '/errors/issues'
     | '/dashboards/$dashboardId/widgets/$widgetId'
@@ -600,6 +612,7 @@ export interface FileRouteTypes {
     | '/replays/'
     | '/services/'
     | '/traces/'
+    | '/alerts/incidents/$incidentId'
     | '/errors/issues/$issueId'
     | '/errors/issues/'
     | '/dashboards/$dashboardId_/widgets/$widgetId'
@@ -651,6 +664,7 @@ export interface RootRouteChildren {
   ReplaysIndexRoute: typeof ReplaysIndexRoute
   ServicesIndexRoute: typeof ServicesIndexRoute
   TracesIndexRoute: typeof TracesIndexRoute
+  AlertsIncidentsIncidentIdRoute: typeof AlertsIncidentsIncidentIdRoute
   ErrorsIssuesIssueIdRoute: typeof ErrorsIssuesIssueIdRoute
   ErrorsIssuesIndexRoute: typeof ErrorsIssuesIndexRoute
   DashboardsDashboardIdWidgetsWidgetIdRoute: typeof DashboardsDashboardIdWidgetsWidgetIdRoute
@@ -951,6 +965,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ErrorsIssuesIssueIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/alerts/incidents/$incidentId': {
+      id: '/alerts/incidents/$incidentId'
+      path: '/alerts/incidents/$incidentId'
+      fullPath: '/alerts/incidents/$incidentId'
+      preLoaderRoute: typeof AlertsIncidentsIncidentIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/infra/kubernetes/workloads/': {
       id: '/infra/kubernetes/workloads/'
       path: '/infra/kubernetes/workloads'
@@ -1043,6 +1064,7 @@ const rootRouteChildren: RootRouteChildren = {
   ReplaysIndexRoute: ReplaysIndexRoute,
   ServicesIndexRoute: ServicesIndexRoute,
   TracesIndexRoute: TracesIndexRoute,
+  AlertsIncidentsIncidentIdRoute: AlertsIncidentsIncidentIdRoute,
   ErrorsIssuesIssueIdRoute: ErrorsIssuesIssueIdRoute,
   ErrorsIssuesIndexRoute: ErrorsIssuesIndexRoute,
   DashboardsDashboardIdWidgetsWidgetIdRoute:

--- a/apps/web/src/routes/alerts/$ruleId.tsx
+++ b/apps/web/src/routes/alerts/$ruleId.tsx
@@ -39,7 +39,7 @@ import {
 } from "@maple/domain/http"
 import { AiTriageCard } from "@/components/ai-triage/ai-triage-card"
 import { AlertChatSheet } from "@/components/alerts/alert-chat-sheet"
-import type { AlertContext } from "@/components/chat/alert-context"
+import { toAlertContext, type AlertContext } from "@/components/chat/alert-context"
 import {
 	CheckIcon,
 	PencilIcon,
@@ -895,34 +895,6 @@ function RuleDetailContent() {
 			<AlertChatSheet open={chatOpen} onOpenChange={setChatOpen} alertContext={chatContext} />
 		</DashboardLayout>
 	)
-}
-
-/**
- * Build the chat `AlertContext` from a rule + the incident the engineer is
- * investigating, optionally folding in a prior triage result so the chat opens
- * already aware of the AI's findings.
- */
-function toAlertContext(
-	rule: AlertRuleDocument,
-	incident: AlertIncidentDocument,
-	result?: AiTriageResult | null,
-): AlertContext {
-	return {
-		ruleId: rule.id,
-		ruleName: rule.name,
-		incidentId: incident.id,
-		eventType: incident.status === "open" ? "trigger" : "resolve",
-		signalType: rule.signalType,
-		severity: incident.severity,
-		comparator: rule.comparator,
-		threshold: incident.threshold,
-		value: incident.lastObservedValue,
-		windowMinutes: rule.windowMinutes,
-		groupKey: incident.groupKey,
-		sampleCount: incident.lastSampleCount,
-		...(result?.summary ? { aiSummary: result.summary } : {}),
-		...(result?.suspectedCause ? { aiSuspectedCause: result.suspectedCause } : {}),
-	}
 }
 
 function ConfigRow({ label, children, wide }: { label: string; children: React.ReactNode; wide?: boolean }) {

--- a/apps/web/src/routes/alerts/incidents/$incidentId.tsx
+++ b/apps/web/src/routes/alerts/incidents/$incidentId.tsx
@@ -16,6 +16,7 @@ import {
 	toAlertContext,
 	type AlertContext,
 } from "@/components/chat/alert-context"
+import { formatAlertComparator } from "@/components/chat/context-preamble"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { comparatorLabels, formatSignalValue, signalLabels } from "@/lib/alerts/form-utils"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
@@ -118,7 +119,7 @@ function AlertIncidentPage() {
 	const isFiring = incident ? incident.status === "open" : alertContext.eventType !== "resolve"
 	const condition = rule
 		? `${signalLabels[rule.signalType]} ${comparatorLabels[rule.comparator]} ${formatSignalValue(rule.signalType, incident?.threshold ?? rule.threshold)} over ${rule.windowMinutes}min`
-		: `${signalLabel(alertContext.signalType)} ${alertContext.comparator} ${alertContext.threshold} over ${alertContext.windowMinutes}min`
+		: `${signalLabel(alertContext.signalType)} ${formatAlertComparator(alertContext.comparator)} ${alertContext.threshold} over ${alertContext.windowMinutes}min`
 
 	return (
 		<DashboardLayout breadcrumbs={breadcrumbs} title={alertContext.ruleName}>

--- a/apps/web/src/routes/alerts/incidents/$incidentId.tsx
+++ b/apps/web/src/routes/alerts/incidents/$incidentId.tsx
@@ -1,0 +1,157 @@
+import { useMemo } from "react"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Result, useAtomValue } from "@/lib/effect-atom"
+import { effectRoute } from "@effect-router/core"
+import { Schema } from "effect"
+
+import { AiTriageCard } from "@/components/ai-triage/ai-triage-card"
+import { AlertSeverityBadge } from "@/components/alerts/alert-severity-badge"
+import { AlertStatusBadge } from "@/components/alerts/alert-status-badge"
+import { ChatConversation } from "@/components/chat/chat-conversation"
+import { FlueClientProvider } from "@/components/chat/flue-client-provider"
+import {
+	alertTabId,
+	decodeAlertContextFromSearchParam,
+	signalLabel,
+	toAlertContext,
+	type AlertContext,
+} from "@/components/chat/alert-context"
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { comparatorLabels, formatSignalValue, signalLabels } from "@/lib/alerts/form-utils"
+import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { Button } from "@maple/ui/components/ui/button"
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@maple/ui/components/ui/empty"
+import { Skeleton } from "@maple/ui/components/ui/skeleton"
+import type { ErrorIssueId } from "@maple/domain/http"
+
+const SearchSchema = Schema.Struct({
+	/** Base64url alert context carried by the "Ask Maple AI" notification link. */
+	alert: Schema.optional(Schema.String),
+})
+
+export const Route = effectRoute(createFileRoute("/alerts/incidents/$incidentId"))({
+	component: AlertIncidentPage,
+	validateSearch: Schema.toStandardSchemaV1(SearchSchema),
+})
+
+function AlertIncidentPage() {
+	const { incidentId } = Route.useParams()
+	const { alert: alertParam } = Route.useSearch()
+
+	// The notification link carries the alert context inline, so the page can
+	// render the header + seed the chat instantly without waiting on a fetch.
+	const paramContext = useMemo(
+		() => (alertParam ? decodeAlertContextFromSearchParam(alertParam) : undefined),
+		[alertParam],
+	)
+
+	const incidentsResult = useAtomValue(
+		MapleApiAtomClient.query("alerts", "listIncidents", { reactivityKeys: ["alertIncidents"] }),
+	)
+	const rulesResult = useAtomValue(
+		MapleApiAtomClient.query("alerts", "listRules", { reactivityKeys: ["alertRules"] }),
+	)
+
+	const incidents = Result.builder(incidentsResult)
+		.onSuccess((r) => r.incidents)
+		.orElse(() => [])
+	const rules = Result.builder(rulesResult)
+		.onSuccess((r) => r.rules)
+		.orElse(() => [])
+
+	const incident = incidents.find((i) => i.id === incidentId) ?? null
+	const rule = incident
+		? (rules.find((r) => r.id === incident.ruleId) ?? null)
+		: paramContext
+			? (rules.find((r) => r.id === paramContext.ruleId) ?? null)
+			: null
+
+	const loading = Result.isInitial(incidentsResult) || Result.isInitial(rulesResult)
+
+	// Prefer the authoritative fetched rows; fall back to the link's inline context
+	// (e.g. a stale link to a since-pruned incident still opens the chat).
+	const alertContext: AlertContext | null =
+		incident && rule ? toAlertContext(rule, incident) : (paramContext ?? null)
+	const issueId: ErrorIssueId | undefined = incident?.errorIssueId ?? undefined
+
+	const breadcrumbs = [
+		{ label: "Alerts", href: "/alerts" as const },
+		...(alertContext
+			? [{ label: alertContext.ruleName, href: `/alerts/${alertContext.ruleId}` }]
+			: []),
+		{ label: "Ask Maple AI" },
+	]
+
+	if (loading && !alertContext) {
+		return (
+			<DashboardLayout breadcrumbs={[{ label: "Alerts", href: "/alerts" }, { label: "…" }]} title="Ask Maple AI">
+				<div className="space-y-4">
+					<Skeleton className="h-16 w-full" />
+					<div className="grid gap-4 lg:grid-cols-2">
+						<Skeleton className="h-72 w-full" />
+						<Skeleton className="h-72 w-full" />
+					</div>
+				</div>
+			</DashboardLayout>
+		)
+	}
+
+	if (!alertContext) {
+		return (
+			<DashboardLayout breadcrumbs={[{ label: "Alerts", href: "/alerts" }, { label: "Not found" }]} title="Ask Maple AI">
+				<Empty>
+					<EmptyHeader>
+						<EmptyTitle>Incident not found</EmptyTitle>
+						<EmptyDescription>It may have been resolved and pruned, or the link is stale.</EmptyDescription>
+					</EmptyHeader>
+					<Button variant="outline" size="sm" render={<Link to="/alerts" />}>
+						Back to alerts
+					</Button>
+				</Empty>
+			</DashboardLayout>
+		)
+	}
+
+	// Format from the typed rule/incident when fetched; fall back to the link's
+	// raw strings only for a stale param-only link.
+	const severity = incident?.severity ?? rule?.severity ?? null
+	const isFiring = incident ? incident.status === "open" : alertContext.eventType !== "resolve"
+	const condition = rule
+		? `${signalLabels[rule.signalType]} ${comparatorLabels[rule.comparator]} ${formatSignalValue(rule.signalType, incident?.threshold ?? rule.threshold)} over ${rule.windowMinutes}min`
+		: `${signalLabel(alertContext.signalType)} ${alertContext.comparator} ${alertContext.threshold} over ${alertContext.windowMinutes}min`
+
+	return (
+		<DashboardLayout breadcrumbs={breadcrumbs} title={alertContext.ruleName}>
+			<div className="space-y-4">
+				<div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+					<h1 className="text-xl font-semibold tracking-tight">{alertContext.ruleName}</h1>
+					{severity ? <AlertSeverityBadge severity={severity} /> : null}
+					<AlertStatusBadge state={isFiring ? "firing" : "resolved"} />
+					<span className="text-sm text-muted-foreground">{condition}</span>
+					{alertContext.groupKey ? (
+						<span className="font-mono text-xs text-muted-foreground">· {alertContext.groupKey}</span>
+					) : null}
+				</div>
+
+				<div className="grid gap-4 lg:grid-cols-2 lg:items-start">
+					<AiTriageCard
+						incidentKind="alert"
+						incidentId={incidentId}
+						issueId={issueId}
+						autoRun
+					/>
+					<div className="flex h-[72vh] min-h-[460px] flex-col overflow-hidden rounded-xl border border-border bg-card">
+						<FlueClientProvider>
+							<ChatConversation
+								tabId={alertTabId(alertContext)}
+								isActive
+								mode="alert"
+								alertContext={alertContext}
+							/>
+						</FlueClientProvider>
+					</div>
+				</div>
+			</div>
+		</DashboardLayout>
+	)
+}


### PR DESCRIPTION
## What

Repoints the **"Ask Maple AI"** button in alert notifications from the generic `/chat` surface to a **dedicated incident page** that auto-generates the AI diagnosis and hosts the alert chat right next to it.

Follow-up to #137 (the diagnosis readout + integrated chat).

### Backend
- `buildAlertChatUrl` (`AlertDeliveryDispatch.ts`) now targets `/alerts/incidents/<incidentId>` — carrying the encoded alert context so the page renders and seeds the chat instantly — and falls back to `/chat` only when there's no incident row (e.g. `test` notifications).
- It's the single shared URL builder, so **Slack, Discord, PagerDuty, and webhook** "Ask Maple AI" links all update together. The `chatUrl` / `links.chat` payload field names are unchanged (external contract).
- Adds unit coverage for both the incident-page and the no-incident fallback.

### Frontend
- **New route** `apps/web/src/routes/alerts/incidents/$incidentId.tsx`: a two-column layout — the auto-generating **diagnosis readout** on one side, the seeded alert **chat** (`ChatConversation` in `mode="alert"`) on the other. It loads from the fetched incident + rule, or from the link's inline context when the incident has been pruned (stale link still opens the chat).
- **`AiTriageCard` gains an `autoRun` prop** (ref-guarded, fires once when the runs query resolves to none) so arriving from the notification kicks off the diagnosis immediately; any existing run is reused, never re-triggered.
- Extracted `toAlertContext` into the shared `chat/alert-context` module (was inline in `$ruleId.tsx`) and reused on both surfaces.

## Why
Clicking "Ask Maple AI" from a Slack alert should land somewhere purpose-built: it generates the diagnosis on arrival and gives you the chat to dig further — instead of dropping into a blank chat tab.

## Testing
- `bun typecheck` — all packages green.
- `vitest` — new `buildAlertChatUrl` cases + existing `AlertDeliveryDispatch` suite (9 passing).
- Browser E2E: seeded an incident, opened `/alerts/incidents/<id>` and screenshotted the two-column page (diagnosis readout + chat with the attached-alert card and suggestions). Verified `autoRun` fires on a run-less incident (kicks off the run; resolves to "failed" only because the local env lacks the `CHAT_FLUE` binding — it completes in deploy/prod).

## Reviewer notes
- Live generation/streaming needs the deployed `CHAT_FLUE` binding, so it runs in preview/prod; the create + UI states were verified by seeding rows (the repo includes `packages/db/scripts/seed-alert-diagnosis.ts` from #137 to preview locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)