### PR TITLE
feat(web): guided ingestion in settings + lean Connect launchpad

### DIFF
--- a/apps/web/src/components/dashboard/setup-checklist.tsx
+++ b/apps/web/src/components/dashboard/setup-checklist.tsx
@@ -1,119 +1,45 @@
-import { useEffect, useState } from "react"
 import { useAuth } from "@clerk/clerk-react"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
 import { Button } from "@maple/ui/components/ui/button"
 import { Card, CardContent } from "@maple/ui/components/ui/card"
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@maple/ui/components/ui/tabs"
 import {
-	InputGroup,
-	InputGroupAddon,
-	InputGroupButton,
-	InputGroupInput,
-} from "@maple/ui/components/ui/input-group"
-import {
-	CheckIcon,
 	ChevronDownIcon,
 	ChevronUpIcon,
 	CircleCheckIcon,
 	CodeIcon,
-	CopyIcon,
-	EyeIcon,
-	PaperPlaneIcon,
-	PulseIcon,
 	RocketIcon,
 	XmarkIcon,
 } from "@/components/icons"
-import { CodeBlock } from "@/components/quick-start/code-block"
-import { PackageManagerCodeBlock } from "@/components/quick-start/package-manager-code-block"
-import { sdkSnippets, type FrameworkId } from "@/components/quick-start/sdk-snippets"
-import {
-	NextjsIcon,
-	NodejsIcon,
-	PythonIcon,
-	GoIcon,
-	EffectIcon,
-	OpenTelemetryIcon,
-} from "@/components/quick-start/framework-icons"
-import { Result, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
-import { ingestUrl } from "@/lib/services/common/ingest-url"
-import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
-import { getServiceOverviewResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
+import { GuidedSetup } from "@/components/ingest/guided-setup"
+import { SendTestEventStrip } from "@/components/ingest/connection-status"
+import { useIngestConnection } from "@/components/ingest/use-ingest-connection"
 import { useQuickStart } from "@/hooks/use-quick-start"
-import type { RoleOption } from "@/atoms/quick-start-atoms"
-import { cn } from "@maple/ui/utils"
-
-const frameworkIconMap: Record<FrameworkId, React.ComponentType<{ size?: number; className?: string }>> = {
-	nextjs: NextjsIcon,
-	nodejs: NodejsIcon,
-	python: PythonIcon,
-	go: GoIcon,
-	effect: EffectIcon,
-	otel: OpenTelemetryIcon,
-}
-
-const ROLE_DEFAULT_FRAMEWORK: Record<RoleOption, FrameworkId> = {
-	engineer: "nodejs",
-	devops_sre: "otel",
-	eng_leader: "nodejs",
-	founder: "nextjs",
-}
-
-function maskKey(key: string): string {
-	if (key.length <= 18) return key
-	const prefix = key.slice(0, 14)
-	const suffix = key.slice(-4)
-	return `${prefix}${"•".repeat(key.length - 18)}${suffix}`
-}
 
 export function SetupChecklist() {
 	const { orgId } = useAuth()
-	const {
-		selectedFramework,
-		setSelectedFramework,
-		checklistDismissed,
-		dismissChecklist,
-		checklistExpanded,
-		setChecklistExpanded,
-		qualifyAnswers,
-		demoDataRequested,
-	} = useQuickStart(orgId)
+	const { checklistDismissed } = useQuickStart(orgId)
 
-	const roleDefault = qualifyAnswers.role ? ROLE_DEFAULT_FRAMEWORK[qualifyAnswers.role] : "nodejs"
-	const framework = selectedFramework ?? roleDefault
-
-	const { startTime, endTime } = useEffectiveTimeRange(undefined, undefined, "1h")
-	const [pollCount, setPollCount] = useState(0)
-
-	const keysResult = useAtomValue(MapleApiAtomClient.query("ingestKeys", "get", {}))
-	const apiKey = Result.isSuccess(keysResult) ? keysResult.value.publicKey : ""
-
-	const overviewResult = useAtomValue(
-		getServiceOverviewResultAtom({
-			data: { startTime, endTime },
-			_poll: pollCount,
-		} as never),
-	)
-
-	useEffect(() => {
-		if (checklistDismissed) return
-		const interval = setInterval(() => setPollCount((c) => c + 1), 15000)
-		return () => clearInterval(interval)
-	}, [checklistDismissed])
-
-	const services = Result.isSuccess(overviewResult) ? overviewResult.value.data : []
-	const realServices = services.filter(
-		(s) => !(typeof s.serviceName === "string" && s.serviceName.startsWith("demo-")),
-	)
-	const hasRealData = realServices.length > 0
-	const firstRealService =
-		typeof realServices[0]?.serviceName === "string" ? (realServices[0].serviceName as string) : undefined
-
+	// Render nothing — and stop polling — once the checklist is dismissed.
 	if (checklistDismissed) return null
 
-	if (hasRealData) {
-		return <FirstTraceCelebration serviceName={firstRealService} onDismiss={dismissChecklist} />
+	return <SetupChecklistCard />
+}
+
+function SetupChecklistCard() {
+	const { orgId } = useAuth()
+	const { dismissChecklist, checklistExpanded, setChecklistExpanded, demoDataRequested } =
+		useQuickStart(orgId)
+
+	const connection = useIngestConnection()
+
+	if (connection.status === "connected") {
+		return (
+			<FirstTraceCelebration
+				serviceName={connection.firstRealService}
+				onDismiss={dismissChecklist}
+			/>
+		)
 	}
 
 	return (
@@ -171,157 +97,12 @@ export function SetupChecklist() {
 			>
 				<div className="overflow-hidden">
 					<CardContent className="border-t border-primary/20 p-5 space-y-5">
-						<FrameworkPicker selected={framework} onSelect={setSelectedFramework} />
-						<ConnectInstructions framework={framework} apiKey={apiKey} />
-						<ListeningStatus apiKey={apiKey} onTestSent={() => setPollCount((c) => c + 1)} />
+						<GuidedSetup apiKey={connection.apiKey} showCredentials />
+						<SendTestEventStrip apiKey={connection.apiKey} onTestSent={connection.refresh} />
 					</CardContent>
 				</div>
 			</div>
 		</Card>
-	)
-}
-
-function FrameworkPicker({
-	selected,
-	onSelect,
-}: {
-	selected: FrameworkId
-	onSelect: (id: FrameworkId) => void
-}) {
-	return (
-		<div className="space-y-2">
-			<span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
-				Pick your stack
-			</span>
-			<div className="flex flex-wrap gap-2">
-				{sdkSnippets.map((snippet) => {
-					const Icon = frameworkIconMap[snippet.language]
-					const active = selected === snippet.language
-					return (
-						<button
-							key={snippet.language}
-							type="button"
-							onClick={() => onSelect(snippet.language)}
-							className={cn(
-								"flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring",
-								active
-									? "border-primary bg-primary/10 text-primary"
-									: "border-border hover:border-foreground/30",
-							)}
-						>
-							<Icon size={14} />
-							{snippet.label}
-						</button>
-					)
-				})}
-			</div>
-		</div>
-	)
-}
-
-function ConnectInstructions({ framework, apiKey }: { framework: FrameworkId; apiKey: string }) {
-	const snippet = sdkSnippets.find((s) => s.language === framework)
-
-	if (!snippet) return null
-
-	function interpolate(template: string) {
-		return template
-			.replace(/\{\{INGEST_URL\}\}/g, ingestUrl)
-			.replace(/\{\{API_KEY\}\}/g, apiKey || "<your-api-key>")
-	}
-
-	return (
-		<div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-5">
-			<div className="space-y-3">
-				<span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
-					Credentials
-				</span>
-				<CopyableInput value={ingestUrl} label="Ingest endpoint" />
-				<CopyableInput value={apiKey || "Loading…"} label="API key" masked />
-			</div>
-
-			<div className="rounded-lg border bg-card overflow-hidden">
-				<Tabs defaultValue="install" className="flex flex-col">
-					<div className="border-b px-3">
-						<TabsList variant="underline" className="h-9">
-							<TabsTrigger value="install">Install</TabsTrigger>
-							<TabsTrigger value="instrument">Instrument</TabsTrigger>
-							<TabsTrigger value="claude-code">Claude Code</TabsTrigger>
-						</TabsList>
-					</div>
-
-					<TabsContent value="install" className="overflow-auto p-3 mt-0">
-						{typeof snippet.install === "string" ? (
-							<CodeBlock code={snippet.install} language="shell" />
-						) : (
-							<PackageManagerCodeBlock packages={snippet.install.packages} />
-						)}
-					</TabsContent>
-
-					<TabsContent value="instrument" className="overflow-auto p-3 mt-0">
-						<CodeBlock
-							code={interpolate(snippet.instrument)}
-							language={snippet.label.toLowerCase()}
-						/>
-					</TabsContent>
-
-					<TabsContent value="claude-code" className="overflow-auto p-3 mt-0 space-y-2">
-						<p className="text-xs text-muted-foreground">
-							Run this prompt in Claude Code (or Codex / Cursor with the skill installed). The{" "}
-							<code className="rounded bg-muted px-1">maple-onboard</code> skill walks every
-							service in the repo, installs OpenTelemetry, wires traces / logs / metrics, and
-							verifies the bootstrap end-to-end.
-						</p>
-						<CodeBlock
-							code={`Install Maple in this repo using the maple-onboard skill.\nMy ingest key is ${apiKey || "<your-api-key>"}.`}
-							language="shell"
-						/>
-					</TabsContent>
-				</Tabs>
-			</div>
-		</div>
-	)
-}
-
-function ListeningStatus({ apiKey, onTestSent }: { apiKey: string; onTestSent: () => void }) {
-	const [sending, setSending] = useState(false)
-
-	async function handleSendTest() {
-		if (!apiKey || sending) return
-		setSending(true)
-		try {
-			await sendTestEvent(apiKey)
-			toast.success("Test event sent — watch for it to land below")
-			onTestSent()
-		} catch {
-			toast.error("Couldn't reach the ingest endpoint — double-check your API key")
-		} finally {
-			setSending(false)
-		}
-	}
-
-	return (
-		<div className="flex flex-col gap-3 rounded-lg border border-dashed border-primary/30 bg-primary/5 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-			<div className="flex items-center gap-2.5">
-				<PulseIcon size={14} className="text-primary animate-pulse" />
-				<span className="text-xs text-muted-foreground">Watching for your first trace…</span>
-			</div>
-			<div className="flex items-center gap-2">
-				<span className="hidden text-[11px] text-muted-foreground sm:inline">
-					Not ready to instrument?
-				</span>
-				<Button
-					variant="outline"
-					size="sm"
-					onClick={handleSendTest}
-					disabled={sending || !apiKey}
-					className="gap-2 shrink-0"
-				>
-					<PaperPlaneIcon size={13} />
-					{sending ? "Sending…" : "Send a test event"}
-				</Button>
-			</div>
-		</div>
 	)
 }
 
@@ -366,110 +147,5 @@ function FirstTraceCelebration({ serviceName, onDismiss }: { serviceName?: strin
 				</Button>
 			</CardContent>
 		</Card>
-	)
-}
-
-function randomHex(byteLength: number): string {
-	const bytes = new Uint8Array(byteLength)
-	crypto.getRandomValues(bytes)
-	return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("")
-}
-
-const TEST_EVENT_SERVICE = "maple-onboarding-test"
-
-async function sendTestEvent(apiKey: string): Promise<void> {
-	const now = Date.now()
-	const endNano = `${now}000000`
-	const startNano = `${now - 87}000000`
-	const payload = {
-		resourceSpans: [
-			{
-				resource: {
-					attributes: [
-						{ key: "service.name", value: { stringValue: TEST_EVENT_SERVICE } },
-						{ key: "deployment.environment", value: { stringValue: "development" } },
-					],
-				},
-				scopeSpans: [
-					{
-						scope: { name: "maple-onboarding" },
-						spans: [
-							{
-								traceId: randomHex(16),
-								spanId: randomHex(8),
-								name: "GET /maple/test-event",
-								kind: 2,
-								startTimeUnixNano: startNano,
-								endTimeUnixNano: endNano,
-								attributes: [
-									{ key: "http.request.method", value: { stringValue: "GET" } },
-									{ key: "http.route", value: { stringValue: "/maple/test-event" } },
-									{ key: "http.response.status_code", value: { intValue: 200 } },
-								],
-								status: { code: 1 },
-							},
-						],
-					},
-				],
-			},
-		],
-	}
-
-	const response = await fetch(`${ingestUrl}/v1/traces`, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Authorization: `Bearer ${apiKey}`,
-		},
-		body: JSON.stringify(payload),
-	})
-	if (!response.ok) {
-		throw new Error(`Ingest gateway returned ${response.status}`)
-	}
-}
-
-function CopyableInput({ value, label, masked }: { value: string; label: string; masked?: boolean }) {
-	const [copied, setCopied] = useState(false)
-	const [isVisible, setIsVisible] = useState(false)
-
-	async function handleCopy() {
-		try {
-			await navigator.clipboard.writeText(value)
-			setCopied(true)
-			toast.success(`${label} copied`)
-			setTimeout(() => setCopied(false), 1500)
-		} catch {
-			toast.error(`Failed to copy ${label.toLowerCase()}`)
-		}
-	}
-
-	return (
-		<div className="space-y-1">
-			<label className="text-xs text-muted-foreground">{label}</label>
-			<InputGroup>
-				<InputGroupInput
-					readOnly
-					value={masked && !isVisible ? maskKey(value) : value}
-					className="font-mono text-xs tracking-wide select-all"
-				/>
-				<InputGroupAddon align="inline-end">
-					{masked && (
-						<InputGroupButton
-							onClick={() => setIsVisible((v) => !v)}
-							aria-label={isVisible ? "Hide key" : "Reveal key"}
-						>
-							<EyeIcon size={14} className={isVisible ? "text-foreground" : undefined} />
-						</InputGroupButton>
-					)}
-					<InputGroupButton onClick={handleCopy} aria-label={`Copy ${label.toLowerCase()}`}>
-						{copied ? (
-							<CheckIcon size={14} className="text-severity-info" />
-						) : (
-							<CopyIcon size={14} />
-						)}
-					</InputGroupButton>
-				</InputGroupAddon>
-			</InputGroup>
-		</div>
 	)
 }

--- a/apps/web/src/components/header/connect-button.tsx
+++ b/apps/web/src/components/header/connect-button.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react"
 import { Link } from "@tanstack/react-router"
-import { toast } from "sonner"
 
 import { Button } from "@maple/ui/components/ui/button"
 import {
@@ -10,26 +9,14 @@ import {
 	PopoverTitle,
 	PopoverTrigger,
 } from "@maple/ui/components/ui/popover"
-import {
-	InputGroup,
-	InputGroupAddon,
-	InputGroupButton,
-	InputGroupInput,
-} from "@maple/ui/components/ui/input-group"
 import { Separator } from "@maple/ui/components/ui/separator"
-import { ArrowRightIcon, CheckIcon, ConnectionIcon, CopyIcon, EyeIcon } from "@/components/icons"
-import { Result, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
-import { ingestUrl } from "@/lib/services/common/ingest-url"
+import { ArrowRightIcon, ConnectionIcon } from "@/components/icons"
+import { CopyableField } from "@/components/ingest/copyable-field"
+import { ConnectCredentials } from "@/components/ingest/connect-credentials"
+import { ConnectionStatusPill } from "@/components/ingest/connection-status"
+import { useIngestConnection } from "@/components/ingest/use-ingest-connection"
 
 const ONBOARD_SKILL_COMMAND = "bunx skills add Makisuo/maple/skills/maple-onboard"
-
-function maskKey(key: string): string {
-	if (key.length <= 18) return key
-	const prefix = key.slice(0, 14)
-	const suffix = key.slice(-4)
-	return `${prefix}${"•".repeat(key.length - 18)}${suffix}`
-}
 
 export function ConnectButton() {
 	const [open, setOpen] = useState(false)
@@ -52,50 +39,29 @@ export function ConnectButton() {
 }
 
 function ConnectPanel() {
-	const keysResult = useAtomValue(MapleApiAtomClient.query("ingestKeys", "get", {}))
+	const connection = useIngestConnection()
 
 	return (
 		<div className="space-y-4">
-			<div className="space-y-1">
-				<PopoverTitle className="text-base">Connect your app</PopoverTitle>
+			<div className="space-y-1.5">
+				<div className="flex items-start justify-between gap-2">
+					<PopoverTitle className="text-base">Connect your app</PopoverTitle>
+					<ConnectionStatusPill connection={connection} />
+				</div>
 				<PopoverDescription className="text-xs">
 					Point your OpenTelemetry SDK at this endpoint to start streaming telemetry into Maple.
 				</PopoverDescription>
 			</div>
 
-			<CopyableField label="Ingest endpoint" value={ingestUrl} />
-
-			{Result.isFailure(keysResult) ? (
-				<p className="rounded-md border border-dashed bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-					Ask an org admin for your ingest keys, or open{" "}
-					<SettingsLink>Settings → Ingestion</SettingsLink>.
-				</p>
-			) : (
-				<>
-					<CopyableField
-						label="Public key"
-						value={Result.builder(keysResult)
-							.onSuccess((v) => v.publicKey)
-							.orElse(() => "Loading…")}
-						masked
-					/>
-					<CopyableField
-						label="Private key"
-						value={Result.builder(keysResult)
-							.onSuccess((v) => v.privateKey)
-							.orElse(() => "Loading…")}
-						masked
-					/>
-				</>
-			)}
+			<ConnectCredentials />
 
 			<Separator />
 
 			<div className="space-y-2">
 				<span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
-					Set up with Claude Code
+					Fastest path · Claude Code
 				</span>
-				<CopyableField label="" value={ONBOARD_SKILL_COMMAND} />
+				<CopyableField value={ONBOARD_SKILL_COMMAND} />
 				<p className="text-xs text-muted-foreground">
 					The <code className="rounded bg-muted px-1">maple-onboard</code> skill installs
 					OpenTelemetry and wires traces, logs, and metrics end-to-end.
@@ -103,10 +69,14 @@ function ConnectPanel() {
 			</div>
 
 			<div className="flex items-center justify-between text-xs">
-				<SettingsLink className="inline-flex items-center gap-1 font-medium text-foreground hover:underline">
-					Manage ingest keys
+				<Link
+					to="/settings"
+					search={{ tab: "ingestion" }}
+					className="inline-flex items-center gap-1 font-medium text-foreground hover:underline"
+				>
+					Open setup guide
 					<ArrowRightIcon size={12} />
-				</SettingsLink>
+				</Link>
 				<a
 					href="https://maple.dev/docs"
 					target="_blank"
@@ -116,69 +86,6 @@ function ConnectPanel() {
 					Documentation
 				</a>
 			</div>
-		</div>
-	)
-}
-
-function SettingsLink({ children, className }: { children: React.ReactNode; className?: string }) {
-	return (
-		<Link
-			to="/settings"
-			search={{ tab: "ingestion" }}
-			className={
-				className ?? "font-medium text-foreground underline underline-offset-2 hover:no-underline"
-			}
-		>
-			{children}
-		</Link>
-	)
-}
-
-function CopyableField({ label, value, masked }: { label: string; value: string; masked?: boolean }) {
-	const [copied, setCopied] = useState(false)
-	const [isVisible, setIsVisible] = useState(false)
-
-	async function handleCopy() {
-		try {
-			await navigator.clipboard.writeText(value)
-			setCopied(true)
-			toast.success(`${label || "Command"} copied`)
-			setTimeout(() => setCopied(false), 1500)
-		} catch {
-			toast.error(`Failed to copy ${(label || "command").toLowerCase()}`)
-		}
-	}
-
-	return (
-		<div className="space-y-1">
-			{label && <label className="text-xs text-muted-foreground">{label}</label>}
-			<InputGroup>
-				<InputGroupInput
-					readOnly
-					value={masked && !isVisible ? maskKey(value) : value}
-					className="font-mono text-xs tracking-wide select-all"
-				/>
-				<InputGroupAddon align="inline-end">
-					{masked && (
-						<InputGroupButton
-							onClick={() => setIsVisible((v) => !v)}
-							aria-label={isVisible ? "Hide key" : "Reveal key"}
-						>
-							<EyeIcon size={14} className={isVisible ? "text-foreground" : undefined} />
-						</InputGroupButton>
-					)}
-					<InputGroupButton
-						onClick={handleCopy}
-						aria-label={`Copy ${(label || "command").toLowerCase()}`}
-					>
-						{copied ? (
-							<CheckIcon size={14} className="text-severity-info" />
-						) : (
-							<CopyIcon size={14} />
-						)}
-					</InputGroupButton>
-				</InputGroupAddon>
-			</InputGroup>
 		</div>
 	)
 }

--- a/apps/web/src/components/ingest/connect-credentials.tsx
+++ b/apps/web/src/components/ingest/connect-credentials.tsx
@@ -1,0 +1,52 @@
+import { Link } from "@tanstack/react-router"
+
+import { Result, useAtomValue } from "@/lib/effect-atom"
+import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { ingestUrl } from "@/lib/services/common/ingest-url"
+import { CopyableField } from "./copyable-field"
+
+/**
+ * Endpoint + public/private ingest keys as copyable fields, with the
+ * permission-failure fallback for members who can't read org keys. Shared by
+ * the Connect popover and any compact credentials surface.
+ */
+export function ConnectCredentials() {
+	const keysResult = useAtomValue(MapleApiAtomClient.query("ingestKeys", "get", {}))
+
+	return (
+		<div className="space-y-3">
+			<CopyableField label="Ingest endpoint" value={ingestUrl} />
+
+			{Result.isFailure(keysResult) ? (
+				<p className="rounded-md border border-dashed bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+					Ask an org admin for your ingest keys, or open{" "}
+					<Link
+						to="/settings"
+						search={{ tab: "ingestion" }}
+						className="font-medium text-foreground underline underline-offset-2 hover:no-underline"
+					>
+						Settings → Ingestion
+					</Link>
+					.
+				</p>
+			) : (
+				<>
+					<CopyableField
+						label="Public key"
+						value={Result.builder(keysResult)
+							.onSuccess((v) => v.publicKey)
+							.orElse(() => "Loading…")}
+						masked
+					/>
+					<CopyableField
+						label="Private key"
+						value={Result.builder(keysResult)
+							.onSuccess((v) => v.privateKey)
+							.orElse(() => "Loading…")}
+						masked
+					/>
+				</>
+			)}
+		</div>
+	)
+}

--- a/apps/web/src/components/ingest/connection-status.tsx
+++ b/apps/web/src/components/ingest/connection-status.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react"
+import { Link } from "@tanstack/react-router"
+import { toast } from "sonner"
+
+import { Button } from "@maple/ui/components/ui/button"
+import { cn } from "@maple/ui/utils"
+import { ArrowRightIcon, CircleCheckIcon, PaperPlaneIcon, PulseIcon } from "@/components/icons"
+import { sendTestEvent, type IngestConnection } from "./use-ingest-connection"
+
+/**
+ * Compact live-connection indicator for the Connect popover header. Amber pulse
+ * while waiting, green dot once telemetry is observed.
+ */
+export function ConnectionStatusPill({ connection }: { connection: IngestConnection }) {
+	const connected = connection.status === "connected"
+	return (
+		<span
+			className={cn(
+				"inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium transition-colors",
+				connected
+					? "border-severity-info/30 bg-severity-info/10 text-severity-info"
+					: "border-primary/30 bg-primary/10 text-primary",
+			)}
+		>
+			{connected ? (
+				<>
+					<span className="size-1.5 rounded-full bg-severity-info" />
+					Connected · {connection.serviceCount}{" "}
+					{connection.serviceCount === 1 ? "service" : "services"}
+				</>
+			) : (
+				<>
+					<PulseIcon size={11} className="animate-pulse motion-reduce:animate-none" />
+					Waiting for telemetry
+				</>
+			)}
+		</span>
+	)
+}
+
+/**
+ * The waiting strip: "Watching for your first trace…" with a fallback
+ * "Send a test event" button. Used by the dashboard checklist (waiting state).
+ */
+export function SendTestEventStrip({ apiKey, onTestSent }: { apiKey: string; onTestSent: () => void }) {
+	const [sending, setSending] = useState(false)
+
+	async function handleSendTest() {
+		if (!apiKey || sending) return
+		setSending(true)
+		try {
+			await sendTestEvent(apiKey)
+			toast.success("Test event sent — watch for it to land below")
+			onTestSent()
+		} catch {
+			toast.error("Couldn't reach the ingest endpoint — double-check your API key")
+		} finally {
+			setSending(false)
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-3 rounded-lg border border-dashed border-primary/30 bg-primary/5 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+			<div className="flex items-center gap-2.5">
+				<PulseIcon size={14} className="text-primary animate-pulse motion-reduce:animate-none" />
+				<span className="text-xs text-muted-foreground">Watching for your first trace…</span>
+			</div>
+			<div className="flex items-center gap-2">
+				<span className="hidden text-[11px] text-muted-foreground sm:inline">
+					Not ready to instrument?
+				</span>
+				<Button
+					variant="outline"
+					size="sm"
+					onClick={handleSendTest}
+					disabled={sending || !apiKey}
+					className="gap-2 shrink-0"
+				>
+					<PaperPlaneIcon size={13} />
+					{sending ? "Sending…" : "Send a test event"}
+				</Button>
+			</div>
+		</div>
+	)
+}
+
+/**
+ * Persistent status panel for ingestion settings: flips between the waiting
+ * strip and a "connected — receiving telemetry" line that links into traces.
+ * Unlike the dashboard checklist this never gets dismissed, so it doubles as an
+ * at-a-glance ingest-health indicator.
+ */
+export function IngestStatusPanel({
+	connection,
+	onTestSent,
+}: {
+	connection: IngestConnection
+	onTestSent: () => void
+}) {
+	if (connection.status === "connected") {
+		return (
+			<div className="flex flex-col gap-3 rounded-lg border border-severity-info/30 bg-severity-info/5 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+				<div className="flex items-center gap-2.5">
+					<CircleCheckIcon size={14} className="text-severity-info" />
+					<span className="text-xs text-foreground">
+						{connection.firstRealService
+							? `Connected — receiving telemetry from ${connection.firstRealService}`
+							: "Connected — receiving your telemetry"}
+					</span>
+				</div>
+				<Button variant="outline" size="sm" className="gap-2 shrink-0" render={<Link to="/traces" />}>
+					Explore traces
+					<ArrowRightIcon size={13} />
+				</Button>
+			</div>
+		)
+	}
+
+	return <SendTestEventStrip apiKey={connection.apiKey} onTestSent={onTestSent} />
+}

--- a/apps/web/src/components/ingest/copyable-field.tsx
+++ b/apps/web/src/components/ingest/copyable-field.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react"
+import { toast } from "sonner"
+
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupButton,
+	InputGroupInput,
+} from "@maple/ui/components/ui/input-group"
+import { CheckIcon, CopyIcon, EyeIcon } from "@/components/icons"
+
+/** Mask an ingest key, keeping the readable prefix + last four characters. */
+export function maskKey(key: string): string {
+	if (key.length <= 18) return key
+	const prefix = key.slice(0, 14)
+	const suffix = key.slice(-4)
+	return `${prefix}${"•".repeat(key.length - 18)}${suffix}`
+}
+
+interface CopyableFieldProps {
+	value: string
+	/** Optional caption rendered above the field. */
+	label?: string
+	/** Mask the value behind a reveal toggle (for secrets). */
+	masked?: boolean
+}
+
+/**
+ * Read-only value with copy (and optional reveal) affordances. The single
+ * implementation shared by the Connect popover, ingestion settings, and the
+ * dashboard setup checklist.
+ */
+export function CopyableField({ value, label, masked }: CopyableFieldProps) {
+	const [copied, setCopied] = useState(false)
+	const [isVisible, setIsVisible] = useState(false)
+
+	async function handleCopy() {
+		try {
+			await navigator.clipboard.writeText(value)
+			setCopied(true)
+			toast.success(`${label || "Command"} copied`)
+			setTimeout(() => setCopied(false), 1500)
+		} catch {
+			toast.error(`Failed to copy ${(label || "command").toLowerCase()}`)
+		}
+	}
+
+	return (
+		<div className="space-y-1">
+			{label && <label className="text-xs text-muted-foreground">{label}</label>}
+			<InputGroup>
+				<InputGroupInput
+					readOnly
+					value={masked && !isVisible ? maskKey(value) : value}
+					className="font-mono text-xs tracking-wide select-all"
+				/>
+				<InputGroupAddon align="inline-end">
+					{masked && (
+						<InputGroupButton
+							onClick={() => setIsVisible((v) => !v)}
+							aria-label={isVisible ? "Hide key" : "Reveal key"}
+						>
+							<EyeIcon size={14} className={isVisible ? "text-foreground" : undefined} />
+						</InputGroupButton>
+					)}
+					<InputGroupButton
+						onClick={handleCopy}
+						aria-label={`Copy ${(label || "command").toLowerCase()}`}
+					>
+						{copied ? (
+							<CheckIcon size={14} className="text-severity-info" />
+						) : (
+							<CopyIcon size={14} />
+						)}
+					</InputGroupButton>
+				</InputGroupAddon>
+			</InputGroup>
+		</div>
+	)
+}

--- a/apps/web/src/components/ingest/guided-setup.tsx
+++ b/apps/web/src/components/ingest/guided-setup.tsx
@@ -1,0 +1,178 @@
+import { useAuth } from "@clerk/clerk-react"
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@maple/ui/components/ui/tabs"
+import { cn } from "@maple/ui/utils"
+import { CodeBlock } from "@/components/quick-start/code-block"
+import { PackageManagerCodeBlock } from "@/components/quick-start/package-manager-code-block"
+import {
+	EffectIcon,
+	GoIcon,
+	NextjsIcon,
+	NodejsIcon,
+	OpenTelemetryIcon,
+	PythonIcon,
+} from "@/components/quick-start/framework-icons"
+import { sdkSnippets, type FrameworkId } from "@/components/quick-start/sdk-snippets"
+import { ingestUrl } from "@/lib/services/common/ingest-url"
+import { useQuickStart } from "@/hooks/use-quick-start"
+import type { RoleOption } from "@/atoms/quick-start-atoms"
+import { CopyableField } from "./copyable-field"
+
+const frameworkIconMap: Record<FrameworkId, React.ComponentType<{ size?: number; className?: string }>> = {
+	nextjs: NextjsIcon,
+	nodejs: NodejsIcon,
+	python: PythonIcon,
+	go: GoIcon,
+	effect: EffectIcon,
+	otel: OpenTelemetryIcon,
+}
+
+const ROLE_DEFAULT_FRAMEWORK: Record<RoleOption, FrameworkId> = {
+	engineer: "nodejs",
+	devops_sre: "otel",
+	eng_leader: "nodejs",
+	founder: "nextjs",
+}
+
+interface GuidedSetupProps {
+	/** Public ingest key, interpolated into the instrument snippet. */
+	apiKey: string
+	/** Render the endpoint + key credentials column beside the snippet tabs. */
+	showCredentials?: boolean
+}
+
+/**
+ * Framework picker + Install / Instrument / Claude Code tabs. The shared body of
+ * the guided ingestion flow, used by the dashboard setup checklist and the
+ * ingestion settings page. Selection persists via the per-org quick-start atom.
+ */
+export function GuidedSetup({ apiKey, showCredentials = false }: GuidedSetupProps) {
+	const { orgId } = useAuth()
+	const { selectedFramework, setSelectedFramework, qualifyAnswers } = useQuickStart(orgId)
+
+	const roleDefault = qualifyAnswers.role ? ROLE_DEFAULT_FRAMEWORK[qualifyAnswers.role] : "nodejs"
+	const framework = selectedFramework ?? roleDefault
+
+	return (
+		<div className="space-y-4">
+			<FrameworkPicker selected={framework} onSelect={setSelectedFramework} />
+			<ConnectInstructions
+				framework={framework}
+				apiKey={apiKey}
+				showCredentials={showCredentials}
+			/>
+		</div>
+	)
+}
+
+function FrameworkPicker({
+	selected,
+	onSelect,
+}: {
+	selected: FrameworkId
+	onSelect: (id: FrameworkId) => void
+}) {
+	return (
+		<div className="space-y-2">
+			<span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+				Pick your stack
+			</span>
+			<div className="flex flex-wrap gap-2">
+				{sdkSnippets.map((snippet) => {
+					const Icon = frameworkIconMap[snippet.language]
+					const active = selected === snippet.language
+					return (
+						<button
+							key={snippet.language}
+							type="button"
+							onClick={() => onSelect(snippet.language)}
+							className={cn(
+								"flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring",
+								active
+									? "border-primary bg-primary/10 text-primary"
+									: "border-border hover:border-foreground/30",
+							)}
+						>
+							<Icon size={14} />
+							{snippet.label}
+						</button>
+					)
+				})}
+			</div>
+		</div>
+	)
+}
+
+function ConnectInstructions({
+	framework,
+	apiKey,
+	showCredentials,
+}: {
+	framework: FrameworkId
+	apiKey: string
+	showCredentials: boolean
+}) {
+	const snippet = sdkSnippets.find((s) => s.language === framework)
+
+	if (!snippet) return null
+
+	function interpolate(template: string) {
+		return template
+			.replace(/\{\{INGEST_URL\}\}/g, ingestUrl)
+			.replace(/\{\{API_KEY\}\}/g, apiKey || "<your-api-key>")
+	}
+
+	const tabs = (
+		<div className="rounded-lg border bg-card overflow-hidden">
+			<Tabs defaultValue="install" className="flex flex-col">
+				<div className="border-b px-3">
+					<TabsList variant="underline" className="h-9">
+						<TabsTrigger value="install">Install</TabsTrigger>
+						<TabsTrigger value="instrument">Instrument</TabsTrigger>
+						<TabsTrigger value="claude-code">Claude Code</TabsTrigger>
+					</TabsList>
+				</div>
+
+				<TabsContent value="install" className="overflow-auto p-3 mt-0">
+					{typeof snippet.install === "string" ? (
+						<CodeBlock code={snippet.install} language="shell" />
+					) : (
+						<PackageManagerCodeBlock packages={snippet.install.packages} />
+					)}
+				</TabsContent>
+
+				<TabsContent value="instrument" className="overflow-auto p-3 mt-0">
+					<CodeBlock code={interpolate(snippet.instrument)} language={snippet.label.toLowerCase()} />
+				</TabsContent>
+
+				<TabsContent value="claude-code" className="overflow-auto p-3 mt-0 space-y-2">
+					<p className="text-xs text-muted-foreground">
+						Run this prompt in Claude Code (or Codex / Cursor with the skill installed). The{" "}
+						<code className="rounded bg-muted px-1">maple-onboard</code> skill walks every service
+						in the repo, installs OpenTelemetry, wires traces / logs / metrics, and verifies the
+						bootstrap end-to-end.
+					</p>
+					<CodeBlock
+						code={`Install Maple in this repo using the maple-onboard skill.\nMy ingest key is ${apiKey || "<your-api-key>"}.`}
+						language="shell"
+					/>
+				</TabsContent>
+			</Tabs>
+		</div>
+	)
+
+	if (!showCredentials) return tabs
+
+	return (
+		<div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-5">
+			<div className="space-y-3">
+				<span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+					Credentials
+				</span>
+				<CopyableField value={ingestUrl} label="Ingest endpoint" />
+				<CopyableField value={apiKey || "Loading…"} label="API key" masked />
+			</div>
+			{tabs}
+		</div>
+	)
+}

--- a/apps/web/src/components/ingest/use-ingest-connection.ts
+++ b/apps/web/src/components/ingest/use-ingest-connection.ts
@@ -1,0 +1,128 @@
+import { useState } from "react"
+
+import { Result, useAtomValue } from "@/lib/effect-atom"
+import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { ingestUrl } from "@/lib/services/common/ingest-url"
+import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { useMountEffect } from "@/hooks/use-mount-effect"
+import { getServiceOverviewResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
+
+export interface IngestConnection {
+	/** `connected` once non-demo telemetry is observed in the last hour. */
+	status: "waiting" | "connected"
+	/** Count of real (non-`demo-`) services seen. */
+	serviceCount: number
+	/** First real service name, if any — handy for "we're seeing X" copy. */
+	firstRealService?: string
+	/** The org's public ingest key (empty string until loaded / when denied). */
+	apiKey: string
+	/** Force an immediate re-poll of the service overview. */
+	refresh: () => void
+}
+
+interface UseIngestConnectionOptions {
+	/** Poll the service overview on an interval (default: true). */
+	poll?: boolean
+}
+
+/**
+ * Live ingest-connection state, shared across the Connect popover, ingestion
+ * settings, and the dashboard setup checklist. Polls the service overview and
+ * filters out the seeded `demo-` services so the signal reflects the user's own
+ * telemetry. Reuses the cached `ingestKeys` query for the public key.
+ */
+export function useIngestConnection({ poll = true }: UseIngestConnectionOptions = {}): IngestConnection {
+	const { startTime, endTime } = useEffectiveTimeRange(undefined, undefined, "1h")
+	const [pollCount, setPollCount] = useState(0)
+
+	const keysResult = useAtomValue(MapleApiAtomClient.query("ingestKeys", "get", {}))
+	const apiKey = Result.isSuccess(keysResult) ? keysResult.value.publicKey : ""
+
+	const overviewResult = useAtomValue(
+		getServiceOverviewResultAtom({
+			data: { startTime, endTime },
+			_poll: pollCount,
+		} as never),
+	)
+
+	useMountEffect(() => {
+		if (!poll) return
+		const interval = setInterval(() => setPollCount((c) => c + 1), 15000)
+		return () => clearInterval(interval)
+	})
+
+	const services = Result.isSuccess(overviewResult) ? overviewResult.value.data : []
+	const realServices = services.filter(
+		(s) => !(typeof s.serviceName === "string" && s.serviceName.startsWith("demo-")),
+	)
+	const firstRealService =
+		typeof realServices[0]?.serviceName === "string" ? (realServices[0].serviceName as string) : undefined
+
+	return {
+		status: realServices.length > 0 ? "connected" : "waiting",
+		serviceCount: realServices.length,
+		firstRealService,
+		apiKey,
+		refresh: () => setPollCount((c) => c + 1),
+	}
+}
+
+function randomHex(byteLength: number): string {
+	const bytes = new Uint8Array(byteLength)
+	crypto.getRandomValues(bytes)
+	return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("")
+}
+
+const TEST_EVENT_SERVICE = "maple-onboarding-test"
+
+/** POST a single synthetic trace to the ingest gateway to prove the key works. */
+export async function sendTestEvent(apiKey: string): Promise<void> {
+	const now = Date.now()
+	const endNano = `${now}000000`
+	const startNano = `${now - 87}000000`
+	const payload = {
+		resourceSpans: [
+			{
+				resource: {
+					attributes: [
+						{ key: "service.name", value: { stringValue: TEST_EVENT_SERVICE } },
+						{ key: "deployment.environment", value: { stringValue: "development" } },
+					],
+				},
+				scopeSpans: [
+					{
+						scope: { name: "maple-onboarding" },
+						spans: [
+							{
+								traceId: randomHex(16),
+								spanId: randomHex(8),
+								name: "GET /maple/test-event",
+								kind: 2,
+								startTimeUnixNano: startNano,
+								endTimeUnixNano: endNano,
+								attributes: [
+									{ key: "http.request.method", value: { stringValue: "GET" } },
+									{ key: "http.route", value: { stringValue: "/maple/test-event" } },
+									{ key: "http.response.status_code", value: { intValue: 200 } },
+								],
+								status: { code: 1 },
+							},
+						],
+					},
+				],
+			},
+		],
+	}
+
+	const response = await fetch(`${ingestUrl}/v1/traces`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${apiKey}`,
+		},
+		body: JSON.stringify(payload),
+	})
+	if (!response.ok) {
+		throw new Error(`Ingest gateway returned ${response.status}`)
+	}
+}

--- a/apps/web/src/components/settings/ingestion-section.tsx
+++ b/apps/web/src/components/settings/ingestion-section.tsx
@@ -26,15 +26,12 @@ import { Separator } from "@maple/ui/components/ui/separator"
 import { AlertWarningIcon, ArrowPathIcon, CheckIcon, CopyIcon, EyeIcon, ShieldIcon } from "@/components/icons"
 import { ingestUrl } from "@/lib/services/common/ingest-url"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { maskKey } from "@/components/ingest/copyable-field"
+import { GuidedSetup } from "@/components/ingest/guided-setup"
+import { IngestStatusPanel } from "@/components/ingest/connection-status"
+import { useIngestConnection } from "@/components/ingest/use-ingest-connection"
 import { AttributeMappingsSection } from "./attribute-mappings-section"
 import { RecommendedMappingsSection } from "./recommended-mappings-section"
-
-function maskKey(key: string): string {
-	if (key.length <= 18) return key
-	const prefix = key.slice(0, 14)
-	const suffix = key.slice(-4)
-	return `${prefix}${"•".repeat(key.length - 18)}${suffix}`
-}
 
 interface ApiKeyRowProps {
 	type: "public" | "private"
@@ -128,6 +125,8 @@ export function IngestionSection() {
 	const keysResult = useAtomValue(keysQueryAtom)
 	const refreshKeys = useAtomRefresh(keysQueryAtom)
 
+	const connection = useIngestConnection()
+
 	const rerollPublicMutation = useAtomSet(MapleApiAtomClient.mutation("ingestKeys", "rerollPublic"), {
 		mode: "promiseExit",
 	})
@@ -207,6 +206,19 @@ export function IngestionSection() {
 	return (
 		<>
 			<div className="space-y-4">
+				<Card>
+					<CardHeader>
+						<CardTitle>Send your first telemetry</CardTitle>
+						<CardDescription>
+							Point your OpenTelemetry SDK at Maple, or let Claude Code wire it up for you.
+						</CardDescription>
+					</CardHeader>
+					<CardContent className="space-y-4">
+						<GuidedSetup apiKey={connection.apiKey} />
+						<IngestStatusPanel connection={connection} onTestSent={connection.refresh} />
+					</CardContent>
+				</Card>
+
 				<div className="grid grid-cols-2 gap-4">
 					<Card>
 						<CardHeader>


### PR DESCRIPTION
## What

Unifies Maple's "first telemetry" experience across three surfaces that previously didn't share code, and upgrades the two weakest ones.

The guided flow (framework picker, Install/Instrument/Claude Code tabs, live "watching for your first trace" status) lived **only** on the dashboard setup checklist. The Connect popover and Settings → Ingestion each re-implemented their own flat copy-field stacks — `maskKey` and the copy-field component were triplicated across all three files.

### New shared module — `apps/web/src/components/ingest/`
- **`copyable-field.tsx`** — one `CopyableField` + `maskKey` (removes the triplication).
- **`use-ingest-connection.ts`** — live connection hook (polls the service overview, filters `demo-` services) + the moved `sendTestEvent`. Uses `useMountEffect` per the no-useEffect convention.
- **`connect-credentials.tsx`** — endpoint + keys with the permission fallback.
- **`guided-setup.tsx`** — framework picker + Install/Instrument/Claude Code tabs (credentials column optional).
- **`connection-status.tsx`** — status pill (popover), waiting strip, and a persistent waiting↔connected panel (settings).

### Surfaces
- **Settings → Ingestion** — new **"Send your first telemetry"** card on top: framework picker, tabbed snippets with credentials interpolated, and a persistent live connection panel — above the existing endpoint/keys/mappings.
- **Connect popover** — lean launchpad: green **"Connected · N services"** status pill, compact credentials, "FASTEST PATH · CLAUDE CODE" hero, and an **"Open setup guide →"** deep-link to `/settings?tab=ingestion`.
- **Dashboard setup checklist** — refactored onto the shared module; collapse/dismiss/celebration behavior preserved.

## Why

Settings → Ingestion was credentials-only with zero guidance on how to actually send telemetry, and the Connect popover gave no feedback on whether data was arriving. The good guided flow was trapped on a dismissible dashboard card. This makes the guidance reachable everywhere, adds a live connection signal, and collapses three copies of the same code into one module.

## Verification
- `bun --filter=@maple/web typecheck` clean.
- Browser-verified all three surfaces: live status flips waiting→connected, popover deep-link resolves to `/settings?tab=ingestion`, framework switching re-renders snippets with the real key interpolated, tablet layout wraps cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)