### PR TITLE
ci: migrate deployment secrets from Doppler to Infisical (OIDC) — retry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ CLICKHOUSE_PASSWORD=maple
 # (`bun run db:up && bun run db:migrate:local` to set it up).
 MAPLE_DB_URL=
 
-# Deployed stages (set in Doppler, not here): one PlanetScale Postgres connection
+# Deployed stages (set in Infisical, not here): one PlanetScale Postgres connection
 # string for the stage's branch (direct port 5432). alchemy.run.ts parses it into
 # the Hyperdrive origin; the CI `drizzle-kit migrate` step and the import scripts
 # use it as-is. NB the connect-time database is `postgres` (the cluster default),

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -15,6 +15,7 @@ concurrency:
 permissions:
     contents: read
     deployments: write
+    id-token: write # Infisical OIDC machine-identity auth
 
 jobs:
     deploy-pr-preview:
@@ -22,15 +23,16 @@ jobs:
         runs-on: ubuntu-latest
         # `pr-preview` environment must require manual approval in repo settings.
         # This blocks PR-controlled code (install scripts, build steps) from
-        # accessing Doppler secrets until a maintainer reviews the diff.
+        # accessing Infisical secrets until a maintainer reviews the diff.
         # `url` surfaces the deployed web app as a clickable deployment on the PR
         # (empty on `closed`, when the deploy step is skipped).
         environment:
             name: pr-preview
             url: ${{ steps.deploy.outputs.web_url }}
         env:
-            DOPPLER_PROJECT: maple
-            DOPPLER_CONFIG: pr
+            # Uses Infisical's default `dev` environment for now; swap to a
+            # dedicated `preview` env later if PR previews need isolated secrets.
+            INFISICAL_ENV_SLUG: dev
             PR_NUMBER: ${{ github.event.pull_request.number }}
             PR_BRANCH: ${{ github.head_ref }}
             # Stamped onto deployed telemetry as `deployment.commit_sha`. Use the PR
@@ -44,13 +46,15 @@ jobs:
             - name: Setup mise (toolchain)
               uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
-            - name: Load deployment secrets from Doppler
-              uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
+            - name: Load deployment secrets from Infisical
+              uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
               with:
-                  doppler-token: ${{ secrets.DOPPLER_TOKEN }}
-                  doppler-project: ${{ env.DOPPLER_PROJECT }}
-                  doppler-config: ${{ env.DOPPLER_CONFIG }}
-                  inject-env-vars: true
+                  method: "oidc"
+                  identity-id: ${{ secrets.INFISICAL_MACHINE_IDENTITY_ID }}
+                  project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
+                  env-slug: ${{ env.INFISICAL_ENV_SLUG }}
+                  export-type: "env"
+                  secret-path: "/"
 
             - name: Install dependencies
               run: bun install --frozen-lockfile
@@ -62,7 +66,7 @@ jobs:
 
             # Create/refresh an ephemeral Tinybird branch `pr_<n>` seeded with the
             # latest prod partition, deploy this PR's schema into it, and override
-            # TINYBIRD_HOST/TINYBIRD_TOKEN (from Doppler `pr`) with the branch's
+            # TINYBIRD_HOST/TINYBIRD_TOKEN (from Infisical `dev`) with the branch's
             # values so the Alchemy deploy below binds the whole stack to the branch.
             - name: Create/refresh Tinybird PR branch
               if: ${{ github.event.action != 'closed' }}
@@ -73,7 +77,7 @@ jobs:
               uses: planetscale/setup-pscale-action@v1
 
             # The PlanetScale + Alchemy steps below are gated on
-            # PLANETSCALE_SERVICE_TOKEN: until the `pr` Doppler config carries the
+            # PLANETSCALE_SERVICE_TOKEN: until the `dev` Infisical environment carries the
             # PlanetScale service token (+ PLANETSCALE_SERVICE_TOKEN_ID,
             # PLANETSCALE_ORG), PR previews can't provision a Postgres branch, so
             # they SKIP cleanly (the check stays green) rather than fail every PR.

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -12,14 +12,14 @@ concurrency:
 
 permissions:
     contents: read
+    id-token: write # Infisical OIDC machine-identity auth
 
 jobs:
     deploy-prd:
         runs-on: ubuntu-latest
         environment: production
         env:
-            DOPPLER_PROJECT: maple
-            DOPPLER_CONFIG: prd
+            INFISICAL_ENV_SLUG: prod
             # Stamped onto deployed telemetry as `deployment.commit_sha` (server SDK
             # reads COMMIT_SHA; web build reads VITE_COMMIT_SHA via Vite define).
             COMMIT_SHA: ${{ github.sha }}
@@ -31,13 +31,15 @@ jobs:
             - name: Setup mise (toolchain)
               uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
-            - name: Load deployment secrets from Doppler
-              uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
+            - name: Load deployment secrets from Infisical
+              uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
               with:
-                  doppler-token: ${{ secrets.DOPPLER_TOKEN }}
-                  doppler-project: ${{ env.DOPPLER_PROJECT }}
-                  doppler-config: ${{ env.DOPPLER_CONFIG }}
-                  inject-env-vars: true
+                  method: "oidc"
+                  identity-id: ${{ secrets.INFISICAL_MACHINE_IDENTITY_ID }}
+                  project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
+                  env-slug: ${{ env.INFISICAL_ENV_SLUG }}
+                  export-type: "env"
+                  secret-path: "/"
 
             - name: Install dependencies
               run: bun install --frozen-lockfile

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -12,14 +12,14 @@ concurrency:
 
 permissions:
     contents: read
+    id-token: write # Infisical OIDC machine-identity auth
 
 jobs:
     deploy-stg:
         runs-on: ubuntu-latest
         environment: staging
         env:
-            DOPPLER_PROJECT: maple
-            DOPPLER_CONFIG: stg
+            INFISICAL_ENV_SLUG: staging
             # Stamped onto deployed telemetry as `deployment.commit_sha` (server SDK
             # reads COMMIT_SHA; web build reads VITE_COMMIT_SHA via Vite define).
             COMMIT_SHA: ${{ github.sha }}
@@ -31,13 +31,15 @@ jobs:
             - name: Setup mise (toolchain)
               uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
-            - name: Load deployment secrets from Doppler
-              uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
+            - name: Load deployment secrets from Infisical
+              uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
               with:
-                  doppler-token: ${{ secrets.DOPPLER_TOKEN }}
-                  doppler-project: ${{ env.DOPPLER_PROJECT }}
-                  doppler-config: ${{ env.DOPPLER_CONFIG }}
-                  inject-env-vars: true
+                  method: "oidc"
+                  identity-id: ${{ secrets.INFISICAL_MACHINE_IDENTITY_ID }}
+                  project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
+                  env-slug: ${{ env.INFISICAL_ENV_SLUG }}
+                  export-type: "env"
+                  secret-path: "/"
 
             - name: Install dependencies
               run: bun install --frozen-lockfile
@@ -45,7 +47,7 @@ jobs:
             # Schema migrations run against the PlanetScale branch over the
             # DIRECT port (5432, never the PSBouncer/Hyperdrive poolers — DDL
             # through a transaction pooler misbehaves). MAPLE_PG_URL is the
-            # single Doppler secret (direct 5432, admin role).
+            # single Infisical secret (direct 5432, admin role).
             - name: Run database migrations
               run: DATABASE_URL="$MAPLE_PG_URL" bun run --cwd packages/db db:migrate
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,16 @@ CI workflows:
 
 Secrets source model (CI):
 
-- GitHub Secrets (only one): `DOPPLER_TOKEN`
-- Doppler configs (`prd`, `stg`, `pr`) must define:
+- Secrets are fetched from **Infisical** via `Infisical/secrets-action` using OIDC
+  (credential-less — GitHub's OIDC token authenticates a machine identity, no long-lived
+  token stored). CI needs:
+    - GitHub repo **variable** `INFISICAL_PROJECT_SLUG` (the project slug — a
+      **variable**, not a secret: GitHub masks secret values everywhere, and a
+      slug like `maple` would then blank out the PR-preview deployment URL
+      `app-pr-<n>.maple.dev`)
+    - GitHub repo **secret** `INFISICAL_MACHINE_IDENTITY_ID` (the machine identity ID)
+- Infisical environments (`prod`, `staging`, `dev` — mapped from the old Doppler
+  `prd`/`stg`/`pr` configs) must define:
     - `ALCHEMY_PASSWORD`
     - `ALCHEMY_STATE_TOKEN`
     - `CLOUDFLARE_API_TOKEN`
@@ -147,7 +155,7 @@ Secrets source model (CI):
     - `CLERK_PUBLISHABLE_KEY`
     - `CLERK_JWT_KEY`
 
-Free/Starter note: when using a personal Doppler token, the workflow must also specify Doppler selectors (`doppler-project`, `doppler-config`). This repo uses `maple` with stage configs `prd`, `stg`, and `pr`.
+Setup note: the machine identity must have a **GitHub OIDC** auth method configured in Infisical (scoped to this repo, ideally to the `production`/`staging`/`pr-preview` GitHub environments) and read access to the project. The workflows select secrets via `project-slug` (`INFISICAL_PROJECT_SLUG`) and per-stage `env-slug` (`prod`/`staging`/`dev`).
 
 Runtime API URL behavior:
 

--- a/docs/tinybird-pr-branches.md
+++ b/docs/tinybird-pr-branches.md
@@ -15,7 +15,7 @@ deploy with two extra steps backed by `scripts/tinybird-pr-branch.ts`:
     - `tb --branch=pr_<n> deploy` — deploys _this PR's_ datasources/materialized views into the
       branch.
     - Resolves the branch's admin token and writes `TINYBIRD_HOST` / `TINYBIRD_TOKEN` to
-      `$GITHUB_ENV`, **overriding** the Doppler `pr` values for the steps that follow.
+      `$GITHUB_ENV`, **overriding** the Infisical `dev` values for the steps that follow.
 2. **`alchemy:deploy:pr`** then binds the whole preview stack (api / web / alerting / chat-agent
    and, if pointed at it, the Rust ingest gateway) to the branch — no app code changes, because
    every `alchemy.run.ts` already reads `TINYBIRD_HOST` / `TINYBIRD_TOKEN` from `process.env`
@@ -34,7 +34,7 @@ in the branch. To add more data to a branch, use the in-app demo seed (`POST /de
 - **Branches share compute with production.** That's why teardown on PR close is mandatory and we
   scope branches to the open-PR set. Avoid leaving stray branches around.
 - Requires a Tinybird plan that supports branches.
-- The Doppler `pr` config's `TINYBIRD_HOST` / `TINYBIRD_TOKEN` must be the **parent workspace
+- The Infisical `dev` environment's `TINYBIRD_HOST` / `TINYBIRD_TOKEN` must be the **parent workspace
   admin** host+token — the script uses them to create the branch before swapping in the branch's
   own credentials.
 - If the CLI's `token ls` output can't be parsed for the admin token, pin it explicitly with the

--- a/mise.toml
+++ b/mise.toml
@@ -25,7 +25,7 @@ python = "3.12.13" # Tinybird tooling + .github/scripts/format-ingest-benchmark-
 # pick them up without an explicit --env-file flag. This is ADDITIVE: the apps
 # still load .env.local explicitly (portless --env-file, apps/ingest `source`,
 # scraper `bun --env-file`), so non-mise users and CI are unaffected. In CI there
-# is no .env.local, so this is a no-op there (Doppler/secret injection is untouched).
+# is no .env.local, so this is a no-op there (Infisical/secret injection is untouched).
 _.file = ".env.local"
 
 [tasks.setup]

--- a/packages/infra/src/cloudflare/stage.ts
+++ b/packages/infra/src/cloudflare/stage.ts
@@ -100,7 +100,7 @@ export function resolveMapleDomains(stage: MapleStage): MapleDomains {
 		case "pr":
 			// Give PR previews a stable, secret-free web URL so GitHub can attach it
 			// to the PR as a clickable deployment. The default workers.dev URL embeds
-			// the Cloudflare account subdomain, which Doppler masks as a secret —
+			// the Cloudflare account subdomain, which Infisical masks as a secret —
 			// GitHub then refuses to set the environment URL. A custom domain under the
 			// `maple.dev` zone has no secret in it. api/chat/ingest stay on workers.dev
 			// (the API allows all origins, so cross-origin calls keep working).

--- a/scripts/tinybird-pr-branch.ts
+++ b/scripts/tinybird-pr-branch.ts
@@ -14,7 +14,7 @@
  * `down` removes the branch (called on PR close, after `alchemy:destroy:pr`).
  *
  * Auth: the PARENT (prod) workspace host+token arrive via the incoming
- * TINYBIRD_HOST / TINYBIRD_TOKEN (Doppler `pr` config). We use them to drive the
+ * TINYBIRD_HOST / TINYBIRD_TOKEN (Infisical `preview` environment). We use them to drive the
  * `tb` CLI for branch ops, then overwrite the same two vars with the branch's
  * values. `tb` is invoked flag-first (`--cloud --host --token`), matching
  * .github/workflows/tinybird-ci.yml — no `.tinyb` state needed.


### PR DESCRIPTION
Re-applies [MAP-20](https://linear.app/mapledev/issue/MAP-20/migrate-doppler-infisical) (originally #145, reverted by `c7defe8a2`). Same code as the merged migration — this is a clean re-apply via revert-of-the-revert.

## ⛔ DO NOT MERGE until `CLERK_JWT_KEY` is fixed in Infisical

The first merge broke prod. **Root cause was NOT the code — it was a bad secret value.**

- The Infisical **`prod`** environment's `CLERK_JWT_KEY` was **malformed** (multi-line PEM mangled on copy — newlines lost / `\n`-escaped).
- At runtime, Maple's networkless Clerk JWT verification failed on every request: `Invalid RSA key in JSON Web Key; missing or invalid Modulus parameter ("n")` → **175 `UnauthorizedError`s**, prod unusable.
- The deploy was green because `CLERK_JWT_KEY` is only used at runtime, never validated at deploy time.
- Everything else (Alchemy state, Cloudflare, Tinybird) worked — diagnosed via Maple's own error telemetry.

### Required before merge
1. Re-enter `CLERK_JWT_KEY` in Infisical **`prod`** as a proper multi-line PEM (real line breaks, full `-----BEGIN/END PUBLIC KEY-----`). Source: Clerk dashboard → API Keys → JWT public key, or the old Doppler `prd` value.
2. Do the same for **`staging`** (merging to main auto-deploys stg too) and **`dev`**.
3. After merge, **verify auth works** (log in to prod) instead of trusting the green deploy — a successful deploy ≠ healthy prod for runtime-only secrets.

## What changed (unchanged from #145)

- 3 deploy workflows use `Infisical/secrets-action` with OIDC (`export-type: env`, drop-in for Doppler's `inject-env-vars`), `id-token: write`, per-stage `INFISICAL_ENV_SLUG` (`prod`/`staging`/`dev`).
- Auth via repo **variable** `INFISICAL_PROJECT_SLUG` (a variable, not a secret — a secret would mask the slug and blank the PR-preview deployment URL) + repo secret `INFISICAL_MACHINE_IDENTITY_ID`.
- Doc/comment updates (Doppler→Infisical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)