### PR TITLE
fix(scraper): stop scrape-loop fiber leak from duplicate PlanetScale sub-targets

### DIFF
--- a/apps/api/src/services/PlanetScaleDiscoveryService.test.ts
+++ b/apps/api/src/services/PlanetScaleDiscoveryService.test.ts
@@ -144,6 +144,36 @@ describe("PlanetScaleDiscoveryService", () => {
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
+	it.effect("collapses groups that fall back to the same host key into one sub-target", () => {
+		const testDb = createTestDb(trackedDbs)
+		const recorded: Array<RecordedRequest> = []
+		return Effect.gen(function* () {
+			const discovery = yield* PlanetScaleDiscoveryService
+			const row = yield* createPlanetScaleTargetRow("my-org")
+
+			// Prod hazard: an http_sd payload with several groups that carry no
+			// `planetscale_database_branch_id`, so subTargetKey falls back to the
+			// shared host. Without dedup these become N rows with the SAME
+			// (id, subTargetKey) and the scraper forks a leaking loop fiber per row.
+			const DUP_HOST_PAYLOAD = [
+				{ targets: ["metrics.psdb.cloud:443"], labels: { planetscale_database: "mydb" } },
+				{ targets: ["metrics.psdb.cloud:443"], labels: { planetscale_database: "other" } },
+				{ targets: ["metrics.psdb.cloud:443"], labels: {} },
+			]
+
+			const entries = yield* discovery.discover(row).pipe(
+				Effect.provideService(
+					FetchHttpClient.Fetch,
+					stubFetch(recorded, () => Response.json(DUP_HOST_PAYLOAD)),
+				),
+			)
+
+			expect(entries).toHaveLength(1)
+			expect(entries[0]?.subTargetKey).toBe("metrics.psdb.cloud:443")
+			expect(entries[0]?.url).toBe("https://metrics.psdb.cloud:443/metrics")
+		}).pipe(Effect.provide(makeLayer(testDb)))
+	})
+
 	it.effect("caches discovery for the TTL and refreshes after it elapses", () => {
 		const testDb = createTestDb(trackedDbs)
 		const recorded: Array<RecordedRequest> = []

--- a/apps/api/src/services/PlanetScaleDiscoveryService.ts
+++ b/apps/api/src/services/PlanetScaleDiscoveryService.ts
@@ -87,6 +87,22 @@ const subTargetsFromGroup = (group: {
 }
 
 /**
+ * Collapse sub-targets sharing a `subTargetKey` (last wins). The scraper keys
+ * one scrape-loop fiber per `(targetId, subTargetKey)`, so duplicate keys would
+ * each fork a fiber that the scheduler can't track — a runaway scrape loop.
+ * Two entries with the same key resolve to the same logical endpoint, so
+ * collapsing them is lossless. Happens when an http_sd payload exposes several
+ * groups that fall back to the same host key (no `planetscale_database_branch_id`).
+ */
+const dedupeBySubTargetKey = (
+	entries: ReadonlyArray<PlanetScaleSubTarget>,
+): ReadonlyArray<PlanetScaleSubTarget> => {
+	const byKey = new Map<string, PlanetScaleSubTarget>()
+	for (const entry of entries) byKey.set(entry.subTargetKey, entry)
+	return [...byKey.values()]
+}
+
+/**
  * Branch name a filter pattern matches against: PlanetScale's http_sd exposes
  * the human branch name as `planetscale_branch`; older payloads only carry
  * `planetscale_database_branch_id`. Fall back to the sub-target key so a filter
@@ -199,11 +215,11 @@ export class PlanetScaleDiscoveryService extends Context.Service<
 				),
 			)
 
-			const entries: Array<PlanetScaleSubTarget> = []
+			const collected: Array<PlanetScaleSubTarget> = []
 			const dropped: Array<string> = []
 			for (const group of groups) {
 				const converted = subTargetsFromGroup(group)
-				entries.push(...converted.ok)
+				collected.push(...converted.ok)
 				dropped.push(...converted.dropped)
 			}
 			if (dropped.length > 0) {
@@ -212,12 +228,25 @@ export class PlanetScaleDiscoveryService extends Context.Service<
 				).pipe(Effect.annotateLogs({ scrapeTargetId: row.id, dropped: dropped.join(", ") }))
 			}
 
+			// Guarantee one entry per subTargetKey so the scraper never forks more
+			// than one loop fiber per key (a runaway scrape loop otherwise).
+			const entries = dedupeBySubTargetKey(collected)
+			if (entries.length < collected.length) {
+				yield* Effect.logWarning("Collapsed duplicate PlanetScale sub-targets sharing a key").pipe(
+					Effect.annotateLogs({
+						scrapeTargetId: row.id,
+						collapsed: collected.length - entries.length,
+						distinct: entries.length,
+					}),
+				)
+			}
+
 			// Apply the org's branch include/exclude globs so PR-preview branches
 			// (et al.) aren't scraped — the main lever against PlanetScale 429s from
 			// fanning out across every branch in the org.
 			const filters = parseBranchFilters(row.discoveryConfigJson)
 			if (filters.include.length === 0 && filters.exclude.length === 0) {
-				return entries as ReadonlyArray<PlanetScaleSubTarget>
+				return entries
 			}
 			const kept = entries.filter((entry) =>
 				branchPassesFilters(branchNameForFilter(entry), filters),
@@ -231,7 +260,7 @@ export class PlanetScaleDiscoveryService extends Context.Service<
 					}),
 				)
 			}
-			return kept as ReadonlyArray<PlanetScaleSubTarget>
+			return kept
 		})
 
 		const discover = Effect.fn("PlanetScaleDiscoveryService.discover")(function* (row: ScrapeTargetRow) {

--- a/apps/scraper/src/ScrapeScheduler.test.ts
+++ b/apps/scraper/src/ScrapeScheduler.test.ts
@@ -319,6 +319,35 @@ describe("ScrapeScheduler", () => {
 		}),
 	)
 
+	it.effect("collapses duplicate (id, subTargetKey) rows to a single loop", () =>
+		Effect.gen(function* () {
+			// Rows that all collapse to targetKey "TARGET_A:metrics.psdb.cloud" —
+			// exactly what PlanetScale discovery emitted in prod when the http_sd
+			// payload carries no per-branch label. Without dedup, reconcile forks a
+			// fiber per duplicate row and leaks all but the last every pass, so the
+			// scrape rate balloons. Duplicates must behave identically to one row.
+			const mkDup = () => mkTarget(TARGET_A, 60, { subTargetKey: "metrics.psdb.cloud" })
+			const harness = makeHarness([mkDup(), mkDup(), mkDup()])
+			yield* startScheduler.pipe(Effect.provide(harnessLayer(harness)))
+
+			// A single (deduped) loop starts after its deterministic jitter, then
+			// scrapes every 60s start-to-start. Derive the exact count for ONE fiber
+			// over the window; the leak runs a fiber per duplicate row, inflating it.
+			const baseMs = 60_000
+			const windowMs = 125_000
+			const jitter = initialJitterMs(`${TARGET_A}:metrics.psdb.cloud`, baseMs)
+			const expectedForOneFiber = Math.floor((windowMs - jitter) / baseMs) + 1
+
+			yield* TestClock.adjust(Duration.millis(windowMs))
+
+			assert.strictEqual(
+				harness.scrapeCalls.filter((id) => id === TARGET_A).length,
+				expectedForOneFiber,
+			)
+			assert.isTrue(harness.subCalls.every((c) => c.subTargetKey === "metrics.psdb.cloud"))
+		}),
+	)
+
 	it.effect("reconcile starts new targets, stops removed ones, and restarts changed ones", () =>
 		Effect.gen(function* () {
 			const harness = makeHarness([mkTarget(TARGET_A, 10)])

--- a/apps/scraper/src/ScrapeScheduler.ts
+++ b/apps/scraper/src/ScrapeScheduler.ts
@@ -300,8 +300,19 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 				const current = yield* Ref.get(fibersRef)
 				const next = new Map<string, TargetEntry>()
 
+				// Collapse the list to one target per `targetKey` (last wins). The
+				// fork decision below reads `existing` from the *previous* map, so
+				// two rows sharing a key would each fork a loop fiber while only the
+				// last is tracked in `next` — the rest leak, uninterrupted, every
+				// reconcile. (Prod hit this: PlanetScale discovery returned many rows
+				// that all collapsed to subTargetKey "metrics.psdb.cloud".) The API
+				// also dedupes now; this keeps the scheduler correct regardless.
+				const deduped = new Map<string, InternalScrapeTarget>()
+				for (const target of targets) deduped.set(targetKey(target), target)
+				const duplicateTargetsDropped = targets.length - deduped.size
+
 				yield* Effect.forEach(
-					targets,
+					deduped.values(),
 					(target) =>
 						Effect.gen(function* () {
 							const key = targetKey(target)
@@ -327,7 +338,12 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 
 				yield* Ref.set(fibersRef, next)
 				yield* Ref.set(lastReconcileRef, yield* Clock.currentTimeMillis)
-				yield* Effect.annotateCurrentSpan({ activeTargets: next.size })
+				yield* Effect.annotateCurrentSpan({ activeTargets: next.size, duplicateTargetsDropped })
+				if (duplicateTargetsDropped > 0) {
+					yield* Effect.logWarning("Dropped duplicate scrape targets sharing one key").pipe(
+						Effect.annotateLogs({ duplicateTargetsDropped, distinctTargets: next.size }),
+					)
+				}
 			}).pipe(
 				Effect.withSpan("scraper.reconcile"),
 				// A failed list fetch keeps the current fibers running untouched.


### PR DESCRIPTION
## Problem

The `scraper` service was burning an obscene amount of RAM/CPU in prod. Telemetry (Maple service `scraper`, 6h window) showed:

- Only **3 active targets**, yet **~1M `scraper.scrape_target` spans in 6h** — the one **"Planetscale"** target (60s interval) was doing **~50–60 scrapes/sec** (~3,000× expected).
- Rate **plateaued at the semaphore-saturation ceiling** (`SCRAPER_CONCURRENCY=10` ÷ ~162ms p50 ≈ 62/sec), and hit 40/sec in the **first minute** → the leak happens within a single reconcile pass.
- Those scrapes produced **zero data points** (`OtlpIngest.send` fired 39× total) — the endpoint returns empty/non-2xx but **not** 429/503, so no backoff; each leaked fiber just re-loops forever.
- The two legitimate targets were **starved** (~20 scrapes in 6h instead of ~1,440) — leaked fibers monopolized all 10 permits.
- Every runaway span carried the **same** `subTargetKey = "metrics.psdb.cloud"`, so `targetKey` was a single key (which is why the `activeTargets` gauge read 3 while thousands of fibers ran).

## Root cause (two compounding bugs)

1. **API emits duplicate rows.** In `PlanetScaleDiscoveryService`, when an http_sd group carries no `planetscale_database_branch_id` label, `subTargetKey` falls back to the host — so multiple groups collapse to the same `(id, subTargetKey)` and `discover()` returns N duplicate sub-targets.
2. **Scraper leaks a fiber per duplicate.** `ScrapeScheduler.reconcile()` decided whether to fork a loop fiber by reading `existing` from the *previous* fiber map, never the `next` map being built. So duplicate rows sharing a `targetKey` each forked a fresh fiber while only the last was tracked in `next` — the rest leaked, uninterrupted, every reconcile.

## Fix

- **Scraper** (`ScrapeScheduler.ts`): dedupe incoming targets by `targetKey` (last-wins) before the fork loop, so duplicate rows can never each spawn a fiber. Annotate `duplicateTargetsDropped` on the `scraper.reconcile` span + warn-log when it happens. Legitimate per-branch fan-out (distinct `subTargetKey`s) is unaffected.
- **API** (`PlanetScaleDiscoveryService.ts`): dedupe assembled sub-targets by `subTargetKey` before caching/returning — removes the source of the duplicate rows. (Also dropped two now-redundant `as ReadonlyArray<…>` casts.)

## Tests

- `ScrapeScheduler.test.ts`: new test feeds 3 rows sharing one `(id, subTargetKey)`; fails pre-fix (inflated scrape count), passes post-fix (exact single-fiber count derived from `initialJitterMs`, so jitter-proof). **56/56 scraper tests pass.**
- `PlanetScaleDiscoveryService.test.ts`: branch-label-less groups resolving to the same host now collapse to exactly one sub-target. **8/8 discovery tests pass.**
- `bun typecheck` clean for both apps.

## Post-merge verification

After the scraper redeploys, re-run the diagnostic: the Planetscale target should drop from ~50–60/sec to ~1/min, the two real targets recover to ~1 scrape/15s, `scrape_target` p95 falls from ~246s to sub-second, and Railway RAM/CPU return to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)