### PR TITLE
fix(dashboard): make reload button actually refresh widget data (MAP-52)

### DIFF
--- a/apps/web/src/atoms/dashboard-time-range-atoms.test.tsx
+++ b/apps/web/src/atoms/dashboard-time-range-atoms.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { Registry, RegistryContext } from "@/lib/effect-atom"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+	PageRefreshProvider,
+	usePageRefreshContext,
+} from "@/components/time-range-picker/page-refresh-context"
+
+import { DashboardTimeRangeProvider, useDashboardTimeRange } from "./dashboard-time-range-atoms"
+
+function createWrapper() {
+	const registry = Registry.make()
+
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return <RegistryContext.Provider value={registry}>{children}</RegistryContext.Provider>
+	}
+}
+
+function ReloadButton() {
+	const { reload } = usePageRefreshContext()
+	return <button onClick={reload}>reload</button>
+}
+
+function ResolvedProbe() {
+	const {
+		state: { resolvedTimeRange },
+	} = useDashboardTimeRange()
+	return <div data-testid="end">{resolvedTimeRange?.endTime ?? "none"}</div>
+}
+
+function Harness({ timePreset }: { timePreset?: string }) {
+	return (
+		<DashboardTimeRangeProvider value={{ type: "relative", value: "1h" }}>
+			<PageRefreshProvider timePreset={timePreset}>
+				<ReloadButton />
+				<ResolvedProbe />
+			</PageRefreshProvider>
+		</DashboardTimeRangeProvider>
+	)
+}
+
+describe("useDashboardTimeRange resolved range on reload", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date("2026-03-10T12:00:00.000Z"))
+	})
+
+	afterEach(() => {
+		cleanup()
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	it("rebases the resolved window to now when reload is clicked", () => {
+		render(<Harness timePreset="1h" />, { wrapper: createWrapper() })
+
+		const before = screen.getByTestId("end").textContent
+		expect(before).toBe("2026-03-10 12:00:00")
+
+		// Advance the wall clock, then reload — the resolved window should follow.
+		act(() => {
+			vi.setSystemTime(new Date("2026-03-10T12:05:00.000Z"))
+			fireEvent.click(screen.getByRole("button", { name: "reload" }))
+		})
+
+		expect(screen.getByTestId("end").textContent).toBe("2026-03-10 12:05:00")
+	})
+})

--- a/apps/web/src/atoms/dashboard-time-range-atoms.ts
+++ b/apps/web/src/atoms/dashboard-time-range-atoms.ts
@@ -1,5 +1,6 @@
 import { type ReactNode, createElement, useCallback, useMemo } from "react"
 import { Atom, ScopedAtom, useAtom } from "@/lib/effect-atom"
+import { useOptionalPageRefreshContext } from "@/components/time-range-picker/page-refresh-context"
 import type { TimeRange } from "@/components/dashboard-builder/types"
 import { relativeToAbsolute } from "@/lib/time-utils"
 
@@ -41,7 +42,18 @@ export function useDashboardTimeRange() {
 	const timeRangeAtom = DashboardTimeRange.use()
 	const [timeRange, setTimeRangeRaw] = useAtom(timeRangeAtom)
 
-	const resolvedTimeRange = useMemo(() => resolveTimeRange(timeRange), [timeRange])
+	// Rebase relative presets to "now" on manual reload, matching
+	// useEffectiveTimeRange. Without refreshVersion in the deps the resolved
+	// absolute window stays frozen, so clicking Reload re-fetches the same stale
+	// range and appears to do nothing. Absolute ranges resolve to the same value,
+	// so they are unaffected (the explicit useRefreshableAtomValue refresh still
+	// re-runs their queries).
+	const refreshVersion = useOptionalPageRefreshContext()?.refreshVersion ?? 0
+	const resolvedTimeRange = useMemo(
+		() => resolveTimeRange(timeRange),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[timeRange, refreshVersion],
+	)
 
 	// Skip atom writes when the new range is structurally equal to the current
 	// one. Without this guard the picker can re-emit the same range on mount


### PR DESCRIPTION
## What

Fixes the dashboard **Reload** button, which previously appeared to do nothing.

## Why

The button was wired correctly — clicking it bumps `refreshVersion`, which `useRefreshableAtomValue` reacts to. The real bug was that the dashboard's resolved **query time window never advanced on reload**.

In `useDashboardTimeRange` ([`apps/web/src/atoms/dashboard-time-range-atoms.ts`](apps/web/src/atoms/dashboard-time-range-atoms.ts)), `resolvedTimeRange` was memoized on `timeRange` only:

```ts
const resolvedTimeRange = useMemo(() => resolveTimeRange(timeRange), [timeRange])
```

For a **relative** preset (Last 1h, Last 1 month, …) clicking Reload re-resolved nothing, so widgets re-fetched the *same stale window* → no new data → "reload does nothing." Every other page already rebases its window on `refreshVersion` via `useEffectiveTimeRange`; the dashboard was the lone exception.

## Change

Add `refreshVersion` (from `useOptionalPageRefreshContext()`) to the `resolvedTimeRange` memo deps so relative presets re-resolve to "now" on reload. This changes the widget query keys and forces a fresh fetch.

- **Relative ranges**: window advances to now → real refetch (the fix).
- **Absolute ranges**: resolve to the same value, so no churn; they keep relying on the existing explicit `useRefreshableAtomValue` refresh.
- No import cycle; `useOptionalPageRefreshContext()` returns `null` outside a provider, so other consumers are unaffected (refreshVersion stays 0).

### Why not wire `onRelativeRangeRefresh` instead
That would convert the stored relative range into an absolute one on every reload (persisted via `DashboardTimeRangeSync` → `updateDashboardTimeRange`), freezing the dashboard's saved range and breaking "live" relative behavior. Rejected.

## Tests

- New `apps/web/src/atoms/dashboard-time-range-atoms.test.tsx` asserts the resolved `endTime` advances when Reload is clicked.
- Existing `page-refresh-context.test.tsx` still passes.

## Verification

- ✅ `bunx vitest run` — 4/4 pass
- ✅ `bun typecheck` clean
- ✅ Browser (live dashboard, relative preset): read the resolved window from React before/after Reload:
  - before → `2026-05-30 16:36:03 → 2026-06-30 16:36:03`
  - after Reload (~3 min later) → `2026-05-30 16:39:14 → 2026-06-30 16:39:14`

  The window rebased to "now" exactly on click — without the fix it stays frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)