### PR TITLE
fix(service-map): stop horizontal overflow from mismatched bleed margin

### DIFF
--- a/apps/web/src/routes/service-map.tsx
+++ b/apps/web/src/routes/service-map.tsx
@@ -66,7 +66,7 @@ function ServiceMapContent() {
 				/>
 			}
 		>
-			<div className="-mx-6 -mb-6 h-[calc(100vh-10rem)]">
+			<div className="-mx-4 -mb-4 h-[calc(100vh-10rem)]">
 				<ServiceMapView startTime={effectiveStartTime} endTime={effectiveEndTime} />
 			</div>
 		</DashboardLayout>


### PR DESCRIPTION
## Summary

The Service Map page (`/service-map`) rendered with an unwanted horizontal scrollbar.

The map wrapper used a `-mx-6 -mb-6` negative-margin "bleed" to push the ReactFlow canvas edge-to-edge, but its parent `PageLayout.ScrollArea` only pads its content by `p-4` (1rem). The `-mx-6`/`-mb-6` bleed pulls **1.5rem**, overshooting the parent padding by 0.5rem per side (1rem total horizontally). Since `ScrollArea` is `overflow-auto`, that overshoot surfaced as a horizontal scrollbar.

`service-map.tsx` was the only route using a `-mx-6`/`-mb-6` bleed — every other page that bleeds already matches its `p-4` parent.

## Change

- `apps/web/src/routes/service-map.tsx` — change the wrapper from `-mx-6 -mb-6` to `-mx-4 -mb-4` so the bleed exactly cancels the parent's `p-4` padding. The map still spans the full content width edge-to-edge; no more overshoot, no horizontal scrollbar.

## Testing

- Verified the negative margin now matches the parent `PageLayout.ScrollArea` `p-4` padding, so the wrapper occupies exactly the scroll area's content width.
- Note: `bun typecheck` fails in the CI/sandbox on a pre-existing, unrelated error (`Cannot find type definition file for 'vite/client'`); this change is a Tailwind class-string edit with no type impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JP5QicYhXFPZx5PYBqs3rb)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->