### PR TITLE
fix(alerting): stop warehouse-timeout fan-out storm in error/anomaly crons

### DIFF
--- a/apps/alerting/src/worker.ts
+++ b/apps/alerting/src/worker.ts
@@ -92,6 +92,7 @@ const buildLayer = (_env: Record<string, unknown>) => {
 			Layer.mergeAll(
 				BaseLive,
 				WarehouseQueryServiceLive,
+				EdgeCacheServiceLive,
 				NotificationDispatcherLive,
 				WorkerEnvironment.layer,
 			),

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -134,7 +134,12 @@ const NotificationDispatcherLive = NotificationDispatcher.layer.pipe(Layer.provi
 
 const ErrorsServiceLive = ErrorsService.layer.pipe(
 	Layer.provideMerge(
-		Layer.mergeAll(CoreServicesLive, WarehouseQueryServiceLive, NotificationDispatcherLive),
+		Layer.mergeAll(
+			CoreServicesLive,
+			WarehouseQueryServiceLive,
+			EdgeCacheServiceLive,
+			NotificationDispatcherLive,
+		),
 	),
 )
 

--- a/apps/api/src/services/AnomalyDetectionService.ts
+++ b/apps/api/src/services/AnomalyDetectionService.ts
@@ -93,6 +93,12 @@ const LOG_BASELINE_CACHE_BUCKET = "anomaly-logbase"
 /** Active-org discovery window — covers the in-progress hour plus the prior one
  *  so an org that just started sending telemetry is picked up within a tick. */
 const ANOMALY_ACTIVE_DISCOVERY_WINDOW_MS = 2 * HOUR_MS
+/** Last-known active-org set. Lets discovery fail CLOSED (reuse the previous set)
+ *  instead of evaluating every known org — the old fallback that turned a
+ *  warehouse blip into a fan-out storm. See ErrorsService for the same pattern. */
+const ANOMALY_ACTIVE_ORGS_CACHE_BUCKET = "anomaly-active-orgs"
+const ANOMALY_ACTIVE_ORGS_CACHE_KEY = "active"
+const ANOMALY_ACTIVE_ORGS_CACHE_TTL_S = 6 * 60 * 60
 /** D1 caps bound parameters per statement (~100); mirror ErrorsService's chunking. */
 const D1_INARRAY_CHUNK_SIZE = 90
 
@@ -260,8 +266,9 @@ const make = Effect.gen(function* () {
 	// CPU. Instead, run ONE cross-org scan of the recent hourly MVs (pinned to
 	// managed Tinybird) and only evaluate orgs that produced telemetry. Idle orgs
 	// have no series to evaluate. BYO-ClickHouse orgs are invisible to that scan
-	// and are always evaluated. Fails OPEN: if discovery errors, every known org
-	// is evaluated (the prior behaviour).
+	// and are always evaluated. Fails CLOSED: if discovery errors, reuse the
+	// last-known active set from cache (or just BYO if cold) rather than
+	// evaluating every known org — the old fan-out amplified warehouse stress.
 	// -----------------------------------------------------------------
 
 	const resolveActiveOrgs = Effect.fn("AnomalyDetectionService.resolveActiveOrgs")(function* (
@@ -282,12 +289,12 @@ const make = Effect.gen(function* () {
 				warehouse.compiledQuery(
 					routingTenant,
 					CH.compile(CH.activeOrgsByTracesQuery(), { startTime }),
-					{ pinToIngestConfig: true, profile: "list", context: "anomalyActiveOrgsTraces" },
+					{ pinToIngestConfig: true, profile: "discovery", context: "anomalyActiveOrgsTraces" },
 				),
 				warehouse.compiledQuery(
 					routingTenant,
 					CH.compile(CH.activeOrgsByLogsQuery(), { startTime }),
-					{ pinToIngestConfig: true, profile: "list", context: "anomalyActiveOrgsLogs" },
+					{ pinToIngestConfig: true, profile: "discovery", context: "anomalyActiveOrgsLogs" },
 				),
 			],
 			{ concurrency: 2 },
@@ -300,11 +307,32 @@ const make = Effect.gen(function* () {
 				}
 				return active as ReadonlySet<string>
 			}),
+			// Cache the freshly-discovered set for reuse on a later discovery failure.
+			Effect.tap((active) =>
+				edgeCache
+					.rawPut(
+						ANOMALY_ACTIVE_ORGS_CACHE_BUCKET,
+						ANOMALY_ACTIVE_ORGS_CACHE_KEY,
+						[...active],
+						ANOMALY_ACTIVE_ORGS_CACHE_TTL_S,
+					)
+					.pipe(Effect.ignore),
+			),
+			// Fail CLOSED: reuse the last-known active set (or just BYO if cold).
 			Effect.catchCause((cause) =>
-				Effect.logWarning("Anomaly active-org discovery failed; evaluating all known orgs").pipe(
-					Effect.annotateLogs({ error: Cause.pretty(cause) }),
-					Effect.as("all" as const),
-				),
+				Effect.gen(function* () {
+					yield* Effect.logWarning(
+						"Anomaly active-org discovery failed; reusing last-known active set",
+					).pipe(Effect.annotateLogs({ error: Cause.pretty(cause) }))
+					const cached = yield* edgeCache
+						.rawGet<ReadonlyArray<string>>(ANOMALY_ACTIVE_ORGS_CACHE_BUCKET, ANOMALY_ACTIVE_ORGS_CACHE_KEY)
+						.pipe(Effect.orElseSucceed(() => Option.none<ReadonlyArray<string>>()))
+					const active = new Set<string>(byo)
+					for (const orgId of Option.getOrElse(cached, () => [] as ReadonlyArray<string>)) {
+						active.add(orgId)
+					}
+					return active as ReadonlySet<string>
+				}),
 			),
 		)
 	})
@@ -1789,7 +1817,7 @@ const make = Effect.gen(function* () {
 
 			const activeOrgs = yield* resolveActiveOrgs([...candidates], nowMs)
 			const orgsToProcess = [...candidates].filter(
-				(org) => activeOrgs === "all" || activeOrgs.has(org) || mustProcess.has(org),
+				(org) => activeOrgs.has(org) || mustProcess.has(org),
 			)
 
 			const orgFailures = yield* Ref.make(0)

--- a/apps/api/src/services/ErrorsService.test.ts
+++ b/apps/api/src/services/ErrorsService.test.ts
@@ -26,6 +26,7 @@ import {
 } from "@maple/db"
 import { eq } from "drizzle-orm"
 import type { CompiledQuery } from "@maple/query-engine/ch"
+import { EdgeCacheService, makeEdgeCacheService, makeMemoryBackend } from "@maple/query-engine/caching"
 import { Database, DatabaseError } from "../lib/DatabaseLive"
 import { Env } from "../lib/Env"
 import { cleanupTestDbs, createTestDb, type TestDb } from "../lib/test-pglite"
@@ -166,6 +167,64 @@ const makeErrorsLayer = (scanRows?: () => ReadonlyArray<Record<string, unknown>>
 				envLive,
 				databaseLive,
 				Layer.succeed(WarehouseQueryService, makeWarehouseStub(scanRows, onScan)),
+				Layer.succeed(EdgeCacheService, makeEdgeCacheService(makeMemoryBackend())),
+				dispatcherStub,
+			),
+		),
+		Layer.provideMerge(databaseLive),
+	)
+}
+
+/**
+ * Layer variant for active-org gating tests. Lets a test force discovery to
+ * FAIL (to exercise the fail-CLOSED path) and/or capture the cost `profile`
+ * each query context was issued with.
+ */
+const makeGatingLayer = (opts: {
+	failDiscovery?: boolean
+	scanRows?: () => ReadonlyArray<Record<string, unknown>>
+	scanned?: Set<string>
+	profiles?: Map<string, string | undefined>
+}) => {
+	const testDb = createTestDb(createdDbs)
+	const envLive = Env.layer.pipe(Layer.provide(testConfig()))
+	const databaseLive = testDb.layer
+	const dispatcherStub = Layer.succeed(NotificationDispatcher, {
+		dispatch: () => Effect.succeed({ delivered: 0, failed: 0 }),
+	})
+	const scanRows = opts.scanRows ?? (() => [])
+	const warehouseStub: WarehouseQueryServiceShape = {
+		query: () => Effect.die(new Error("unexpected warehouse query")),
+		sqlQuery: () => Effect.succeed([]),
+		compiledQuery: <T>(tenant: unknown, compiled: CompiledQuery<T>, options?: SqlQueryOptions) => {
+			if (options?.context) opts.profiles?.set(options.context, options.profile)
+			if (options?.context === "errorActiveOrgsDiscovery") {
+				if (opts.failDiscovery) return Effect.die(new Error("discovery down"))
+				const orgId = (tenant as { orgId?: string }).orgId ?? ""
+				return Effect.sync(() => compiled.castRows(scanRows().length > 0 ? [{ orgId }] : []))
+			}
+			if (options?.context === "errorIssuesScan") {
+				const orgId = (tenant as { orgId?: string }).orgId ?? ""
+				return Effect.sync(() => {
+					opts.scanned?.add(orgId)
+					return compiled.castRows(scanRows())
+				})
+			}
+			return Effect.sync(() => compiled.castRows([]))
+		},
+		compiledQueryFirst: () => Effect.die(new Error("unexpected warehouse query")),
+		ingest: () => Effect.void,
+		asExecutor: () => {
+			throw new Error("asExecutor is not supported by this test stub")
+		},
+	}
+	return ErrorsService.layer.pipe(
+		Layer.provide(
+			Layer.mergeAll(
+				envLive,
+				databaseLive,
+				Layer.succeed(WarehouseQueryService, warehouseStub),
+				Layer.succeed(EdgeCacheService, makeEdgeCacheService(makeMemoryBackend())),
 				dispatcherStub,
 			),
 		),
@@ -518,6 +577,41 @@ describe("ErrorsService.runTick", () => {
 				),
 			),
 		)
+	})
+
+	it.effect("discovery failure fails CLOSED — stateful orgs scanned, idle orgs skipped", () => {
+		const scanned = new Set<string>()
+		const IDLE = asOrgId("org_idle_ingest_only")
+		return Effect.gen(function* () {
+			const errors = yield* ErrorsService
+			yield* TestClock.setTime(TICK_MS)
+			// ORG becomes known + stateful via an issue; IDLE is known via an ingest
+			// key only (no issue, no incident state).
+			yield* seedIssue(asIssueId(randomUUID()))
+			yield* seedIngestKey(IDLE)
+
+			yield* errors.runTick()
+
+			// The stateful org is still scanned so resolution/aging keeps running…
+			assert.isTrue(scanned.has(ORG))
+			// …but the idle org is NOT scanned: no fan-out to every known org (the old
+			// fail-OPEN behaviour would have scanned it via activeOrgs="all").
+			assert.isFalse(scanned.has(IDLE))
+		}).pipe(Effect.provide(makeGatingLayer({ failDiscovery: true, scanned })))
+	})
+
+	it.effect("discovery uses the 5s discovery profile; the per-org scan uses the list profile", () => {
+		const profiles = new Map<string, string | undefined>()
+		return Effect.gen(function* () {
+			const errors = yield* ErrorsService
+			yield* TestClock.setTime(TICK_MS)
+			yield* seedIssue(asIssueId(randomUUID()))
+
+			yield* errors.runTick()
+
+			assert.strictEqual(profiles.get("errorActiveOrgsDiscovery"), "discovery")
+			assert.strictEqual(profiles.get("errorIssuesScan"), "list")
+		}).pipe(Effect.provide(makeGatingLayer({ scanRows: () => [scanRow()], profiles })))
 	})
 
 	it.effect(

--- a/apps/api/src/services/ErrorsService.ts
+++ b/apps/api/src/services/ErrorsService.ts
@@ -74,6 +74,7 @@ import { Env } from "../lib/Env"
 import { dateToMs, msToDate } from "../lib/time"
 import { NotificationDispatcher } from "./NotificationDispatcher"
 import { WarehouseQueryService } from "../lib/WarehouseQueryService"
+import { EdgeCacheService } from "@maple/query-engine/caching"
 
 const decodeErrorIssueIdSync = Schema.decodeUnknownSync(ErrorIssueDocument.fields.id)
 const decodeErrorIncidentIdSync = Schema.decodeUnknownSync(ErrorIncidentDocument.fields.id)
@@ -100,6 +101,15 @@ const TICK_WINDOW_MS = 2 * 60_000
  *  with recent (but not last-2-min) errors still gets scanned, with slack for
  *  cron jitter and MV write lag. */
 const ERROR_ACTIVE_DISCOVERY_WINDOW_MS = 15 * 60_000
+// Last-known active-org set, cached so a discovery failure can fail CLOSED
+// (reuse the previous active set) instead of fanning out to every known org —
+// the latter melts the warehouse exactly when it is already struggling. Keyed
+// globally (discovery is cross-org, one set covers the whole managed workspace).
+// TTL generous enough to survive a multi-hour warehouse brown-out; a slightly
+// stale set only costs a few cheap empty scans of recently-idle orgs.
+const ACTIVE_ORGS_CACHE_BUCKET = "errors-active-orgs"
+const ACTIVE_ORGS_CACHE_KEY = "active"
+const ACTIVE_ORGS_CACHE_TTL_S = 6 * 60 * 60
 const RESOLVED_RETENTION_DAYS = 14
 const ARCHIVED_RETENTION_DAYS = 90
 const RETENTION_PHASE_EVERY_N_TICKS = 30
@@ -352,10 +362,11 @@ export interface ErrorsServiceShape {
 const make: Effect.Effect<
 	ErrorsServiceShape,
 	never,
-	Database | WarehouseQueryService | Env | NotificationDispatcher
+	Database | WarehouseQueryService | EdgeCacheService | Env | NotificationDispatcher
 > = Effect.gen(function* () {
 	const database = yield* Database
 	const warehouse = yield* WarehouseQueryService
+	const edgeCache = yield* EdgeCacheService
 	const env = yield* Env
 	const dispatcher = yield* NotificationDispatcher
 	// Optional: present only inside a Worker isolate. Used to kick off the
@@ -408,8 +419,12 @@ const make: Effect.Effect<
 	// dominated Tinybird CPU. Instead, run ONE cross-org scan of recent error
 	// events (pinned to managed Tinybird) and only scan orgs that show up.
 	// BYO-ClickHouse orgs are invisible to that scan, so they are always treated
-	// as active. Fails OPEN: if discovery errors, every known org is scanned (the
-	// prior behaviour), never silently dropped.
+	// as active. Fails CLOSED: discovery fails precisely when the warehouse is
+	// stressed, so the old "scan every known org" fallback amplified the outage
+	// into a fan-out storm. Instead reuse the last-known active set from cache;
+	// if none, fall back to just the BYO set. Orgs with existing issue/incident
+	// state are still scanned by the caller (`withState`), so auto-resolution
+	// keeps working even when discovery is down.
 	// ---------------------------------------------------------------
 
 	const resolveActiveOrgs = Effect.fn("ErrorsService.resolveActiveOrgs")(function* (
@@ -429,6 +444,10 @@ const make: Effect.Effect<
 		return yield* warehouse
 			.compiledQuery(systemTenant(knownOrgs[0] as OrgId), compiled, {
 				pinToIngestConfig: true,
+				// Bound the one cross-org scan (no OrgId predicate ⇒ can't prune the
+				// primary key): abort server-side at 5s instead of riding the ~30s
+				// client timeout when the warehouse is slow.
+				profile: "discovery",
 				context: "errorActiveOrgsDiscovery",
 			})
 			.pipe(
@@ -440,11 +459,28 @@ const make: Effect.Effect<
 					}
 					return active as ReadonlySet<string>
 				}),
+				// Cache the freshly-discovered set so a later discovery failure can
+				// reuse it instead of fanning out to all known orgs. Best-effort.
+				Effect.tap((active) =>
+					edgeCache
+						.rawPut(ACTIVE_ORGS_CACHE_BUCKET, ACTIVE_ORGS_CACHE_KEY, [...active], ACTIVE_ORGS_CACHE_TTL_S)
+						.pipe(Effect.ignore),
+				),
+				// Fail CLOSED: reuse the last-known active set (or just BYO if cold).
 				Effect.catchCause((cause) =>
-					Effect.logWarning("Error active-org discovery failed; scanning all known orgs").pipe(
-						Effect.annotateLogs({ error: Cause.pretty(cause) }),
-						Effect.as("all" as const),
-					),
+					Effect.gen(function* () {
+						yield* Effect.logWarning(
+							"Error active-org discovery failed; reusing last-known active set",
+						).pipe(Effect.annotateLogs({ error: Cause.pretty(cause) }))
+						const cached = yield* edgeCache
+							.rawGet<ReadonlyArray<string>>(ACTIVE_ORGS_CACHE_BUCKET, ACTIVE_ORGS_CACHE_KEY)
+							.pipe(Effect.orElseSucceed(() => Option.none<ReadonlyArray<string>>()))
+						const active = new Set<string>(byo)
+						for (const orgId of Option.getOrElse(cached, () => [] as ReadonlyArray<string>)) {
+							active.add(orgId)
+						}
+						return active as ReadonlySet<string>
+					}),
 				),
 			)
 	})
@@ -2129,7 +2165,7 @@ const make: Effect.Effect<
 		})
 		const issuesRaw = isActive
 			? yield* warehouse
-					.compiledQuery(tenant, issuesCompiled, { context: "errorIssuesScan" })
+					.compiledQuery(tenant, issuesCompiled, { profile: "list", context: "errorIssuesScan" })
 					.pipe(Effect.mapError(makePersistenceError))
 			: []
 
@@ -2569,7 +2605,7 @@ const make: Effect.Effect<
 			...stateOrgs.map((r) => r.orgId),
 			...issueOrgs.map((r) => r.orgId),
 		])
-		const isActive = (org: string) => activeOrgs === "all" || activeOrgs.has(org) || withState.has(org)
+		const isActive = (org: string) => activeOrgs.has(org) || withState.has(org)
 
 		const emptyResult = {
 			issuesTouched: 0,
@@ -2617,7 +2653,7 @@ const make: Effect.Effect<
 
 		yield* Effect.annotateCurrentSpan({
 			orgsKnown: knownOrgs.size,
-			orgsScanned: activeOrgs === "all" ? knownOrgs.size : activeOrgs.size,
+			orgsScanned: activeOrgs.size,
 			orgFailures: yield* Ref.get(orgFailures),
 			...totals,
 		})

--- a/packages/query-engine/src/execution/executor.test.ts
+++ b/packages/query-engine/src/execution/executor.test.ts
@@ -176,4 +176,23 @@ describe("makeWarehouseExecutor client timeout", () => {
 			expect(yield* Ref.get(outcome)).toBe("@maple/http/errors/WarehouseQueryError")
 		}),
 	)
+
+	it.effect("does NOT client-timeout an explicitly unbounded query", () =>
+		Effect.gen(function* () {
+			const executor = makeWarehouseExecutor(makeHangingDeps())
+			const outcome = yield* Ref.make("pending")
+			yield* Effect.forkChild(
+				executor.compiledQuery(tenant, compiled, { profile: "unbounded", context: "test" }).pipe(
+					Effect.matchEffect({
+						onFailure: (error) => Ref.set(outcome, error._tag),
+						onSuccess: () => Ref.set(outcome, "success"),
+					}),
+				),
+			)
+			// Well past the 30s hard cap: `unbounded` opts out of the client timeout,
+			// so the query is never cut off (it only rides the ambient Worker limit).
+			yield* TestClock.adjust(Duration.seconds(60))
+			expect(yield* Ref.get(outcome)).toBe("pending")
+		}),
+	)
 })

--- a/packages/query-engine/src/execution/executor.test.ts
+++ b/packages/query-engine/src/execution/executor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Duration, Effect, Ref } from "effect"
+import { TestClock } from "effect/testing"
 import type { OrgId } from "@maple/domain"
 import { compile, listRuleChecksQuery } from "../ch"
 import { makeWarehouseExecutor } from "./executor"
@@ -136,6 +137,43 @@ describe("makeWarehouseExecutor restricted-settings strip", () => {
 				settings: { maxBlockSize: 512 },
 			})
 			expect(sqls[0]).toContain("max_block_size=512")
+		}),
+	)
+})
+
+// A client whose query never resolves — models a Tinybird request stuck in the
+// execution queue (the failure mode behind the 03:00–05:00 timeout storm, where
+// queries rode the ambient ~30s Worker fetch limit despite a server-side budget).
+const makeHangingDeps = (): WarehouseExecutorDeps => ({
+	createClient: () => ({
+		sql: () => new Promise<{ data: never[] }>(() => {}),
+		insert: async () => {},
+	}),
+	resolveConfig: () => Effect.succeed({ config: tinybirdConfig, source: "managed" as const }),
+	resolveIngestConfig: () => Effect.succeed({ config: tinybirdConfig, source: "managed" as const }),
+})
+
+describe("makeWarehouseExecutor client timeout", () => {
+	it.effect("bounds a hung managed query at the profile budget and fails non-transiently", () =>
+		Effect.gen(function* () {
+			const executor = makeWarehouseExecutor(makeHangingDeps())
+			const outcome = yield* Ref.make("pending")
+			// discovery profile ⇒ 5s server budget + 5s buffer = 10s client budget.
+			yield* Effect.forkChild(
+				executor.compiledQuery(tenant, compiled, { profile: "discovery", context: "test" }).pipe(
+					Effect.matchEffect({
+						onFailure: (error) => Ref.set(outcome, error._tag),
+						onSuccess: () => Ref.set(outcome, "success"),
+					}),
+				),
+			)
+			// Before the budget: still pending (not cut off early).
+			yield* TestClock.adjust(Duration.seconds(9))
+			expect(yield* Ref.get(outcome)).toBe("pending")
+			// Past the budget: the timeout fires as a non-transient WarehouseQueryError
+			// (so it is NOT fed back into the retry loop).
+			yield* TestClock.adjust(Duration.seconds(2))
+			expect(yield* Ref.get(outcome)).toBe("@maple/http/errors/WarehouseQueryError")
 		}),
 	)
 })

--- a/packages/query-engine/src/execution/executor.ts
+++ b/packages/query-engine/src/execution/executor.ts
@@ -1,4 +1,4 @@
-import { Clock, Effect, Ref, Schedule } from "effect"
+import { Clock, Duration, Effect, Ref, Schedule } from "effect"
 import {
 	type WarehouseQueryRequest,
 	WarehouseQueryResponse,
@@ -51,6 +51,23 @@ const TRANSIENT_RETRY_SCHEDULE = Schedule.exponential("100 millis", 2.0).pipe(
 
 const isTransientUpstreamError = (error: WarehouseSqlError): boolean =>
 	error instanceof WarehouseUpstreamError
+
+// Client-side ceiling for a single query attempt. Tinybird's server-side
+// `max_execution_time` is not always honored — when its query queue is saturated
+// the request sits waiting, then rides the ambient ~30s Cloudflare Worker fetch
+// timeout (observed: a `list`-profile query with `max_execution_time=15` still
+// aborting at 30s). We enforce our own bound derived from the query's cost
+// profile: the server budget plus headroom for queue + network. Queries with no
+// declared budget fall back to a hard 30s cap (no worse than the ambient limit).
+// The timeout maps to a non-transient WarehouseQueryError, so it fails fast
+// instead of feeding the retry loop.
+const CLIENT_TIMEOUT_BUFFER_MS = 5_000
+const MANAGED_QUERY_HARD_TIMEOUT_MS = 30_000
+
+const clientTimeoutMs = (maxExecutionTimeS: number | undefined): number =>
+	maxExecutionTimeS !== undefined
+		? maxExecutionTimeS * 1000 + CLIENT_TIMEOUT_BUFFER_MS
+		: MANAGED_QUERY_HARD_TIMEOUT_MS
 
 /**
  * Build the managed-warehouse executor. Owns SQL execution, retry, error
@@ -143,11 +160,25 @@ export const makeWarehouseExecutor = (deps: WarehouseExecutorDeps): WarehouseQue
 
 		const cacheKey = resolved.source === "managed" ? "__managed__" : tenant.orgId
 		const client = getCachedOrCreateClient(cacheKey, resolved.config, yield* Clock.currentTimeMillis)
+		const attemptTimeoutMs = clientTimeoutMs(settings?.maxExecutionTime)
 		const retryAttempts = yield* Ref.make(0)
 		const result = yield* Effect.tryPromise({
 			try: () => client.sql(finalSql),
 			catch: (error) => mapWarehouseError(pipe, error),
 		}).pipe(
+			// Bound each attempt: don't let a queued query ride the ambient ~30s
+			// Worker fetch limit past its declared budget. Non-transient, so it
+			// fails fast rather than retrying into a struggling warehouse.
+			Effect.timeoutOrElse({
+				duration: Duration.millis(attemptTimeoutMs),
+				orElse: () =>
+					Effect.fail(
+						toWarehouseQueryError(
+							pipe,
+							new Error(`Warehouse query exceeded ${attemptTimeoutMs}ms client timeout`),
+						),
+					),
+			}),
 			Effect.tapError((error) =>
 				isTransientUpstreamError(error) ? Ref.update(retryAttempts, (n) => n + 1) : Effect.void,
 			),

--- a/packages/query-engine/src/execution/executor.ts
+++ b/packages/query-engine/src/execution/executor.ts
@@ -9,7 +9,12 @@ import {
 import type { WarehouseQueryName } from "@maple/domain/warehouse-queries"
 import { compilePipeQuery, type CompiledQuery } from "../ch"
 import type { ExecutorQueryOptions, WarehouseExecutorShape } from "../observability"
-import { appendSettings, resolveSettings, stripTinybirdRestrictedSettings } from "../profiles"
+import {
+	appendSettings,
+	type QueryProfileName,
+	resolveSettings,
+	stripTinybirdRestrictedSettings,
+} from "../profiles"
 import { mapWarehouseError, toWarehouseQueryError, type WarehouseSqlError } from "./errors"
 import {
 	SQL_LOG_MAX,
@@ -59,15 +64,22 @@ const isTransientUpstreamError = (error: WarehouseSqlError): boolean =>
 // aborting at 30s). We enforce our own bound derived from the query's cost
 // profile: the server budget plus headroom for queue + network. Queries with no
 // declared budget fall back to a hard 30s cap (no worse than the ambient limit).
-// The timeout maps to a non-transient WarehouseQueryError, so it fails fast
-// instead of feeding the retry loop.
+// The `unbounded` profile is the explicit opt-out from cost limits, so it gets no
+// client cap either (documented for known-cheap queries; on Workers it still
+// rides the ambient ~30s limit). The timeout maps to a non-transient
+// WarehouseQueryError, so it fails fast instead of feeding the retry loop.
 const CLIENT_TIMEOUT_BUFFER_MS = 5_000
 const MANAGED_QUERY_HARD_TIMEOUT_MS = 30_000
 
-const clientTimeoutMs = (maxExecutionTimeS: number | undefined): number =>
-	maxExecutionTimeS !== undefined
+const clientTimeoutMs = (
+	profile: QueryProfileName | undefined,
+	maxExecutionTimeS: number | undefined,
+): number | undefined => {
+	if (profile === "unbounded") return undefined
+	return maxExecutionTimeS !== undefined
 		? maxExecutionTimeS * 1000 + CLIENT_TIMEOUT_BUFFER_MS
 		: MANAGED_QUERY_HARD_TIMEOUT_MS
+}
 
 /**
  * Build the managed-warehouse executor. Owns SQL execution, retry, error
@@ -160,25 +172,32 @@ export const makeWarehouseExecutor = (deps: WarehouseExecutorDeps): WarehouseQue
 
 		const cacheKey = resolved.source === "managed" ? "__managed__" : tenant.orgId
 		const client = getCachedOrCreateClient(cacheKey, resolved.config, yield* Clock.currentTimeMillis)
-		const attemptTimeoutMs = clientTimeoutMs(settings?.maxExecutionTime)
+		const attemptTimeoutMs = clientTimeoutMs(options?.profile, settings?.maxExecutionTime)
 		const retryAttempts = yield* Ref.make(0)
-		const result = yield* Effect.tryPromise({
+		const queryAttempt = Effect.tryPromise({
 			try: () => client.sql(finalSql),
 			catch: (error) => mapWarehouseError(pipe, error),
-		}).pipe(
+		})
+		const result = yield* (
 			// Bound each attempt: don't let a queued query ride the ambient ~30s
 			// Worker fetch limit past its declared budget. Non-transient, so it
-			// fails fast rather than retrying into a struggling warehouse.
-			Effect.timeoutOrElse({
-				duration: Duration.millis(attemptTimeoutMs),
-				orElse: () =>
-					Effect.fail(
-						toWarehouseQueryError(
-							pipe,
-							new Error(`Warehouse query exceeded ${attemptTimeoutMs}ms client timeout`),
-						),
-					),
-			}),
+			// fails fast rather than retrying into a struggling warehouse. Skipped
+			// entirely for the `unbounded` profile (explicit opt-out).
+			attemptTimeoutMs === undefined
+				? queryAttempt
+				: queryAttempt.pipe(
+						Effect.timeoutOrElse({
+							duration: Duration.millis(attemptTimeoutMs),
+							orElse: () =>
+								Effect.fail(
+									toWarehouseQueryError(
+										pipe,
+										new Error(`Warehouse query exceeded ${attemptTimeoutMs}ms client timeout`),
+									),
+								),
+						}),
+					)
+		).pipe(
 			Effect.tapError((error) =>
 				isTransientUpstreamError(error) ? Ref.update(retryAttempts, (n) => n + 1) : Effect.void,
 			),


### PR DESCRIPTION
## What & why

On 2026-07-01 (03:30–05:10 UTC) the **alerting** worker fired a burst of ~3,300 `WarehouseQueryError: "The operation was aborted due to timeout"` from its `error_tick` / `anomaly_tick` crons. It was **not** a Tinybird outage (`maple-api` warehouse queries were fine, alerting cron volume was flat) — it was a self-inflicted fan-out storm.

**Root cause:** active-org discovery **failed open**. A brief warehouse slowdown made the unbounded cross-org discovery query (`SELECT OrgId FROM error_events_by_time … GROUP BY OrgId`, no `OrgId` predicate ⇒ no primary-key pruning, no cost profile ⇒ no server-side `max_execution_time`) time out. On that failure the tick fell back to scanning **every known org** (hundreds) instead of the ~26 active ones — dumping maximum load exactly when the warehouse was already struggling, which sustained the storm for ~90 min until the blip cleared.

The telemetry fingerprint (per-10-min `executeSql` spans, distinct orgs scanned):

| Time (UTC) | queries | timeouts | distinct orgs | p90 |
|---|---|---|---|---|
| 02:30–03:20 | ~630 | 0 | 26 | 0.3s |
| 03:40–04:20 | ~38 | ~28 | 1 | 30.2s |
| 04:40 | 722 | 483 | 101 | 30.2s |
| 05:00 | 2521 | 58 | 252 | 0.9s |
| 05:10+ | ~625 | 0 | 26 | 0.4s |

## The fix (low-risk hardening, reuses existing machinery)

- **P0a — bound the trigger:** discovery queries now use the existing `discovery` cost profile (5s server-side) instead of riding the ~30s client abort.
- **P0b — fail *closed*:** on discovery failure, reuse the **last-known active-org set** (edge-cached, 6h TTL) instead of fanning out to all orgs. Cold cache → just BYO + the `withState` / open-incident floor (so resolution/aging keeps running). The `"all"` sentinel is removed entirely. Wires `EdgeCacheService` into `ErrorsService` (Anomaly already had it).
- **P1a — bound per-org scans:** `errorIssuesScan` now carries the `list` profile (15s) so a scan can't hang the full ~30s.
- **P1b — client timeout:** each managed query attempt in the executor is bounded at `server budget + 5s` (or a 30s hard cap), mapped to a **non-transient** `WarehouseQueryError` so a queued query fails fast instead of feeding the retry loop. This directly addresses the observed case where a `list` query with `max_execution_time=15` still rode to 30s because Tinybird queued it.

Deferred: P2 (per-tick circuit breaker + overall tick timeout) — follow-up.

## Reviewer notes

- Happy-path behavior is unchanged: discovery success still returns the active set (now also cached); only the failure path changed (was `"all"`, now cached/BYO).
- `ErrorsService` gains an `EdgeCacheService` dependency — wired in `app.ts` and the test layer.
- Backend cron/warehouse logic, nothing browser-observable.

## Tests

New: fail-closed gating (stateful orgs still scanned, idle orgs skipped), profile assertions (discovery→`discovery`, scan→`list`), and a hung-query timeout test (bounded + non-transient). 

- `query-engine`: 648 pass, typecheck clean
- `apps/api` ErrorsService + anomaly: 85 pass, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->