### PR TITLE
fix(dashboards): make default widgets & templates work with demo data + chart polish (MAP-49)

### DIFF
--- a/apps/api/src/dashboard-templates/application/jvm-runtime.ts
+++ b/apps/api/src/dashboard-templates/application/jvm-runtime.ts
@@ -1,5 +1,4 @@
 import {
-	CHART_DISPLAY_AREA,
 	CHART_DISPLAY_LINE,
 	buildPortableDashboard,
 	metricsBreakdown,
@@ -44,6 +43,9 @@ function widgets(serviceName?: string): WidgetDef[] {
 			layout: { x: 6, y: 0, w: 6, h: 4 },
 		},
 		{
+			// The query-builder metrics source supports avg/sum/min/max/count/rate/
+			// increase only — no percentiles over histogram buckets — so chart the
+			// worst pause per bucket (max over the histogram's Max column).
 			id: "gc-pause",
 			visualization: "chart",
 			dataSource: metricsTimeseries({
@@ -51,11 +53,11 @@ function widgets(serviceName?: string): WidgetDef[] {
 				name: "GC Pause",
 				metricName: "jvm.gc.duration",
 				metricType: "histogram",
-				aggregation: "p95_duration",
+				aggregation: "max",
 				whereClause: where,
 				groupBy,
 			}),
-			display: { title: "GC Pause Time (P95)", ...CHART_DISPLAY_AREA, unit: "duration_ms" },
+			display: { title: "GC Pause Time (Max)", ...CHART_DISPLAY_LINE, unit: "duration_ms" },
 			layout: { x: 0, y: 4, w: 6, h: 4 },
 		},
 		{
@@ -102,6 +104,7 @@ export const jvmRuntimeTemplate: TemplateDefinition = {
 	category: "application",
 	tags: ["jvm", "runtime"],
 	requirements: ["OpenTelemetry JVM instrumentation"],
+	requiredMetricPrefixes: ["jvm."],
 	parameters: [
 		{
 			key: paramKey("service_name"),

--- a/apps/api/src/dashboard-templates/application/metric-overview.ts
+++ b/apps/api/src/dashboard-templates/application/metric-overview.ts
@@ -119,6 +119,9 @@ export const metricOverviewTemplate: TemplateDefinition = {
 	category: "application",
 	tags: ["metrics"],
 	requirements: ["OpenTelemetry metrics"],
+	// Empty-string prefix matches any metric name — this template is usable
+	// as soon as the org has at least one metric of any kind.
+	requiredMetricPrefixes: [""],
 	parameters: [
 		{
 			key: paramKey("metric_name"),

--- a/apps/api/src/dashboard-templates/application/nodejs-runtime.ts
+++ b/apps/api/src/dashboard-templates/application/nodejs-runtime.ts
@@ -15,18 +15,22 @@ function widgets(serviceName?: string): WidgetDef[] {
 	const groupBy = ["service.name"]
 	return [
 		{
+			// The query-builder metrics source supports avg/sum/min/max/count/rate/
+			// increase only — no percentiles — and event-loop lag is emitted as a
+			// gauge (ms) by the Node.js runtime instrumentation, so chart the
+			// worst-case lag per bucket instead of a P95.
 			id: "event-loop-lag",
 			visualization: "chart",
 			dataSource: metricsTimeseries({
 				id: "node-eventloop-lag",
 				name: "Event Loop Lag",
 				metricName: "process.runtime.nodejs.eventloop.lag",
-				metricType: "histogram",
-				aggregation: "p95_duration",
+				metricType: "gauge",
+				aggregation: "max",
 				whereClause: where,
 				groupBy,
 			}),
-			display: { title: "Event Loop Lag (P95)", ...CHART_DISPLAY_AREA, unit: "duration_ms" },
+			display: { title: "Event Loop Lag (Max)", ...CHART_DISPLAY_LINE, unit: "duration_ms" },
 			layout: { x: 0, y: 0, w: 6, h: 4 },
 		},
 		{
@@ -83,6 +87,7 @@ export const nodejsRuntimeTemplate: TemplateDefinition = {
 	category: "application",
 	tags: ["nodejs", "runtime"],
 	requirements: ["OpenTelemetry Node.js instrumentation"],
+	requiredMetricPrefixes: ["process.runtime.nodejs."],
 	parameters: [
 		{
 			key: paramKey("service_name"),

--- a/apps/api/src/dashboard-templates/database/mongodb.ts
+++ b/apps/api/src/dashboard-templates/database/mongodb.ts
@@ -98,6 +98,7 @@ export const mongodbTemplate: TemplateDefinition = {
 	category: "database",
 	tags: ["mongodb", "database"],
 	requirements: ["OpenTelemetry mongodbreceiver"],
+	requiredMetricPrefixes: ["mongodb."],
 	parameters: [
 		{
 			key: paramKey("service_name"),

--- a/apps/api/src/dashboard-templates/database/mysql.ts
+++ b/apps/api/src/dashboard-templates/database/mysql.ts
@@ -111,6 +111,7 @@ export const mysqlTemplate: TemplateDefinition = {
 	category: "database",
 	tags: ["mysql", "database"],
 	requirements: ["OpenTelemetry mysqlreceiver"],
+	requiredMetricPrefixes: ["mysql."],
 	parameters: [
 		{
 			key: paramKey("service_name"),

--- a/apps/api/src/dashboard-templates/database/postgres.ts
+++ b/apps/api/src/dashboard-templates/database/postgres.ts
@@ -114,6 +114,7 @@ export const postgresTemplate: TemplateDefinition = {
 	category: "database",
 	tags: ["postgres", "database"],
 	requirements: ["OpenTelemetry postgresreceiver"],
+	requiredMetricPrefixes: ["postgresql."],
 	parameters: [
 		{
 			key: paramKey("service_name"),

--- a/apps/api/src/dashboard-templates/database/redis.ts
+++ b/apps/api/src/dashboard-templates/database/redis.ts
@@ -109,6 +109,7 @@ export const redisTemplate: TemplateDefinition = {
 	category: "database",
 	tags: ["redis", "cache"],
 	requirements: ["OpenTelemetry redisreceiver"],
+	requiredMetricPrefixes: ["redis."],
 	parameters: [
 		{
 			key: paramKey("service_name"),

--- a/apps/api/src/dashboard-templates/index.ts
+++ b/apps/api/src/dashboard-templates/index.ts
@@ -100,6 +100,7 @@ export function listTemplateMetadata(): TemplateMetadata[] {
 		category: t.category,
 		tags: t.tags,
 		requirements: t.requirements,
+		requiredMetricPrefixes: t.requiredMetricPrefixes ?? [],
 		parameters: t.parameters,
 		preview: TEMPLATE_PREVIEWS.get(t.id) ?? [],
 	}))

--- a/apps/api/src/dashboard-templates/infrastructure/host-metrics.ts
+++ b/apps/api/src/dashboard-templates/infrastructure/host-metrics.ts
@@ -10,13 +10,15 @@ import {
 } from "../helpers"
 import type { TemplateDefinition, WidgetDef } from "../types"
 
+// Host identity (`host.name`) lives on ResourceAttributes — the metrics
+// query-builder reaches it via the `resource.` prefix.
 function hostWhere(hostName?: string): string {
-	return hostName ? `host.name = "${hostName}"` : ""
+	return hostName ? `resource.host.name = "${hostName}"` : ""
 }
 
 function widgets(hostName?: string): WidgetDef[] {
 	const where = hostWhere(hostName)
-	const groupBy = ["host.name"]
+	const groupBy = ["resource.host.name"]
 	return [
 		{
 			id: "cpu",
@@ -116,6 +118,7 @@ export const hostMetricsTemplate: TemplateDefinition = {
 	category: "infrastructure",
 	tags: ["host", "infra"],
 	requirements: ["OpenTelemetry hostmetricsreceiver"],
+	requiredMetricPrefixes: ["system."],
 	parameters: [
 		{
 			key: paramKey("host_name"),

--- a/apps/api/src/dashboard-templates/infrastructure/kubernetes-cluster.ts
+++ b/apps/api/src/dashboard-templates/infrastructure/kubernetes-cluster.ts
@@ -11,7 +11,9 @@ import {
 import type { TemplateDefinition, WidgetDef } from "../types"
 
 function widgets(clusterName?: string): WidgetDef[] {
-	const where = combineWhere(clusterName ? `k8s.cluster.name = "${clusterName}"` : "")
+	// Node/namespace/cluster identity lives on ResourceAttributes — the metrics
+	// query-builder reaches it via the `resource.` prefix.
+	const where = combineWhere(clusterName ? `resource.k8s.cluster.name = "${clusterName}"` : "")
 	return [
 		{
 			id: "node-count",
@@ -22,7 +24,7 @@ function widgets(clusterName?: string): WidgetDef[] {
 				metricName: "k8s.node.condition_ready",
 				metricType: "gauge",
 				whereClause: where,
-				groupBy: ["k8s.node.name"],
+				groupBy: ["resource.k8s.node.name"],
 			}),
 			display: { title: "Node Ready Status", ...CHART_DISPLAY_LINE, unit: "number" },
 			layout: { x: 0, y: 0, w: 6, h: 4 },
@@ -36,7 +38,7 @@ function widgets(clusterName?: string): WidgetDef[] {
 				metricName: "k8s.pod.phase",
 				metricType: "gauge",
 				whereClause: where,
-				groupBy: ["k8s.namespace.name"],
+				groupBy: ["resource.k8s.namespace.name"],
 			}),
 			display: { title: "Pod Phase by Namespace", ...CHART_DISPLAY_AREA, unit: "number" },
 			layout: { x: 6, y: 0, w: 6, h: 4 },
@@ -50,7 +52,7 @@ function widgets(clusterName?: string): WidgetDef[] {
 				metricName: "k8s.deployment.available",
 				metricType: "gauge",
 				whereClause: where,
-				groupBy: ["k8s.namespace.name"],
+				groupBy: ["resource.k8s.namespace.name"],
 			}),
 			display: { title: "Deployment Availability", ...CHART_DISPLAY_LINE, unit: "number" },
 			layout: { x: 0, y: 4, w: 6, h: 4 },
@@ -64,7 +66,7 @@ function widgets(clusterName?: string): WidgetDef[] {
 				metricName: "k8s.namespace.phase",
 				metricType: "gauge",
 				whereClause: where,
-				groupBy: ["k8s.namespace.name"],
+				groupBy: ["resource.k8s.namespace.name"],
 			}),
 			display: { title: "Namespace Phase", ...CHART_DISPLAY_AREA, unit: "number" },
 			layout: { x: 6, y: 4, w: 6, h: 4 },
@@ -79,6 +81,7 @@ export const kubernetesClusterTemplate: TemplateDefinition = {
 	category: "infrastructure",
 	tags: ["kubernetes", "k8s"],
 	requirements: ["OpenTelemetry k8sclusterreceiver"],
+	requiredMetricPrefixes: ["k8s."],
 	parameters: [
 		{
 			key: paramKey("cluster_name"),

--- a/apps/api/src/dashboard-templates/infrastructure/kubernetes-pod.ts
+++ b/apps/api/src/dashboard-templates/infrastructure/kubernetes-pod.ts
@@ -11,8 +11,10 @@ import {
 import type { TemplateDefinition, WidgetDef } from "../types"
 
 function widgets(namespace?: string): WidgetDef[] {
-	const where = combineWhere(namespace ? `k8s.namespace.name = "${namespace}"` : "")
-	const groupBy = ["k8s.pod.name"]
+	// Pod/namespace identity lives on ResourceAttributes — the metrics
+	// query-builder reaches it via the `resource.` prefix.
+	const where = combineWhere(namespace ? `resource.k8s.namespace.name = "${namespace}"` : "")
+	const groupBy = ["resource.k8s.pod.name"]
 	return [
 		{
 			id: "pod-cpu",
@@ -82,6 +84,7 @@ export const kubernetesPodTemplate: TemplateDefinition = {
 	category: "infrastructure",
 	tags: ["kubernetes", "k8s", "pods"],
 	requirements: ["OpenTelemetry kubeletstatsreceiver", "OpenTelemetry k8sclusterreceiver"],
+	requiredMetricPrefixes: ["k8s.pod."],
 	parameters: [
 		{
 			key: paramKey("namespace"),

--- a/apps/api/src/dashboard-templates/messaging/kafka.ts
+++ b/apps/api/src/dashboard-templates/messaging/kafka.ts
@@ -93,6 +93,7 @@ export const kafkaTemplate: TemplateDefinition = {
 	category: "messaging",
 	tags: ["kafka", "messaging"],
 	requirements: ["OpenTelemetry kafkametricsreceiver"],
+	requiredMetricPrefixes: ["kafka."],
 	parameters: [
 		{
 			key: paramKey("service_name"),

--- a/apps/api/src/dashboard-templates/messaging/nats.ts
+++ b/apps/api/src/dashboard-templates/messaging/nats.ts
@@ -92,6 +92,7 @@ export const natsTemplate: TemplateDefinition = {
 	category: "messaging",
 	tags: ["nats", "messaging"],
 	requirements: ["NATS Prometheus exporter via prometheusreceiver"],
+	requiredMetricPrefixes: ["nats."],
 	parameters: [
 		{
 			key: paramKey("service_name"),

--- a/apps/api/src/dashboard-templates/messaging/rabbitmq.ts
+++ b/apps/api/src/dashboard-templates/messaging/rabbitmq.ts
@@ -98,6 +98,7 @@ export const rabbitmqTemplate: TemplateDefinition = {
 	category: "messaging",
 	tags: ["rabbitmq", "messaging"],
 	requirements: ["OpenTelemetry rabbitmqreceiver"],
+	requiredMetricPrefixes: ["rabbitmq."],
 	parameters: [
 		{
 			key: paramKey("service_name"),

--- a/apps/api/src/dashboard-templates/query-specs.test.ts
+++ b/apps/api/src/dashboard-templates/query-specs.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Schema } from "effect"
+import { QueryBuilderQueryDraftSchema } from "@maple/domain/http"
+import { buildBreakdownQuerySpec, buildTimeseriesQuerySpec } from "@maple/query-engine/query-builder"
+import type { BuildSpecResult } from "@maple/query-engine/query-builder"
+import { DASHBOARD_TEMPLATES } from "./index"
+import type { TemplateDefinition, TemplateParameterValues } from "./types"
+
+// "Templates never rot" guard (mirrors the widget-preset guard in
+// apps/web/src/components/dashboard-builder/widgets/widget-definitions.test.ts):
+// every query-builder-backed widget in every dashboard template must decode as
+// a valid query draft and lower to a QuerySpec with no warnings. The original
+// bug — the Node.js/JVM runtime templates using `p95_duration` on a metrics
+// query, which the engine rejects outright — shipped widgets that could never
+// render, and nothing caught it.
+
+const decodeQueryDraft = Schema.decodeUnknownSync(QueryBuilderQueryDraftSchema)
+
+function sampleParams(template: TemplateDefinition): TemplateParameterValues {
+	const values: TemplateParameterValues = {}
+	for (const param of template.parameters) {
+		if (param.required) {
+			values[param.key] = param.placeholder ?? "sample"
+		}
+	}
+	return values
+}
+
+// Optional params usually thread scoping filters (host_name, cluster_name,
+// namespace, …) into where clauses. Building with every param filled ensures
+// those clauses actually lower — an optional filter the engine ignores with a
+// warning (e.g. an unsupported key) must fail the guard, not silently no-op.
+function allParams(template: TemplateDefinition): TemplateParameterValues {
+	const values: TemplateParameterValues = {}
+	for (const param of template.parameters) {
+		values[param.key] = param.placeholder ?? "sample"
+	}
+	return values
+}
+
+function specBuilderFor(
+	endpoint: string,
+): ((query: Parameters<typeof buildTimeseriesQuerySpec>[0]) => BuildSpecResult) | null {
+	if (endpoint === "custom_query_builder_timeseries") return buildTimeseriesQuerySpec
+	if (endpoint === "custom_query_builder_breakdown") return buildBreakdownQuerySpec
+	return null
+}
+
+describe("dashboard template query specs", () => {
+	let checkedQueries = 0
+
+	function checkTemplate(template: TemplateDefinition, params: TemplateParameterValues, variant: string) {
+		const built = template.build(params)
+		for (const widget of built.widgets) {
+			const buildSpec = specBuilderFor(widget.dataSource.endpoint)
+			if (!buildSpec) continue
+
+			const rawQueries = widget.dataSource.params?.queries
+			expect(Array.isArray(rawQueries), `${template.id}/${widget.id}: params.queries`).toBe(true)
+			if (!Array.isArray(rawQueries)) continue
+			expect(rawQueries.length, `${template.id}/${widget.id}`).toBeGreaterThan(0)
+
+			for (const raw of rawQueries) {
+				const query = decodeQueryDraft(raw)
+				const result = buildSpec(query)
+				const label = `${template.id}/${widget.id}/${query.name} (${variant})`
+				expect(result.query, `${label}: ${result.error ?? ""}`).not.toBeNull()
+				expect(result.warnings, label).toEqual([])
+				checkedQueries++
+			}
+		}
+	}
+
+	for (const template of DASHBOARD_TEMPLATES) {
+		it(`${template.id} query-builder widgets lower to valid query specs`, () => {
+			checkTemplate(template, sampleParams(template), "required params")
+			// Second pass with every optional param filled: scoping params must
+			// emit where clauses the engine actually honors — an ignored filter
+			// surfaces as a warning and fails here.
+			if (template.parameters.some((p) => !p.required)) {
+				checkTemplate(template, allParams(template), "all params")
+			}
+		})
+	}
+
+	// If the query-builder endpoints are ever renamed, the loop above would
+	// silently skip everything and the guard would pass vacuously.
+	it("exercises at least one query-builder widget across templates", () => {
+		expect(checkedQueries).toBeGreaterThan(0)
+	})
+})

--- a/apps/api/src/dashboard-templates/types.ts
+++ b/apps/api/src/dashboard-templates/types.ts
@@ -35,6 +35,13 @@ export interface TemplateDefinition {
 	category: DashboardTemplateCategory
 	tags: readonly string[]
 	requirements: readonly string[]
+	/**
+	 * Metric-name prefixes this template's widgets query. The template picker
+	 * greys out a template when the org has no metric matching every prefix —
+	 * a metrics-only template renders entirely empty without them. Empty/absent
+	 * means the template is never gated (trace/log templates).
+	 */
+	requiredMetricPrefixes?: readonly string[]
 	parameters: readonly TemplateParameter[]
 	build: (params: TemplateParameterValues) => PortableDashboardDocument
 }
@@ -55,6 +62,7 @@ export interface TemplateMetadata {
 	category: DashboardTemplateCategory
 	tags: readonly string[]
 	requirements: readonly string[]
+	requiredMetricPrefixes: readonly string[]
 	parameters: readonly TemplateParameter[]
 	preview: readonly TemplatePreviewWidget[]
 }

--- a/apps/api/src/routes/dashboards.http.ts
+++ b/apps/api/src/routes/dashboards.http.ts
@@ -106,6 +106,7 @@ export const HttpDashboardsLive = HttpApiBuilder.group(MapleApi, "dashboards", (
 										category: t.category,
 										tags: t.tags,
 										requirements: t.requirements,
+										requiredMetricPrefixes: t.requiredMetricPrefixes,
 										parameters: t.parameters,
 										preview: t.preview,
 									}),

--- a/apps/api/src/services/DemoService.ts
+++ b/apps/api/src/services/DemoService.ts
@@ -25,13 +25,16 @@ export class DemoService extends Context.Service<DemoService>()("@maple/api/serv
 			hours: number = DEMO_HOURS_DEFAULT,
 		) {
 			const safeHours = Math.max(1, Math.min(24, Math.floor(hours)))
-			const { traceRows, logRows } = generateDemoRows({
+			const { traceRows, logRows, metricGaugeRows, metricSumRows } = generateDemoRows({
 				orgId: tenant.orgId,
 				hours: safeHours,
 				ratePerHour: DEMO_RATE_PER_HOUR,
 			})
 
-			const ingestAll = (datasource: "traces" | "logs", rows: ReadonlyArray<unknown>) =>
+			const ingestAll = (
+				datasource: "traces" | "logs" | "metrics_gauge" | "metrics_sum",
+				rows: ReadonlyArray<unknown>,
+			) =>
 				Effect.forEach(
 					chunk(rows, INGEST_CHUNK),
 					(batch) =>
@@ -47,13 +50,17 @@ export class DemoService extends Context.Service<DemoService>()("@maple/api/serv
 			// before the user has picked a plan).
 			yield* ingestAll("traces", traceRows)
 			yield* ingestAll("logs", logRows)
+			// Runtime metrics so metric-based dashboard templates (Node.js
+			// Runtime, Metric Overview) have data to show.
+			yield* ingestAll("metrics_gauge", metricGaugeRows)
+			yield* ingestAll("metrics_sum", metricSumRows)
 
 			return new DemoSeedResponse({
 				seeded: true,
 				skippedReason: null,
 				spansSent: traceRows.length,
 				logsSent: logRows.length,
-				metricsSent: 0,
+				metricsSent: metricGaugeRows.length + metricSumRows.length,
 			})
 		})
 

--- a/apps/api/src/services/demo/fixtures.test.ts
+++ b/apps/api/src/services/demo/fixtures.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+import { generateDemoRows } from "./fixtures"
+
+describe("generateDemoRows metrics", () => {
+	const rows = generateDemoRows({ orgId: "org_test", hours: 2, ratePerHour: 10 })
+
+	it("emits runtime gauge and sum metrics alongside traces/logs", () => {
+		expect(rows.metricGaugeRows.length).toBeGreaterThan(0)
+		expect(rows.metricSumRows.length).toBeGreaterThan(0)
+
+		const gaugeNames = new Set(rows.metricGaugeRows.map((r) => r.metric_name))
+		expect(gaugeNames).toEqual(
+			new Set([
+				"process.runtime.nodejs.memory.heap.used",
+				"process.runtime.nodejs.handles",
+				"process.runtime.nodejs.eventloop.lag",
+			]),
+		)
+		const sumNames = new Set(rows.metricSumRows.map((r) => r.metric_name))
+		expect(sumNames).toEqual(new Set(["process.runtime.nodejs.gc.count"]))
+	})
+
+	it("scopes every metric row to the org (maple_org_id drives OrgId)", () => {
+		for (const row of [...rows.metricGaugeRows, ...rows.metricSumRows]) {
+			expect(row.resource_attributes.maple_org_id).toBe("org_test")
+			expect(["demo-api", "demo-worker"]).toContain(row.service_name)
+		}
+	})
+
+	it("marks sums as cumulative monotonic counters with non-decreasing values per service", () => {
+		const byService = new Map<string, number[]>()
+		for (const row of rows.metricSumRows) {
+			expect(row.aggregation_temporality).toBe(2)
+			expect(row.is_monotonic).toBe(true)
+			const list = byService.get(row.service_name) ?? []
+			list.push(row.value)
+			byService.set(row.service_name, list)
+		}
+		for (const [service, values] of byService) {
+			for (let i = 1; i < values.length; i++) {
+				expect(values[i], `${service} gc.count at ${i}`).toBeGreaterThanOrEqual(values[i - 1])
+			}
+		}
+	})
+
+	it("stamps timestamps inside the seeded window (ClickHouse DateTime64 format)", () => {
+		const now = Date.now()
+		const windowStart = now - 2 * 3600 * 1000 - 60_000
+		for (const row of rows.metricGaugeRows.slice(0, 20)) {
+			expect(row.timestamp).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/)
+			const ms = new Date(`${row.timestamp.replace(" ", "T")}Z`).getTime()
+			expect(ms).toBeGreaterThanOrEqual(windowStart)
+			expect(ms).toBeLessThanOrEqual(now + 60_000)
+		}
+	})
+})

--- a/apps/api/src/services/demo/fixtures.ts
+++ b/apps/api/src/services/demo/fixtures.ts
@@ -87,9 +87,47 @@ interface LogRow {
 	log_attributes: Attrs
 }
 
-export interface DemoRows {
+/**
+ * One row in the `metrics_gauge` datasource (collector Tinybird exporter
+ * shape — see metricsGauge in packages/domain/src/tinybird/datasources.ts).
+ */
+interface MetricGaugeRow {
+	timestamp: string
+	start_timestamp: string
+	metric_name: string
+	metric_description: string
+	metric_unit: string
+	metric_attributes: Attrs
+	service_name: string
+	resource_schema_url: string
+	resource_attributes: Attrs
+	scope_schema_url: string
+	scope_name: string
+	scope_version: string
+	scope_attributes: Attrs
+	value: number
+	flags: number
+	exemplars_trace_id: string[]
+	exemplars_span_id: string[]
+	exemplars_timestamp: string[]
+	exemplars_value: number[]
+	exemplars_filtered_attributes: Attrs[]
+}
+
+/** One row in the `metrics_sum` datasource. */
+interface MetricSumRow extends MetricGaugeRow {
+	aggregation_temporality: number
+	is_monotonic: boolean
+}
+
+interface DemoTraceBatch {
 	traceRows: TraceRow[]
 	logRows: LogRow[]
+}
+
+export interface DemoRows extends DemoTraceBatch {
+	metricGaugeRows: MetricGaugeRow[]
+	metricSumRows: MetricSumRow[]
 }
 
 const SCOPE_NAME = "@maple/demo-instr"
@@ -185,7 +223,7 @@ const makeLogRow = (
 	...over,
 })
 
-function generateHttpTrace(timestamp: Date, orgId: string): DemoRows {
+function generateHttpTrace(timestamp: Date, orgId: string): DemoTraceBatch {
 	const route = pick(HTTP_ROUTES)
 	const traceId = traceIdHex()
 	const rootSpanId = spanIdHex()
@@ -277,7 +315,7 @@ function generateHttpTrace(timestamp: Date, orgId: string): DemoRows {
 	return { traceRows: [apiRow, dbRow], logRows }
 }
 
-function generateWorkerTrace(timestamp: Date, orgId: string): DemoRows {
+function generateWorkerTrace(timestamp: Date, orgId: string): DemoTraceBatch {
 	const job = pick(WORKER_JOBS)
 	const traceId = traceIdHex()
 	const spanId = spanIdHex()
@@ -320,6 +358,98 @@ function generateWorkerTrace(timestamp: Date, orgId: string): DemoRows {
 	return { traceRows: [row], logRows: [] }
 }
 
+// ---------------------------------------------------------------------------
+// Demo runtime metrics — Node.js process gauges/counters for demo-api and
+// demo-worker, one point per service per minute. These make the metric-based
+// dashboard templates (Node.js Runtime, Metric Overview) show real data
+// instead of rendering empty against demo orgs.
+// ---------------------------------------------------------------------------
+
+const METRIC_SERVICES = ["demo-api", "demo-worker"] as const satisfies readonly DemoServiceName[]
+const METRIC_INTERVAL_MS = 60_000
+
+const makeMetricBase = (service: DemoServiceName, orgId: string, startMs: number, tsMs: number) => ({
+	timestamp: fmtTs(tsMs),
+	start_timestamp: fmtTs(startMs),
+	metric_description: "",
+	metric_attributes: { "maple.demo": "true" } as Attrs,
+	service_name: service,
+	resource_schema_url: "",
+	resource_attributes: resourceAttrs(service, orgId),
+	scope_schema_url: "",
+	scope_name: SCOPE_NAME,
+	scope_version: "",
+	scope_attributes: {} as Attrs,
+	flags: 0,
+	exemplars_trace_id: [] as string[],
+	exemplars_span_id: [] as string[],
+	exemplars_timestamp: [] as string[],
+	exemplars_value: [] as number[],
+	exemplars_filtered_attributes: [] as Attrs[],
+})
+
+function generateRuntimeMetrics(
+	orgId: string,
+	startMs: number,
+	endMs: number,
+): { metricGaugeRows: MetricGaugeRow[]; metricSumRows: MetricSumRow[] } {
+	const metricGaugeRows: MetricGaugeRow[] = []
+	const metricSumRows: MetricSumRow[] = []
+
+	for (const [serviceIdx, service] of METRIC_SERVICES.entries()) {
+		// Cumulative monotonic GC counter, per service.
+		let gcCount = 0
+		let point = 0
+		for (let tsMs = startMs; tsMs <= endMs; tsMs += METRIC_INTERVAL_MS, point++) {
+			const base = makeMetricBase(service, orgId, startMs, tsMs)
+			// Slow sine around ~120MB with per-service phase offset + jitter.
+			const heapUsed =
+				120e6 + 30e6 * Math.sin(point / 20 + serviceIdx * 1.7) + (Math.random() - 0.5) * 8e6
+			metricGaugeRows.push({
+				...base,
+				metric_name: "process.runtime.nodejs.memory.heap.used",
+				metric_unit: "By",
+				value: Math.max(40e6, Math.round(heapUsed)),
+			})
+			metricGaugeRows.push({
+				...base,
+				metric_name: "process.runtime.nodejs.handles",
+				metric_unit: "{handles}",
+				value: Math.max(
+					8,
+					Math.round(50 + 18 * Math.sin(point / 12 + serviceIdx) + (Math.random() - 0.5) * 10),
+				),
+			})
+			// Event loop lag gauge in ms — calm ~8ms baseline with occasional
+			// spikes so the Node.js Runtime template's "Event Loop Lag (Max)"
+			// panel shows visible structure against demo orgs.
+			const lagSpikeMs = Math.random() < 0.06 ? 20 + Math.random() * 60 : 0
+			metricGaugeRows.push({
+				...base,
+				metric_name: "process.runtime.nodejs.eventloop.lag",
+				metric_unit: "ms",
+				value: Math.max(
+					1,
+					Math.round(
+						8 + 3 * Math.sin(point / 15 + serviceIdx * 2.3) + (Math.random() - 0.5) * 4 + lagSpikeMs,
+					),
+				),
+			})
+			gcCount += Math.max(0, Math.round(gaussian(4, 2)))
+			metricSumRows.push({
+				...base,
+				metric_name: "process.runtime.nodejs.gc.count",
+				metric_unit: "{collections}",
+				value: gcCount,
+				aggregation_temporality: 2, // cumulative
+				is_monotonic: true,
+			})
+		}
+	}
+
+	return { metricGaugeRows, metricSumRows }
+}
+
 export function generateDemoRows({
 	orgId,
 	hours,
@@ -334,9 +464,10 @@ export function generateDemoRows({
 	const logRows: LogRow[] = []
 
 	const totalTraces = hours * ratePerHour
+	const startMs = now - hours * 3600 * 1000
 	for (let i = 0; i < totalTraces; i++) {
 		const offsetMs = Math.floor((i / totalTraces) * hours * 3600 * 1000)
-		const ts = new Date(now - hours * 3600 * 1000 + offsetMs)
+		const ts = new Date(startMs + offsetMs)
 
 		const isWorker = Math.random() < 0.25
 		const result = isWorker ? generateWorkerTrace(ts, orgId) : generateHttpTrace(ts, orgId)
@@ -345,5 +476,7 @@ export function generateDemoRows({
 		logRows.push(...result.logRows)
 	}
 
-	return { traceRows, logRows }
+	const { metricGaugeRows, metricSumRows } = generateRuntimeMetrics(orgId, startMs, now)
+
+	return { traceRows, logRows, metricGaugeRows, metricSumRows }
 }

--- a/apps/web/src/api/warehouse/query-builder-breakdown.test.ts
+++ b/apps/web/src/api/warehouse/query-builder-breakdown.test.ts
@@ -1,12 +1,56 @@
 import { describe, expect, it } from "vitest"
 
 import * as breakdownModule from "@/api/warehouse/query-builder-breakdown"
+import { __testables, type QueryBuilderBreakdownInput } from "@/api/warehouse/query-builder-breakdown"
 
 describe("query-builder breakdown units", () => {
 	it("does not rescale error_rate values — the engine's 0–1 ratio is canonical", () => {
 		// Regression guard: a ÷100 "normalize" survived from the Tinybird-pipe
 		// era (which returned percent points) long after the CH engine switched
 		// to emitting ratios, making error_rate breakdowns 100× too small.
-		expect(breakdownModule).not.toHaveProperty("__testables")
+		expect(breakdownModule.__testables).not.toHaveProperty("normalizeErrorRatePoints")
+	})
+})
+
+describe("mergeBreakdownResults legend naming (MAP-49)", () => {
+	const queryDraft = (id: string, name: string, legend: string) =>
+		({
+			id,
+			name,
+			legend,
+			enabled: true,
+		}) as unknown as QueryBuilderBreakdownInput["queries"][number]
+
+	const result = (queryId: string, queryName: string, data: Array<{ name: string; value: number }>) => ({
+		queryId,
+		queryName,
+		status: "success" as const,
+		error: null,
+		data,
+	})
+
+	it("uses query legends as merged column names, so heatmap axes read 'Errors'/'OK' instead of 'A'/'B'", () => {
+		const rows = __testables.mergeBreakdownResults(
+			[
+				result("q-a", "A", [{ name: "demo-api", value: 12 }]),
+				result("q-b", "B", [
+					{ name: "demo-api", value: 480 },
+					{ name: "demo-worker", value: 210 },
+				]),
+			],
+			[queryDraft("q-a", "A", "Errors"), queryDraft("q-b", "B", "OK")],
+		)
+
+		expect(rows).toContainEqual({ name: "demo-api", Errors: 12, OK: 480 })
+		expect(rows).toContainEqual({ name: "demo-worker", Errors: 0, OK: 210 })
+	})
+
+	it("falls back to the query name when no legend is set", () => {
+		const rows = __testables.mergeBreakdownResults(
+			[result("q-a", "A", [{ name: "x", value: 1 }]), result("q-b", "B", [{ name: "x", value: 2 }])],
+			[queryDraft("q-a", "A", ""), queryDraft("q-b", "B", "")],
+		)
+
+		expect(rows).toEqual([{ name: "x", A: 1, B: 2 }])
 	})
 })

--- a/apps/web/src/api/warehouse/query-builder-breakdown.ts
+++ b/apps/web/src/api/warehouse/query-builder-breakdown.ts
@@ -13,10 +13,7 @@ import {
 // Discriminate the typed query-engine error channel on `_tag` (both the local
 // `WarehouseQueryError` and the backend `@maple/http/errors/Warehouse*` union
 // carry a `message` field) rather than collapsing it via `instanceof Error`.
-function queryEngineErrorMessage(
-	error: WarehouseQueryError | BackendError,
-	fallback: string,
-): string {
+function queryEngineErrorMessage(error: WarehouseQueryError | BackendError, fallback: string): string {
 	return "message" in error && typeof error.message === "string" ? error.message : fallback
 }
 
@@ -202,3 +199,7 @@ const getQueryBuilderBreakdownEffect = Effect.fn("QueryEngine.getQueryBuilderBre
 		data: mergeBreakdownResults(results, enabledQueries),
 	}
 })
+
+export const __testables = {
+	mergeBreakdownResults,
+}

--- a/apps/web/src/api/warehouse/query-builder-timeseries.test.ts
+++ b/apps/web/src/api/warehouse/query-builder-timeseries.test.ts
@@ -359,6 +359,30 @@ describe("query-builder timeseries strategy", () => {
 		expect(rows[0]["Errors: checkout (%Δ)"]).toBe(100)
 	})
 
+	it("prev=0 & cur=0 is 0% (genuinely unchanged); prev=0 & cur>0 leaves a gap, not a fake 0%", () => {
+		const rows: Array<Record<string, string | number>> = [
+			{
+				bucket: "2026-01-01T00:00:00.000Z",
+				"Errors: checkout": 0,
+				"Errors: checkout (prev)": 0,
+			},
+			{
+				bucket: "2026-01-01T01:00:00.000Z",
+				"Errors: checkout": 5,
+				"Errors: checkout (prev)": 0,
+			},
+		]
+
+		__testables.appendPercentChangeSeries(
+			rows,
+			new Map([["q-1::checkout", "Errors: checkout"]]),
+			new Map([["q-1::checkout", "Errors: checkout (prev)"]]),
+		)
+
+		expect(rows[0]["Errors: checkout (%Δ)"]).toBe(0)
+		expect(rows[1]).not.toHaveProperty("Errors: checkout (%Δ)")
+	})
+
 	it("does not rescale error_rate series — the engine's 0–1 ratio is canonical", () => {
 		// Regression guard: a ÷100 "normalize" survived from the Tinybird-pipe
 		// era (which returned percent points) long after the CH engine switched

--- a/apps/web/src/api/warehouse/query-builder-timeseries.ts
+++ b/apps/web/src/api/warehouse/query-builder-timeseries.ts
@@ -548,8 +548,13 @@ function appendPercentChangeSeries(
 			const currentValue = typeof current === "number" && Number.isFinite(current) ? current : 0
 			const previousValue = typeof previous === "number" && Number.isFinite(previous) ? previous : 0
 
-			row[deltaSeriesName] =
-				previousValue === 0 ? 0 : ((currentValue - previousValue) / Math.abs(previousValue)) * 100
+			// prev=0 & cur=0 is genuinely "unchanged"; prev=0 & cur>0 has no
+			// meaningful percent — omit the point (gap) instead of fabricating 0%.
+			if (previousValue === 0) {
+				if (currentValue === 0) row[deltaSeriesName] = 0
+				continue
+			}
+			row[deltaSeriesName] = ((currentValue - previousValue) / Math.abs(previousValue)) * 100
 		}
 	}
 }

--- a/apps/web/src/components/dashboard-builder/config/chart-picker.tsx
+++ b/apps/web/src/components/dashboard-builder/config/chart-picker.tsx
@@ -28,6 +28,7 @@ import {
 import { formatValue } from "@/components/dashboard-builder/widgets/stat-widget"
 import { formatCellValue } from "@/components/dashboard-builder/widgets/table-widget"
 import { createQueryDraft } from "@/lib/query-builder/model"
+import { deriveDefaultWidgetTitle } from "@/lib/query-builder/widget-builder-utils"
 
 type ChartCategory = "bar" | "area" | "line"
 
@@ -304,12 +305,13 @@ export function WidgetPicker({ open, onOpenChange, onSelect }: WidgetPickerProps
 	const [activeTab, setActiveTab] = useState<PickerTab>("all")
 
 	const handleSelectChart = (chartId: string) => {
+		const draft = createQueryDraft(0)
 		onSelect(
 			"chart",
 			{
 				endpoint: "custom_query_builder_timeseries",
 				params: {
-					queries: [createQueryDraft(0)],
+					queries: [draft],
 					formulas: [],
 					comparison: {
 						mode: "none",
@@ -318,7 +320,9 @@ export function WidgetPicker({ open, onOpenChange, onSelect }: WidgetPickerProps
 					debug: false,
 				},
 			},
-			{ chartId },
+			// Derived title ("Error rate by service.name") so freshly added
+			// charts never render as "Untitled".
+			{ chartId, title: deriveDefaultWidgetTitle([draft]) },
 		)
 		onOpenChange(false)
 	}

--- a/apps/web/src/components/dashboard-builder/templates/template-card.tsx
+++ b/apps/web/src/components/dashboard-builder/templates/template-card.tsx
@@ -1,6 +1,7 @@
 import type { DashboardTemplatePreviewWidget } from "@maple/domain/http"
 import { Badge } from "@maple/ui/components/ui/badge"
 import { Button } from "@maple/ui/components/ui/button"
+import { cn } from "@maple/ui/utils"
 import { ArrowRightIcon } from "@/components/icons"
 import { templateIcon } from "./template-icons"
 import { TemplatePreview } from "./template-preview"
@@ -30,6 +31,11 @@ interface TemplateCardProps {
 	requirements: readonly string[]
 	preview: ReadonlyArray<DashboardTemplatePreviewWidget>
 	disabled?: boolean
+	/**
+	 * The org has no data matching the template's required metrics — the card
+	 * is dimmed and badged but stays usable (informative, not blocking).
+	 */
+	noMatchingData?: boolean
 	onUse: () => void
 }
 
@@ -42,12 +48,18 @@ export function TemplateCard({
 	requirements,
 	preview,
 	disabled = false,
+	noMatchingData = false,
 	onUse,
 }: TemplateCardProps) {
 	const Icon = templateIcon(id, category)
 	const composition = compositionLabel(preview)
 	return (
-		<div className="group ring-1 ring-border hover:ring-border-active bg-card flex h-full flex-col overflow-hidden rounded-md transition-all">
+		<div
+			className={cn(
+				"group ring-1 ring-border hover:ring-border-active bg-card flex h-full flex-col overflow-hidden rounded-md transition-all",
+				noMatchingData && "opacity-60 hover:opacity-100",
+			)}
+		>
 			<div className="border-b border-border bg-sidebar/60">
 				<TemplatePreview templateId={id} preview={preview} className="h-28 w-full" />
 			</div>
@@ -55,6 +67,15 @@ export function TemplateCard({
 				<div className="flex items-center gap-2">
 					<Icon size={16} className="shrink-0 text-muted-foreground" aria-hidden="true" />
 					<span className="text-sm font-semibold text-foreground">{name}</span>
+					{noMatchingData && (
+						<Badge
+							variant="outline"
+							className="ml-auto shrink-0 text-[10px] px-1.5 py-0 h-4 font-medium text-muted-foreground"
+							title="This template queries metrics your org isn't sending yet — it would render empty."
+						>
+							No matching data yet
+						</Badge>
+					)}
 				</div>
 				<p className="text-xs text-dim leading-relaxed">{description}</p>
 				{composition.length > 0 && (

--- a/apps/web/src/components/dashboard-builder/templates/template-picker.tsx
+++ b/apps/web/src/components/dashboard-builder/templates/template-picker.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from "react"
 import type { DashboardTemplateMetadata } from "@maple/domain/http"
+import { Result, useAtomValue } from "@/lib/effect-atom"
+import { listMetricsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { TemplateCard } from "./template-card"
 import { ParameterDialog, type TemplateParameterField } from "./parameter-dialog"
 
@@ -21,6 +23,28 @@ interface TemplatePickerProps {
 
 export function TemplatePicker({ templates, disabled = false, submitting, onUse }: TemplatePickerProps) {
 	const [pendingTemplate, setPendingTemplate] = useState<DashboardTemplateMetadata | null>(null)
+
+	// Org metric names, used to dim templates whose required metrics the org
+	// isn't sending (a metrics-only template renders entirely empty without
+	// them). Fail-open: while loading or on error, nothing is dimmed.
+	const metricsResult = useAtomValue(listMetricsResultAtom({ data: { limit: 1000 } }))
+	const metricNames = useMemo(
+		() =>
+			Result.builder(metricsResult)
+				.onSuccess((response) =>
+					(response as { data: Array<{ metricName: string }> }).data.map((m) => m.metricName),
+				)
+				.orElse(() => null),
+		[metricsResult],
+	)
+
+	const hasMatchingData = (template: DashboardTemplateMetadata): boolean => {
+		if (template.requiredMetricPrefixes.length === 0) return true
+		if (metricNames == null) return true // loading / error — fail open
+		return template.requiredMetricPrefixes.every((prefix) =>
+			metricNames.some((name) => name.startsWith(prefix)),
+		)
+	}
 
 	const grouped = useMemo(() => {
 		const byCategory = new Map<string, DashboardTemplateMetadata[]>()
@@ -75,6 +99,7 @@ export function TemplatePicker({ templates, disabled = false, submitting, onUse 
 									requirements={template.requirements}
 									preview={template.preview}
 									disabled={disabled || submitting}
+									noMatchingData={!hasMatchingData(template)}
 									onUse={() => handleUse(template)}
 								/>
 							))}

--- a/apps/web/src/components/dashboard-builder/widgets/widget-definitions.test.ts
+++ b/apps/web/src/components/dashboard-builder/widgets/widget-definitions.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import type { QueryBuilderQueryDraftPayload } from "@maple/domain/http"
+import { buildBreakdownQuerySpec, buildListQuerySpec } from "@/lib/query-builder/model"
+import {
+	funnelPresets,
+	heatmapPresets,
+	histogramPresets,
+	listPresets,
+	piePresets,
+	statPresets,
+	tablePresets,
+	type WidgetPresetDefinition,
+} from "./widget-definitions"
+
+// "Presets never rot" guard (MAP-49): every query-builder-backed preset must
+// produce a valid QuerySpec. The original bug — presets carrying group-by
+// tokens the engine rejected — made every pie/funnel/histogram/heatmap preset
+// render empty, and nothing caught it.
+
+const allPresets: WidgetPresetDefinition[] = [
+	...statPresets,
+	...listPresets,
+	...piePresets,
+	...funnelPresets,
+	...histogramPresets,
+	...heatmapPresets,
+	...tablePresets,
+]
+
+function presetQueries(preset: WidgetPresetDefinition): QueryBuilderQueryDraftPayload[] {
+	const params = preset.dataSource.params as { queries?: QueryBuilderQueryDraftPayload[] } | undefined
+	return params?.queries ?? []
+}
+
+describe("widget preset query specs", () => {
+	for (const preset of allPresets.filter(
+		(p) => p.dataSource.endpoint === "custom_query_builder_breakdown",
+	)) {
+		it(`${preset.id} builds a valid breakdown spec for every query`, () => {
+			const queries = presetQueries(preset)
+			expect(queries.length).toBeGreaterThan(0)
+			for (const query of queries) {
+				const result = buildBreakdownQuerySpec(query)
+				expect(result.query, `${preset.id}/${query.name}: ${result.error ?? ""}`).not.toBeNull()
+				expect(result.warnings, `${preset.id}/${query.name}`).toEqual([])
+			}
+		})
+	}
+
+	for (const preset of allPresets.filter((p) => p.dataSource.endpoint === "custom_query_builder_list")) {
+		it(`${preset.id} builds a valid list spec`, () => {
+			const queries = presetQueries(preset)
+			expect(queries.length).toBeGreaterThan(0)
+			for (const query of queries) {
+				const result = buildListQuerySpec(query)
+				expect(result.query, `${preset.id}/${query.name}: ${result.error ?? ""}`).not.toBeNull()
+				expect(result.warnings, `${preset.id}/${query.name}`).toEqual([])
+			}
+		})
+	}
+
+	it("heatmap preset labels its queries Errors/OK (axis labels, not A/B)", () => {
+		const heatmap = heatmapPresets.find((p) => p.id === "heatmap-errors-by-service")
+		expect(heatmap).toBeDefined()
+		const legends = presetQueries(heatmap!).map((q) => q.legend)
+		expect(legends).toEqual(["Errors", "OK"])
+	})
+
+	it("histogram duration preset queries raw durations, not a category breakdown", () => {
+		const histogram = histogramPresets.find((p) => p.id === "histogram-trace-duration")
+		expect(histogram).toBeDefined()
+		expect(histogram!.dataSource.endpoint).toBe("custom_query_builder_list")
+		expect((histogram!.dataSource.params as { columns?: string[] }).columns).toEqual(["durationMs"])
+		expect(histogram!.display.unit).toBe("duration_ms")
+	})
+})

--- a/apps/web/src/components/dashboard-builder/widgets/widget-definitions.ts
+++ b/apps/web/src/components/dashboard-builder/widgets/widget-definitions.ts
@@ -288,6 +288,7 @@ function buildBreakdownQuery(
 		aggregation: string
 		groupBy: string[]
 		name?: string
+		legend?: string
 	},
 ): QueryBuilderQueryDraft {
 	const draft = createQueryDraft(index)
@@ -300,6 +301,7 @@ function buildBreakdownQuery(
 		groupBy: overrides.groupBy,
 		addOns: { groupBy: true, having: false, orderBy: false, limit: true, legend: false },
 		limit: "10",
+		legend: overrides.legend ?? draft.legend,
 	}
 	return overrides.dataSource === "logs"
 		? { ...base, dataSource: "logs" }
@@ -321,7 +323,7 @@ export const piePresets: WidgetPresetDefinition[] = [
 						dataSource: "traces",
 						whereClause: "has_error = true",
 						aggregation: "count",
-						groupBy: ["service_name"],
+						groupBy: ["service.name"],
 					}),
 				],
 				formulas: [],
@@ -350,7 +352,7 @@ export const piePresets: WidgetPresetDefinition[] = [
 						dataSource: "logs",
 						whereClause: "",
 						aggregation: "count",
-						groupBy: ["severity_text"],
+						groupBy: ["severity"],
 					}),
 				],
 				formulas: [],
@@ -379,7 +381,7 @@ export const piePresets: WidgetPresetDefinition[] = [
 						dataSource: "traces",
 						whereClause: "root_only = true",
 						aggregation: "count",
-						groupBy: ["service_name"],
+						groupBy: ["service.name"],
 					}),
 				],
 				formulas: [],
@@ -411,7 +413,7 @@ export const funnelPresets: WidgetPresetDefinition[] = [
 						dataSource: "traces",
 						whereClause: "root_only = true",
 						aggregation: "count",
-						groupBy: ["service_name"],
+						groupBy: ["service.name"],
 					}),
 				],
 				formulas: [],
@@ -440,7 +442,7 @@ export const funnelPresets: WidgetPresetDefinition[] = [
 						dataSource: "traces",
 						whereClause: "has_error = true",
 						aggregation: "count",
-						groupBy: ["service_name"],
+						groupBy: ["service.name"],
 					}),
 				],
 				formulas: [],
@@ -461,29 +463,51 @@ export const histogramPresets: WidgetPresetDefinition[] = [
 	{
 		id: "histogram-trace-duration",
 		name: "Trace Duration Distribution",
-		description: "Spread of root span durations across buckets",
+		description: "Distribution of recent root span durations",
 		icon: ChartBarIcon,
 		visualization: "histogram",
+		// A list of raw root-span durations, bucketized client-side by the
+		// histogram chart — a count-by-service breakdown is NOT a duration
+		// distribution (MAP-49).
 		dataSource: {
-			endpoint: "custom_query_builder_breakdown",
+			endpoint: "custom_query_builder_list",
 			params: {
 				queries: [
-					buildBreakdownQuery(0, {
+					{
+						id: "preset-histogram-durations",
+						name: "A",
+						enabled: true,
 						dataSource: "traces",
+						signalSource: "default",
+						metricName: "",
+						metricType: "sum",
+						isMonotonic: false,
 						whereClause: "root_only = true",
 						aggregation: "count",
-						groupBy: ["service_name"],
-					}),
+						stepInterval: "",
+						orderByDirection: "desc",
+						addOns: {
+							groupBy: false,
+							having: false,
+							orderBy: false,
+							limit: false,
+							legend: false,
+						},
+						groupBy: [],
+						having: "",
+						orderBy: "",
+						limit: "",
+						legend: "",
+					},
 				],
-				formulas: [],
-				comparison: { mode: "none", includePercentChange: false },
-				debug: false,
+				limit: 200,
+				columns: ["durationMs"],
 			},
 		},
 		display: {
 			title: "Trace Duration Distribution",
 			chartId: "query-builder-histogram",
-			unit: "number",
+			unit: "duration_ms",
 			histogram: { bucketCount: 30 },
 		},
 	},
@@ -501,7 +525,7 @@ export const histogramPresets: WidgetPresetDefinition[] = [
 						dataSource: "logs",
 						whereClause: "",
 						aggregation: "count",
-						groupBy: ["service_name"],
+						groupBy: ["service.name"],
 					}),
 				],
 				formulas: [],
@@ -531,17 +555,19 @@ export const heatmapPresets: WidgetPresetDefinition[] = [
 				queries: [
 					buildBreakdownQuery(0, {
 						name: "A",
+						legend: "Errors",
 						dataSource: "traces",
 						whereClause: "has_error = true",
 						aggregation: "count",
-						groupBy: ["service_name"],
+						groupBy: ["service.name"],
 					}),
 					buildBreakdownQuery(1, {
 						name: "B",
+						legend: "OK",
 						dataSource: "traces",
 						whereClause: "has_error = false",
 						aggregation: "count",
-						groupBy: ["service_name"],
+						groupBy: ["service.name"],
 					}),
 				],
 				formulas: [],

--- a/apps/web/src/components/dashboard-builder/widgets/widget-shell.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/widget-shell.tsx
@@ -169,7 +169,11 @@ export function WidgetShell({
 					</CardAction>
 				)}
 			</CardHeader>
-			<CardContent className={contentClassName ?? "flex-1 min-h-0 p-2"}>
+			{/* Default containment: no chart may paint outside its card (MAP-49 —
+			    funnel rows spilled over the header). Widgets that scroll
+			    (list/table/markdown) override with overflow-auto, which wins the
+			    tailwind-merge conflict. */}
+			<CardContent className={cn("overflow-hidden", contentClassName ?? "flex-1 min-h-0 p-2")}>
 				<ChartLegendSlotContext.Provider value={legendSlot}>
 					{children}
 				</ChartLegendSlotContext.Provider>

--- a/apps/web/src/components/widget-lab/scenarios.ts
+++ b/apps/web/src/components/widget-lab/scenarios.ts
@@ -479,6 +479,32 @@ const allZeroSeries: Record<string, unknown>[] = [
 	{ bucket: "2026-01-01T03:00:00Z", a: 0, b: 0 },
 ]
 
+// Sparse rate-like series — 24 zero-filled buckets with a handful of isolated
+// non-zero points at 0.02-0.08 (the MAP-49 screenshot shape: low-volume demo
+// data bucketed at 30m over 12h). Isolated points must render as visible dots,
+// not invisible zero-width triangles.
+const sparseRateSeries: Record<string, unknown>[] = Array.from({ length: 24 }, (_, i) => {
+	const base = new Date("2026-01-01T00:00:00Z").getTime()
+	const row: Record<string, unknown> = {
+		bucket: new Date(base + i * 1_800_000).toISOString(),
+		"demo-api": 0,
+		"demo-frontend": 0,
+		"demo-worker": 0,
+	}
+	if (i === 4) row["demo-api"] = 0.05
+	if (i === 9) row["demo-frontend"] = 0.04
+	if (i === 10) row["demo-frontend"] = 0.07
+	if (i === 15) row["demo-worker"] = 0.07
+	if (i === 20) row["demo-api"] = 0.02
+	if (i === 21) row["demo-frontend"] = 0.045
+	return row
+})
+
+// Single-point series — one bucket only.
+const singlePointSeries: Record<string, unknown>[] = [
+	{ bucket: "2026-01-01T00:00:00Z", "demo-api": 42, "demo-worker": 17 },
+]
+
 export const stressScenarios: ChartScenario[] = [
 	{
 		label: "Line — 25 series (compact legend)",
@@ -627,6 +653,66 @@ export const stressScenarios: ChartScenario[] = [
 			{ name: "b", value: 0 },
 		]),
 		display: { title: "Empty distribution", chartId: "query-builder-pie", pie: {} },
+	},
+	{
+		label: "Area — sparse rate (isolated points)",
+		chartId: "query-builder-area",
+		chartName: "Query Builder Area",
+		category: "area",
+		dataState: ready(sparseRateSeries),
+		display: {
+			title: "Error rate by service (sparse)",
+			chartId: "query-builder-area",
+			chartPresentation: { legend: "visible", seriesStats: false },
+		},
+	},
+	{
+		label: "Bar — sparse rate (isolated points)",
+		chartId: "query-builder-bar",
+		chartName: "Query Builder Bar",
+		category: "bar",
+		dataState: ready(sparseRateSeries),
+		display: {
+			title: "Error rate by service (sparse)",
+			chartId: "query-builder-bar",
+			chartPresentation: { legend: "visible", seriesStats: false },
+		},
+	},
+	{
+		label: "Line — sparse rate (isolated points)",
+		chartId: "query-builder-line",
+		chartName: "Query Builder Line",
+		category: "line",
+		dataState: ready(sparseRateSeries),
+		display: {
+			title: "Error rate by service (sparse)",
+			chartId: "query-builder-line",
+			chartPresentation: { legend: "visible", seriesStats: false },
+		},
+	},
+	{
+		label: "Area — single point",
+		chartId: "query-builder-area",
+		chartName: "Query Builder Area",
+		category: "area",
+		dataState: ready(singlePointSeries),
+		display: {
+			title: "Single bucket",
+			chartId: "query-builder-area",
+			chartPresentation: { legend: "visible", seriesStats: false },
+		},
+	},
+	{
+		label: "Bar — all-zero series",
+		chartId: "query-builder-bar",
+		chartName: "Query Builder Bar",
+		category: "bar",
+		dataState: ready(allZeroSeries),
+		display: {
+			title: "Flat at zero (bar)",
+			chartId: "query-builder-bar",
+			chartPresentation: { legend: "visible", seriesStats: true },
+		},
 	},
 ]
 
@@ -1004,6 +1090,42 @@ export const funnelScenarios: WidgetScenario[] = [
 		display: { title: "Single stage", unit: "number", funnel: {} },
 	},
 	{
+		// MAP-49: more stages than fit in the card — must cap rows inside the
+		// card (+N more), never spill above/below it.
+		label: "30 stages (overflow cap)",
+		dataState: ready(
+			Array.from({ length: 30 }, (_, i) => ({
+				name: `stage-${i + 1}`,
+				value: Math.max(0, Math.round(12840 / (i + 1))),
+			})),
+		),
+		display: { title: "Deep funnel", unit: "number", funnel: { showStepPercent: true } },
+	},
+	{
+		// MAP-49: mis-wired funnel receiving timeseries rows ({bucket, A}) — must
+		// aggregate per series instead of one "—" row per bucket.
+		label: "Timeseries-shaped input",
+		dataState: ready(
+			Array.from({ length: 12 }, (_, i) => ({
+				bucket: new Date(new Date("2026-01-01T00:00:00Z").getTime() + i * 3_600_000).toISOString(),
+				A: 125,
+			})),
+		),
+		display: { title: "Traces by service", unit: "number", funnel: { showStepPercent: true } },
+	},
+	{
+		// MAP-49: zero-value stages + missing labels — no "0 · 0% ↓ 0%" noise rows.
+		label: "Zero stages + missing labels",
+		dataState: ready([
+			{ name: "Visited", value: 4820 },
+			{ name: undefined, value: 940 },
+			{ name: "Converted", value: 0 },
+			{ name: "Ghost A", value: 0 },
+			{ name: "Ghost B", value: 0 },
+		]),
+		display: { title: "Noisy funnel", unit: "number", funnel: { showStepPercent: true } },
+	},
+	{
 		label: "Loading",
 		dataState: loadingState,
 		display: { title: "Signup conversion" },
@@ -1072,6 +1194,34 @@ export const histogramScenarios: WidgetScenario[] = [
 		display: { title: "Fine-grained" },
 	},
 	{
+		// MAP-49: long range labels must not overlap on the x axis.
+		label: "Long range labels (duration)",
+		dataState: ready(
+			Array.from({ length: 30 }, (_, i) => ({
+				name: `${(i * 1.2).toFixed(1)}ms-${((i + 1) * 1.2).toFixed(1)}ms`,
+				value: Math.round(Math.exp(-((i - 12) ** 2) / 40) * 180) + 2,
+			})),
+		),
+		display: { title: "Duration distribution", unit: "duration_ms" },
+	},
+	{
+		// MAP-49: raw numeric rows (trace-list durationMs) — chart must bucketize
+		// client-side into a real distribution.
+		label: "Raw durations (auto-bucketed)",
+		dataState: ready(
+			Array.from({ length: 200 }, (_, i) => ({
+				durationMs: Math.round(
+					30 + Math.abs((Math.sin(i * 12.9898) * 43758.5453) % 1) * 400 + (i % 17 === 0 ? 900 : 0),
+				),
+			})),
+		),
+		display: {
+			title: "Trace duration distribution",
+			unit: "duration_ms",
+			histogram: { bucketCount: 30 },
+		},
+	},
+	{
 		label: "Loading",
 		dataState: loadingState,
 		display: { title: "Trace duration" },
@@ -1128,6 +1278,21 @@ export const heatmapScenarios: WidgetScenario[] = [
 			title: "Log scale",
 			heatmap: { colorScale: "viridis", scaleType: "log" },
 		},
+	},
+	{
+		// MAP-49: many time rows on the y axis — labels must thin out without
+		// the last two colliding.
+		label: "24 time rows (y-label stride)",
+		dataState: ready(
+			Array.from({ length: 24 }, (_, hi) => hi).flatMap((hi) =>
+				["Errors", "OK"].map((x, xi) => ({
+					x,
+					y: `2026-01-01T${String(hi).padStart(2, "0")}:30:00Z`,
+					value: xi === 0 ? (hi % 7 === 0 ? 12 : 0) : 90 + Math.round(Math.sin(hi / 3) * 30),
+				})),
+			),
+		),
+		display: { title: "Errors vs OK over time", heatmap: { colorScale: "blues" } },
 	},
 	{
 		label: "Loading",

--- a/apps/web/src/lib/query-builder/widget-builder-utils.test.ts
+++ b/apps/web/src/lib/query-builder/widget-builder-utils.test.ts
@@ -3,6 +3,7 @@ import { createFormulaDraft, createQueryDraft } from "@/lib/query-builder/model"
 import {
 	buildWidgetDataSource,
 	buildWidgetDisplay,
+	deriveDefaultWidgetTitle,
 	inferDisplayUnitForQuery,
 	inferDefaultUnitForQueries,
 	type QueryBuilderWidgetState,
@@ -196,5 +197,64 @@ describe("widget-builder hidden series behavior", () => {
 			queries: state.queries,
 			formulas: state.formulas,
 		})
+	})
+})
+
+describe("funnel/heatmap endpoint routing (MAP-49)", () => {
+	it.each(["funnel", "heatmap", "pie", "histogram"] as const)(
+		"routes %s widgets to the breakdown endpoint",
+		(visualization) => {
+			const widget = makeWidget()
+			const state = { ...makeState(), visualization }
+			const dataSource = buildWidgetDataSource(widget, state, ["A", "B"])
+			expect(dataSource.endpoint).toBe("custom_query_builder_breakdown")
+		},
+	)
+
+	it("keeps charts on the timeseries endpoint", () => {
+		const widget = makeWidget()
+		const dataSource = buildWidgetDataSource(widget, makeState(), ["A", "B"])
+		expect(dataSource.endpoint).toBe("custom_query_builder_timeseries")
+	})
+})
+
+describe("deriveDefaultWidgetTitle (MAP-49)", () => {
+	it("derives from the default traces draft (error rate grouped by service)", () => {
+		expect(deriveDefaultWidgetTitle([createQueryDraft(0)])).toBe("Error rate by service.name")
+	})
+
+	it("describes counts and group-bys", () => {
+		const draft = { ...createQueryDraft(1), aggregation: "count" }
+		expect(deriveDefaultWidgetTitle([draft])).toBe("Count of traces by service.name")
+	})
+
+	it("handles logs and metrics sources", () => {
+		const logs = { ...createQueryDraft(0), dataSource: "logs" as const, groupBy: ["severity"] }
+		expect(deriveDefaultWidgetTitle([logs])).toBe("Count of logs by severity")
+
+		const base = createQueryDraft(0)
+		const metrics = {
+			...base,
+			dataSource: "metrics" as const,
+			signalSource: "default" as const,
+			metricName: "process.runtime.nodejs.handles",
+			metricType: "gauge" as const,
+			isMonotonic: false,
+			aggregation: "avg",
+			addOns: { ...base.addOns, groupBy: false },
+		}
+		expect(deriveDefaultWidgetTitle([metrics])).toBe("avg of process.runtime.nodejs.handles")
+	})
+
+	it("fills an empty saved title with the derived one", () => {
+		const widget = makeWidget()
+		const display = buildWidgetDisplay(widget, makeState())
+		expect(display.title).toBe("Error rate by service.name")
+	})
+
+	it("keeps an explicit title", () => {
+		const widget = makeWidget()
+		const display = buildWidgetDisplay(widget, { ...makeState(), title: "My chart" })
+		expect(display.title).toBe("My chart")
 	})
 })

--- a/apps/web/src/lib/query-builder/widget-builder-utils.ts
+++ b/apps/web/src/lib/query-builder/widget-builder-utils.ts
@@ -227,6 +227,45 @@ function isVisibleQuery(query: QueryBuilderQueryDraft): boolean {
 	return query.enabled !== false && !query.hidden
 }
 
+const TRACES_AGGREGATION_TITLES: Record<string, string> = {
+	count: "Count of traces",
+	avg_duration: "Avg duration",
+	p50_duration: "P50 duration",
+	p95_duration: "P95 duration",
+	p99_duration: "P99 duration",
+	error_rate: "Error rate",
+	apdex: "Apdex",
+}
+
+/**
+ * Human-readable fallback title derived from the first visible query, e.g.
+ * "Error rate by service.name" or "Count of logs by severity" — so widgets
+ * added from the chart picker never render as "Untitled" (MAP-49).
+ */
+export function deriveDefaultWidgetTitle(queries: readonly QueryBuilderQueryDraft[]): string {
+	const query = queries.find(isVisibleQuery) ?? queries[0]
+	if (!query) return "Untitled"
+
+	const groupBy = hasActiveGroupBy(query)
+		? query.groupBy
+				.map((g) => g.trim())
+				.filter((g) => g !== "" && g.toLowerCase() !== "none")
+				.join(", ")
+		: ""
+	const bySuffix = groupBy ? ` by ${groupBy}` : ""
+
+	if (query.dataSource === "metrics") {
+		const metric = query.metricName.trim()
+		if (!metric) return "Metric"
+		return `${query.aggregation} of ${metric}${bySuffix}`
+	}
+	if (query.dataSource === "logs") {
+		return `Count of logs${bySuffix}`
+	}
+	const base = TRACES_AGGREGATION_TITLES[query.aggregation] ?? `${query.aggregation} of traces`
+	return `${base}${bySuffix}`
+}
+
 function hasActiveGroupBy(query: QueryBuilderQueryDraft): boolean {
 	return (
 		query.addOns.groupBy &&
@@ -529,13 +568,18 @@ export function buildWidgetDataSource(
 		}
 	}
 
-	// Pie + histogram render a breakdown (one row per category) — they need the
-	// `breakdown` endpoint that returns `{name, value}[]`, not the timeseries
-	// endpoint that returns `{bucket, series}[]`. Without this, the preview tile
-	// silently calls the wrong endpoint and renders weighted pie/histogram bars
-	// from time-bucket counts (looks like uniform slices because every bucket
-	// has roughly the same count).
-	if (state.visualization === "pie" || state.visualization === "histogram") {
+	// Pie, histogram, funnel, and heatmap render a breakdown (one row per
+	// category) — they need the `breakdown` endpoint that returns
+	// `{name, value}[]`, not the timeseries endpoint that returns
+	// `{bucket, series}[]`. Without this, the widget silently calls the wrong
+	// endpoint and renders one row/slice per time bucket (uniform values,
+	// missing labels) instead of per group.
+	if (
+		state.visualization === "pie" ||
+		state.visualization === "histogram" ||
+		state.visualization === "funnel" ||
+		state.visualization === "heatmap"
+	) {
 		const visibleQueries = state.queries.filter(isVisibleQuery)
 		return {
 			endpoint: "custom_query_builder_breakdown",
@@ -595,7 +639,13 @@ export function buildWidgetDisplay(
 
 	const display: WidgetDisplayConfig = {
 		...widget.display,
-		title: state.title.trim() ? state.title.trim() : undefined,
+		// Query-driven widgets saved without a title get a derived one
+		// ("Error rate by service.name") instead of rendering as "Untitled".
+		title: state.title.trim()
+			? state.title.trim()
+			: state.visualization === "markdown"
+				? undefined
+				: deriveDefaultWidgetTitle(state.queries),
 		description: state.description.trim() || undefined,
 		chartPresentation: {
 			...widget.display.chartPresentation,

--- a/bun.lock
+++ b/bun.lock
@@ -276,7 +276,6 @@
         "@tanstack/react-virtual": "^3.14.3",
         "@xyflow/react": "catalog:ui",
         "alchemy": "^0.93.12",
-        "autumn-js": "^1.2.29",
         "class-variance-authority": "catalog:ui",
         "clsx": "catalog:ui",
         "date-fns": "^4.4.0",

--- a/packages/domain/src/http/dashboards.ts
+++ b/packages/domain/src/http/dashboards.ts
@@ -459,14 +459,7 @@ export class DashboardTemplateParameter extends Schema.Class<DashboardTemplatePa
 	placeholder: Schema.optionalKey(Schema.String),
 }) {}
 
-export const DashboardTemplatePreviewKind = Schema.Literals([
-	"line",
-	"area",
-	"bar",
-	"stat",
-	"table",
-	"list",
-])
+export const DashboardTemplatePreviewKind = Schema.Literals(["line", "area", "bar", "stat", "table", "list"])
 export type DashboardTemplatePreviewKind = typeof DashboardTemplatePreviewKind.Type
 
 export class DashboardTemplatePreviewWidget extends Schema.Class<DashboardTemplatePreviewWidget>(
@@ -489,6 +482,12 @@ export class DashboardTemplateMetadata extends Schema.Class<DashboardTemplateMet
 	category: DashboardTemplateCategory,
 	tags: Schema.Array(Schema.String),
 	requirements: Schema.Array(Schema.String),
+	/**
+	 * Metric-name prefixes the template's widgets query; the picker greys out
+	 * templates whose prefixes match none of the org's metrics. Empty array =
+	 * never gated. An empty-string prefix means "any metric".
+	 */
+	requiredMetricPrefixes: Schema.Array(Schema.String),
 	parameters: Schema.Array(DashboardTemplateParameter),
 	preview: Schema.Array(DashboardTemplatePreviewWidget),
 }) {}

--- a/packages/domain/src/query-engine.ts
+++ b/packages/domain/src/query-engine.ts
@@ -104,7 +104,12 @@ export const MetricsFilters = Schema.Struct({
 	metricType: MetricType,
 	serviceName: Schema.optional(ServiceName),
 	groupByAttributeKey: Schema.optional(Schema.String),
+	// Resource-attribute counterpart of `groupByAttributeKey` — groups by a
+	// ResourceAttributes key (host.name, k8s.pod.name, …) instead of a datapoint
+	// Attributes key. Required when groupBy includes "resource_attribute".
+	groupByResourceAttributeKey: Schema.optional(Schema.String),
 	attributeFilters: Schema.optional(Schema.Array(AttributeFilter)),
+	resourceAttributeFilters: Schema.optional(Schema.Array(AttributeFilter)),
 })
 export type MetricsFilters = Schema.Schema.Type<typeof MetricsFilters>
 
@@ -145,7 +150,9 @@ export const MetricsTimeseriesQuery = Schema.Struct({
 	kind: Schema.Literal("timeseries"),
 	source: Schema.Literal("metrics"),
 	metric: MetricsMetric,
-	groupBy: Schema.optional(Schema.Array(Schema.Literals(["service", "attribute", "none"]))),
+	groupBy: Schema.optional(
+		Schema.Array(Schema.Literals(["service", "attribute", "resource_attribute", "none"])),
+	),
 	filters: MetricsFilters,
 	bucketSeconds: Schema.optional(Schema.Number.check(Schema.isInt(), Schema.isGreaterThan(0))),
 })
@@ -180,7 +187,7 @@ export const MetricsBreakdownQuery = Schema.Struct({
 	kind: Schema.Literal("breakdown"),
 	source: Schema.Literal("metrics"),
 	metric: Schema.Literals(["avg", "sum", "count"]),
-	groupBy: Schema.Literals(["service", "attribute"]),
+	groupBy: Schema.Literals(["service", "attribute", "resource_attribute"]),
 	filters: MetricsFilters,
 	limit: Schema.optional(
 		Schema.Number.check(Schema.isInt(), Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(100)),

--- a/packages/query-engine/src/ch/queries/metrics.test.ts
+++ b/packages/query-engine/src/ch/queries/metrics.test.ts
@@ -87,6 +87,22 @@ describe("metricsTimeseriesQuery", () => {
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("'' AS attributeValue")
 	})
+
+	it("applies groupByResourceAttributeKey against ResourceAttributes", () => {
+		const q = metricsTimeseriesQuery({ metricType: "gauge", groupByResourceAttributeKey: "host.name" })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("ResourceAttributes['host.name'] AS attributeValue")
+		expect(sql).toContain("GROUP BY bucket, serviceName, attributeValue")
+	})
+
+	it("applies resourceAttributeFilters", () => {
+		const q = metricsTimeseriesQuery({
+			metricType: "gauge",
+			resourceAttributeFilters: [{ key: "k8s.cluster.name", mode: "equals", value: "prod-us-east" }],
+		})
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("ResourceAttributes['k8s.cluster.name'] = 'prod-us-east'")
+	})
 })
 
 // ---------------------------------------------------------------------------
@@ -138,6 +154,42 @@ describe("metricsTimeseriesRateQuery", () => {
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("Attributes['host']")
 		expect(sql).toContain("GROUP BY bucket, serviceName, attributeValue")
+	})
+
+	it("applies groupByResourceAttributeKey through the deltas CTE", () => {
+		const q = metricsTimeseriesRateQuery({ groupByResourceAttributeKey: "k8s.pod.name" })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("ResourceAttributes['k8s.pod.name'] AS resourceAttributeValue")
+		expect(sql).toContain("resourceAttributeValue AS attributeValue")
+		expect(sql).toContain("GROUP BY bucket, serviceName, attributeValue")
+	})
+
+	it("applies resourceAttributeFilters in the CTE", () => {
+		const q = metricsTimeseriesRateQuery({
+			resourceAttributeFilters: [{ key: "host.name", mode: "equals", value: "web-01" }],
+		})
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("ResourceAttributes['host.name'] = 'web-01'")
+	})
+
+	it("falls back to raw metrics_sum when resource opts are present (hourly rollup lacks the map)", () => {
+		const withGroup = metricsTimeseriesRateQuery({
+			metricName: "span.metrics.calls",
+			bucketSeconds: 3600,
+			groupByResourceAttributeKey: "host.name",
+		})
+		expect(compileCH(withGroup, { ...baseParams, metricName: "span.metrics.calls" }).sql).toContain(
+			"FROM metrics_sum",
+		)
+
+		const withFilter = metricsTimeseriesRateQuery({
+			metricName: "span.metrics.calls",
+			bucketSeconds: 3600,
+			resourceAttributeFilters: [{ key: "host.name", mode: "equals", value: "web-01" }],
+		})
+		expect(compileCH(withFilter, { ...baseParams, metricName: "span.metrics.calls" }).sql).toContain(
+			"FROM metrics_sum",
+		)
 	})
 
 	it("uses the hourly SpanMetrics calls rollup for hourly calls increases", () => {
@@ -239,6 +291,23 @@ describe("metricsBreakdownQuery", () => {
 		const q = metricsBreakdownQuery({ metricType: "sum", limit: 25 })
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("LIMIT 25")
+	})
+
+	it("breaks down by resource attribute when groupByResourceAttributeKey is set", () => {
+		const q = metricsBreakdownQuery({ metricType: "sum", groupByResourceAttributeKey: "host.name" })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("ResourceAttributes['host.name'] AS name")
+		// Drops datapoints missing the resource label.
+		expect(sql).toContain("ResourceAttributes['host.name'] != ''")
+	})
+
+	it("applies resourceAttributeFilters", () => {
+		const q = metricsBreakdownQuery({
+			metricType: "sum",
+			resourceAttributeFilters: [{ key: "k8s.namespace.name", mode: "equals", value: "default" }],
+		})
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("ResourceAttributes['k8s.namespace.name'] = 'default'")
 	})
 
 	it("breaks down by attribute label instead of service when groupByAttributeKey is set", () => {

--- a/packages/query-engine/src/ch/queries/metrics.ts
+++ b/packages/query-engine/src/ch/queries/metrics.ts
@@ -5,7 +5,7 @@
 // a raw-SQL builder for counter rate/increase (which requires CTEs).
 // ---------------------------------------------------------------------------
 
-import type { MetricType } from "../../query-engine"
+import type { AttributeFilter, MetricType } from "../../query-engine"
 import * as CH from "@maple-dev/clickhouse-builder/expr"
 import * as T from "@maple-dev/clickhouse-builder/types"
 import { param } from "@maple-dev/clickhouse-builder"
@@ -14,6 +14,19 @@ import { table } from "@maple-dev/clickhouse-builder"
 import { MetricsSum, MetricCatalog, SpanMetricsCallsHourly } from "../tables"
 import { compileCH } from "@maple-dev/clickhouse-builder"
 import { resolveMetricTable, metricsSelectExprs } from "./query-helpers"
+import { buildAttrFilterCondition } from "../../traces-shared"
+
+/**
+ * WHERE conditions for `resourceAttributeFilters` — predicates on the
+ * ResourceAttributes map (host.name, k8s.pod.name, …), which carries
+ * host/pod/node identity on metrics rows (datapoint labels live on
+ * `Attributes` instead).
+ */
+function resourceFilterConditions(
+	filters: readonly AttributeFilter[] | undefined,
+): ReadonlyArray<CH.Condition> {
+	return (filters ?? []).map((rf) => buildAttrFilterCondition(rf, "ResourceAttributes"))
+}
 
 // ---------------------------------------------------------------------------
 // Shared options & output types
@@ -23,8 +36,11 @@ interface MetricsQueryOpts {
 	metricType: MetricType
 	serviceName?: string
 	groupByAttributeKey?: string
+	/** Group by a ResourceAttributes key instead of a datapoint Attributes key. */
+	groupByResourceAttributeKey?: string
 	attributeKey?: string
 	attributeValue?: string
+	resourceAttributeFilters?: readonly AttributeFilter[]
 }
 
 export interface MetricsTimeseriesOpts extends MetricsQueryOpts {}
@@ -51,9 +67,14 @@ export function metricsTimeseriesQuery(opts: MetricsTimeseriesOpts) {
 		.select(($) => ({
 			bucket: CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
 			serviceName: $.ServiceName,
-			attributeValue: opts.groupByAttributeKey
-				? $.Attributes.get(opts.groupByAttributeKey)
-				: CH.lit(""),
+			// A query groups by at most one attribute dimension (enforced by
+			// runtime validation); resource takes the shared attributeValue slot
+			// when requested.
+			attributeValue: opts.groupByResourceAttributeKey
+				? $.ResourceAttributes.get(opts.groupByResourceAttributeKey)
+				: opts.groupByAttributeKey
+					? $.Attributes.get(opts.groupByAttributeKey)
+					: CH.lit(""),
 			...metricsSelectExprs($, isHistogram),
 		}))
 		.where(($) => [
@@ -63,10 +84,11 @@ export function metricsTimeseriesQuery(opts: MetricsTimeseriesOpts) {
 			$.TimeUnix.lte(param.dateTime("endTime")),
 			CH.when(opts.serviceName, (v: string) => $.ServiceName.eq(v)),
 			CH.when(opts.attributeKey, (k: string) => $.Attributes.get(k).eq(opts.attributeValue ?? "")),
+			...resourceFilterConditions(opts.resourceAttributeFilters),
 		])
 
 	return (
-		opts.groupByAttributeKey
+		opts.groupByAttributeKey || opts.groupByResourceAttributeKey
 			? q.groupBy("bucket", "serviceName", "attributeValue")
 			: q.groupBy("bucket", "serviceName")
 	)
@@ -87,8 +109,11 @@ export interface MetricsRateTimeseriesOpts {
 	bucketSeconds?: number
 	serviceName?: string
 	groupByAttributeKey?: string
+	/** Group by a ResourceAttributes key instead of a datapoint Attributes key. */
+	groupByResourceAttributeKey?: string
 	attributeKey?: string
 	attributeValue?: string
+	resourceAttributeFilters?: readonly AttributeFilter[]
 }
 
 export interface MetricsRateTimeseriesOutput {
@@ -115,7 +140,11 @@ function canUseSpanMetricsCallsHourly(opts: MetricsRateTimeseriesOpts): boolean 
 		opts.bucketSeconds % 3600 === 0 &&
 		(opts.attributeValue === undefined || opts.attributeKey !== undefined) &&
 		(opts.attributeKey === undefined || opts.attributeKey === "span.kind") &&
-		(opts.groupByAttributeKey === undefined || opts.groupByAttributeKey === "span.kind")
+		(opts.groupByAttributeKey === undefined || opts.groupByAttributeKey === "span.kind") &&
+		// The hourly MV folds ResourceAttributes into a fingerprint — it cannot
+		// serve resource-attribute filters or group-bys.
+		opts.groupByResourceAttributeKey === undefined &&
+		(opts.resourceAttributeFilters === undefined || opts.resourceAttributeFilters.length === 0)
 	)
 }
 
@@ -279,6 +308,12 @@ export function metricsTimeseriesRateQuery(
 					TimeUnix: $.TimeUnix,
 					ServiceName: $.ServiceName,
 					Attributes: $.Attributes,
+					// Project just the requested resource group value through the CTE —
+					// carrying the whole ResourceAttributes map per row would be pure
+					// overhead for the (common) non-resource-grouped case.
+					resourceAttributeValue: opts.groupByResourceAttributeKey
+						? $.ResourceAttributes.get(opts.groupByResourceAttributeKey)
+						: CH.lit(""),
 					Value: $.Value,
 					delta: $.Value.sub(previousValue),
 					time_delta: CH.toFloat64(
@@ -296,6 +331,7 @@ export function metricsTimeseriesRateQuery(
 				$.TimeUnix.lte(param.dateTime("endTime")),
 				CH.when(opts.serviceName, (v: string) => $.ServiceName.eq(v)),
 				CH.when(opts.attributeKey, (k: string) => $.Attributes.get(k).eq(opts.attributeValue ?? "")),
+				...resourceFilterConditions(opts.resourceAttributeFilters),
 			]),
 		{},
 		{ skipFormat: true },
@@ -306,6 +342,7 @@ export function metricsTimeseriesRateQuery(
 		TimeUnix: T.dateTime64,
 		ServiceName: T.string,
 		Attributes: T.map(T.string, T.string),
+		resourceAttributeValue: T.string,
 		Value: T.float64,
 		delta: T.float64,
 		time_delta: T.float64,
@@ -316,9 +353,11 @@ export function metricsTimeseriesRateQuery(
 		.select(($) => ({
 			bucket: CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
 			serviceName: $.ServiceName,
-			attributeValue: opts.groupByAttributeKey
-				? $.Attributes.get(opts.groupByAttributeKey)
-				: CH.lit(""),
+			attributeValue: opts.groupByResourceAttributeKey
+				? $.resourceAttributeValue
+				: opts.groupByAttributeKey
+					? $.Attributes.get(opts.groupByAttributeKey)
+					: CH.lit(""),
 			rateValue: CH.sumIf($.delta.div($.time_delta), $.delta.gte(0).and($.time_delta.gt(0))),
 			increaseValue: CH.sumIf($.delta, $.delta.gte(0)),
 			dataPointCount: CH.count(),
@@ -326,7 +365,7 @@ export function metricsTimeseriesRateQuery(
 		.where(($) => [$.TimeUnix.gte(param.dateTime("startTime"))])
 
 	return (
-		opts.groupByAttributeKey
+		opts.groupByAttributeKey || opts.groupByResourceAttributeKey
 			? q.groupBy("bucket", "serviceName", "attributeValue")
 			: q.groupBy("bucket", "serviceName")
 	)
@@ -341,6 +380,9 @@ export function metricsTimeseriesRateQuery(
 export interface MetricsBreakdownOpts {
 	metricType: MetricType
 	groupByAttributeKey?: string
+	/** Break down by a ResourceAttributes key instead of a datapoint Attributes key. */
+	groupByResourceAttributeKey?: string
+	resourceAttributeFilters?: readonly AttributeFilter[]
 	limit?: number
 }
 
@@ -355,13 +397,19 @@ export function metricsBreakdownQuery(opts: MetricsBreakdownOpts) {
 	const { tbl, isHistogram } = resolveMetricTable(opts.metricType)
 	const limit = opts.limit ?? 10
 	const groupKey = opts.groupByAttributeKey
+	const resourceGroupKey = opts.groupByResourceAttributeKey
 
 	return from(tbl as typeof MetricsSum)
 		.select(($) => {
 			const exprs = metricsSelectExprs($, isHistogram)
 			return {
-				// Break down by a metric label value when requested, otherwise by service.
-				name: groupKey ? $.Attributes.get(groupKey) : $.ServiceName,
+				// Break down by a resource attribute or metric label value when
+				// requested, otherwise by service.
+				name: resourceGroupKey
+					? $.ResourceAttributes.get(resourceGroupKey)
+					: groupKey
+						? $.Attributes.get(groupKey)
+						: $.ServiceName,
 				avgValue: exprs.avgValue,
 				sumValue: exprs.sumValue,
 				count: exprs.dataPointCount,
@@ -374,6 +422,8 @@ export function metricsBreakdownQuery(opts: MetricsBreakdownOpts) {
 			$.TimeUnix.lte(param.dateTime("endTime")),
 			// Drop datapoints missing the label so an empty bucket doesn't dominate.
 			CH.when(groupKey, (k: string) => $.Attributes.get(k).neq("")),
+			CH.when(resourceGroupKey, (k: string) => $.ResourceAttributes.get(k).neq("")),
+			...resourceFilterConditions(opts.resourceAttributeFilters),
 		])
 		.groupBy("name")
 		.orderBy(["count", "desc"])

--- a/packages/query-engine/src/ch/queries/query-helpers.ts
+++ b/packages/query-engine/src/ch/queries/query-helpers.ts
@@ -109,6 +109,21 @@ export interface TracesBaseWhereOpts {
 	excludedNamespaces?: readonly string[]
 }
 
+/**
+ * Tri-state errorsOnly filter: `true` keeps only errored spans, `false` keeps
+ * only non-errored spans, `undefined` applies no filter. The `false` case
+ * backs `has_error = false` clauses (e.g. the "OK" side of an errors-vs-OK
+ * comparison) — collapsing it to "no filter" silently counts every span.
+ */
+export function errorsOnlyCondition(
+	statusCode: CH.Expr<string>,
+	errorsOnly: boolean | undefined,
+): CH.Condition | undefined {
+	if (errorsOnly === true) return statusCode.eq("Error")
+	if (errorsOnly === false) return statusCode.neq("Error")
+	return undefined
+}
+
 type TracesBaseWhereColumns = Pick<
 	typeof Traces.columns,
 	| "OrgId"
@@ -161,7 +176,7 @@ export function tracesBaseWhereConditions(
 				: $.SpanName.eq(v).or(display.eq(v))
 		}),
 		CH.whenTrue(!!opts.rootOnly, () => $.SpanKind.in_("Server", "Consumer").or($.ParentSpanId.eq(""))),
-		CH.whenTrue(!!opts.errorsOnly, () => $.StatusCode.eq("Error")),
+		errorsOnlyCondition($.StatusCode, opts.errorsOnly),
 	]
 
 	if (opts.minDurationMs != null) {
@@ -283,7 +298,7 @@ export function serviceOverviewWhereConditions(
 				? CH.positionCaseInsensitive($.ServiceName, CH.lit(v)).gt(0)
 				: $.ServiceName.eq(v),
 		),
-		CH.whenTrue(!!opts.errorsOnly, () => $.StatusCode.eq("Error")),
+		errorsOnlyCondition($.StatusCode, opts.errorsOnly),
 	]
 
 	if (opts.minDurationMs != null) {
@@ -383,7 +398,7 @@ export function tracesAggregatesWhereConditions(
 				: $.SpanName.eq(v),
 		),
 		CH.whenTrue(!!opts.rootOnly, () => $.IsEntryPoint.eq(1)),
-		CH.whenTrue(!!opts.errorsOnly, () => $.StatusCode.eq("Error")),
+		errorsOnlyCondition($.StatusCode, opts.errorsOnly),
 	]
 
 	if (opts.environments?.length) {

--- a/packages/query-engine/src/query-builder/model.test.ts
+++ b/packages/query-engine/src/query-builder/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { QueryBuilderQueryDraftPayload } from "@maple/domain/http"
-import { buildTimeseriesQuerySpec } from "./model"
+import { buildBreakdownQuerySpec, buildTimeseriesQuerySpec } from "./model"
 
 // Minimal traces draft factory — only the fields the builder reads matter; the
 // rest satisfy the payload shape.
@@ -117,5 +117,137 @@ describe("buildTimeseriesQuerySpec series limit", () => {
 
 		expect(seriesLimitOf({ seriesLimit: "-3" }).seriesLimit).toBeUndefined()
 		expect(seriesLimitOf({ seriesLimit: "abc" }).seriesLimit).toBeUndefined()
+	})
+})
+
+describe("group-by token aliases (MAP-49)", () => {
+	const breakdownDraft = (overrides: Partial<QueryBuilderQueryDraftPayload> = {}) =>
+		tracesDraft({
+			addOns: { groupBy: true, having: false, orderBy: false, limit: false, legend: false },
+			groupBy: ["service.name"],
+			...overrides,
+		})
+
+	it("accepts canonical and snake_case traces group-by tokens", () => {
+		for (const token of ["service.name", "service_name", "span_name", "status_code"]) {
+			const result = buildBreakdownQuerySpec(breakdownDraft({ groupBy: [token] }))
+			expect(result.query, `token ${token}`).not.toBeNull()
+			expect(result.warnings).toEqual([])
+		}
+	})
+
+	it("accepts snake_case logs group-by tokens", () => {
+		for (const token of ["severity", "severity_text", "service_name"]) {
+			const result = buildBreakdownQuerySpec(breakdownDraft({ dataSource: "logs", groupBy: [token] }))
+			expect(result.query, `token ${token}`).not.toBeNull()
+			expect(result.warnings).toEqual([])
+		}
+	})
+
+	it("still rejects unknown tokens", () => {
+		const result = buildBreakdownQuerySpec(breakdownDraft({ groupBy: ["not_a_column"] }))
+		expect(result.query).toBeNull()
+	})
+})
+
+describe("metrics resource.* support", () => {
+	function metricsDraft(
+		overrides: Partial<QueryBuilderQueryDraftPayload> = {},
+	): QueryBuilderQueryDraftPayload {
+		return tracesDraft({
+			dataSource: "metrics",
+			aggregation: "avg",
+			metricName: "system.cpu.utilization",
+			metricType: "gauge",
+			isMonotonic: false,
+			signalSource: "default",
+			...overrides,
+		} as Partial<QueryBuilderQueryDraftPayload>)
+	}
+
+	function metricsFiltersOf(overrides: Partial<QueryBuilderQueryDraftPayload>) {
+		const result = buildTimeseriesQuerySpec(metricsDraft(overrides))
+		return {
+			result,
+			warnings: result.warnings,
+			groupBy: (result.query as { groupBy?: string[] } | null)?.groupBy,
+			filters: (result.query as { filters?: Record<string, unknown> } | null)?.filters,
+		}
+	}
+
+	it("resource.<key> where clauses become resourceAttributeFilters", () => {
+		const { warnings, filters } = metricsFiltersOf({
+			whereClause: 'resource.host.name = "web-01" AND resource.k8s.cluster.name != "staging"',
+		})
+		expect(warnings).toEqual([])
+		expect(filters?.resourceAttributeFilters).toEqual([
+			{ key: "host.name", mode: "equals", value: "web-01" },
+			{ key: "k8s.cluster.name", mode: "equals", negated: true, value: "staging" },
+		])
+	})
+
+	it("omits resourceAttributeFilters entirely when no resource.* clause is present", () => {
+		const { filters } = metricsFiltersOf({ whereClause: 'service.name = "api"' })
+		expect(filters).not.toHaveProperty("resourceAttributeFilters")
+		expect(filters?.serviceName).toBe("api")
+	})
+
+	it("warns (blocking) when the 5 resource-filter cap is exceeded", () => {
+		const clause = ["a", "b", "c", "d", "e", "f"].map((k) => `resource.${k} = "1"`).join(" AND ")
+		const { warnings, filters } = metricsFiltersOf({ whereClause: clause })
+		expect(filters?.resourceAttributeFilters).toHaveLength(5)
+		expect(warnings.some((w) => w.includes("Maximum of 5 resource.* filters"))).toBe(true)
+	})
+
+	it("resource.<key> group-by resolves to resource_attribute + groupByResourceAttributeKey", () => {
+		const { warnings, groupBy, filters } = metricsFiltersOf({
+			addOns: { groupBy: true, having: false, orderBy: false, limit: false, legend: false },
+			groupBy: ["resource.k8s.pod.name"],
+		})
+		expect(warnings).toEqual([])
+		expect(groupBy).toEqual(["resource_attribute"])
+		expect(filters?.groupByResourceAttributeKey).toBe("k8s.pod.name")
+	})
+
+	it("keeps the first dimension and warns when attr.* and resource.* group-bys are combined", () => {
+		const { warnings, groupBy, filters } = metricsFiltersOf({
+			addOns: { groupBy: true, having: false, orderBy: false, limit: false, legend: false },
+			groupBy: ["attr.state", "resource.host.name"],
+		})
+		expect(warnings.some((w) => w.includes("single attribute group by"))).toBe(true)
+		expect(groupBy).toEqual(["attribute"])
+		expect(filters?.groupByAttributeKey).toBe("state")
+		expect(filters).not.toHaveProperty("groupByResourceAttributeKey")
+	})
+
+	it("resource.* group-by drives breakdown specs", () => {
+		const result = buildBreakdownQuerySpec(
+			metricsDraft({
+				addOns: { groupBy: true, having: false, orderBy: false, limit: false, legend: false },
+				groupBy: ["resource.host.name"],
+			}),
+		)
+		expect(result.error).toBeNull()
+		expect(result.warnings).toEqual([])
+		expect((result.query as { groupBy?: string } | null)?.groupBy).toBe("resource_attribute")
+	})
+})
+
+describe("has_error tri-state (MAP-49)", () => {
+	const errorsOnlyOf = (whereClause: string) => {
+		const result = buildTimeseriesQuerySpec(tracesDraft({ whereClause }))
+		return (result.query as { filters?: { errorsOnly?: boolean } } | null)?.filters?.errorsOnly
+	}
+
+	it("has_error = true → errorsOnly: true", () => {
+		expect(errorsOnlyOf("has_error = true")).toBe(true)
+	})
+
+	it("has_error = false survives as errorsOnly: false (not dropped)", () => {
+		expect(errorsOnlyOf("has_error = false")).toBe(false)
+	})
+
+	it("absent clause leaves errorsOnly unset", () => {
+		expect(errorsOnlyOf("")).toBeUndefined()
 	})
 })

--- a/packages/query-engine/src/query-builder/model.ts
+++ b/packages/query-engine/src/query-builder/model.ts
@@ -133,6 +133,7 @@ export const GROUP_BY_OPTIONS: Record<QueryBuilderDataSource, Array<{ label: str
 	metrics: [
 		{ label: "service.name", value: "service.name" },
 		{ label: "attr.*", value: "attr." },
+		{ label: "resource.*", value: "resource." },
 		{ label: "none", value: "none" },
 	],
 }
@@ -439,12 +440,38 @@ function applyLogsClause(
 	)
 }
 
+interface MetricsFilterAccumulator {
+	metricName: string
+	metricType: QueryBuilderMetricType
+	serviceName?: string
+	groupByAttributeKey?: string
+	groupByResourceAttributeKey?: string
+	resourceAttributeFilters: AccumulatedAttributeFilter[]
+}
+
 function applyMetricsClause(
-	filters: { metricName: string; metricType: QueryBuilderMetricType; serviceName?: string },
-	clause: { key: string; value: string },
+	filters: MetricsFilterAccumulator,
+	clause: { key: string; operator: string; value: string },
 	warnings: string[],
-): { metricName: string; metricType: QueryBuilderMetricType; serviceName?: string } {
+): MetricsFilterAccumulator {
 	const key = normalizeKey(clause.key)
+
+	// Host/pod/node identity on metrics lives in the ResourceAttributes map —
+	// `resource.<key>` filters predicate on it (mirrors the traces handler).
+	if (key.startsWith("resource.")) {
+		const resourceKey = key.slice(9)
+		if (filters.resourceAttributeFilters.length >= 5) {
+			warnings.push(`Maximum of 5 resource.* filters supported; ignoring resource.${resourceKey}`)
+			return filters
+		}
+		return {
+			...filters,
+			resourceAttributeFilters: [
+				...filters.resourceAttributeFilters,
+				makeAttrFilter(resourceKey, clause.operator, clause.value),
+			],
+		}
+	}
 
 	return Match.value(key).pipe(
 		Match.when("service.name", () => ({ ...filters, serviceName: clause.value })),
@@ -475,9 +502,12 @@ function resolveTracesGroupByToken(
 	raw: string,
 ): TracesGroupByKey | null {
 	return Match.value(token).pipe(
-		Match.whenOr("service", "service.name", () => "service" as const),
-		Match.whenOr("span", "span.name", () => "span_name" as const),
-		Match.whenOr("status", "status.code", () => "status_code" as const),
+		// snake_case aliases match the warehouse column spellings — dashboard
+		// widget presets (and widgets persisted from them) use those, so
+		// dropping them silently broke every preset breakdown (MAP-49).
+		Match.whenOr("service", "service.name", "service_name", () => "service" as const),
+		Match.whenOr("span", "span.name", "span_name", () => "span_name" as const),
+		Match.whenOr("status", "status.code", "status_code", () => "status_code" as const),
 		Match.when("http.method", () => "http_method" as const),
 		Match.whenOr("none", "all", () => "none" as const),
 		Match.orElse((t) => {
@@ -501,8 +531,8 @@ type LogsGroupByKey = "service" | "severity" | "none"
 
 function resolveLogsGroupByToken(token: string, warnings: string[], raw: string): LogsGroupByKey | null {
 	return Match.value(token).pipe(
-		Match.whenOr("service", "service.name", () => "service" as const),
-		Match.when("severity", () => "severity" as const),
+		Match.whenOr("service", "service.name", "service_name", () => "service" as const),
+		Match.whenOr("severity", "severity_text", () => "severity" as const),
 		Match.whenOr("none", "all", () => "none" as const),
 		Match.orElse(() => {
 			warnings.push(`Unsupported logs group by ignored: ${raw}`)
@@ -511,7 +541,7 @@ function resolveLogsGroupByToken(token: string, warnings: string[], raw: string)
 	)
 }
 
-type MetricsGroupByKey = "service" | "attribute" | "none"
+type MetricsGroupByKey = "service" | "attribute" | "resource_attribute" | "none"
 
 function resolveMetricsGroupByToken(
 	token: string,
@@ -520,6 +550,7 @@ function resolveMetricsGroupByToken(
 		metricType: string
 		serviceName?: string
 		groupByAttributeKey?: string
+		groupByResourceAttributeKey?: string
 	},
 	warnings: string[],
 	raw: string,
@@ -536,6 +567,15 @@ function resolveMetricsGroupByToken(
 				}
 				metricsFilters.groupByAttributeKey = attributeKey
 				return "attribute" as const
+			}
+			if (t.startsWith("resource.")) {
+				const resourceKey = t.slice(9)
+				if (!resourceKey) {
+					warnings.push("Invalid resource.* group by ignored")
+					return null
+				}
+				metricsFilters.groupByResourceAttributeKey = resourceKey
+				return "resource_attribute" as const
 			}
 			warnings.push(`Unsupported metrics group by ignored: ${raw}`)
 			return null
@@ -554,6 +594,8 @@ export interface ResolvedGroupBy {
 	readonly tokens: ReadonlyArray<string>
 	/** Span/metric attribute keys referenced via `attr.<key>` group-by tokens. */
 	readonly attributeKeys: ReadonlyArray<string>
+	/** Resource attribute keys referenced via `resource.<key>` group-by tokens (metrics only). */
+	readonly resourceAttributeKeys: ReadonlyArray<string>
 	/** Warnings emitted while resolving (unsupported tokens, malformed input). */
 	readonly warnings: ReadonlyArray<string>
 }
@@ -564,9 +606,11 @@ export function resolveGroupBy(
 ): ResolvedGroupBy {
 	const tokens: string[] = []
 	const attributeKeys: string[] = []
+	const resourceAttributeKeys: string[] = []
 	const warnings: string[] = []
 	const seenTokens = new Set<string>()
 	const seenAttrKeys = new Set<string>()
+	const seenResourceKeys = new Set<string>()
 
 	for (const raw of rawTokens) {
 		const token = raw.trim().toLowerCase()
@@ -589,6 +633,28 @@ export function resolveGroupBy(
 			if (!seenTokens.has("attribute")) {
 				seenTokens.add("attribute")
 				tokens.push("attribute")
+			}
+			continue
+		}
+
+		if (token.startsWith("resource.")) {
+			const resourceKey = token.slice(9)
+			if (!resourceKey) {
+				warnings.push("Invalid resource.* group by ignored")
+				continue
+			}
+			// Only the metrics QuerySpec has a resource_attribute group dimension.
+			if (source !== "metrics") {
+				warnings.push(`${source} source does not support resource.* group by: ${raw}`)
+				continue
+			}
+			if (!seenResourceKeys.has(resourceKey)) {
+				seenResourceKeys.add(resourceKey)
+				resourceAttributeKeys.push(resourceKey)
+			}
+			if (!seenTokens.has("resource_attribute")) {
+				seenTokens.add("resource_attribute")
+				tokens.push("resource_attribute")
 			}
 			continue
 		}
@@ -631,7 +697,7 @@ export function resolveGroupBy(
 		}
 	}
 
-	return { tokens, attributeKeys, warnings }
+	return { tokens, attributeKeys, resourceAttributeKeys, warnings }
 }
 
 // ---------------------------------------------------------------------------
@@ -644,7 +710,9 @@ function buildTracesSpecFilters(acc: TracesFilterAccumulator): Record<string, un
 	if (acc.serviceName) filters.serviceName = acc.serviceName
 	if (acc.spanName) filters.spanName = acc.spanName
 	if (acc.rootSpansOnly) filters.rootSpansOnly = acc.rootSpansOnly
-	if (acc.errorsOnly) filters.errorsOnly = acc.errorsOnly
+	// Tri-state: `has_error = false` must survive as an explicit filter (only
+	// non-errored spans), not collapse into "no filter".
+	if (acc.errorsOnly != null) filters.errorsOnly = acc.errorsOnly
 	if (acc.environments?.length) filters.environments = acc.environments
 	if (acc.commitShas?.length) filters.commitShas = acc.commitShas
 	if (acc.groupByAttributeKeys?.length) filters.groupByAttributeKeys = acc.groupByAttributeKeys
@@ -858,15 +926,14 @@ export function buildTimeseriesQuerySpec(query: QueryBuilderQueryDraftPayload): 
 		}
 	}
 
-	const metricsFilters = clauses.reduce((acc, clause) => applyMetricsClause(acc, clause, warnings), {
-		metricName: query.metricName,
-		metricType: query.metricType ?? "gauge",
-	} as {
-		metricName: string
-		metricType: QueryBuilderMetricType
-		serviceName?: string
-		groupByAttributeKey?: string
-	})
+	const metricsFilters = clauses.reduce<MetricsFilterAccumulator>(
+		(acc, clause) => applyMetricsClause(acc, clause, warnings),
+		{
+			metricName: query.metricName,
+			metricType: query.metricType ?? "gauge",
+			resourceAttributeFilters: [],
+		},
+	)
 
 	const metricsGroupByKeys: MetricsGroupByKey[] = []
 	if (query.addOns?.groupBy && (query.groupBy?.length ?? 0) > 0) {
@@ -877,7 +944,33 @@ export function buildTimeseriesQuerySpec(query: QueryBuilderQueryDraftPayload): 
 			if (resolved) metricsGroupByKeys.push(resolved)
 		}
 	}
+
+	// The metrics queries carry a single attribute group column; when both an
+	// attr.* and a resource.* token are given, keep whichever came first and
+	// warn about the other (silently dropping either is the footgun this file
+	// exists to prevent).
+	const attrIdx = metricsGroupByKeys.indexOf("attribute")
+	const resourceIdx = metricsGroupByKeys.indexOf("resource_attribute")
+	if (attrIdx !== -1 && resourceIdx !== -1) {
+		const dropResource = attrIdx < resourceIdx
+		warnings.push(
+			`Metrics queries support a single attribute group by; ignoring ${
+				dropResource
+					? `resource.${metricsFilters.groupByResourceAttributeKey}`
+					: `attr.${metricsFilters.groupByAttributeKey}`
+			}`,
+		)
+		const dropped: MetricsGroupByKey = dropResource ? "resource_attribute" : "attribute"
+		for (let i = metricsGroupByKeys.length - 1; i >= 0; i--) {
+			if (metricsGroupByKeys[i] === dropped) metricsGroupByKeys.splice(i, 1)
+		}
+		if (dropResource) delete metricsFilters.groupByResourceAttributeKey
+		else delete metricsFilters.groupByAttributeKey
+	}
+
 	const groupBy = metricsGroupByKeys.length > 0 ? dedupeGroupByKeys(metricsGroupByKeys) : undefined
+
+	const { resourceAttributeFilters: metricsResourceFilters, ...metricsSpecFilters } = metricsFilters
 
 	return {
 		query: {
@@ -885,7 +978,12 @@ export function buildTimeseriesQuerySpec(query: QueryBuilderQueryDraftPayload): 
 			source: "metrics",
 			metric: query.aggregation as "avg" | "sum" | "min" | "max" | "count" | "rate" | "increase",
 			groupBy,
-			filters: metricsFilters,
+			filters: {
+				...metricsSpecFilters,
+				...(metricsResourceFilters.length > 0
+					? { resourceAttributeFilters: metricsResourceFilters }
+					: {}),
+			},
 			bucketSeconds,
 		} as QuerySpec,
 		warnings,

--- a/packages/query-engine/src/runtime/query-engine.ts
+++ b/packages/query-engine/src/runtime/query-engine.ts
@@ -364,12 +364,29 @@ const validateMetricsAttributeFilters = Effect.fn(
 	// `groupBy` is an array for timeseries, a single literal for breakdown.
 	const groupBy = query.groupBy
 	const wantsAttribute = Array.isArray(groupBy) ? groupBy.includes("attribute") : groupBy === "attribute"
+	const wantsResourceAttribute = Array.isArray(groupBy)
+		? groupBy.includes("resource_attribute")
+		: groupBy === "resource_attribute"
 	if (wantsAttribute && !query.filters.groupByAttributeKey) {
 		// Mirror the traces guard: never silently downgrade an attribute grouping
 		// to a service grouping — the agent asked for a label breakdown.
 		return yield* new QueryEngineValidationError({
 			message: "Invalid metrics attribute grouping",
 			details: ["groupBy=attribute requires filters.groupByAttributeKey"],
+		})
+	}
+	if (wantsResourceAttribute && !query.filters.groupByResourceAttributeKey) {
+		return yield* new QueryEngineValidationError({
+			message: "Invalid metrics attribute grouping",
+			details: ["groupBy=resource_attribute requires filters.groupByResourceAttributeKey"],
+		})
+	}
+	if (wantsAttribute && wantsResourceAttribute) {
+		// The metrics queries carry a single attributeValue group column — one
+		// attribute dimension per query.
+		return yield* new QueryEngineValidationError({
+			message: "Invalid metrics attribute grouping",
+			details: ["groupBy cannot combine attribute and resource_attribute"],
 		})
 	}
 })
@@ -1064,7 +1081,11 @@ export const makeQueryEngineExecute = <T extends QueryTenant>(warehouse: QueryEn
 			const groupByAttributeKey = groupByAttribute
 				? request.query.filters.groupByAttributeKey
 				: undefined
+			const groupByResourceAttributeKey = request.query.groupBy?.includes("resource_attribute")
+				? request.query.filters.groupByResourceAttributeKey
+				: undefined
 			const attributeFilter = request.query.filters.attributeFilters?.[0]
+			const resourceAttributeFilters = request.query.filters.resourceAttributeFilters
 
 			const isRateOrIncrease = request.query.metric === "rate" || request.query.metric === "increase"
 
@@ -1076,8 +1097,10 @@ export const makeQueryEngineExecute = <T extends QueryTenant>(warehouse: QueryEn
 						bucketSeconds: bucketSeconds!,
 						serviceName: request.query.filters.serviceName,
 						groupByAttributeKey,
+						groupByResourceAttributeKey,
 						attributeKey: attributeFilter?.key,
 						attributeValue: attributeFilter?.value,
+						resourceAttributeFilters,
 					}),
 					{
 						orgId: tenant.orgId,
@@ -1101,7 +1124,7 @@ export const makeQueryEngineExecute = <T extends QueryTenant>(warehouse: QueryEn
 					rateResult,
 					(row) => Number(row[rateValueField]),
 					request.query.groupBy,
-					groupByAttributeKey,
+					groupByAttributeKey ?? groupByResourceAttributeKey,
 					fillOptions,
 				)
 
@@ -1121,8 +1144,10 @@ export const makeQueryEngineExecute = <T extends QueryTenant>(warehouse: QueryEn
 					metricType: request.query.filters.metricType,
 					serviceName: request.query.filters.serviceName,
 					groupByAttributeKey,
+					groupByResourceAttributeKey,
 					attributeKey: attributeFilter?.key,
 					attributeValue: attributeFilter?.value,
+					resourceAttributeFilters,
 				}),
 				{
 					orgId: tenant.orgId,
@@ -1157,7 +1182,7 @@ export const makeQueryEngineExecute = <T extends QueryTenant>(warehouse: QueryEn
 							result,
 							(row) => Number(row[valueField]),
 							request.query.groupBy,
-							groupByAttributeKey,
+							groupByAttributeKey ?? groupByResourceAttributeKey,
 							fillOptions,
 						)
 
@@ -1241,6 +1266,11 @@ export const makeQueryEngineExecute = <T extends QueryTenant>(warehouse: QueryEn
 						request.query.filters.groupByAttributeKey && {
 							groupByAttributeKey: request.query.filters.groupByAttributeKey,
 						}),
+					...(request.query.groupBy === "resource_attribute" &&
+						request.query.filters.groupByResourceAttributeKey && {
+							groupByResourceAttributeKey: request.query.filters.groupByResourceAttributeKey,
+						}),
+					resourceAttributeFilters: request.query.filters.resourceAttributeFilters,
 					limit: request.query.limit,
 				}),
 				{
@@ -1592,7 +1622,9 @@ const composeMetricsGroupKey = (
 	const parts: string[] = []
 	for (const dim of groupBy) {
 		if (dim === "service") parts.push(serviceName || "")
-		else if (dim === "attribute") parts.push(attributeValue || "")
+		// Both attribute dimensions surface through the query's single
+		// attributeValue column (only one can be active per query).
+		else if (dim === "attribute" || dim === "resource_attribute") parts.push(attributeValue || "")
 	}
 	const filtered = parts.filter((p) => p.length > 0)
 	if (filtered.length === 0) return "all"
@@ -1696,6 +1728,9 @@ export const computeEvaluateBuckets = Effect.fnUntraced(function* <T extends Que
 	} else {
 		const groupByAttribute = query.groupBy?.includes("attribute")
 		const groupByAttributeKey = groupByAttribute ? query.filters.groupByAttributeKey : undefined
+		const groupByResourceAttributeKey = query.groupBy?.includes("resource_attribute")
+			? query.filters.groupByResourceAttributeKey
+			: undefined
 		const rows = yield* executeCHQuery(
 			warehouse,
 			tenant,
@@ -1703,6 +1738,8 @@ export const computeEvaluateBuckets = Effect.fnUntraced(function* <T extends Que
 				metricType: query.filters.metricType,
 				serviceName: query.filters.serviceName,
 				groupByAttributeKey,
+				groupByResourceAttributeKey,
+				resourceAttributeFilters: query.filters.resourceAttributeFilters,
 			}),
 			{
 				orgId: tenant.orgId,
@@ -1858,6 +1895,9 @@ export const makeQueryEngineEvaluate = <T extends QueryTenant>(warehouse: QueryE
 			const groupByAttributeKey = groupByAttribute
 				? metricsQuery.filters.groupByAttributeKey
 				: undefined
+			const groupByResourceAttributeKey = metricsQuery.groupBy?.includes("resource_attribute")
+				? metricsQuery.filters.groupByResourceAttributeKey
+				: undefined
 
 			const rows = yield* executeCHQuery(
 				warehouse,
@@ -1866,6 +1906,8 @@ export const makeQueryEngineEvaluate = <T extends QueryTenant>(warehouse: QueryE
 					metricType: metricsQuery.filters.metricType,
 					serviceName: metricsQuery.filters.serviceName,
 					groupByAttributeKey,
+					groupByResourceAttributeKey,
+					resourceAttributeFilters: metricsQuery.filters.resourceAttributeFilters,
 				}),
 				{
 					orgId: tenant.orgId,

--- a/packages/query-engine/src/runtime/validate-metrics-attribute.test.ts
+++ b/packages/query-engine/src/runtime/validate-metrics-attribute.test.ts
@@ -62,4 +62,60 @@ describe("validateMetricsAttributeFilters", () => {
 			assert.isDefined(range)
 		}),
 	)
+
+	it.effect("rejects groupBy=resource_attribute when groupByResourceAttributeKey is missing", () =>
+		Effect.gen(function* () {
+			const exit = yield* validateEvaluate(
+				makeRequest({
+					kind: "timeseries",
+					source: "metrics",
+					metric: "avg",
+					groupBy: ["resource_attribute"],
+					filters: baseFilters,
+				}),
+			).pipe(Effect.exit)
+
+			assert.isTrue(exit._tag === "Failure")
+			assert.include(
+				JSON.stringify(exit),
+				"groupBy=resource_attribute requires filters.groupByResourceAttributeKey",
+			)
+		}),
+	)
+
+	it.effect("accepts groupBy=resource_attribute when groupByResourceAttributeKey is present", () =>
+		Effect.gen(function* () {
+			const range = yield* validateEvaluate(
+				makeRequest({
+					kind: "timeseries",
+					source: "metrics",
+					metric: "avg",
+					groupBy: ["resource_attribute"],
+					filters: { ...baseFilters, groupByResourceAttributeKey: "host.name" },
+				}),
+			)
+			assert.isDefined(range)
+		}),
+	)
+
+	it.effect("rejects combining attribute and resource_attribute group-bys", () =>
+		Effect.gen(function* () {
+			const exit = yield* validateEvaluate(
+				makeRequest({
+					kind: "timeseries",
+					source: "metrics",
+					metric: "avg",
+					groupBy: ["attribute", "resource_attribute"],
+					filters: {
+						...baseFilters,
+						groupByAttributeKey: "region",
+						groupByResourceAttributeKey: "host.name",
+					},
+				}),
+			).pipe(Effect.exit)
+
+			assert.isTrue(exit._tag === "Failure")
+			assert.include(JSON.stringify(exit), "groupBy cannot combine attribute and resource_attribute")
+		}),
+	)
 })

--- a/packages/ui/src/components/charts/_shared/query-builder-legend.tsx
+++ b/packages/ui/src/components/charts/_shared/query-builder-legend.tsx
@@ -48,6 +48,23 @@ export function computeSeriesStats(
 	return result
 }
 
+function isAllZeroStats(stats: SeriesStats | undefined): boolean {
+	return stats != null && stats.min === 0 && stats.max === 0 && stats.mean === 0 && stats.last === 0
+}
+
+/**
+ * Stable sort that pushes all-zero series to the bottom of the legend, so
+ * series with actual data aren't buried under rows of zeros (MAP-49).
+ */
+export function sortZeroSeriesLast(
+	series: ReadonlyArray<LegendSeries>,
+	stats: Record<string, SeriesStats>,
+): LegendSeries[] {
+	return [...series].sort(
+		(a, b) => Number(isAllZeroStats(stats[a.key])) - Number(isAllZeroStats(stats[b.key])),
+	)
+}
+
 interface QueryBuilderLegendProps {
 	series: ReadonlyArray<LegendSeries>
 	stats: Record<string, SeriesStats>
@@ -187,6 +204,7 @@ export function QueryBuilderLegend({
 					{series.map((entry) => {
 						const entryStats = stats[entry.key]
 						const isHidden = hidden.has(entry.key)
+						const allZero = isAllZeroStats(entryStats)
 						return (
 							<tr
 								key={entry.key}
@@ -202,17 +220,31 @@ export function QueryBuilderLegend({
 											className="size-2 shrink-0 rounded-[2px]"
 											style={{ backgroundColor: entry.color }}
 										/>
-										<span className="truncate">{entry.label}</span>
+										<span className={cn("truncate", allZero && "text-muted-foreground")}>
+											{entry.label}
+										</span>
 									</span>
 								</td>
-								{STAT_COLUMNS.map((column) => (
+								{allZero ? (
+									// Four zeros in a row read as noise — collapse to one muted 0.
 									<td
-										key={column.field}
-										className="px-2 text-right font-mono tabular-nums last:pr-0"
+										colSpan={STAT_COLUMNS.length}
+										className="px-2 text-right font-mono tabular-nums text-muted-foreground/60"
 									>
-										{entryStats ? formatValueByUnit(entryStats[column.field], unit) : "—"}
+										0
 									</td>
-								))}
+								) : (
+									STAT_COLUMNS.map((column) => (
+										<td
+											key={column.field}
+											className="px-2 text-right font-mono tabular-nums last:pr-0"
+										>
+											{entryStats
+												? formatValueByUnit(entryStats[column.field], unit)
+												: "—"}
+										</td>
+									))
+								)}
 							</tr>
 						)
 					})}

--- a/packages/ui/src/components/charts/_shared/sparse-series.ts
+++ b/packages/ui/src/components/charts/_shared/sparse-series.ts
@@ -1,0 +1,63 @@
+/**
+ * Sparse-series detection for time-series charts.
+ *
+ * Low-volume data (a handful of non-zero buckets among zero-filled ones)
+ * renders as invisible zero-width spikes on line/area charts. When a series
+ * is "sparse" — mostly zeros, or containing isolated non-zero points whose
+ * neighbors are all zero — charts auto-enable point dots so single-bucket
+ * values stay visible (MAP-49).
+ */
+
+const SPARSE_NONZERO_FRACTION = 0.3
+
+function valueAt(row: Record<string, unknown> | undefined, key: string): number {
+	const value = row?.[key]
+	return typeof value === "number" && Number.isFinite(value) ? value : 0
+}
+
+export function isSparseSeries(
+	data: ReadonlyArray<Record<string, unknown>>,
+	keys: ReadonlyArray<string>,
+): boolean {
+	if (data.length < 3 || keys.length === 0) return false
+
+	let nonZero = 0
+	let total = 0
+	for (const key of keys) {
+		for (let i = 0; i < data.length; i++) {
+			const value = valueAt(data[i], key)
+			total++
+			if (value === 0) continue
+			nonZero++
+			// An isolated point (both neighbors zero/missing) can never render as
+			// a visible line segment — that alone warrants dots.
+			const prev = valueAt(data[i - 1], key)
+			const next = valueAt(data[i + 1], key)
+			if (prev === 0 && next === 0) return true
+		}
+	}
+
+	if (nonZero === 0) return false
+	return nonZero / total < SPARSE_NONZERO_FRACTION
+}
+
+/**
+ * True when every finite value across the given keys is an integer — used to
+ * suppress fractional y-axis ticks (0.5, 1.5) on count-like axes while keeping
+ * decimal ticks for rates/ratios.
+ */
+export function hasOnlyIntegerValues(
+	data: ReadonlyArray<Record<string, unknown>>,
+	keys: ReadonlyArray<string>,
+): boolean {
+	let sawValue = false
+	for (const row of data) {
+		for (const key of keys) {
+			const value = row[key]
+			if (typeof value !== "number" || !Number.isFinite(value)) continue
+			if (!Number.isInteger(value)) return false
+			sawValue = true
+		}
+	}
+	return sawValue
+}

--- a/packages/ui/src/components/charts/area/query-builder-area-chart.tsx
+++ b/packages/ui/src/components/charts/area/query-builder-area-chart.tsx
@@ -9,6 +9,7 @@ import {
 	type LegendSeries,
 	QueryBuilderLegend,
 	computeSeriesStats,
+	sortZeroSeriesLast,
 	responsiveLegendHeight,
 } from "../_shared/query-builder-legend"
 import { thresholdReferenceLines } from "../_shared/threshold-lines"
@@ -22,6 +23,7 @@ import {
 	ChartTooltipContent,
 } from "../../ui/chart"
 import { formatValueByUnit, inferBucketSeconds, inferRangeMs, formatBucketLabel } from "../../../lib/format"
+import { isSparseSeries, hasOnlyIntegerValues } from "../_shared/sparse-series"
 
 const fallbackData: Record<string, unknown>[] = [
 	{ bucket: "2026-01-01T00:00:00Z", A: 12, B: 8 },
@@ -61,6 +63,7 @@ export function QueryBuilderAreaChart({
 	fitYAxisToData,
 	syncId,
 	thresholds,
+	showPoints,
 }: BaseChartProps) {
 	const { chartData, seriesDefinitions } = React.useMemo(() => {
 		const source = Array.isArray(data) && data.length > 0 ? data : fallbackData
@@ -161,14 +164,29 @@ export function QueryBuilderAreaChart({
 		[processedData, valueKeys],
 	)
 
+	// Sparse data (isolated non-zero buckets between zeros) renders as barely
+	// visible spikes — auto-enable dots so single-bucket values stay readable.
+	const sparse = React.useMemo(() => isSparseSeries(processedData, valueKeys), [processedData, valueKeys])
+	const renderDots = showPoints || sparse
+
+	// Integer-only data (counts) shouldn't get fractional ticks (0.5/1.5); a
+	// unit or any fractional value keeps decimal ticks (rates, ratios).
+	const integerOnlyData = React.useMemo(
+		() => hasOnlyIntegerValues(processedData, valueKeys),
+		[processedData, valueKeys],
+	)
+
 	const legendSeries = React.useMemo<LegendSeries[]>(
 		() =>
-			seriesDefinitions.map((definition) => ({
-				key: definition.chartKey,
-				label: definition.rawKey,
-				color: chartConfig[definition.chartKey]?.color ?? "var(--chart-1)",
-			})),
-		[seriesDefinitions, chartConfig],
+			sortZeroSeriesLast(
+				seriesDefinitions.map((definition) => ({
+					key: definition.chartKey,
+					label: definition.rawKey,
+					color: chartConfig[definition.chartKey]?.color ?? "var(--chart-1)",
+				})),
+				seriesStats,
+			),
+		[seriesDefinitions, chartConfig, seriesStats],
 	)
 
 	const containerRef = React.useRef<HTMLDivElement>(null)
@@ -282,10 +300,11 @@ export function QueryBuilderAreaChart({
 					<YAxis
 						tickLine={false}
 						axisLine={false}
-						tickMargin={8}
-						width={80}
+						tickMargin={6}
+						width={56}
 						scale={logScale ? "log" : "auto"}
 						domain={[yDomainMin, yDomainMax]}
+						allowDecimals={!integerOnlyData}
 						allowDataOverflow={
 							logScale || softMin != null || softMax != null || fitDomainMin != null
 						}
@@ -380,6 +399,15 @@ export function QueryBuilderAreaChart({
 							stroke={`var(--color-${definition.chartKey})`}
 							fill={`url(#fill-${definition.chartKey})`}
 							strokeWidth={2}
+							dot={
+								renderDots
+									? {
+											r: 2.5,
+											strokeWidth: 0,
+											fill: `var(--color-${definition.chartKey})`,
+										}
+									: false
+							}
 							hide={hiddenSeries.has(definition.chartKey)}
 							isAnimationActive={false}
 							activeDot={(props: { cx?: number; cy?: number }) => {

--- a/packages/ui/src/components/charts/bar/query-builder-bar-chart.tsx
+++ b/packages/ui/src/components/charts/bar/query-builder-bar-chart.tsx
@@ -9,6 +9,7 @@ import {
 	type LegendSeries,
 	QueryBuilderLegend,
 	computeSeriesStats,
+	sortZeroSeriesLast,
 	responsiveLegendHeight,
 } from "../_shared/query-builder-legend"
 import { bucketTimeseries, MAX_BAR_SERIES, OTHER_COLOR, OTHER_LABEL } from "../_shared/bucket-series"
@@ -21,6 +22,7 @@ import {
 	ChartTooltipContent,
 } from "../../ui/chart"
 import { formatValueByUnit, inferBucketSeconds, inferRangeMs, formatBucketLabel } from "../../../lib/format"
+import { hasOnlyIntegerValues } from "../_shared/sparse-series"
 
 const fallbackData: Record<string, unknown>[] = [
 	{ bucket: "2026-01-01T00:00:00Z", A: 12, B: 8 },
@@ -168,16 +170,28 @@ export function QueryBuilderBarChart({
 
 	const legendSeries = React.useMemo<LegendSeries[]>(
 		() =>
-			seriesDefinitions.map((definition) => ({
-				key: definition.chartKey,
-				label: definition.rawKey,
-				color: chartConfig[definition.chartKey]?.color ?? "var(--chart-1)",
-			})),
-		[seriesDefinitions, chartConfig],
+			sortZeroSeriesLast(
+				seriesDefinitions.map((definition) => ({
+					key: definition.chartKey,
+					label: definition.rawKey,
+					color: chartConfig[definition.chartKey]?.color ?? "var(--chart-1)",
+				})),
+				seriesStats,
+			),
+		[seriesDefinitions, chartConfig, seriesStats],
 	)
 
 	const containerRef = React.useRef<HTMLDivElement>(null)
 	const { height: containerHeight } = useContainerSize(containerRef)
+
+	const integerOnlyData = React.useMemo(
+		() =>
+			hasOnlyIntegerValues(
+				displayData,
+				seriesDefinitions.map((d) => d.chartKey),
+			),
+		[displayData, seriesDefinitions],
+	)
 
 	const variant = showStats ? "stats" : "compact"
 	const showLegendBlock = legend === "visible" || legend === "right"
@@ -191,7 +205,14 @@ export function QueryBuilderBarChart({
 				className="h-full w-full aspect-auto"
 				hoistLegend={!showLegendBlock}
 			>
-				<BarChart data={displayData} accessibilityLayer syncId={syncId} syncMethod="value">
+				<BarChart
+					data={displayData}
+					accessibilityLayer
+					syncId={syncId}
+					syncMethod="value"
+					maxBarSize={48}
+					barCategoryGap="15%"
+				>
 					<CartesianGrid vertical={false} />
 					<XAxis
 						dataKey="bucket"
@@ -203,10 +224,11 @@ export function QueryBuilderBarChart({
 					<YAxis
 						tickLine={false}
 						axisLine={false}
-						tickMargin={8}
-						width={80}
+						tickMargin={6}
+						width={56}
 						scale={logScale ? "log" : "auto"}
 						domain={[softMin ?? (logScale ? 1 : "auto"), softMax ?? "auto"]}
+						allowDecimals={!integerOnlyData}
 						allowDataOverflow={logScale || softMin != null || softMax != null}
 						tickFormatter={(value) => formatValueByUnit(asFiniteNumber(value), unit)}
 					/>
@@ -289,8 +311,9 @@ export function QueryBuilderBarChart({
 							dataKey={definition.chartKey}
 							fill={`var(--color-${definition.chartKey})`}
 							radius={
-								stacked && index < seriesDefinitions.length - 1 ? [0, 0, 0, 0] : [4, 4, 0, 0]
+								stacked && index < seriesDefinitions.length - 1 ? [0, 0, 0, 0] : [2, 2, 0, 0]
 							}
+							minPointSize={(value: number | null | undefined) => ((value ?? 0) > 0 ? 2 : 0)}
 							hide={hiddenSeries.has(definition.chartKey)}
 							isAnimationActive={false}
 							{...(stacked ? { stackId: "a" } : {})}

--- a/packages/ui/src/components/charts/funnel/query-builder-funnel-chart.tsx
+++ b/packages/ui/src/components/charts/funnel/query-builder-funnel-chart.tsx
@@ -5,9 +5,12 @@ import { cn } from "../../../lib/utils"
 import { formatNumber, formatValueByUnit } from "../../../lib/format"
 import { funnelSampleData } from "../_shared/sample-data"
 import { resolveSeriesColor } from "../../../lib/semantic-series-colors"
+import { useContainerSize } from "../../../hooks/use-container-size"
 
 interface Row {
 	name: string
+	/** True when the source row had no usable label. */
+	unnamed: boolean
 	value: number
 }
 
@@ -17,8 +20,8 @@ interface Stage extends Row {
 	widthPct: number
 	/** Share of the first stage's value (0–1). */
 	pctOfFirst: number
-	/** Conversion from the previous stage (0–1); 1 for the first stage. */
-	pctOfPrev: number
+	/** Conversion from the previous stage (0–1); null when there is no previous non-zero stage. */
+	pctOfPrev: number | null
 }
 
 function asFiniteNumber(value: unknown): number {
@@ -36,6 +39,55 @@ function pickValueField(rows: ReadonlyArray<Record<string, unknown>>): string {
 	return "value"
 }
 
+/**
+ * Normalize source rows into named stages. Guards the mis-wired case where a
+ * funnel receives timeseries rows (`{bucket, seriesA, seriesB}`) instead of a
+ * breakdown (`{name, value}`): rendering one "—" row per time bucket is
+ * meaningless, so aggregate each numeric series across buckets into a single
+ * stage instead (MAP-49).
+ */
+function toRows(source: ReadonlyArray<Record<string, unknown>>, valueField: string): Row[] {
+	const first = source[0]
+	const isTimeseriesShaped = first != null && "bucket" in first && !("name" in first)
+	if (isTimeseriesShaped) {
+		const totals = new Map<string, number>()
+		for (const row of source) {
+			for (const [key, value] of Object.entries(row)) {
+				if (key === "bucket" || typeof value !== "number") continue
+				totals.set(key, (totals.get(key) ?? 0) + asFiniteNumber(value))
+			}
+		}
+		return Array.from(totals, ([name, value]) => ({ name, unnamed: false, value })).sort(
+			(a, b) => b.value - a.value,
+		)
+	}
+	return source.map((row) => {
+		const raw = row.name == null ? "" : String(row.name).trim()
+		return {
+			name: raw === "" ? "(no value)" : raw,
+			unnamed: raw === "",
+			value: asFiniteNumber(row[valueField]),
+		}
+	})
+}
+
+/**
+ * Drop meaningless zero rows: a zero stage is kept only when a non-zero stage
+ * follows it (a genuine funnel drop-to-zero step reads differently from a pile
+ * of empty groups at the tail).
+ */
+function dropTrailingZeroRows(rows: Row[]): Row[] {
+	let lastNonZero = -1
+	for (let i = rows.length - 1; i >= 0; i--) {
+		if (rows[i].value > 0) {
+			lastNonZero = i
+			break
+		}
+	}
+	// Keep one zero stage directly after the last non-zero one ("dropped to 0").
+	return rows.slice(0, Math.min(rows.length, lastNonZero + 2))
+}
+
 function fmtValue(value: number, unit?: string): string {
 	return unit ? formatValueByUnit(value, unit) : formatNumber(value)
 }
@@ -47,7 +99,10 @@ function fmtPct(fraction: number): string {
 
 const ROW_GAP = 6
 const ROW_MIN_H = 22
+/** Label line (~11px) + gap + bar (10px). */
+const ROW_FULL_H = ROW_MIN_H + ROW_GAP
 const BAR_MIN_PCT = 0.04
+const MORE_ROW_H = 16
 
 export function QueryBuilderFunnelChart({ data, className, unit, funnel }: BaseChartProps) {
 	const source: ReadonlyArray<Record<string, unknown>> =
@@ -57,11 +112,11 @@ export function QueryBuilderFunnelChart({ data, className, unit, funnel }: BaseC
 
 	const valueField = React.useMemo(() => pickValueField(source), [source])
 
+	const containerRef = React.useRef<HTMLDivElement>(null)
+	const { height } = useContainerSize(containerRef)
+
 	const stages = React.useMemo(() => {
-		const rows: Row[] = source.map((row) => ({
-			name: String(row.name ?? "—"),
-			value: asFiniteNumber(row[valueField]),
-		}))
+		const rows = dropTrailingZeroRows(toRows(source, valueField))
 		const max = rows.reduce((acc, r) => Math.max(acc, r.value), 0)
 		const first = rows[0]?.value ?? 0
 		if (max <= 0) return [] as Stage[]
@@ -73,10 +128,19 @@ export function QueryBuilderFunnelChart({ data, className, unit, funnel }: BaseC
 				color,
 				widthPct: Math.max(BAR_MIN_PCT, row.value / max),
 				pctOfFirst: first > 0 ? row.value / first : 0,
-				pctOfPrev: idx === 0 ? 1 : prev && prev > 0 ? row.value / prev : 0,
+				pctOfPrev: idx === 0 || prev == null || prev <= 0 ? null : row.value / prev,
 			}
 		})
 	}, [source, valueField])
+
+	// Render only the rows that fit the measured container, with a muted
+	// "+N more" row when stages are cut — rows must never spill out of the
+	// card (MAP-49). Before the first measurement (height 0) render everything;
+	// the card clips and the next frame corrects.
+	const maxRows = height > 0 ? Math.max(1, Math.floor((height - MORE_ROW_H) / ROW_FULL_H)) : stages.length
+	const truncated = stages.length > maxRows
+	const visibleStages = truncated ? stages.slice(0, maxRows) : stages
+	const hiddenCount = stages.length - visibleStages.length
 
 	const [hover, setHover] = React.useState<number | null>(null)
 	const showStepPercent = funnel?.showStepPercent === true
@@ -91,30 +155,41 @@ export function QueryBuilderFunnelChart({ data, className, unit, funnel }: BaseC
 
 	return (
 		<div
-			className={cn("flex h-full w-full flex-col justify-center gap-1.5 px-1 select-none", className)}
+			ref={containerRef}
+			className={cn(
+				"flex h-full w-full flex-col gap-1.5 overflow-hidden px-1 select-none",
+				truncated ? "justify-start" : "justify-center",
+				className,
+			)}
 			style={{ rowGap: ROW_GAP }}
 			onPointerLeave={() => setHover(null)}
 		>
-			{stages.map((stage, i) => {
+			{visibleStages.map((stage, i) => {
 				const isHover = hover === i
 				const fade = hover !== null && !isHover ? 0.55 : 1
 				return (
 					<div
-						key={stage.name}
-						className="flex min-h-0 flex-1 flex-col justify-center gap-0.5"
+						key={`${stage.name}-${i}`}
+						className="flex min-h-0 flex-col justify-center gap-0.5"
 						style={{ minHeight: ROW_MIN_H }}
 						onPointerEnter={() => setHover(i)}
 					>
 						{/* Label row */}
 						<div className="flex items-baseline justify-between gap-2 text-[11px] leading-none">
-							<span className="truncate text-foreground/90" title={stage.name}>
+							<span
+								className={cn(
+									"truncate",
+									stage.unnamed ? "italic text-muted-foreground" : "text-foreground/90",
+								)}
+								title={stage.name}
+							>
 								{stage.name}
 							</span>
 							<span className="shrink-0 tabular-nums text-muted-foreground">
 								<span className="text-foreground/90">{fmtValue(stage.value, unit)}</span>
 								<span className="px-1 text-muted-foreground/50">·</span>
 								<span>{fmtPct(stage.pctOfFirst)}</span>
-								{showStepPercent && i > 0 && (
+								{showStepPercent && stage.pctOfPrev != null && (
 									<>
 										<span className="px-1 text-muted-foreground/50">↓</span>
 										<span>{fmtPct(stage.pctOfPrev)}</span>
@@ -137,6 +212,11 @@ export function QueryBuilderFunnelChart({ data, className, unit, funnel }: BaseC
 					</div>
 				)
 			})}
+			{hiddenCount > 0 && (
+				<div className="shrink-0 text-[10px] leading-none text-muted-foreground">
+					+{hiddenCount} more
+				</div>
+			)}
 		</div>
 	)
 }

--- a/packages/ui/src/components/charts/heatmap/query-builder-heatmap-chart.tsx
+++ b/packages/ui/src/components/charts/heatmap/query-builder-heatmap-chart.tsx
@@ -190,7 +190,7 @@ const Y_LABEL_MIN_PX = 36
 const Y_LABEL_MAX_PX = 96
 
 // Minimum vertical room each y-label needs to avoid stacking neighbours.
-const Y_LABEL_MIN_VERTICAL_PX = 13
+const Y_LABEL_MIN_VERTICAL_PX = 16
 
 interface HoverState {
 	x: string
@@ -252,7 +252,11 @@ function computeLayout(
 	const yTickStep = Math.max(1, Math.ceil(Y_LABEL_MIN_VERTICAL_PX / yStride))
 	const yTickIndices: number[] = []
 	for (let i = 0; i < yValues.length; i += yTickStep) yTickIndices.push(i)
-	if (yTickIndices[yTickIndices.length - 1] !== yValues.length - 1) {
+	// Always label the last row, but drop the previous pick if the two would
+	// land within one step of each other (they'd visually collide).
+	const lastPicked = yTickIndices[yTickIndices.length - 1]
+	if (lastPicked !== yValues.length - 1) {
+		if (yValues.length - 1 - lastPicked < yTickStep) yTickIndices.pop()
 		yTickIndices.push(yValues.length - 1)
 	}
 
@@ -356,8 +360,9 @@ export function QueryBuilderHeatmapChart({ data, className, tooltip, unit, heatm
 	const colCenterX = (xi: number) => xi * xStride + cellW / 2
 	const rowCenterY = (yi: number) => yi * yStride + cellH / 2
 
-	// Legend ticks: linear shows endpoints; log adds a geometric midpoint so
-	// the spacing reads as logarithmic.
+	// Legend ticks: both scales get a midpoint so the gradient reads as a
+	// scale, not just two endpoints; log uses a geometric midpoint so the
+	// spacing reads as logarithmic.
 	const legendTicks: Array<{ value: number; pct: number; anchor: "start" | "middle" | "end" }> =
 		span <= 0
 			? [{ value: min, pct: 0, anchor: "start" }]
@@ -373,6 +378,7 @@ export function QueryBuilderHeatmapChart({ data, className, tooltip, unit, heatm
 					]
 				: [
 						{ value: min, pct: 0, anchor: "start" },
+						{ value: min + span / 2, pct: 50, anchor: "middle" },
 						{ value: max, pct: 100, anchor: "end" },
 					]
 

--- a/packages/ui/src/components/charts/histogram/query-builder-histogram-chart.tsx
+++ b/packages/ui/src/components/charts/histogram/query-builder-histogram-chart.tsx
@@ -107,14 +107,21 @@ export function QueryBuilderHistogramChart({
 					axisLine={false}
 					tickMargin={8}
 					interval="preserveStartEnd"
-					minTickGap={20}
+					minTickGap={32}
+					tick={{ fontSize: 10 }}
+					// Axis ticks show only the bucket's lower bound ("150" instead
+					// of "150-200") — halves label width so ticks stop overlapping;
+					// the full range stays in the tooltip.
+					tickFormatter={(value) => String(value).split("-")[0] || String(value)}
 				/>
 				<YAxis
 					tickLine={false}
 					axisLine={false}
-					tickMargin={8}
+					tickMargin={6}
+					width={48}
 					scale={useLogY ? "log" : "auto"}
 					domain={useLogY ? [1, "auto"] : ["auto", "auto"]}
+					allowDecimals={false}
 					allowDataOverflow={useLogY}
 					tickFormatter={(value) => formatNumber(asFiniteNumber(value))}
 				/>

--- a/packages/ui/src/components/charts/line/query-builder-line-chart.tsx
+++ b/packages/ui/src/components/charts/line/query-builder-line-chart.tsx
@@ -9,6 +9,7 @@ import {
 	type LegendSeries,
 	QueryBuilderLegend,
 	computeSeriesStats,
+	sortZeroSeriesLast,
 	responsiveLegendHeight,
 } from "../_shared/query-builder-legend"
 import { thresholdReferenceLines } from "../_shared/threshold-lines"
@@ -22,6 +23,7 @@ import {
 	ChartTooltipContent,
 } from "../../ui/chart"
 import { formatValueByUnit, inferBucketSeconds, inferRangeMs, formatBucketLabel } from "../../../lib/format"
+import { isSparseSeries, hasOnlyIntegerValues } from "../_shared/sparse-series"
 
 const fallbackData: Record<string, unknown>[] = [
 	{ bucket: "2026-01-01T00:00:00Z", A: 12, B: 8 },
@@ -172,14 +174,26 @@ export function QueryBuilderLineChart({
 		[processedData, valueKeys],
 	)
 
+	// Sparse data (isolated non-zero buckets between zeros) renders as barely
+	// visible spikes — auto-enable dots so single-bucket values stay readable.
+	const sparse = React.useMemo(() => isSparseSeries(processedData, valueKeys), [processedData, valueKeys])
+	const renderDots = showPoints || sparse
+	const integerOnlyData = React.useMemo(
+		() => hasOnlyIntegerValues(processedData, valueKeys),
+		[processedData, valueKeys],
+	)
+
 	const legendSeries = React.useMemo<LegendSeries[]>(
 		() =>
-			seriesDefinitions.map((definition) => ({
-				key: definition.chartKey,
-				label: definition.rawKey,
-				color: chartConfig[definition.chartKey]?.color ?? "var(--chart-1)",
-			})),
-		[seriesDefinitions, chartConfig],
+			sortZeroSeriesLast(
+				seriesDefinitions.map((definition) => ({
+					key: definition.chartKey,
+					label: definition.rawKey,
+					color: chartConfig[definition.chartKey]?.color ?? "var(--chart-1)",
+				})),
+				seriesStats,
+			),
+		[seriesDefinitions, chartConfig, seriesStats],
 	)
 
 	const containerRef = React.useRef<HTMLDivElement>(null)
@@ -246,8 +260,9 @@ export function QueryBuilderLineChart({
 					<YAxis
 						tickLine={false}
 						axisLine={false}
-						tickMargin={8}
-						width={80}
+						tickMargin={6}
+						width={56}
+						allowDecimals={!integerOnlyData}
 						scale={logScale ? "log" : "auto"}
 						domain={[yDomainMin, yDomainMax]}
 						allowDataOverflow={
@@ -340,7 +355,11 @@ export function QueryBuilderLineChart({
 							dataKey={definition.chartKey}
 							stroke={`var(--color-${definition.chartKey})`}
 							strokeWidth={2}
-							dot={showPoints ? { r: 2 } : false}
+							dot={
+								renderDots
+									? { r: 2.5, strokeWidth: 0, fill: `var(--color-${definition.chartKey})` }
+									: false
+							}
 							hide={hiddenSeries.has(definition.chartKey)}
 							isAnimationActive={false}
 							activeDot={(props: { cx?: number; cy?: number }) => {

--- a/packages/ui/src/components/charts/pie/query-builder-pie-chart.tsx
+++ b/packages/ui/src/components/charts/pie/query-builder-pie-chart.tsx
@@ -39,6 +39,17 @@ function fmtValue(value: number, unit?: string): string {
 }
 
 /**
+ * Donut-centre total: exact counts under 10k read better than compact
+ * notation ("1,500" instead of "1.5K"); larger totals stay compact.
+ */
+function fmtCenterTotal(value: number, unit?: string): string {
+	if (!unit && Number.isInteger(value) && Math.abs(value) < 10_000) {
+		return value.toLocaleString()
+	}
+	return fmtValue(value, unit)
+}
+
+/**
  * Cartesian point on a circle centred at (cx, cy) with radius r, at angle
  * `angle` measured clockwise from 12 o'clock (so 0 is top, π/2 is right).
  */
@@ -116,10 +127,17 @@ export function QueryBuilderPieChart({ data, className, legend, tooltip, unit, p
 	const valueField = React.useMemo(() => pickValueField(source), [source])
 
 	const { slices, total } = React.useMemo(() => {
-		const rows: Row[] = source.map((row) => ({
-			name: String(row.name ?? "—"),
-			value: asFiniteNumber(row[valueField]),
-		}))
+		const rows: Row[] = source
+			.map((row) => {
+				const raw = row.name == null ? "" : String(row.name).trim()
+				return {
+					name: raw === "" ? "(no value)" : raw,
+					value: asFiniteNumber(row[valueField]),
+				}
+			})
+			// Zero/negative rows render as invisible arcs but still occupy
+			// legend rows — drop them.
+			.filter((row) => row.value > 0)
 		// Collapse the long tail of small categories into a single "Other" slice
 		// (also sorts largest-first). Keeps both the pie and its 2-row legend
 		// legible when a group-by produces dozens of categories.
@@ -302,7 +320,7 @@ export function QueryBuilderPieChart({ data, className, legend, tooltip, unit, p
 								letterSpacing: "-0.02em",
 							}}
 						>
-							{fmtValue(total, unit)}
+							{fmtCenterTotal(total, unit)}
 						</text>
 						<text
 							x={cx}

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -26,16 +26,22 @@ export function formatDuration(ms: number): string {
 
 /**
  * Format a number with compact notation.
- * - >= 1M: displays as e.g. "1.2M"
- * - >= 1K: displays as e.g. "3.4K"
- * - < 1K: displays with locale formatting
+ * - |n| >= 1M: displays as e.g. "1.2M"
+ * - |n| >= 1K: displays as e.g. "3.4K"
+ * - 0 < |n| < 1: 3 significant digits (e.g. "0.08", "0.0267") — axis ticks for
+ *   rates/ratios must not collapse to "0" or trail "0.026666…"
+ * - otherwise: locale formatting
  */
 export function formatNumber(num: number): string {
-	if (num >= 1_000_000) {
+	const abs = Math.abs(num)
+	if (abs >= 1_000_000) {
 		return `${(num / 1_000_000).toFixed(1)}M`
 	}
-	if (num >= 1_000) {
+	if (abs >= 1_000) {
 		return `${(num / 1_000).toFixed(1)}K`
+	}
+	if (abs > 0 && abs < 1) {
+		return num.toLocaleString(undefined, { maximumSignificantDigits: 3 })
 	}
 	return num.toLocaleString()
 }


### PR DESCRIPTION
Fixes [MAP-49](https://linear.app/mapledev/issue/MAP-49/most-default-dashboard-widgets-dont-work-with-test-data): most default dashboard widgets rendered empty or garbage against demo/test data, and one chart overflowed its card.

## Root causes & fixes

**Every breakdown preset was dead on arrival.** The "Add Widget" presets passed `groupBy: ["service_name"]` but the engine only accepted `service.name`, so the token was dropped and the spec failed to build — for all 8 pie/funnel/histogram/heatmap presets. The engine now accepts snake_case aliases (also healing already-persisted widgets), guarded by a new "presets never rot" test.

**`has_error = false` was silently dropped**, so the errors-vs-OK heatmap's "OK" query counted *all* traces. It's now a real tri-state filter (`errorsOnlyCondition`).

**Funnel/heatmap widgets called the timeseries endpoint** and rendered one "—" row per time bucket (the screenshot's uniform rows of 125). They now route to the breakdown endpoint; the heatmap preset also labels its queries `Errors`/`OK` so the axis stops reading `A`/`B`.

**"Trace Duration Distribution" wasn't one** — it queried count-by-service. It now bucketizes raw root-span `durationMs` values from a trace list.

**Templates:** metrics queries support `resource.<key>` filters/group-bys; the db/infra/messaging templates are rewritten onto them and the Node.js/JVM runtime templates' invalid `p95_duration` metrics aggregations are fixed — with a "templates never rot" guard test that lowers every template widget to a QuerySpec.

**Demo data & gating:** the seeder now emits Node.js runtime metrics (heap, handles, eventloop lag, GC count), and templates declare `requiredMetricPrefixes` so the picker dims templates whose metrics the org isn't sending ("No matching data yet", fail-open, still clickable).

**Misc correctness:** percent-change with prev=0 leaves a gap instead of a fake "0% ↓"; chart widgets saved without a title derive one ("Error rate by service.name") instead of "Untitled".

## Chart polish

- Widget cards clip content by default; the funnel chart caps rows to the measured height with a "+N more" row, aggregates timeseries-shaped input defensively, drops trailing all-zero rows, and renders "(no value)" for missing labels
- Sparse time series auto-render point dots (isolated non-zero buckets used to be invisible spikes); bars get min/max sizes; integer-only axes drop fractional ticks
- `formatNumber` uses 3 significant digits for |n| < 1 (rate axes read `0.08`, not `0`); histogram x-ticks show bucket lower bounds; heatmap color legend gains a midpoint tick and y time labels no longer collide; all-zero legend rows collapse to a single muted 0 and sort last; pies drop zero slices and donut centers show exact totals under 10k
- New widget-lab scenarios cover all of these edge cases (sparse/single-point series, 30-stage funnel, timeseries-shaped funnel input, zero/missing labels, long histogram labels, 24-row heatmaps)

## Verification

- `bun typecheck` green; vitest: query-engine 672, web 527, api 666 — all passing
- `/widget-lab`: mechanical containment check (every chart rect inside its card rect, ignoring scroll containers) passes for all 115 scenario cards; funnel/sparse/histogram/heatmap fixes verified visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->