### PR TITLE
fix(web): custom time range selector timezone jump and button label

### DIFF
--- a/apps/web/src/components/time-range-picker/custom-range-picker.tsx
+++ b/apps/web/src/components/time-range-picker/custom-range-picker.tsx
@@ -5,6 +5,7 @@ import { Input } from "@maple/ui/components/ui/input"
 import { format, parse, isValid, setHours, setMinutes } from "date-fns"
 import type { DateRange } from "react-day-picker"
 import { formatForTinybird } from "@/lib/time-utils"
+import { normalizeTimestampInput } from "@/lib/timezone-format"
 
 interface CustomRangePickerProps {
 	startTime?: string
@@ -14,18 +15,20 @@ interface CustomRangePickerProps {
 }
 
 export function CustomRangePicker({ startTime, endTime, onApply, onCancel }: CustomRangePickerProps) {
+	// Stored times are tz-less UTC warehouse strings; normalize to explicit UTC
+	// before constructing Dates or the value shifts by the local offset.
 	const [dateRange, setDateRange] = useState<DateRange | undefined>(() => {
-		const from = startTime ? new Date(startTime) : undefined
-		const to = endTime ? new Date(endTime) : undefined
+		const from = startTime ? new Date(normalizeTimestampInput(startTime)) : undefined
+		const to = endTime ? new Date(normalizeTimestampInput(endTime)) : undefined
 		return from || to ? { from, to } : undefined
 	})
 
 	const [startTimeInput, setStartTimeInput] = useState(() => {
-		return startTime ? format(new Date(startTime), "HH:mm") : "00:00"
+		return startTime ? format(new Date(normalizeTimestampInput(startTime)), "HH:mm") : "00:00"
 	})
 
 	const [endTimeInput, setEndTimeInput] = useState(() => {
-		return endTime ? format(new Date(endTime), "HH:mm") : "23:59"
+		return endTime ? format(new Date(normalizeTimestampInput(endTime)), "HH:mm") : "23:59"
 	})
 
 	const handleApply = () => {

--- a/apps/web/src/routes/alerts/$ruleId.tsx
+++ b/apps/web/src/routes/alerts/$ruleId.tsx
@@ -384,7 +384,7 @@ function RuleDetailContent() {
 					<TimeRangeHeaderControls
 						startTime={search.startTime}
 						endTime={search.endTime}
-						presetValue={search.timePreset ?? "24h"}
+						presetValue={search.timePreset ?? (search.startTime ? undefined : "24h")}
 						defaultPreset="24h"
 						onTimeChange={(range) =>
 							navigate({ search: (prev) => applyTimeRangeSearch(prev, range) })

--- a/apps/web/src/routes/errors/$errorType.tsx
+++ b/apps/web/src/routes/errors/$errorType.tsx
@@ -412,7 +412,8 @@ function ErrorDetailContent() {
 				<TimeRangeHeaderControls
 					startTime={search.startTime}
 					endTime={search.endTime}
-					presetValue={search.timePreset ?? "24h"}
+					presetValue={search.timePreset ?? (search.startTime ? undefined : "24h")}
+					defaultPreset="24h"
 					onTimeChange={handleTimeChange}
 				/>
 			}

--- a/apps/web/src/routes/errors/index.tsx
+++ b/apps/web/src/routes/errors/index.tsx
@@ -82,7 +82,7 @@ function ErrorsContent() {
 				<TimeRangeHeaderControls
 					startTime={search.startTime}
 					endTime={search.endTime}
-					presetValue={search.timePreset ?? "12h"}
+					presetValue={search.timePreset ?? (search.startTime ? undefined : "12h")}
 					onTimeChange={handleTimeChange}
 				/>
 			}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -402,7 +402,8 @@ function DashboardContent({
 					<TimeRangeHeaderControls
 						startTime={search.startTime ?? effectiveStartTime}
 						endTime={search.endTime ?? effectiveEndTime}
-						presetValue={search.timePreset ?? defaultPreset}
+						presetValue={search.timePreset ?? (search.startTime ? undefined : defaultPreset)}
+						defaultPreset={defaultPreset}
 						onTimeChange={handleTimeChange}
 					/>
 				</div>

--- a/apps/web/src/routes/infra/kubernetes/nodes/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/nodes/index.tsx
@@ -136,7 +136,7 @@ function NodesPageContent() {
 					<TimeRangeHeaderControls
 						startTime={search.startTime ?? startTime}
 						endTime={search.endTime ?? endTime}
-						presetValue={search.timePreset ?? "12h"}
+						presetValue={search.timePreset ?? (search.startTime ? undefined : "12h")}
 						onTimeChange={handleTimeChange}
 					/>
 				}

--- a/apps/web/src/routes/infra/kubernetes/pods/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/pods/index.tsx
@@ -150,7 +150,7 @@ function PodsPageContent() {
 					<TimeRangeHeaderControls
 						startTime={search.startTime ?? startTime}
 						endTime={search.endTime ?? endTime}
-						presetValue={search.timePreset ?? "12h"}
+						presetValue={search.timePreset ?? (search.startTime ? undefined : "12h")}
 						onTimeChange={handleTimeChange}
 					/>
 				}

--- a/apps/web/src/routes/infra/kubernetes/workloads/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/workloads/index.tsx
@@ -154,7 +154,7 @@ function WorkloadsPageContent() {
 					<TimeRangeHeaderControls
 						startTime={search.startTime ?? startTime}
 						endTime={search.endTime ?? endTime}
-						presetValue={search.timePreset ?? "12h"}
+						presetValue={search.timePreset ?? (search.startTime ? undefined : "12h")}
 						onTimeChange={handleTimeChange}
 					/>
 				}

--- a/apps/web/src/routes/query-builder-lab.tsx
+++ b/apps/web/src/routes/query-builder-lab.tsx
@@ -64,7 +64,8 @@ function QueryBuilderLabContent() {
 				<TimeRangeHeaderControls
 					startTime={search.startTime}
 					endTime={search.endTime}
-					presetValue={search.timePreset ?? "1h"}
+					presetValue={search.timePreset ?? (search.startTime ? undefined : "1h")}
+					defaultPreset="1h"
 					onTimeChange={handleTimeChange}
 				/>
 			}

--- a/apps/web/src/routes/replays/index.tsx
+++ b/apps/web/src/routes/replays/index.tsx
@@ -116,7 +116,7 @@ function ReplaysPage() {
 		<TimeRangeHeaderControls
 			startTime={search.startTime ?? startTime}
 			endTime={search.endTime ?? endTime}
-			presetValue={search.timePreset ?? "24h"}
+			presetValue={search.timePreset ?? (search.startTime ? undefined : "24h")}
 			defaultPreset="24h"
 			onTimeChange={handleTimeChange}
 		/>

--- a/apps/web/src/routes/service-map.tsx
+++ b/apps/web/src/routes/service-map.tsx
@@ -61,7 +61,7 @@ function ServiceMapContent() {
 				<TimeRangeHeaderControls
 					startTime={search.startTime}
 					endTime={search.endTime}
-					presetValue={search.timePreset ?? "12h"}
+					presetValue={search.timePreset ?? (search.startTime ? undefined : "12h")}
 					onTimeChange={handleTimeChange}
 				/>
 			}

--- a/apps/web/src/routes/services/$serviceName.tsx
+++ b/apps/web/src/routes/services/$serviceName.tsx
@@ -195,7 +195,7 @@ function ServiceDetailContent() {
 						<TimeRangeHeaderControls
 							startTime={search.startTime}
 							endTime={search.endTime}
-							presetValue={search.timePreset ?? "12h"}
+							presetValue={search.timePreset ?? (search.startTime ? undefined : "12h")}
 							onTimeChange={handleTimeChange}
 						/>
 						<Button

--- a/apps/web/src/routes/services/index.tsx
+++ b/apps/web/src/routes/services/index.tsx
@@ -61,7 +61,7 @@ export function ServicesPage() {
 					<TimeRangeHeaderControls
 						startTime={search.startTime ?? effectiveStartTime}
 						endTime={search.endTime ?? effectiveEndTime}
-						presetValue={search.timePreset ?? "12h"}
+						presetValue={search.timePreset ?? (search.startTime ? undefined : "12h")}
 						onTimeChange={handleTimeChange}
 					/>
 				}

--- a/apps/web/src/routes/traces/index.tsx
+++ b/apps/web/src/routes/traces/index.tsx
@@ -123,7 +123,7 @@ export function TracesPage() {
 							<TimeRangeHeaderControls
 								startTime={search.startTime ?? effectiveStartTime}
 								endTime={search.endTime ?? effectiveEndTime}
-								presetValue={search.timePreset ?? "12h"}
+								presetValue={search.timePreset ?? (search.startTime ? undefined : "12h")}
 								onTimeChange={handleTimeChange}
 							/>
 						</div>


### PR DESCRIPTION
## Summary

Fixes two bugs that made the dashboard's custom time range selector unusable.

### 1. Timezone jump on reopen
`CustomRangePicker` parsed stored warehouse timestamps (`"YYYY-MM-DD HH:mm:ss"` — tz-less UTC, ClickHouse format) directly with `new Date()`, which JavaScript interprets as **local** time. So a range picked at 10:30 was stored as its UTC value and then re-displayed as if that UTC wall-clock were local — a jump of the user's UTC offset every time the picker reopened. Re-applying baked the shift in, drifting the range further with each cycle.

Fix: normalize the incoming `startTime`/`endTime` via the existing `normalizeTimestampInput` helper (which rewrites the tz-less string to explicit-UTC ISO) before constructing `Date`s — the same canonical path the header display already used.

### 2. Button kept showing "Last 12 hours"
Every route passed `presetValue={search.timePreset ?? "12h"}` to the picker. Applying a custom range correctly clears `timePreset` from the URL and sets `startTime`/`endTime`, but the `?? "12h"` fallback re-injected a preset value — and the picker prefers the preset label over the actual range — so the button always read "Last 12 hours" (or "24h" on some pages).

Fix: only apply the preset fallback when there's no explicit custom range in the URL — `search.timePreset ?? (search.startTime ? undefined : "12h")`. This is the pattern the metrics/logs routes already used; applied to the other 13 call sites. This also restores the reset "×" button (which only renders for custom ranges), and wires `defaultPreset` through the query-builder-lab (1h) and error-detail (24h) routes so reset targets the correct default rather than falling back to 12h.

## Testing
- `bun typecheck` (apps/web) — clean
- Route tests for traces/services/logs — 6/6 pass
- Simulated the picker round-trip in `Europe/Berlin` and `America/Los_Angeles`: old code displayed the UTC-shifted time (08:30 / 17:30 for a picked 10:30); fixed code displays 10:30 and re-applying produces an identical stored value (no drift).

## Note
A pre-existing quirk remains: if a custom range ends within ~1 minute of "now", the display formats it as "Last N hours/days". That heuristic predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->