### PR TITLE
[codex] fix cloudflare migration journal order

### DIFF
--- a/packages/db/drizzle/0008_elite_butterfly.sql
+++ b/packages/db/drizzle/0008_elite_butterfly.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "cloudflare_analytics_state" ADD COLUMN "backfill_at" timestamp with time zone;
+ALTER TABLE "cloudflare_analytics_state" ADD COLUMN IF NOT EXISTS "backfill_at" timestamp with time zone;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -61,7 +61,7 @@
     {
       "idx": 8,
       "version": "7",
-      "when": 1783109881592,
+      "when": 1783200004000,
       "tag": "0008_elite_butterfly",
       "breakpoints": true
     }

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+type MigrationJournal = {
+	readonly entries: ReadonlyArray<{
+		readonly idx: number
+		readonly tag: string
+		readonly when: number
+	}>
+}
+
+const readJournal = (): MigrationJournal => {
+	const path = resolve(dirname(fileURLToPath(import.meta.url)), "../drizzle/meta/_journal.json")
+	return JSON.parse(readFileSync(path, "utf8")) as MigrationJournal
+}
+
+describe("drizzle migrations", () => {
+	it("keeps journal timestamps increasing in migration order", () => {
+		const { entries } = readJournal()
+
+		for (let i = 0; i < entries.length; i++) {
+			expect(entries[i]!.idx).toBe(i)
+			if (i === 0) continue
+
+			// Drizzle only compares each journal timestamp against the highest
+			// created_at already recorded in the DB. A lower timestamp after a
+			// deployed migration is silently skipped on the next migrate.
+			expect(
+				entries[i]!.when,
+				`${entries[i]!.tag} must be newer than ${entries[i - 1]!.tag}`,
+			).toBeGreaterThan(entries[i - 1]!.when)
+		}
+	})
+})


### PR DESCRIPTION
## What changed

- Bumped the `0008_elite_butterfly` Drizzle journal timestamp so it sorts after `0007_slippery_winter_soldier`.
- Made the Cloudflare `backfill_at` column migration idempotent with `ADD COLUMN IF NOT EXISTS`.
- Added a focused DB test that fails if Drizzle journal timestamps stop increasing in migration order.

## Why

Prod can already have `0007_slippery_winter_soldier` recorded as the latest Drizzle migration. `0008_elite_butterfly` was appended after it by index/name, but its journal `when` was lower than `0007`'s timestamp. Drizzle applies migrations by comparing each journal timestamp against the highest `created_at` in `drizzle.__drizzle_migrations`, so it silently skipped `0008` and never added `cloudflare_analytics_state.backfill_at`.

## Impact

Running `bun run migrate:prod` should now apply the Cloudflare `backfill_at` migration on databases that already applied `0007`, while remaining safe on databases where the column already exists.

## Validation

- `bun install --frozen-lockfile`
- `bun run --cwd packages/db test`
- `bun run --cwd packages/db typecheck`
