### PR TITLE
fix(integrations): coerce ClickHouse UInt64 counts in Cloudflare usage (fixes BYO-CH 500)

### DIFF
--- a/apps/api/src/services/CloudflareAnalyticsService.test.ts
+++ b/apps/api/src/services/CloudflareAnalyticsService.test.ts
@@ -910,6 +910,50 @@ describe("CloudflareAnalyticsService", () => {
 		}).pipe(Effect.provide(makeLayer(testDb, captured, {}, {}, queryStub)))
 	})
 
+	it.effect("getUsage coerces ClickHouse string-encoded counts (BYO-CH raw-CH response)", () => {
+		const testDb = createTestDb(trackedDbs)
+		const captured: CapturedIngest[] = []
+		// Raw ClickHouse `FORMAT JSON` serializes count()/UInt64 as STRINGS (Tinybird
+		// returns numbers). A ready BYO-CH org reads its own CH, so `datapoints` (and
+		// defensively `requests`) arrive as strings — they must be coerced, not thrown
+		// inside the `CloudflareUsageBucket` Schema.Class (which would 500 with no body).
+		const queryStub: CompiledQueryStub = {
+			rows: [
+				{
+					serviceName: "cloudflare/example.com",
+					bucket: "2026-07-02T10:00:00.000Z",
+					requests: "100.2",
+					datapoints: "24",
+					lastTimeUnix: "2026-07-02T10:55:00.000Z",
+				},
+				{
+					serviceName: "cloudflare/example.com",
+					bucket: "2026-07-02T11:00:00.000Z",
+					requests: "50",
+					datapoints: "10",
+					lastTimeUnix: "2026-07-02T11:40:00.000Z",
+				},
+			],
+			calls: [],
+		}
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(T0)
+			yield* seedConnection()
+			yield* seedByoClickHouse()
+			const service = yield* CloudflareAnalyticsService
+			const usage = yield* service.getUsage(ORG)
+
+			assert.strictEqual(usage.services.length, 1)
+			const zone = usage.services[0]!
+			assert.strictEqual(zone.totalRequests, 150)
+			assert.strictEqual(zone.totalDatapoints, 34)
+			assert.strictEqual(zone.buckets.length, 2)
+			assert.strictEqual(zone.buckets[0]?.datapoints, 24)
+			assert.strictEqual(zone.buckets[0]?.requests, 100)
+			assert.strictEqual(usage.totalRequests, 150)
+		}).pipe(Effect.provide(makeLayer(testDb, captured, {}, {}, queryStub)))
+	})
+
 	it.effect("getUsage returns an empty window when not connected", () => {
 		const testDb = createTestDb(trackedDbs)
 		const captured: CapturedIngest[] = []

--- a/apps/api/src/services/CloudflareAnalyticsService.ts
+++ b/apps/api/src/services/CloudflareAnalyticsService.ts
@@ -1474,16 +1474,23 @@ export class CloudflareAnalyticsService extends Context.Service<
 					totalDatapoints: 0,
 					lastDataAt: null,
 				}
-				const requests = Math.round(row.requests)
+				// ClickHouse's `FORMAT JSON` serializes 64-bit ints (here `count()` →
+				// `datapoints`, a UInt64) as JSON STRINGS, while Tinybird returns them as
+				// numbers. Coerce at this boundary so a BYO-CH org's raw-CH response can't
+				// throw a ParseError inside the `CloudflareUsageBucket` Schema.Class (which
+				// would surface as a bare, message-less 500). See the CH-UInt64-JSON-string
+				// convention: coerce `Number(row.x)` at the handler edge.
+				const requests = Math.round(Number(row.requests))
+				const datapoints = Number(row.datapoints)
 				agg.buckets.push(
 					new CloudflareUsageBucket({
 						bucketStart: Date.parse(row.bucket),
 						requests,
-						datapoints: row.datapoints,
+						datapoints,
 					}),
 				)
 				agg.totalRequests += requests
-				agg.totalDatapoints += row.datapoints
+				agg.totalDatapoints += datapoints
 				const lastMs = Date.parse(row.lastTimeUnix)
 				if (Number.isFinite(lastMs)) {
 					agg.lastDataAt = agg.lastDataAt == null ? lastMs : Math.max(agg.lastDataAt, lastMs)


### PR DESCRIPTION
## Problem

`GET /api/integrations/cloudflare/usage` returned a **bare, message-less 500 for BYO-ClickHouse orgs** (the integration sparklines silently degraded to the poller-only view — "works for Tinybird, empty for BYO").

## Root cause

Raw ClickHouse `FORMAT JSON` serializes 64-bit ints as **JSON strings**. The usage query's `datapoints` field is `count()` (a `UInt64`), so ClickHouse returns `"2"`, while **Tinybird returns a number**. Once readiness-aware routing began sending write-ready BYO-CH orgs to their own ClickHouse, `getUsage` received `datapoints: "2"` and passed it straight into the `CloudflareUsageBucket` `Schema.Class` (`datapoints: Schema.Number`). The `ParseError` was thrown as an **unhandled defect**, so the HTTP layer surfaced it as a 500 with no body.

Diagnosed from the `CloudflareAnalyticsService.getUsage` span `StatusMessage`:

```
Expected number, got "2"
  at ["datapoints"]
```

The span also confirms the CH query returned rows — so those BYO-CH orgs are ready, their metrics are in ClickHouse, and the decode was the only thing left breaking.

## Fix

Coerce `datapoints` / `requests` with `Number(...)` at the handler edge (the established CH-UInt64-as-string convention), so a raw-CH response can't throw inside the response `Schema.Class`. Adds a regression test that feeds string-encoded counts exactly as raw ClickHouse does (fails without the fix, passes with it).

## Testing

- `CloudflareAnalyticsService` suite: 20 passed (incl. the new coercion guard)
- `bun typecheck`: clean

Builds on the readiness-aware routing already merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->