### PR TITLE
fix(api): decode Cloudflare usage rows through a schema (BYO-CH 500)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ Pattern (see `apps/api/src/routes/query-engine.http.ts` and `apps/api/src/servic
 
 Never use raw `fetch()` calls to `/v0/sql` — always go through `warehouse.sqlQuery()` with a DSL-compiled query.
 
+**ClickHouse 64-bit ints decode as strings (BYO-CH).** ClickHouse `FORMAT JSON` serializes `UInt64`/`Int64` columns (the result of `count()`, `sum()`, `uniqExact()`, …) as JSON **strings**, while managed Tinybird returns them as numbers. A BYO-ClickHouse org reads its own ClickHouse, so those columns arrive as strings. Any DSL query whose numeric outputs flow into a runtime `Schema.Number` (a `Schema.Class` constructor or an HTTP response encode) **must attach a `rowSchema`** built with `CH.CHNumber` (`Schema.Union([Schema.Finite, Schema.FiniteFromString])`) so `decodeRows` coerces them centrally — pass it as the third arg to `CH.compile(query, params, { rowSchema })`. Without it the string trips a `ParseError` that surfaces as a bare, message-less 500 for BYO-CH orgs only. See `cloudflareUsageRowSchema` and the `*OutputSchema` definitions in `packages/query-engine/src/ch/queries/service-map.ts`.
+
 **Trace annotations on `WarehouseQueryService.executeSql`:** every SQL execution leaves a span carrying `db.query.text` (full SQL up to 16 KB), `db.query.length`, `db.query.fingerprint` (stable hash with literals normalized), `db.query.truncated`, `db.duration_ms`, `db.system.name`, `result.rowCount`, `orgId`, `tenant.userId`, `query.context`, and `query.profile`. When debugging slow queries, pull a trace and filter on these. (Spans recorded before 2026-06 carry the legacy `db.statement*`/`db.system` spellings; warehouse read paths coalesce both.)
 
 ## Environment Variables

--- a/apps/api/src/services/CloudflareAnalyticsService.test.ts
+++ b/apps/api/src/services/CloudflareAnalyticsService.test.ts
@@ -265,13 +265,23 @@ const makeWarehouseStub = (
 			}),
 		compiledQuery: (
 			tenant: { orgId: string },
-			compiled: { sql: string },
+			compiled: {
+				sql: string
+				decodeRows: (
+					rows: ReadonlyArray<Record<string, unknown>>,
+				) => Effect.Effect<ReadonlyArray<unknown>, unknown>
+			},
 			options?: CompiledQueryStub["calls"][number]["options"],
 		) =>
+			// Mirror the real executor: run the compiled query's `decodeRows` so a
+			// query's `rowSchema` (e.g. cloudflareUsageRowSchema's CHNumber coercion)
+			// is actually exercised instead of passing raw stub rows straight through.
 			Effect.sync(() => {
 				queryStub?.calls.push({ sql: compiled.sql, orgId: tenant.orgId, options })
-				return queryStub?.rows ?? []
-			}),
+			}).pipe(
+				Effect.flatMap(() => compiled.decodeRows(queryStub?.rows ?? [])),
+				Effect.orDie,
+			),
 	}) as unknown as WarehouseQueryServiceShape
 
 const makeLayer = (
@@ -907,6 +917,50 @@ describe("CloudflareAnalyticsService", () => {
 
 			assert.strictEqual(queryStub.calls.length, 1)
 			assert.strictEqual(queryStub.calls[0]?.options?.pinToIngestConfig, true)
+		}).pipe(Effect.provide(makeLayer(testDb, captured, {}, {}, queryStub)))
+	})
+
+	it.effect("getUsage coerces ClickHouse string-encoded counts (BYO-CH raw-CH response)", () => {
+		const testDb = createTestDb(trackedDbs)
+		const captured: CapturedIngest[] = []
+		// Raw ClickHouse `FORMAT JSON` serializes count()/UInt64 as STRINGS (Tinybird
+		// returns numbers). A ready BYO-CH org reads its own CH, so `datapoints` (and
+		// defensively `requests`) arrive as strings — they must be coerced, not thrown
+		// inside the `CloudflareUsageBucket` Schema.Class (which would 500 with no body).
+		const queryStub: CompiledQueryStub = {
+			rows: [
+				{
+					serviceName: "cloudflare/example.com",
+					bucket: "2026-07-02T10:00:00.000Z",
+					requests: "100.2",
+					datapoints: "24",
+					lastTimeUnix: "2026-07-02T10:55:00.000Z",
+				},
+				{
+					serviceName: "cloudflare/example.com",
+					bucket: "2026-07-02T11:00:00.000Z",
+					requests: "50",
+					datapoints: "10",
+					lastTimeUnix: "2026-07-02T11:40:00.000Z",
+				},
+			],
+			calls: [],
+		}
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(T0)
+			yield* seedConnection()
+			yield* seedByoClickHouse()
+			const service = yield* CloudflareAnalyticsService
+			const usage = yield* service.getUsage(ORG)
+
+			assert.strictEqual(usage.services.length, 1)
+			const zone = usage.services[0]!
+			assert.strictEqual(zone.totalRequests, 150)
+			assert.strictEqual(zone.totalDatapoints, 34)
+			assert.strictEqual(zone.buckets.length, 2)
+			assert.strictEqual(zone.buckets[0]?.datapoints, 24)
+			assert.strictEqual(zone.buckets[0]?.requests, 100)
+			assert.strictEqual(usage.totalRequests, 150)
 		}).pipe(Effect.provide(makeLayer(testDb, captured, {}, {}, queryStub)))
 	})
 

--- a/apps/api/src/services/CloudflareAnalyticsService.ts
+++ b/apps/api/src/services/CloudflareAnalyticsService.ts
@@ -1425,12 +1425,20 @@ export class CloudflareAnalyticsService extends Context.Service<
 				})
 			}
 
-			const compiled = CH.compile(CH.cloudflareUsageQuery(), {
-				orgId,
-				bucketSeconds: USAGE_BUCKET_SECONDS,
-				startTime: toWarehouseDateTime64(windowStart),
-				endTime: toWarehouseDateTime64(now),
-			})
+			const compiled = CH.compile(
+				CH.cloudflareUsageQuery(),
+				{
+					orgId,
+					bucketSeconds: USAGE_BUCKET_SECONDS,
+					startTime: toWarehouseDateTime64(windowStart),
+					endTime: toWarehouseDateTime64(now),
+				},
+				// Decode rows through the schema: `requests`/`datapoints` arrive as JSON
+				// strings from a BYO-CH org's raw ClickHouse (`FORMAT JSON` quotes 64-bit
+				// ints), and `CHNumber` coerces them centrally in `decodeRows`. Without it
+				// the string trips a `ParseError` inside `CloudflareUsageBucket` → bare 500.
+				{ rowSchema: CH.cloudflareUsageRowSchema },
+			)
 			// Metrics flow through the ingest gateway, which routes each org to the SAME
 			// warehouse the gateway wrote to: a BYO-CH org's own ClickHouse when it is
 			// write-ready, otherwise managed Tinybird (the gateway's fallback). Mirror
@@ -1474,16 +1482,20 @@ export class CloudflareAnalyticsService extends Context.Service<
 					totalDatapoints: 0,
 					lastDataAt: null,
 				}
+				// `requests`/`datapoints` are already decoded to numbers by
+				// `cloudflareUsageRowSchema` (`CHNumber` coerces ClickHouse's
+				// string-quoted 64-bit ints). Round requests since counts are integers.
 				const requests = Math.round(row.requests)
+				const datapoints = row.datapoints
 				agg.buckets.push(
 					new CloudflareUsageBucket({
 						bucketStart: Date.parse(row.bucket),
 						requests,
-						datapoints: row.datapoints,
+						datapoints,
 					}),
 				)
 				agg.totalRequests += requests
-				agg.totalDatapoints += row.datapoints
+				agg.totalDatapoints += datapoints
 				const lastMs = Date.parse(row.lastTimeUnix)
 				if (Number.isFinite(lastMs)) {
 					agg.lastDataAt = agg.lastDataAt == null ? lastMs : Math.max(agg.lastDataAt, lastMs)

--- a/lib/clickhouse-builder/src/ch/compile.ts
+++ b/lib/clickhouse-builder/src/ch/compile.ts
@@ -132,7 +132,7 @@ export function compileCH<
 >(
 	query: CHQuery<Cols, Output, Joins>,
 	params: Params,
-	options?: { skipFormat?: boolean },
+	options?: { skipFormat?: boolean; rowSchema?: CompiledQueryRowSchema<Output> },
 ): CompiledQuery<Output> {
 	const state = query._state
 
@@ -231,7 +231,7 @@ export function compileCH<
 	}
 
 	return {
-		...makeCompiledQuery<Output>(sql),
+		...makeCompiledQuery<Output>(sql, options?.rowSchema),
 	}
 }
 

--- a/packages/query-engine/src/ch/index.ts
+++ b/packages/query-engine/src/ch/index.ts
@@ -19,6 +19,9 @@ export { compilePipeQuery, type PipeCompiledQuery } from "./pipe-dispatch"
 // Tables
 export * as tables from "./tables"
 
+// Shared row-schema codecs (ClickHouse `FORMAT JSON` 64-bit-int-as-string coercion).
+export { CHNumber } from "./schema"
+
 // Queries — Traces
 export {
 	tracesTimeseriesQuery,
@@ -286,6 +289,7 @@ export {
 export {
 	CLOUDFLARE_USAGE_METRIC_NAMES,
 	cloudflareUsageQuery,
+	cloudflareUsageRowSchema,
 	type CloudflareUsageOutput,
 } from "./queries/cloudflare-usage"
 

--- a/packages/query-engine/src/ch/queries/cloudflare-usage.ts
+++ b/packages/query-engine/src/ch/queries/cloudflare-usage.ts
@@ -7,8 +7,10 @@
 // poller, so sum(Value) per bucket is the true request count.
 // ---------------------------------------------------------------------------
 
+import { Schema } from "effect"
 import * as CH from "@maple-dev/clickhouse-builder/expr"
-import { from, param } from "@maple-dev/clickhouse-builder"
+import { from, param, type CompiledQueryRowSchema } from "@maple-dev/clickhouse-builder"
+import { CHNumber } from "../schema"
 import { MetricsSum } from "../tables"
 
 const ISO_Z_FORMAT = "%Y-%m-%dT%H:%i:%S.%fZ"
@@ -31,6 +33,21 @@ export interface CloudflareUsageOutput {
 	/** Most recent datapoint timestamp within the bucket, ISO-8601 UTC. */
 	readonly lastTimeUnix: string
 }
+
+/**
+ * Row schema for {@link cloudflareUsageQuery}. `requests` (`sum`) and
+ * `datapoints` (`count`, a `UInt64`) use {@link CHNumber} so a BYO-ClickHouse
+ * org's string-encoded aggregates decode identically to Tinybird's numbers —
+ * pass it as the `rowSchema` to `CH.compile` so `decodeRows` coerces centrally
+ * instead of a `ParseError` surfacing downstream.
+ */
+export const cloudflareUsageRowSchema: CompiledQueryRowSchema<CloudflareUsageOutput> = Schema.Struct({
+	serviceName: Schema.String,
+	bucket: Schema.String,
+	requests: CHNumber,
+	datapoints: CHNumber,
+	lastTimeUnix: Schema.String,
+})
 
 export function cloudflareUsageQuery() {
 	return from(MetricsSum)

--- a/packages/query-engine/src/ch/queries/service-map.ts
+++ b/packages/query-engine/src/ch/queries/service-map.ts
@@ -37,13 +37,13 @@ import {
 	Traces,
 } from "../tables"
 import { unionAll } from "@maple-dev/clickhouse-builder"
+import { CHNumber } from "../schema"
 
 // Local CH function declarations used by the live topology-join branch's
 // sample-weighting math. Kept here (not promoted to ch/functions/) because
 // they're niche and only this builder uses them; promote later if reused.
 const _toFloat64 = defineFn<[CH.Expr<unknown>], number>("toFloat64")
 const _matchRegex = defineCondFn<[CH.Expr<string>, string]>("match")
-const CHNumber = Schema.Union([Schema.Finite, Schema.FiniteFromString])
 
 // ---------------------------------------------------------------------------
 // Service dependencies

--- a/packages/query-engine/src/ch/schema.ts
+++ b/packages/query-engine/src/ch/schema.ts
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------------------
+// Shared ClickHouse row-schema codecs
+//
+// ClickHouse's `FORMAT JSON` serializes 64-bit integers (`UInt64`/`Int64`, the
+// result of `count()`, `sum()`, `uniqExact()`, …) as JSON *strings*, whereas
+// managed Tinybird returns them as numbers. A BYO-ClickHouse org reads its own
+// ClickHouse, so its aggregate columns arrive as strings.
+//
+// `CHNumber` decodes *either* representation to a finite number, so BYO-CH and
+// managed orgs behave identically. Attach it (via a `Schema.Struct` row schema)
+// to any compiled query whose numeric outputs flow into a runtime `Schema.Number`
+// — otherwise the string trips a `ParseError` the moment it hits a `Schema.Class`
+// constructor or an HTTP response encode.
+// ---------------------------------------------------------------------------
+
+import { Schema } from "effect"
+
+/**
+ * Decodes a ClickHouse-quoted numeric string (`"2"`) or a native JSON number
+ * (`2`) to a finite `number`. Rejects `NaN`/`Infinity`.
+ */
+export const CHNumber = Schema.Union([Schema.Finite, Schema.FiniteFromString])


### PR DESCRIPTION
## Problem

`GET /api/integrations/cloudflare/usage` returns **500** in production for **write-ready BYO-ClickHouse** orgs. From Maple's own telemetry the span `CloudflareAnalyticsService.getUsage` fails with `Expected number, got "2" at ["datapoints"]` — an Effect-Schema `ParseError` thrown as an **uncaught defect**, while the SQL span itself is `Ok`.

## Root cause

- `cloudflareUsageQuery` selects `datapoints: count()` (a `UInt64`). A ready BYO-CH org reads its **own** ClickHouse, whose `FORMAT JSON` serializes 64-bit ints as JSON **strings** (`"2"`); managed Tinybird returns **numbers**.
- The typed-DSL query is compiled **without a `rowSchema`**, so `decodeRows` passes the raw string straight through.
- The handler builds `new CloudflareUsageBucket({ datapoints: "2" })`. That `Schema.Class` **constructor validates its input** (`datapoints: Schema.Number`), so the string is rejected with a `ParseError` thrown *outside* the Effect error channel → bare 500. Only BYO-CH is affected.

## Fix — decode through a Schema (the Effect way)

Rather than an imperative `Number(row.x)` coercion in the handler, decode rows through a Schema so coercion is declarative and failures land in the typed error channel:

- **Shared codec** `CHNumber = Schema.Union([Schema.Finite, Schema.FiniteFromString])` in `packages/query-engine/src/ch/schema.ts` (mirrors the existing `service-map.ts` pattern, now de-duped onto the shared export).
- **Thread `rowSchema`** through the typed-DSL `compileCH` (`unsafeCompiledQuery` already supported it; the DSL entrypoint didn't).
- **`cloudflareUsageRowSchema`** attached to the usage query via `CH.compile(query, params, { rowSchema })`, so `warehouse.compiledQuery` → `decodeRows` coerces `requests`/`datapoints` centrally.

Valid CH string-numbers now decode → **200**. Genuine schema drift → typed `WarehouseSchemaDriftError` → `IntegrationsPersistenceError` (handled), never a thrown defect. The imperative `Number()` band-aid is removed.

The test warehouse stub is made faithful (runs `decodeRows`, like the real executor) so the string-encoded regression test (`requests: "100.2"`, `datapoints: "24"`) exercises the real schema instead of the handler's coercion.

## Testing

- `vitest run apps/api/src/services/CloudflareAnalyticsService.test.ts` — 20 passed (incl. new BYO-CH string-encoded regression test).
- `vitest run packages/query-engine` — 709 passed.
- `bun typecheck` — clean (query-engine, clickhouse-builder, api).

> Note: `lib/clickhouse-builder/dist` is a gitignored build artifact regenerated by `turbo build`, so only source is committed here.

## Out of scope — separate live incident

A second prod error on the same integration — `IntegrationsPersistenceError` → `column "backfill_at" does not exist` on `cloudflare_analytics_state` — is **migration drift** (migration `0008_elite_butterfly.sql` not applied to the affected org's prod Postgres branch), not a code bug. Needs `drizzle-kit migrate` against that branch; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->