### PR TITLE
docs: source-linked OpenTelemetry specification map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,7 @@ End-user and platform documentation lives in `docs/`:
 - `docs/sst-fork-workflow.md` — Running maple against a local SST fork, syncing with upstream, and opening PRs from fork branches
 - `docs/local-mode.md` — Local mode (single Bun-compiled `maple` binary from `apps/cli`: CLI + OTLP-ingest/query server + bundled UI, talking to embedded chDB via `bun:ffi`→libchdb), the `/local/query` contract, dev workflow, and the 2-file release bundle
 - `docs/tinybird-pr-branches.md` — Per-PR ephemeral Tinybird branches for preview deploys (`--last-partition` data, branch lifecycle wired into `deploy-pr-preview.yml`)
+- `docs/otel-spec/` — Source-linked internal map of the OpenTelemetry specifications (traces, metrics, logs, OTLP, semconv, resource/config, propagation, stability, profiles/compat), snapshotted at spec v1.58.0. Use it for ingest-gateway OTLP-server compliance, self-instrumentation best practices, and UI data-semantics questions; start at `docs/otel-spec/README.md`
 
 ## Self-Observability (Trace Loop Prevention)
 

--- a/docs/otel-spec/README.md
+++ b/docs/otel-spec/README.md
@@ -1,0 +1,88 @@
+# OpenTelemetry Specification Map
+
+An internal, source-linked map of the OpenTelemetry specifications, built for three uses:
+
+1. **Spec-compliance checks** — especially for the ingest gateway (`apps/ingest`), which is an
+   OTLP server and must honor the server-side MUSTs in [otlp.md](otlp.md).
+2. **Best-practices material** — the normative rules here are the raw input for an internal
+   best-practice skill (instrumentation hygiene, status semantics, attribute rules).
+3. **Fact-checking reference** — every section in every file carries inline `Source:` deep links
+   to the official spec pages so claims can be re-verified as the spec moves.
+
+**Snapshot:** researched 2026-07-05 against specification **v1.58.0** (released 2026-06-22,
+per the [spec CHANGELOG](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md)).
+Method: each file was written from freshly fetched official pages (opentelemetry.io/docs/specs,
+the specification/semconv/proto GitHub repos, W3C TRs) — not from model memory. Stability labels
+are the spec's own, recorded per section.
+
+## Files
+
+| File | Scope | Headline stability |
+| --- | --- | --- |
+| [traces.md](traces.md) | Trace API & SDK: span model, SpanKind, status, samplers, processors, span limits, ID generators | Stable (several subsections Development) |
+| [metrics.md](metrics.md) | Metrics API, SDK & data model: instruments, temporality, exemplars, views, exponential histograms, cardinality | Stable (reset-detection notes Development) |
+| [logs.md](logs.md) | Log data model, severity, bridge API, SDK, events-as-logs | Data model & bridge API Stable; events Development |
+| [context-propagation.md](context-propagation.md) | Context, W3C traceparent/tracestate, baggage, B3/Jaeger interop | Stable (OTel `ot=` tracestate extension Development) |
+| [otlp.md](otlp.md) | OTLP protocol: transports, partial success, retry semantics, JSON encoding, exporter env vars | Stable for traces/metrics/logs; profiles Development |
+| [resource-and-config.md](resource-and-config.md) | Resource spec & merge rules, resource semconv, consolidated SDK env-var table, declarative config, entities | Resource Stable; declarative config Stable (`OTEL_CONFIG_FILE`); entities Development |
+| [semantic-conventions.md](semantic-conventions.md) | Naming rules, requirement levels, HTTP/DB/messaging/RPC/exceptions/code/gen-ai domains, schema-URL migrations | HTTP & DB Stable; RPC RC; messaging & gen-ai Development |
+| [stability-and-compliance.md](stability-and-compliance.md) | Stability taxonomies, versioning guarantees, compliance matrix, error-handling & performance principles, instrumentation guidelines | Meta-spec (see per-section labels) |
+| [emerging-and-compat.md](emerging-and-compat.md) | Profiles signal, telemetry schemas deep-dive, Prometheus/OpenMetrics interop, OpenTracing/OpenCensus shims | Profiles Alpha/Development; schemas Stable (file format 1.1.0 Development); shims Deprecated |
+
+## Maple's three compliance surfaces
+
+**1. Ingest gateway as an OTLP server** ([otlp.md](otlp.md) is the contract):
+partial-success responses are a MUST (200 + `rejected_*` counts for partially-bad batches —
+never fail the whole batch for a few bad items; 400 only for fully undecodable requests);
+the retryable HTTP status set is exactly {429, 502, 503, 504}; every 4xx/5xx body MUST be a
+protobuf `Status`; gzip decoding is a server MUST; OTLP/JSON uses hex IDs, lowerCamelCase
+fields, numeric enums, and unknown fields MUST be ignored.
+
+**2. Self-instrumentation as an SDK consumer** ([traces.md](traces.md),
+[resource-and-config.md](resource-and-config.md), [stability-and-compliance.md](stability-and-compliance.md)):
+per-component instrumentation scopes over one global tracer; SDKs MUST NOT throw at runtime;
+SERVER-span status = Error only on 5xx (already implemented in `apps/ingest` —
+`otel_status_for_rejection`); `deployment.environment.name` is the canonical key (the legacy
+`deployment.environment` is formally deprecated — our dual-emission is a migration bridge, not
+the end state).
+
+**3. UI/query semantics as a data consumer** ([semantic-conventions.md](semantic-conventions.md),
+[logs.md](logs.md), [metrics.md](metrics.md)): span status stored as `"Ok"/"Error"/"Unset"`
+matches the spec enum spelling (the wire form `STATUS_CODE_*` is translated once at the OTLP
+boundary); log error classification should key on `SeverityNumber >= 17`, not `SeverityText`
+string-matching; the `db.statement`→`db.query.text` / `db.system`→`db.system.name` coalescing in
+warehouse reads mirrors the official DB-semconv stabilization renames; an "event" is now a
+LogRecord with `EventName` set, and span events / `RecordException()` are on a deprecation path
+toward log-based events.
+
+## Known gaps / items to re-verify
+
+Honest residue from the research pass — each is also flagged inline in its file:
+
+- **Jaeger `uber-trace-id` format** was sourced via search synthesis (official page 404'd);
+  spot-check against current Jaeger docs before quoting externally
+  ([context-propagation.md](context-propagation.md)).
+- **W3C Baggage document-track status** (Editor's Draft vs Candidate Recommendation) can shift;
+  re-check before citing externally.
+- **Global metrics cardinality-limit env var**: none found in the general spec — recorded as
+  unverified absence, not confirmed absence ([metrics.md](metrics.md)).
+- **Env-var vs declarative-config precedence** when both are present is not precisely specified
+  by the spec yet ([resource-and-config.md](resource-and-config.md)).
+- **Semconv general-naming and registry landing pages** were partially sourced from search
+  snippets after URL churn ([semantic-conventions.md](semantic-conventions.md)).
+- ~~Attribute value-type unification~~ — resolved 2026-07-05 against raw
+  `specification/common/README.md`: attribute values are full `AnyValue` (nested maps/arrays
+  allowed); older SDKs emit the stricter primitives+homogeneous-arrays subset.
+
+## Canonical sources
+
+- Spec hub: https://opentelemetry.io/docs/specs/otel/
+- Semantic conventions: https://opentelemetry.io/docs/specs/semconv/ ·
+  registry repo: https://github.com/open-telemetry/semantic-conventions
+- OTLP: https://opentelemetry.io/docs/specs/otlp/ ·
+  proto: https://github.com/open-telemetry/opentelemetry-proto
+- Specification repo (raw markdown is the ground truth when the website summarizes):
+  https://github.com/open-telemetry/opentelemetry-specification
+- W3C Trace Context: https://www.w3.org/TR/trace-context/ · W3C Baggage: https://www.w3.org/TR/baggage/
+- Compliance matrix (SDK conformance, not receiver conformance):
+  https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md

--- a/docs/otel-spec/context-propagation.md
+++ b/docs/otel-spec/context-propagation.md
@@ -1,0 +1,463 @@
+# Context, Baggage & Propagation
+
+This page covers the OpenTelemetry **Context** abstraction, the **Baggage** API and its W3C wire
+format, and the **Propagators API** (W3C TraceContext primary; B3/Jaeger at reference level). It is
+part of the internal OTel spec reference used for spec-compliance checks and the best-practices
+skill. Every section links to its normative source — verify against the source, not this summary,
+before treating anything here as authoritative for a compliance decision.
+
+> **Stability at a glance:** Context API — Stable. Propagators API — Stable (a few per-language
+> details, e.g. `GetAll`, are pre-stable). Baggage API — Stable. W3C Trace Context — W3C
+> Recommendation (normative, versioned `00`). W3C Baggage — W3C Editor's Draft / Candidate
+> Recommendation track (not yet a final REC as of this writing — treat as stable-in-practice but
+> re-check status). OTel `tracestate` handling (the `ot=` vendor key, consistent probability
+> sampling `th`/`rv`) — **Development** (not stable) at the OTel-spec level.
+
+## Relevance to Maple
+
+- Maple's Rust ingest gateway (`apps/ingest`) is primarily an **OTLP receiver**, not an HTTP
+  trace-context propagator: incoming spans already carry `TraceId` / `SpanId` / `ParentSpanId` /
+  `TraceState` as OTLP fields (populated upstream by the *sending* SDK's propagator before OTLP
+  export), and these are inserted verbatim into ClickHouse/Tinybird (see
+  `apps/ingest/src/clickhouse_insert_mappings.rs`, columns `TraceId`, `SpanId`, `ParentSpanId`,
+  `TraceState`). Maple does not need to parse a `traceparent` HTTP header to ingest span data.
+- Where W3C TraceContext propagation *does* apply directly to Maple: the ingest gateway's own
+  **self-instrumentation** (`apps/ingest` exports its own OTLP traces per
+  `docs/otel-spec/context-propagation.md`'s sibling doc on self-observability — see root
+  `CLAUDE.md` "Self-Observability" section) and any outbound HTTP calls the API/web app makes that
+  should carry a live `Context` (e.g. `warehouse.sqlQuery` spans, Hyperdrive calls) rely on
+  `@effect/opentelemetry`'s context propagation, which implements this spec under the hood.
+  `service.name`, `deployment.environment.name`, etc. are Resource attributes, not part of Context
+  propagation, but they ride the same OTel SDK plumbing.
+- Because Maple is a **backend/consumer of arbitrary customer OTLP**, expect payloads whose
+  `TraceId` came from a variety of upstream propagators (W3C, but also legacy B3/Jaeger bridged by
+  some customer collectors). The ingest gateway should treat a **128-bit** `TraceId` and a
+  **64-bit** `SpanId`/`ParentSpanId` as the canonical OTel shapes; anything shorter (e.g. a 64-bit
+  B3 trace ID zero-padded to 128 bits) is a valid *interop* case, not a data error — see
+  [B3/Jaeger interop notes](#b3-and-jaeger-reference-level) below.
+- `Baggage` is orthogonal to span data: **baggage entries do not automatically become span
+  attributes**. If Maple ever wants baggage values (e.g. a customer's `user.id` propagated via
+  baggage) to show up as searchable span/log attributes, an explicit "baggage → span attribute"
+  bridge (a processor) is required — this is not implicit OTel behavior. Useful to know when
+  triaging "why isn't this baggage key showing up as a facet" questions.
+- The W3C `tracestate` field is captured today (`TraceState` column, `LinksTraceState` for span
+  links) but Maple does not currently parse or act on the OTel `ot=` sampling sub-keys (`th`, `rv`)
+  — that spec area is explicitly **Development**/unstable upstream, so there's no compliance
+  expectation to implement it yet. Worth revisiting if/when OTel's consistent probability sampling
+  spec stabilizes and Maple wants cross-service consistent sampling.
+
+---
+
+## Context
+
+**Stability: Stable.**
+Source: https://opentelemetry.io/docs/specs/otel/context/
+
+`Context` is defined as "a propagation mechanism which carries execution-scoped values across API
+boundaries and between logically associated execution units." It underlies both distributed trace
+propagation (via `SpanContext`) and Baggage propagation, but is a general-purpose mechanism — any
+cross-cutting concern can ride in `Context`.
+
+### Immutability
+
+> A `Context` **MUST** be immutable, and its write operations **MUST** result in the creation of a
+> new `Context` containing the original values and the specified values updated.
+
+A "write" (`SetValue`) never mutates the context you started with; it returns a new `Context`
+layered on top of the old one. This is why context propagation composes safely across concurrent
+call stacks — nobody can retroactively change a `Context` another goroutine/task/fiber already
+captured.
+
+### Core operations
+
+| Operation | Signature (conceptual) | Notes |
+|---|---|---|
+| `CreateKey` | `(name: string) -> Key` | `name` is for debugging only. "Multiple calls to `CreateKey` with the same name SHOULD NOT return the same value unless language constraints dictate otherwise" — keys are unforgeable/opaque, not string-keyed maps. |
+| `GetValue` | `(context, key) -> value` | Read-only lookup against a given `Context`. |
+| `SetValue` | `(context, key, value) -> Context` | Returns a **new** `Context`; does not mutate the input. |
+
+### Implicit-context operations (languages with implicit/ambient context, e.g. via thread-locals or async-local storage)
+
+| Operation | Purpose |
+|---|---|
+| `Get Current Context` | Returns the `Context` associated with the current execution unit. |
+| `Attach` | Associates a given `Context` with the current execution unit; returns a **token** for later restoration. |
+| `Detach` | Resets the current context using the token returned by `Attach`; implementations are expected to be able to signal incorrect call ordering (e.g. detaching out of order/detaching twice). |
+
+Attach/detach is explicitly a stack-like discipline: detach with the token you got from the
+matching attach, not just "restore to whatever was current a moment ago" — misuse (double-detach,
+out-of-order detach) is something implementations may — and are encouraged to — detect and signal.
+
+---
+
+## Propagators API
+
+**Stability: Stable** (except where a language explicitly marks a piece, e.g. `GetAll`, as
+pre-stable).
+Source: https://opentelemetry.io/docs/specs/otel/context/api-propagators/
+
+The Propagators API is how a `Context` (specifically, the active `SpanContext` and `Baggage`)
+crosses a wire. It is deliberately format-agnostic; `TextMapPropagator` is the concrete shape used
+for HTTP-style string-keyed carriers.
+
+### `TextMapPropagator`
+
+| Method | Contract |
+|---|---|
+| `Fields(carrier)` | Returns the list of propagation field/header names this propagator uses for a given carrier type — lets a caller pre-clear those fields before re-injecting into a reused carrier ("If your carrier is reused, you should delete the fields here before calling Inject"). |
+| `Inject(context, carrier, setter?)` | Writes values from `context` into `carrier` using `setter`. |
+| `Extract(context, carrier, getter?)` | Reads values from `carrier`, returns a **new** `Context` (per Context's immutability rule) with the extracted values layered on top of the passed-in `context`. **On parse failure, the implementation MUST NOT throw and MUST NOT store a new value** — i.e., extraction failures degrade to a no-op, they never crash the caller or poison the context. |
+
+### `Setter` / `Getter` carrier interfaces
+
+- **Setter.Set(carrier, key, value)** — writes one field into the carrier. Implementations
+  "SHOULD preserve casing" for case-insensitive protocols like HTTP headers (don't rewrite
+  `Traceparent` to `traceparent`, etc., gratuitously).
+- **Getter.Get(carrier, key)** — returns the first value for `key`, or null/absent if not present;
+  for HTTP-like carriers this "MUST be case insensitive."
+- **Getter.Keys(carrier)** — returns all keys in the carrier; enables prefix/pattern-based
+  extraction (the doc calls out B3's `X-B3-*` family as the motivating example).
+- **Getter.GetAll(carrier, key)** — returns *all* values for a repeated key, in original order
+  (relevant for headers that can legitimately repeat). Noted as pre-stable in some language
+  implementations.
+
+Both Setter and Getter "MUST be stateless and allowed to be saved as constants" — they carry no
+per-call state, so a single shared instance is safe to reuse across concurrent injects/extracts.
+
+### Composite Propagator
+
+Multiple `TextMapPropagator`s can be combined into one composite propagator. The composite runs
+its constituent propagators **in the order they were specified**, for both `Inject` and `Extract`
+— order matters (e.g., running `tracecontext` before `baggage` vs. after can matter if propagators
+interact with the same carrier keys, though in the common case they touch disjoint headers).
+
+### Global propagator registration
+
+The API defines a way to get/set a process-wide default propagator. Per spec, implementations
+"MUST use no-op propagators unless explicitly configured otherwise" — propagation is opt-in by
+default at the raw-API level; SDKs, not the bare API, are what typically wire up sane defaults.
+Language/framework integration guidance (e.g. ASP.NET) suggests defaulting to a composite of W3C
+TraceContext + W3C Baggage.
+
+### `OTEL_PROPAGATORS` environment variable
+
+Source: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+
+| Env var | Description | Default |
+|---|---|---|
+| `OTEL_PROPAGATORS` | Comma-separated list of propagators to register, composited together | `tracecontext,baggage` |
+
+| Value | Propagator | Status |
+|---|---|---|
+| `tracecontext` | W3C Trace Context | Stable |
+| `baggage` | W3C Baggage | Stable |
+| `b3` | B3 Single header | — |
+| `b3multi` | B3 Multi header | — |
+| `jaeger` | Jaeger `uber-trace-id` | **Deprecated** |
+| `xray` | AWS X-Ray (third-party format) | — |
+| `ottrace` | OT Trace | **Deprecated** |
+| `none` | No automatically configured propagator | — |
+
+Values **MUST be deduplicated** so a propagator is only registered once even if named twice (or
+implied twice by other config).
+
+### Propagators distribution
+
+Source: https://opentelemetry.io/docs/specs/otel/context/api-propagators/#propagators-distribution
+
+- **Core/mandatory packages:** W3C TraceContext, W3C Baggage, B3.
+- **Additional/optional packages:** Jaeger (Deprecated), OT Trace (Deprecated), OpenCensus
+  BinaryFormat.
+- Vendor-specific propagator formats "MUST NOT be maintained or distributed as part of the
+  OpenTelemetry Core packages" — they live in contrib/vendor repos instead.
+
+---
+
+## W3C Trace Context — `traceparent`
+
+**Status: W3C Recommendation** (normative wire format). Version field in this spec assumes `00`.
+Source: https://www.w3.org/TR/trace-context/#traceparent-header
+
+### Grammar (§3.2, ABNF)
+
+```
+HEXDIGLC      = DIGIT / "a" / "b" / "c" / "d" / "e" / "f"
+value         = version "-" version-format
+version       = 2HEXDIGLC
+version-format = trace-id "-" parent-id "-" trace-flags
+trace-id      = 32HEXDIGLC   ; 16 bytes
+parent-id     = 16HEXDIGLC   ; 8 bytes
+trace-flags   = 2HEXDIGLC    ; 1 byte
+```
+
+Example: `traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
+
+### Field-by-field
+
+| Field | Size | Encoding | Invalid value | On invalid, receiver behavior |
+|---|---|---|---|---|
+| `version` | 1 byte | 2 lowercase hex digits | `ff` is explicitly forbidden | Reject/ignore the header |
+| `trace-id` | 16 bytes | 32 lowercase hex chars | All-zero (`00000000000000000000000000000000`) | Invalid — vendors **must ignore** a `traceparent` with an invalid trace-id (i.e., treat as if no `traceparent` was received; start a new trace) |
+| `parent-id` (a.k.a. span-id) | 8 bytes | 16 lowercase hex chars | All-zero (`0000000000000000`) | Invalid — same treatment: ignore the header |
+| `trace-flags` | 1 byte | 2 lowercase hex digits | — (all 256 bit-patterns are structurally valid) | Only the least-significant bit is currently defined |
+
+### Sampled flag (§3.2.2.5.1... i.e. the trace-flags LSB)
+
+> When set, the least significant bit (right-most), denotes that the caller may have recorded
+> trace data.
+
+This is **not** a command ("you must sample") — it communicates the upstream's own recording
+decision so downstream participants can make consistent joint decisions, but each vendor's sampler
+still owns its own decision. All other trace-flags bits are reserved for future use and MUST be set
+to `0` by a conforming producer that doesn't understand them (don't invent bit meanings).
+
+### Version handling (§3.3 "Versioning of traceparent")
+
+- `version = ff` is invalid outright.
+- If a receiver sees a **higher** version number than it knows about, it MUST still try to parse
+  the fields it understands from a version-`00`-shaped payload: parse `trace-id` as the 32 hex
+  chars after the first dash, `parent-id` as the next 16 hex chars, and the sampled bit from the
+  `trace-flags` byte that follows — then ignore any additional trailing fields the newer version
+  might append.
+  - If the header is shorter than the minimum length required to contain those three fields
+    (roughly, under ~55 characters for the version-00 shape), the receiver should not attempt to
+    parse it and should restart the trace (treat as if absent) rather than guess.
+- When forwarding an unknown-version header onward, unknown/未定义 flag bits must be reset to zero
+  on the outgoing request (don't blindly forward bits you don't understand as if you understood
+  them).
+
+### Practical MUSTs for an ingest gateway
+
+- Reject (treat as absent / start fresh) a `traceparent` whose `trace-id` or `parent-id` is
+  all-zero — these are the two explicitly normative "invalid value" cases.
+- Never throw on a malformed `traceparent` — per the Propagators API contract, extraction failure
+  degrades to "no context extracted," not an exception.
+- Preserve `trace-flags` bits you don't understand as `0` when re-emitting, don't round-trip
+  garbage bits.
+
+---
+
+## W3C Trace Context — `tracestate`
+
+**Status: W3C Recommendation.**
+Source: https://www.w3.org/TR/trace-context/#tracestate-header
+
+### Grammar (§3.3, ABNF)
+
+```
+list         = list-member 0*31( OWS "," OWS list-member )
+list-member  = (key "=" value) / OWS ; allows empty list-members
+key          = simple-key / multi-tenant-key
+simple-key   = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+multi-tenant-key = tenant-id "@" system-id
+tenant-id    = ( lcalpha / DIGIT ) 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+system-id    = lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+lcalpha      = %x61-7A ; a-z
+value        = 0*255(chr) nblk-chr
+nblk-chr     = %x21-2B / %x2D-3C / %x3E-7E
+chr          = %x20 / nblk-chr
+```
+
+### Key rules
+
+| Key form | Format | Purpose |
+|---|---|---|
+| Simple key | lowercase alphanum + `_ - * /`, ≤256 chars | Single-tenant vendor identifier, e.g. `congo` |
+| Multi-tenant key | `tenant-id@system-id` | Lets a multi-tenant vendor (`system-id`) namespace by `tenant-id` so lookups can jump straight to `@system-id` |
+
+### Value rules
+
+Opaque, printable-ASCII (`0x20`–`0x7E`), **excluding** comma and `=`; max **256 characters**.
+
+### Limits
+
+| Limit | Value |
+|---|---|
+| Max list-members | 32 |
+| Max total header size a vendor should be able to propagate | 512 characters |
+| Truncation strategy when trimming to fit | Drop entries over 128 characters first; then drop from the end of the list; only whole list-members may be dropped, never partially |
+
+### Mutation rules (§3.4/"Mutating the tracestate field")
+
+- A participant adding a new entry inserts it **at the front (left)** of the list.
+- A participant updating its own existing entry **moves it to the front** (as if delete +
+  re-add).
+- Only one entry per key is allowed — it represents that vendor's *last* position in the trace; a
+  vendor re-entering the trace overwrites its previous entry rather than appending a duplicate.
+  When a vendor is only reading (not modifying) an entry, order of all *other*, unmodified
+  list-members must be preserved.
+- Deleting keys: a vendor should not delete keys it did not itself generate — the spec's guidance
+  is that removing another vendor's entry breaks that vendor's correlation ability, so participants
+  should be conservative about deleting others' state.
+
+### OTel's own `tracestate` usage — the `ot=` vendor key
+
+**Status: Development (not stable).**
+Source: https://opentelemetry.io/docs/specs/otel/trace/tracestate-handling/ ,
+https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/
+
+OpenTelemetry SDKs consolidate all OTel-internal `tracestate` data into a **single** list-member
+under the key `ot`, itself an internal `;`-separated set of sub-keys (e.g. `ot=th:c8;rv:1a2b3c...`),
+capped at 256 characters total for that entry. Individual instrumentation libraries get their own
+separate list-member keys rather than writing into the shared `ot` entry.
+
+| Sub-key | Meaning | Format |
+|---|---|---|
+| `th` | Sampling **threshold** (rejection threshold `T`), conveys effective sampling probability. `0` = 100% sampling. Probability = `(2^56 - Threshold) / 2^56`. | 1–14 lowercase hex digits (right-padded conceptually to 56 bits) |
+| `rv` | Explicit **randomness value** — an alternative source of the common random value `R` used for consistent sampling decisions, instead of relying on the trailing bits of the `trace-id` | Exactly 14 lowercase hex digits |
+| `p` | Legacy/older probability encoding predating `th`/`rv` | — |
+
+This mechanism underpins **OTel consistent probability sampling**: every participant compares the
+shared randomness `R` (from `rv`, or else derived from the low 7 bytes of the `trace-id`) against
+its own rejection threshold `T` (`th`), so independently-configured samplers along a trace make
+*consistent* keep/drop decisions without needing to agree out-of-band. This whole area is marked
+**Development** stability in the OTel spec — do not treat it as a compliance requirement, but do
+recognize `ot=th:...;rv:...` if you see it in customer `tracestate` values.
+
+---
+
+## Baggage
+
+### API
+
+**Stability: Stable.**
+Source: https://opentelemetry.io/docs/specs/otel/baggage/api/
+
+| Operation | Signature | Notes |
+|---|---|---|
+| `Get Value` | `(baggage, name) -> value \| absent` | Simple lookup. |
+| `Get All Values` | `(baggage) -> [(name, value, metadata)]` | Order is **not significant**; may be exposed as an iterator or immutable collection. |
+| `Set Value` | `(baggage, name, value, metadata?) -> Baggage` | Returns a new `Baggage`; `metadata` is "an opaque wrapper for a string with no semantic meaning" to the API itself (vendor-defined use, e.g. W3C's `property` syntax). |
+| `Remove Value` | `(baggage, name) -> Baggage` | Returns a new `Baggage` without that entry. |
+
+Entry shape: **key** — any non-empty valid UTF-8 string, case-sensitive; **value** — any valid
+UTF-8 string, case-sensitive; **metadata** — optional opaque string. Exactly one value is
+associated with a given name at a time (setting again replaces).
+
+**Security requirement:** "To avoid sending any name/value pairs to an untrusted process, the
+Baggage API MUST provide a way to remove all baggage entries from a context" — i.e., a
+`ClearBaggage`-equivalent full-wipe capability is mandatory, specifically framed as a
+trust-boundary safeguard.
+
+**Baggage vs. span attributes — explicitly separate concerns.** The Baggage API spec only defines
+the `Baggage` value type and its context-scoped CRUD; it says nothing about auto-copying baggage
+into span attributes. In practice across OTel: **baggage entries do NOT automatically become span
+attributes** (or log/metric attributes). Any such correlation requires an explicit bridge/processor
+that reads `Baggage` from `Context` and calls `SetAttribute` on the current span itself. Treat
+"baggage shows up as a span attribute" as something that must be deliberately wired, not a
+default.
+
+### W3C Baggage header — wire format
+
+**Status:** W3C Editor's Draft (Baggage spec has moved slower through W3C process than Trace
+Context — re-verify current REC status before citing as a final Recommendation).
+Source: https://www.w3.org/TR/baggage/
+
+#### Grammar
+
+```
+baggage-string  = list-member 0*179( OWS "," OWS list-member )
+list-member     = key OWS "=" OWS value *( OWS ";" OWS property )
+key             = token                     ; RFC 7230 token, ASCII only
+value           = *baggage-octet            ; percent-encode anything outside this set
+property        = key OWS "=" OWS value / key OWS
+```
+
+`baggage-octet` excludes control characters, whitespace, `"`, `,`, `;`, and `\`; any character
+outside the allowed set must be percent-encoded per RFC 3986.
+
+#### Limits
+
+| Limit | Requirement |
+|---|---|
+| Max list-members | Implementations **must** propagate all list-members when the total is **64 or fewer** |
+| Max header size | Implementations **must** propagate the full baggage-string when it is **8192 bytes or fewer** |
+| Over either limit | Implementations **may** drop list-members to come back into compliance (no single normative drop order is mandated the way `tracestate` prescribes one) |
+
+No minimum-length constraint is specified for individual keys/values.
+
+#### Security considerations
+
+> Application owners should either ensure that no proprietary or confidential information is
+> stored in baggage, or they should ensure that baggage isn't present in requests that cross
+> trust-boundaries.
+
+The spec also expects implementations to defend against malicious/oversized baggage strings
+(length validation, careful parsing) to avoid buffer-overflow/injection-style failure modes on
+receipt — relevant directly to Maple's ingest gateway if it ever parses inbound `baggage` headers
+rather than only OTLP payloads.
+
+---
+
+## B3 and Jaeger (reference level)
+
+These are **not** part of OTel's core/mandatory propagator set; B3 ships in the optional contrib
+distribution, Jaeger propagation is explicitly **Deprecated** in OTel. Documented here because
+Maple, as an ingest backend, may see traffic from collectors/proxies still emitting them.
+
+Source (B3): https://github.com/openzipkin/b3-propagation
+Source (Jaeger, reference): https://www.jaegertracing.io/docs/1.6/client-libraries/#tracespan-identity ,
+deprecation noted at https://opentelemetry.io/docs/specs/otel/context/api-propagators/#propagators-distribution
+
+### B3 multi-header format
+
+| Header | Format |
+|---|---|
+| `X-B3-TraceId` | 16 (64-bit) or 32 (128-bit) lowercase hex chars |
+| `X-B3-SpanId` | 16 lowercase hex chars (64-bit) |
+| `X-B3-ParentSpanId` | 16 lowercase hex chars; optional, absent on root spans |
+| `X-B3-Sampled` | `1` = accept/sampled, `0` = deny/not-sampled; absent = defer decision downstream |
+| `X-B3-Flags` | Debug flag; `1` implies an accept/sampled decision, overriding `X-B3-Sampled` |
+
+### B3 single-header format
+
+Header name: `b3`. Format: `b3: {TraceId}-{SpanId}-{SamplingState}-{ParentSpanId}` — last two
+fields optional. `SamplingState`: `1` = accept, `0` = deny, `d` = debug, absent = defer.
+
+Examples: `b3: 80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1-05e3ac9a4f6e3b90`,
+`b3: 0` (deny only), `b3: 80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-d` (debug).
+
+When both single- and multi-header forms are present, the single-header (`b3`) form takes
+precedence.
+
+### Jaeger `uber-trace-id`
+
+Header: `uber-trace-id: {trace-id}:{span-id}:{parent-span-id}:{flags}`.
+
+- `trace-id`: variable length, 16 or 32 hex chars (64-bit or 128-bit); shorter values are
+  zero-padded on the left when converting to/from OTel's fixed 128-bit `TraceId`.
+- `span-id`: 16 hex chars.
+- `parent-span-id`: historically present but deprecated/unused — conventionally `0`.
+- `flags`: one byte as two hex digits (bit 0 = sampled, similar spirit to W3C's trace-flags LSB).
+
+OTel's own docs mark the Jaeger propagator/format as **Deprecated** in favor of W3C Trace Context;
+new integrations should not add Jaeger propagation, only consume it for legacy interop.
+
+### 64-bit vs 128-bit trace-id interop note
+
+OTel's canonical `TraceId` is always 128-bit (32 hex chars) internally. B3 and Jaeger both allow
+legacy 64-bit trace IDs. The standard interop rule (as implemented by OTel's B3/Jaeger propagators)
+is: a 64-bit incoming trace-id is **zero-extended on the left** to fill the 128-bit OTel `TraceId`;
+on the way back out to a 64-bit-only system, the low 64 bits are used (the propagator may drop the
+high, zero-padded bits). This is why Maple ingest should not treat a `TraceId` with a long run of
+leading zero bytes as inherently anomalous — it's a legitimate signature of a bridged 64-bit trace
+ID — while still rejecting the fully-all-zero 128-bit case for **W3C `traceparent` parsing
+specifically** (that all-zero rule is a W3C traceparent-parsing rule, not a generic "all-zero
+trace ids are always invalid" rule for OTLP payloads already carrying a `TraceId` field).
+
+---
+
+## Key references
+
+- OTel Context spec — https://opentelemetry.io/docs/specs/otel/context/
+- OTel Propagators API spec — https://opentelemetry.io/docs/specs/otel/context/api-propagators/
+- OTel Propagators distribution — https://opentelemetry.io/docs/specs/otel/context/api-propagators/#propagators-distribution
+- OTel Baggage API spec — https://opentelemetry.io/docs/specs/otel/baggage/api/
+- OTel SDK environment variables (`OTEL_PROPAGATORS`) — https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+- OTel TraceState handling (`ot=` vendor key) — https://opentelemetry.io/docs/specs/otel/trace/tracestate-handling/
+- OTel TraceState probability sampling (`th`/`rv`) — https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/
+- W3C Trace Context (Recommendation) — https://www.w3.org/TR/trace-context/
+- W3C Baggage (Editor's Draft/CR) — https://www.w3.org/TR/baggage/
+- B3 propagation (OpenZipkin) — https://github.com/openzipkin/b3-propagation
+- Jaeger client trace/span identity (`uber-trace-id`) — https://www.jaegertracing.io/docs/1.6/client-libraries/#tracespan-identity
+- Canonical spec repo — https://github.com/open-telemetry/opentelemetry-specification

--- a/docs/otel-spec/emerging-and-compat.md
+++ b/docs/otel-spec/emerging-and-compat.md
@@ -1,0 +1,407 @@
+# Emerging Signals & Compatibility (Profiles, Schemas, Prometheus, Shims)
+
+This page covers the parts of the OpenTelemetry spec tree that are either **not yet stable**
+(Profiles signal, Entities) or **exist to bridge OTel with something else** (telemetry
+schemas' rename/transform machinery, and the OpenCensus/OpenTracing/Prometheus compatibility
+specs). Maple is primarily a *consumer* of OTLP data and a *producer* of its own
+self-instrumentation, so this doc exists to flag: (a) data we may see on the wire that isn't
+"plain" OTLP yet, (b) a signal (Profiles) we don't ingest today but should plan schema/storage
+for, and (c) the principled alternative to the ad-hoc legacy-field coalescing we already do by
+hand.
+
+> **Stability key used below:** OpenTelemetry specs use a formal lifecycle — Draft → Experimental
+> → Stable → Deprecated → Removed — plus, specifically for Profiles, a pre-Experimental **Alpha**
+> stage. See `Source:` links per claim; do not assume anything in this file is Stable unless
+> explicitly marked so.
+
+## Relevance to Maple
+
+- **Profiles: not ingested today.** Maple's pipeline (Rust ingest gateway → collector →
+  ClickHouse/Tinybird) has no Profiles datasource, no `/v1development/profiles` route, and no
+  schema for `Profile`/`Sample`/`Location`/`Function` tables. If/when we add it, expect a
+  dictionary-compressed, pprof-derived shape (below), not flat rows like spans/logs — this
+  changes the storage model materially (string/location/function tables are shared across
+  samples within a profile, closer to how we already dedupe attribute tables than to how we
+  store span rows).
+- **Telemetry schemas are the principled version of what we do by hand.** CLAUDE.md documents
+  that `WarehouseQueryService.executeSql` spans "coalesce both" legacy `db.statement*`/`db.system`
+  and current `db.query.text`/`db.system.name` spellings, and that semconv renamed
+  `deployment.environment` → `deployment.environment.name` (dual-emitted by `apps/ingest`). That
+  is exactly the `rename_attributes` transform a schema file encodes formally. We do not currently
+  read `schema_url` off ingested `ResourceSpans`/`ResourceLogs`/`ResourceMetrics` to drive this
+  automatically — it's manual per-migration logic. This doc is the reference for what a
+  schema-aware coalescing layer would look like if we ever generalize it.
+- **Prometheus/OpenMetrics naming rules matter directly** if Maple ever accepts Prometheus
+  remote-write, scrapes `/metrics` from anything, or exposes an OTLP→Prometheus bridge for
+  customers. The `_total`/unit-suffix/`target_info` rules below are the exact translation table
+  to implement or validate against.
+- **OpenCensus/OpenTracing shim artifacts can show up in customer data** from services mid-migration
+  (the "OpenTelemetry sandwich" pattern) — e.g., an `opentracing.ref_type` span attribute, or
+  span links that originated as OpenCensus `Link`s. Both shims are now deprecated specs, so this
+  is legacy-interop knowledge, not something to build new support for.
+- **Entities** (pointer only) is a Development-stage remodeling of Resource that every signal,
+  including Profiles, will eventually attach to — worth tracking but not actionable yet.
+
+---
+
+## 1. Profiles signal
+
+### Status
+
+- Signal/data-model stability: **Alpha** (pre-Experimental; explicitly "should not be used for
+  critical production workloads"). `Source: https://opentelemetry.io/docs/specs/otel/profiles/`,
+  `Source: https://opentelemetry.io/docs/specs/status/`, `Source: https://opentelemetry.io/blog/2026/profiles-alpha/`
+- Protocol (OTLP transport) stability: **Development** — the spec's own status table lists
+  "Protocol: development" for profiles, distinct from the Stable protocol status for
+  traces/metrics/logs. `Source: https://opentelemetry.io/docs/specs/status/`
+- Wire/endpoint: default path is **`/v1development/profiles`** (an `ExportProfilesServiceRequest`
+  protobuf), the `v1development` path segment itself signaling non-stable status — it will drop
+  to `v1` only once the proto reaches release candidate. `Source: https://opentelemetry.io/docs/specs/otlp/`
+- The signal entered **public Alpha on 2026-03-26**; roadmap targets Beta then GA, with GA
+  originally hoped for ~Q3 2026 per community commentary (treat that date as unconfirmed —
+  it's from secondary sources, not the spec itself).
+  `Source: https://opentelemetry.io/blog/2026/profiles-alpha/`
+
+Every message-level type below (`Profile`, `Sample`, `Location`, `Function`, `Mapping`, `Link`,
+`ProfilesDictionary`) is itself annotated **Alpha** in the current proto.
+`Source: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/profiles/v1development/profiles.proto`
+
+### Data model shape (pprof-derived, dictionary-compressed)
+
+The model **modifies the pprof protobuf format**, adding OTel-native concepts (Resource,
+InstrumentationScope, trace/span links, semconv attributes) while preserving round-trip
+conversion to/from pprof "with no loss of information."
+`Source: https://opentelemetry.io/docs/specs/otel/profiles/`,
+`Source: https://opentelemetry.io/blog/2026/profiles-alpha/`
+
+Key design point for a backend: **profiles are not flat sample rows.** A `ProfilesDictionary`
+holds shared tables that samples reference by index, deduplicating everything that repeats
+across a profile (this is conceptually the same dedup trick as an attribute/string table, just
+applied to stack frames too):
+
+- `mapping_table` (`Mapping[]`) — binary/library memory regions (load address, file offset,
+  filename index) that a stack address falls into.
+- `location_table` (`Location[]`) — a single stack frame: which `Mapping`, an instruction
+  `address`, and one or more `Line`s (to represent inlined frames) each pointing at a `Function`.
+- `function_table` (`Function[]`) — function metadata: human-readable name, system
+  (e.g. mangled) name, source filename, starting line — all as string-table indices.
+- `link_table` (`Link[]`) — the cross-signal join: a `trace_id` + `span_id` pair a sample can
+  point at.
+- `string_table` (`string[]`) — shared strings referenced everywhere else by index.
+- `attribute_table` (`KeyValueAndUnit[]`) — key/value/unit triples (UCUM unit as a string index),
+  referenced by index from `Profile`, `Sample`, `Location`, and `Mapping`.
+- `stack_table` (`Stack[]`) — a deduplicated call stack (sequence of `Location` indices), shared
+  across samples that hit the same stack.
+
+`Profile` (the batch-level container) then carries: `sample_type` (a `ValueType` = measurement
+kind + unit, e.g. `cpu`/`nanoseconds`), `samples[]`, `time_unix_nano`, `duration_nano`,
+`period_type`/`period` (sampling interval descriptor), a 16-byte `profile_id`,
+`dropped_attributes_count`, and optionally the **original untouched payload**
+(`original_payload_format` + `original_payload` bytes) for lossless pprof round-trip.
+
+`Sample` is the actual observation: a `stack_index` into `stack_table`, `attribute_indices` for
+sample-specific attributes, `values[]` (the measured quantities — e.g. CPU ns, allocated bytes),
+optional `timestamps_unix_nano[]`, and a `link_index` into `link_table` (0 = none, following the
+dictionary convention that index 0 is a null sentinel throughout).
+`Source: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/profiles/v1development/profiles.proto`
+
+### Linking profiles to traces
+
+A `Sample` MAY carry a `Link` (via `link_index` → `link_table` → `{trace_id, span_id}`),
+enabling direct "what code was running during this span" correlation — the profiles concept
+page frames this explicitly as answering "which code is responsible" as a complement to an
+existing trace/span. Correlation otherwise happens the same way every signal correlates: shared
+Resource/InstrumentationScope context.
+`Source: https://opentelemetry.io/docs/specs/otel/profiles/`,
+`Source: https://opentelemetry.io/docs/concepts/signals/profiles/`
+
+### What a backend would need to store/query profiles (implication, not spec text)
+
+Given the shape above, ingesting Profiles is architecturally closer to ingesting a small
+relational bundle per batch (dictionary tables + samples referencing them by index) than to
+appending flat rows. A ClickHouse-style backend would plausibly need either (a) to materialize
+the dictionary tables into their own keyed tables and resolve indices at query time, or (b) to
+fully denormalize/flatten each sample (function names, file, line, mapping) at ingest — trading
+storage for query simplicity, the same trade-off Maple already makes for span attributes.
+Cross-signal correlation (`trace_id`/`span_id` on `Link`) is the one piece that maps cleanly onto
+existing trace-join infrastructure. **Maple does not implement any of this today** — this section
+is forward-looking, not a description of current behavior.
+
+### Collector-side status (pointer, not spec)
+
+The OpenTelemetry Collector is **not part of the specification** — it's a reference
+implementation — but is worth noting as context: the 2026 Alpha announcement highlights a
+`pprof` receiver, Kubernetes metadata enrichment, OTTL transforms for profiles, and an
+eBPF eBPF profiling agent donated by Elastic now distributed as part of the official Collector
+distribution. None of this is spec-mandated behavior.
+`Source: https://opentelemetry.io/blog/2026/profiles-alpha/` ·
+Collector docs (non-spec): `https://github.com/open-telemetry/opentelemetry-collector`
+
+---
+
+## 2. Telemetry schemas (deep dive)
+
+### Status
+
+**Stable.** `Source: https://opentelemetry.io/docs/specs/otel/schemas/`
+
+The Schema File Format sub-spec (versions 1.0.0 and 1.1.0) is separately versioned; the current
+file format spec (1.1.0) is marked **Development** in its own document header even though the
+overall "Telemetry Schemas" concept page is Stable — read the file-format details as less settled
+than the top-level mechanism.
+`Source: https://opentelemetry.io/docs/specs/otel/schemas/file_format_v1.1.0/`
+
+### Why schemas exist
+
+Semantic conventions evolve (attributes get renamed, split, etc.), but telemetry producers,
+telemetry consumers, and the semantic conventions themselves all evolve independently — "the
+coupling complicates the independent evolution of these 3 parties." A schema is the versioned,
+machine-readable description of *what changed between semconv versions* so a consumer can
+transform old-shaped data into the shape it expects (or vice versa) without bespoke code per
+field rename. `Source: https://opentelemetry.io/docs/specs/otel/schemas/`
+
+### `schema_url` mechanics end-to-end
+
+1. **Format:** `http[s]://server[:port]/path/<version>`. Everything before `<version>` is the
+   **Schema Family** identifier — every version in a family shares that prefix.
+2. **Where it's attached in OTLP:** `schema_url` fields exist on `ResourceSpans`,
+   `ResourceMetrics`, `ResourceLogs` (applies to the Resource and everything nested under it) and
+   separately on the `InstrumentationLibrary*`/scope-level messages (applies to just that
+   scope's data). **If both are set, the scope-level value takes precedence** over the
+   resource-level one for the data under that scope.
+3. **Immutability + caching:** "Schema files are immutable once they are published" — once you've
+   resolved a `schema_url` to a file, it is safe to cache that resolution permanently. Fetchers
+   must follow HTTP redirects. Consumers/backends MAY bundle known schema files at build time
+   instead of fetching over the network at all.
+4. **Versioning:** MAJOR.MINOR.PATCH, SemVer 2.0 ordering, and — importantly for anyone mapping
+   this to semconv — **"OpenTelemetry schema version numbers match OpenTelemetry Semantic
+   Conventions version numbers,"** i.e. schema `1.27.0` corresponds to semconv `1.27.0`.
+
+`Source: https://opentelemetry.io/docs/specs/otel/schemas/`
+
+### Schema file format (1.1.0)
+
+A schema file is YAML:
+
+```yaml
+file_format: 1.1.0
+schema_url: /schemas/1.2.0
+versions:
+  1.2.0:
+    all:
+      changes: [...]
+    resources:
+      changes: [...]
+    spans:
+      changes: [...]
+    span_events:
+      changes: [...]
+    metrics:
+      changes: [...]
+    logs:
+      changes: [...]
+```
+
+- `file_format` must literally be `"1.1.0"`.
+- `schema_url`'s trailing version must equal the highest version key present under `versions`.
+- The **`all`** section's transforms apply first, to every signal type; then per-signal sections
+  apply on top.
+- Transformations are **intentionally minimal by design** ("we intentionally limit the types of
+  transformations of schemas to the bare minimum") — this is not a general ETL DSL.
+
+Transform types by section, per the 1.1.0 format:
+
+| Section       | Supported transforms                          |
+| ------------- | ---------------------------------------------- |
+| `all`         | `rename_attributes`                            |
+| `resources`   | `rename_attributes`                            |
+| `spans`       | `rename_attributes`                            |
+| `span_events` | `rename_events`, `rename_attributes`           |
+| `metrics`     | `rename_metrics`, `rename_attributes`, `split` |
+| `logs`        | `rename_attributes`                            |
+
+`rename_attributes` — the one most relevant to Maple's existing manual coalescing — takes an
+`attribute_map` of old→new names, optionally scoped to specific span names / event names / metric
+names via `apply_to_spans` / `apply_to_events` / `apply_to_metrics`:
+
+```yaml
+- rename_attributes:
+    attribute_map:
+      old_name: new_name
+    apply_to_spans: [span_name]
+    apply_to_events: [event_name]
+    apply_to_metrics: [metric_name]
+```
+
+`rename_metrics` renames a metric name outright; `split` breaks one metric into several by an
+attribute's value (e.g. `system.paging.operations` split by `direction` into
+`system.paging.operations.in` / `.out`).
+
+Version 1.1.0's change versus 1.0.0 was introducing this structured, declarative transform
+framework so tooling can walk a chain of schema versions and apply/reverse the diffs
+automatically, rather than each consumer hand-rolling migrations.
+`Source: https://opentelemetry.io/docs/specs/otel/schemas/file_format_v1.1.0/`
+
+### Applying transformations (the pattern Maple's manual coalescing approximates)
+
+Two implementation patterns the spec describes:
+
+1. **Schema-aware backend:** compare the `schema_url` on incoming data against the schema
+   version the backend wants; walk the schema file's declared changes between those versions;
+   apply them (e.g., the spec's own example — renaming `deployment.environment` to
+   `environment`). This is precisely the shape of the `deployment.environment` →
+   `deployment.environment.name` rename Maple's `apps/ingest` currently handles by **dual-emitting
+   both keys** (per CLAUDE.md) rather than by reading `schema_url` and transforming — i.e. we're
+   doing the outcome without the mechanism.
+2. **Collector-Assisted Schema Transformation:** delegate the conversion to an OpenTelemetry
+   Collector's Schema Translate Processor sitting in the pipeline, so producers/consumers never
+   need schema logic themselves.
+
+`Source: https://opentelemetry.io/docs/specs/otel/schemas/`
+
+**Note for Maple:** we do not currently read `schema_url` from ingested `ResourceSpans` /
+`ResourceMetrics` / `ResourceLogs` anywhere in the ingest gateway or collector config (verify
+against `apps/ingest` if this needs to be load-bearing) — the legacy-field coalescing described in
+CLAUDE.md (`db.statement*`/`db.system` ↔ `db.query.text`/`db.system.name`,
+`deployment.environment` ↔ `deployment.environment.name`) is hand-written per-field logic, not
+schema-driven. If schema-aware coalescing is ever generalized, this is the mechanism to build on.
+
+---
+
+## 3. Prometheus & OpenMetrics compatibility
+
+### Status
+
+**Stable**, with two carve-outs the spec itself marks **Development**: resource-attribute →
+`target_info`/`job`/`instance` handling, and Prometheus "Unknown"-type metric handling.
+`Source: https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/`
+
+### OTLP → Prometheus naming rules
+
+- **Unit suffixes:** UCUM units are mapped to Prometheus unit words via a lookup table (`By` →
+  `bytes`, `ms` → `milliseconds`, etc.); bracketed annotations like `{packet}` are dropped; units
+  expressed as rates (`m/s`) become `_per_` words (`meters_per_second`). The resulting unit
+  **SHOULD** also be set as OpenMetrics `UNIT` metadata. A unit suffix **SHOULD** be appended to
+  the metric name unless the name already ends with it (before any type suffix).
+- **`_total` suffix:** for monotonic Sum points, a `_total` suffix **SHOULD** be added by default
+  if not already present; if already present, the name **MUST** stay unchanged (no double
+  suffixing).
+- **Character sanitization:** characters Prometheus discourages in metric names **SHOULD** be
+  replaced with `_` by default, and repeated `_` collapsed to one.
+- **Resource attributes → `job`/`instance`/`target_info`:** `service.namespace` +
+  `service.name` **MUST** combine into `<namespace>/<name>` (or just `<name>` if no namespace) to
+  form the `job` label; `service.instance.id`, if present, **MUST** become the `instance` label
+  (else `instance` is emitted empty). Other resource attributes **SHOULD** become a synthetic
+  `target_info` metric (an OpenMetrics "info" metric, or — if the client library lacks info-metric
+  support — a gauge named `target_info` with constant value `1`) or **MUST** be dropped.
+  *(Development status.)*
+- **Untyped/Gauge round-trip:** exporting an OTLP Gauge back toward Prometheus, if the datapoint
+  carries a `prometheus.type` attribute equal to `unknown`, it **MUST** become a Prometheus
+  Unknown-typed sample. *(Development status.)*
+
+### Prometheus → OTLP naming rules
+
+- By default, label keys/values **MUST NOT** be altered (e.g., no automatic `_`→`.` translation)
+  — the opposite direction is lossier/more speculative than OTLP→Prom, so the spec is
+  conservative here.
+- `UNIT` metadata, if present on the Prometheus side, **MUST** be converted into the OTLP metric's
+  unit.
+- A Prometheus **Unknown**-typed metric **MUST** be converted to an **OTLP Gauge** on ingest.
+  *(Development status.)*
+- Summary quantiles carry a `quantile` label with the stringified float (e.g. `0.99`); histogram
+  buckets use Prometheus's standard `le` (less-than-or-equal) label — the spec does not add new
+  bucket-naming rules beyond these Prometheus/OpenMetrics conventions.
+
+`Source: https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/`
+
+---
+
+## 4. OpenCensus compatibility (shim)
+
+### Status
+
+**Deprecated** as of **June 2026**; removal not before **June 2027**. Existing shims MAY keep
+being supported, but implementing new OpenCensus compatibility is explicitly not required by the
+spec going forward. `Source: https://opentelemetry.io/docs/specs/otel/compatibility/opencensus/`
+
+### What it guarantees / why customer data may show OpenCensus artifacts
+
+The shim implements the OpenCensus Trace API and a Stats/Metrics bridge (`OpenCensus-Metrics-Shim`
+implementing `MetricProducer`) on top of OpenTelemetry, so legacy OpenCensus instrumentation can
+keep running unmodified while everything around it moves to OTel. It guarantees parent/child span
+relationships and span **Links** survive translation, and both push/pull metric exporters keep
+working, covering Gauges, Counters, Cumulative Histograms, and Summaries. The reason a Maple
+customer's data could carry OpenCensus fingerprints is the well-known **"OpenTelemetry
+sandwich"**: outer application layers adopt OTel first while inner dependencies are still on
+OpenCensus, and the shim bridges the two until migration completes.
+`Source: https://opentelemetry.io/docs/specs/otel/compatibility/opencensus/`
+
+---
+
+## 5. OpenTracing compatibility (shim)
+
+### Status
+
+**Deprecated** as of **March 2026**; removal not before **March 2027**. Same posture as
+OpenCensus above — existing shims MAY continue, new implementation isn't required.
+`Source: https://opentelemetry.io/docs/specs/otel/compatibility/opentracing/`
+
+### What it guarantees / span kind & reference mapping
+
+The shim implements the OpenTracing API as a bridge over the OpenTelemetry API/SDK, without
+exposing OTel internals to OpenTracing-instrumented code. The part most likely to surface as an
+artifact in ingested data: OpenTracing's two **Reference** types (`Child Of`, `Follows From`)
+become OpenTelemetry **Links**, with the original reference type preserved as an
+**`opentracing.ref_type`** span attribute — so seeing that attribute key in customer traces is a
+tell that the data passed through this shim. The first `Child Of` reference (or the first
+reference of any kind if none is `Child Of`) is chosen as the span's actual OTel parent; Baggage
+from referenced spans is merged into the new span's initial Baggage.
+
+**Known limitation called out by the spec:** mixing the OpenTracing shim and the native
+OpenTelemetry API in the same process risks broken Baggage propagation, because OpenTelemetry has
+no awareness of the shim's association between a shim span and its Baggage; in languages with
+implicit context propagation (e.g. JavaScript) this can also produce incorrect parent/child
+relationships, violating OpenTracing's explicit-propagation-only semantics.
+`Source: https://opentelemetry.io/docs/specs/otel/compatibility/opentracing/`
+
+---
+
+## 6. Other emerging spec-tree items (pointers)
+
+- **Entities** — a Development-stage remodeling of the Resource concept: each signal (including
+  Profiles) will be able to attach one or more typed Entities (`k8s.cluster`, `host`,
+  `container`, …), each with stable identifying attributes plus mutable descriptive attributes,
+  layered on top of the existing Resource attribute pool for OTLP 1.x backward compatibility.
+  Not otherwise covered in this doc set — treat as a future Resource-model change to watch, not
+  something to implement against yet.
+  `Source: https://opentelemetry.io/docs/specs/otel/entities/data-model/`
+- **Trace Context in non-OTLP Log Formats** — a compatibility spec (sibling to OpenCensus/
+  OpenTracing/Prometheus above) for propagating trace context through log formats that aren't
+  OTLP; noted here as a pointer since it's linked from the same compatibility index but out of
+  this pass's detailed scope.
+  `Source: https://opentelemetry.io/docs/specs/otel/compatibility/logging_trace_context/`
+- **The Collector itself is not part of the OpenTelemetry specification.** Its docs
+  (`https://github.com/open-telemetry/opentelemetry-collector`) describe a reference
+  implementation's data flow, processors, and receivers (including the `pprof` receiver and
+  Schema Translate Processor mentioned above) — useful for understanding available tooling, but
+  none of it is spec-mandated or spec-versioned.
+
+---
+
+## Key references
+
+- Profiles data model: https://opentelemetry.io/docs/specs/otel/profiles/
+- Profiles concept overview: https://opentelemetry.io/docs/concepts/signals/profiles/
+- Profiles proto (v1development): https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/profiles/v1development/profiles.proto
+- OTLP spec (endpoint paths, protocol status): https://opentelemetry.io/docs/specs/otlp/
+- Spec-wide status summary: https://opentelemetry.io/docs/specs/status/
+- Profiles Alpha announcement (2026-03-26): https://opentelemetry.io/blog/2026/profiles-alpha/
+- Telemetry schemas: https://opentelemetry.io/docs/specs/otel/schemas/
+- Schema file format 1.1.0: https://opentelemetry.io/docs/specs/otel/schemas/file_format_v1.1.0/
+- Compatibility index: https://opentelemetry.io/docs/specs/otel/compatibility/
+- Prometheus & OpenMetrics compatibility: https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/
+- OpenCensus compatibility: https://opentelemetry.io/docs/specs/otel/compatibility/opencensus/
+- OpenTracing compatibility (shim): https://opentelemetry.io/docs/specs/otel/compatibility/opentracing/
+- Trace context in non-OTLP log formats: https://opentelemetry.io/docs/specs/otel/compatibility/logging_trace_context/
+- Entities data model: https://opentelemetry.io/docs/specs/otel/entities/data-model/
+- Document status definitions (Draft/Experimental/Stable/Deprecated/Removed, Alpha): https://opentelemetry.io/docs/specs/otel/document-status/

--- a/docs/otel-spec/logs.md
+++ b/docs/otel-spec/logs.md
@@ -1,0 +1,464 @@
+# Logs & Events (Data Model, Bridge API & SDK)
+
+This page documents the OpenTelemetry **Logs** specification: the log data model, the Logs API
+(a.k.a. the "Bridge API"), the Logs SDK, and the current (2026) direction on **Events** as
+log-based records rather than a separate signal. It is a reference for spec-compliance checks and
+for a best-practices skill — every claim below is sourced from the official specification (or the
+OTLP proto, for wire-level field names).
+
+## Relevance to Maple
+
+> Maple's Rust ingest gateway (`apps/ingest`) receives OTLP logs and forwards them to the
+> collector → ClickHouse/Tinybird. Maple is primarily a **consumer/backend** of OTel log data, not
+> an app-side log-emitting SDK author. The parts of this spec that matter most to us:
+>
+> - **Data model field semantics** (`docs/otel-spec/logs.md#logrecord-fields`) — how to interpret
+>   `Timestamp` vs `ObservedTimestamp`, `SeverityNumber` vs `SeverityText`, and `Body` as an
+>   `AnyValue` when mapping incoming OTLP `LogRecord`s into our ClickHouse schema.
+> - **Severity normalization** — our dashboards should key error/warn facets off `SeverityNumber`
+>   ranges (see CLAUDE.md: "Span Status Codes: use title case" — analogous care is needed for
+>   severity display strings, which the spec also title-cases: `Trace`/`Debug`/`Info`/`Warn`/
+>   `Error`/`Fatal`).
+> - **Trace correlation fields** (`TraceId`/`SpanId`/`TraceFlags`) — these are how our logs UI
+>   should link a log line back to a trace/span; validity rules below (e.g. `SpanId` implies
+>   `TraceId`) matter for defensive parsing of malformed producers.
+> - **EventName / Events direction** — OpenTelemetry is actively deprecating `Span.AddEvent` in
+>   favor of log-based events (see [Events](#events)). If Maple ever ingests or displays
+>   "events" as a first-class concept, the wire format is `LogRecord.event_name` (proto field 12),
+>   not a separate signal. Self-instrumentation should also check whether our own Rust ingest
+>   gateway or web app should switch to log-based events for anything currently using span events.
+> - **SDK batch/limits env vars** — not directly consumed by Maple's backend (we don't run a Logs
+>   SDK ourselves in the hot ingest path), but relevant if/when Maple's own services (API, web,
+>   alerting) adopt an OpenTelemetry Logs SDK for self-instrumented application logging, and for
+>   validating third-party SDK behavior when debugging customer data gaps (e.g. "why did 2000 logs
+>   arrive in one batch 30s late" → default `OTEL_BLRP_*` values below).
+
+---
+
+## 1. Overview
+
+**Stability: no single badge for the overview page; it links out to Stable Data Model, Stable
+API, Stable SDK (see [Stability summary](#stability-summary) below).**
+Source: https://opentelemetry.io/docs/specs/otel/logs/
+
+Unlike traces and metrics, OpenTelemetry does **not** introduce a brand-new logging API that
+applications are expected to adopt wholesale. Instead the logs spec is designed to **embrace
+existing logging libraries** and unify their output with traces/metrics via three correlation
+dimensions:
+
+1. **Temporal correlation** — logs, traces, and metrics all carry timestamps, the most basic form
+   of correlation.
+2. **Contextual (execution) correlation** — a `LogRecord` can carry `TraceId`/`SpanId` so a log
+   line is attributable to the exact request/span that produced it.
+3. **Resource correlation** — a `LogRecord` carries the same `Resource` model used by traces and
+   metrics (e.g. identical `k8s.pod.*` attributes), so a log, trace, and metric from the same
+   process describe their origin identically.
+
+Three ways logs reach OpenTelemetry are called out on this page:
+
+- **Existing/legacy log files**, parsed and enriched by the OpenTelemetry Collector (with or
+  without an intermediate agent like FluentBit).
+- **Log appenders / bridges** — library-specific glue that hooks an existing logging framework
+  (e.g. Log4j, Winston, `slog`) so it emits through the OpenTelemetry data model and automatically
+  injects trace context into each record.
+- **Direct logging** — new application code emits `LogRecord`s straight through the Logs API/SDK
+  over OTLP, skipping files/parsers/rotation entirely.
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/
+
+---
+
+## 2. Log Data Model
+
+**Stability: Stable.**
+Source: https://opentelemetry.io/docs/specs/otel/logs/data-model/ (spec source:
+[`specification/logs/data-model.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md))
+
+### 2.1 LogRecord fields
+
+All fields are conceptually optional at the data-model level (a valid `LogRecord` may have zero
+fields populated — see [§2.4](#24-minimal-validity--missing-fields)); the table below states each
+field's type, meaning, and the specific SHOULD/MUST guidance the spec attaches to it.
+
+| Field | Type | Meaning | Requirement-level notes |
+|---|---|---|---|
+| `Timestamp` | `uint64` nanoseconds since Unix epoch | Time the event occurred, per the **origin clock** (i.e., the producer's clock, which may be unsynchronized) | Optional. May be omitted for early instrumentation phases per the spec's incremental-adoption note. |
+| `ObservedTimestamp` | `uint64` nanoseconds since Unix epoch | Time the OpenTelemetry collection/observation system (SDK, collector, receiver) **first observed/recorded** the event, e.g. file-read time for tailed logs | SHOULD be set when the event's true origin timestamp is unavailable or untrusted. If unspecified by an SDK's `Emit`, the SDK **SHOULD** set it to current time (see [§4 SDK](#41-logrecord-lifecycle--observedtimestamp-default)). |
+| `TraceId` | byte sequence (16 bytes on the wire) | W3C Trace Context trace identifier for the request being processed when the log was emitted | Optional. |
+| `SpanId` | byte sequence (8 bytes on the wire) | Identifier of the specific span being processed when the log was emitted | Optional, but **if `SpanId` is present, `TraceId` SHOULD also be present.** |
+| `TraceFlags` | 1 byte | W3C trace flags (currently only defines the `SAMPLED` bit) | Optional. |
+| `SeverityText` | string | The **original**, source-native string representation of severity (e.g. `"WARN"`, `"ERR"`, framework-specific spelling) — preserved as-is, not normalized | Optional. |
+| `SeverityNumber` | integer, 0–24 | The **normalized** severity, mapped onto OpenTelemetry's fixed 1–24 numeric scale (0 = unspecified) | Optional. See full table in [§2.2](#22-severitynumber-reference-table). |
+| `Body` | `AnyValue` | The log payload: a human-readable message string, **or** structured data (maps/arrays/scalars) | Optional. Body **MUST support `AnyValue`** so structured logs from applications survive without lossy stringification. |
+| `Resource` | `Resource` | Describes the entity producing the log (same `Resource` model as traces/metrics) | Optional at the data-model layer; in practice always populated by the SDK. |
+| `InstrumentationScope` | `InstrumentationScope` | The logger (name/version/schema_url/attributes) that emitted the record; stable across many log events from the same source | Optional at the data-model layer; populated by the SDK. |
+| `Attributes` | collection of key-value pairs | Additional structured data about this **specific occurrence** (as opposed to `Resource`, which describes the origin) | Optional. Subject to the same attribute limits as spans (count/length limits, see [§4.3](#43-logrecord-limits)). |
+| `EventName` | string | Identifies the **class/type** of the event this log record represents | Optional. A non-empty `EventName` makes this record an **Event** — see [§5](#5-events). |
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/data-model/#log-and-event-record-definition
+
+### 2.2 SeverityNumber reference table
+
+The severity scale is a fixed 1–24 integer range divided into six named bands, each with a
+"finer-grained" sub-level (`+1`..`+4`) for systems whose native severities don't align exactly:
+
+| SeverityNumber | Name | Meaning |
+|---|---|---|
+| 0 | *(unspecified)* | No severity information; `SeverityNumber` omitted/zero. |
+| 1 | `TRACE` | A fine-grained debugging event. Typically disabled by default. |
+| 2 | `TRACE2` | |
+| 3 | `TRACE3` | |
+| 4 | `TRACE4` | |
+| 5 | `DEBUG` | A debugging event. |
+| 6 | `DEBUG2` | |
+| 7 | `DEBUG3` | |
+| 8 | `DEBUG4` | |
+| 9 | `INFO` | An informational event. Indicates that an event happened. |
+| 10 | `INFO2` | |
+| 11 | `INFO3` | |
+| 12 | `INFO4` | |
+| 13 | `WARN` | A warning event. Not an error but is likely more important than an informational event. |
+| 14 | `WARN2` | |
+| 15 | `WARN3` | |
+| 16 | `WARN4` | |
+| 17 | `ERROR` | An error event. Something went wrong. |
+| 18 | `ERROR2` | |
+| 19 | `ERROR3` | |
+| 20 | `ERROR4` | |
+| 21 | `FATAL` | A fatal error such as an application or system crash. |
+| 22 | `FATAL2` | |
+| 23 | `FATAL3` | |
+| 24 | `FATAL4` | |
+
+Normative guidance for producers mapping a **source system's own severities** onto this scale:
+
+- If a source severity level maps to a **single** OpenTelemetry `SeverityNumber` range (e.g.
+  source "WARN" → the `WARN` band), use the **lowest/smallest** value in that band (i.e. plain
+  `WARN` = 13, not 14–16).
+- If a source has **multiple** distinct severities that all fall into the same OpenTelemetry band
+  (e.g. a framework with both "notice" and "warning" both conceptually "warn-ish"), spread them
+  across that band's four values (13–16) in order of increasing importance so relative ordering is
+  preserved.
+- **`SeverityNumber >= ERROR (17)` is a signal the record represents an erroneous situation** — this
+  is the normative hook backends should use to classify a log line as an error for dashboards/alerts,
+  not string-matching on `SeverityText`.
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber and
+https://opentelemetry.io/docs/specs/otel/logs/data-model/#displaying-severity
+
+### 2.3 Body / AnyValue semantics
+
+`Body` is typed as `AnyValue`, the same recursive value type used for attribute values but
+extended to structures: a scalar (string/bool/int/double/bytes), or a structured value — an array
+of `AnyValue`, or a map of string keys to `AnyValue`. This is explicitly to preserve **structured
+logging** semantics (e.g. a JSON-object log line) without forcing lossy stringification into a
+single message field. The spec states the data model **MUST** support `AnyValue` for `Body` for
+exactly this reason — different occurrences of a log from the same statement/call-site can still
+vary in shape (e.g. conditionally-included fields).
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-body
+
+### 2.4 Minimal validity / missing fields
+
+The data model does not mandate a minimum set of populated fields for a record to be "valid" — an
+empty `LogRecord` is technically legal, though useless. Practical guidance:
+
+- **`Timestamp` vs `ObservedTimestamp`**: when a consumer/exporter needs to reduce a record to a
+  single timestamp (e.g. exporting to a system that only understands one time field), the rule is:
+  **use `Timestamp` if it is present, otherwise fall back to `ObservedTimestamp`.** A consumer
+  should never treat a record with only `ObservedTimestamp` set as invalid — that's the expected
+  shape for tailed/parsed legacy logs where the true origin time is unknown or untrustworthy.
+- **`SpanId` without `TraceId`** should be treated as a malformed/unusual record by a strict
+  consumer, since the spec says `TraceId` SHOULD accompany `SpanId`; a defensive backend (like
+  Maple's ingest path) should not assume the reverse is disallowed (a record MAY carry `TraceId`
+  alone, e.g. no active span at emit time).
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-observedtimestamp and
+https://opentelemetry.io/docs/specs/otel/logs/data-model/#trace-context-fields
+
+### 2.5 Data Model Appendix — mappings from other systems
+
+**Stability: Stable (companion to the data model).**
+Source: https://opentelemetry.io/docs/specs/otel/logs/data-model-appendix/
+
+The appendix gives field-by-field mapping tables from common log formats onto the OpenTelemetry
+`LogRecord`, useful when writing or auditing a receiver/exporter. Examples covered: RFC 5424
+Syslog, Windows Event Log, SignalFx Events, Splunk HEC, Log4j, Zap, Apache HTTP Server access
+logs, AWS CloudTrail, Google Cloud Logging, and the Elastic Common Schema. Pattern is consistent
+across all of them: native timestamp → `Timestamp`, native severity/level → `SeverityNumber`
+(+ `SeverityText` for the original string), free-form message → `Body`, host/service/cloud
+identity fields → `Resource`, everything else structured → `Attributes`. A companion **Appendix B**
+gives severity-level equivalency mappings (e.g. Syslog `Debug`/Java `FINEST` → `TRACE`(1); Syslog
+`Emergency`/Log4j `FATAL` → `FATAL`(21)), which is the authoritative source if Maple ever needs to
+normalize a specific framework's severities for ingestion.
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/data-model-appendix/
+
+---
+
+## 3. Logs API ("Bridge API")
+
+**Stability: Stable, except where otherwise specified** (the page explicitly calls out an
+"Ergonomic API" as still in **Development**).
+Source: https://opentelemetry.io/docs/specs/otel/logs/api/ (spec source:
+[`specification/logs/api.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/api.md))
+
+### 3.1 Intended audience
+
+This is explicitly called the **Logs Bridge API** in the spec, and it is **not meant for
+application developers to call directly in everyday code**. The primary audience is:
+
+- **Log appender / bridge authors** — people writing the glue that lets an existing logging
+  library (Log4j, Winston, `slog`, Python `logging`, etc.) emit through OpenTelemetry.
+- Secondarily, instrumentation and instrumented-library authors, who *may* call it directly, though
+  a language may offer a more ergonomic wrapper for that purpose.
+
+This matters for Maple only insofar as we should not expect our own application code (if we ever
+add OTel-based logging to the Rust ingest gateway, `apps/api`, etc.) to call this low-level API
+directly — we'd reach for a logging-library integration/bridge, or the language's ergonomic
+wrapper, not `Logger.Emit` by hand.
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/api/#overview
+
+### 3.2 LoggerProvider
+
+Entry point; **MUST** provide a "Get a Logger" operation, parameterized by the **Instrumentation
+Scope**: `name` (required), `version` (optional), `schema_url` (optional), `attributes` (optional).
+Also must support access to a global default `LoggerProvider`.
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/api/#loggerprovider
+
+### 3.3 Logger — Emit a LogRecord
+
+The `Logger` interface's core operation accepts (all optional except where noted):
+
+- `Timestamp`, `ObservedTimestamp`
+- `Context` — **"When implicit Context is supported, then this parameter SHOULD be optional and if
+  unspecified then MUST use current Context. When only explicit Context is supported, this
+  parameter SHOULD be required."** This is the mechanism by which trace correlation
+  (`TraceId`/`SpanId`) gets attached to a log record automatically: the SDK reads the active
+  span/trace out of whatever `Context` is in scope (implicit ambient context, or an explicitly
+  passed one) at emit time and copies its `TraceId`/`SpanId`/`TraceFlags` onto the record.
+- `SeverityNumber`, `SeverityText`
+- `Body`
+- `Attributes`
+- `EventName`
+- `Exception` — optional/MAY be accepted as a convenience for exception-recording
+
+### 3.4 Enabled
+
+`Logger` **SHOULD** provide an `Enabled(context, severityNumber, eventName)` operation returning a
+boolean, so callers can cheaply skip expensive log-construction work when the record would be
+dropped anyway. The spec notes the result "is not always static, it can change over time" (e.g.
+dynamic sampling/config), so callers should be documented to call it fresh each time rather than
+caching the result.
+
+### 3.5 Concurrency
+
+Both `LoggerProvider` and `Logger`: **all methods MUST be documented as safe for concurrent use by
+default.**
+
+Source (3.2–3.5): https://opentelemetry.io/docs/specs/otel/logs/api/
+
+---
+
+## 4. Logs SDK
+
+**Stability: Stable, except where otherwise specified** — the page explicitly marks
+**`LoggerConfigurator`, per-`LoggerConfig` behavior (`enabled`/`minimum_severity`/`trace_based`),
+`Enabled`-based filtering rules, and the "Event to span event bridge processor" as Development.**
+Source: https://opentelemetry.io/docs/specs/otel/logs/sdk/ (spec source:
+[`specification/logs/sdk.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md))
+
+### 4.1 LogRecord lifecycle / ObservedTimestamp default
+
+The SDK-level `Emit` operation implements the data-model rule from [§2.4](#24-minimal-validity--missing-fields):
+**"If Observed Timestamp is unspecified, the implementation SHOULD set it equal to the current
+time."** This is the concrete SDK-side guarantee behind the data model's "SHOULD be set" language
+for `ObservedTimestamp`.
+
+### 4.2 LoggerProvider / Logger (SDK)
+
+- A `LoggerProvider` **MUST** provide a way to configure/attach a `Resource`.
+- Owns the set of registered `LogRecordProcessor`s and (Development-status) a `LoggerConfigurator`.
+- Supports multiple independent `LoggerProvider` instances in one process.
+- **Shutdown**: called once; SDK should make the `Logger` a no-op after shutdown.
+- **ForceFlush**: tells all registered processors to flush pending records.
+- `LoggerConfig` (Development) parameters, per logger: `enabled` (default `true`),
+  `minimum_severity` (default `0`, filters records below this `SeverityNumber`), `trace_based`
+  (default `false`; when `true`, drops records for unsampled traces).
+
+### 4.3 LogRecordProcessor
+
+Interface operations:
+
+- **OnEmit** — called synchronously on the emitting thread with a `ReadWriteLogRecord` and the
+  resolved `Context`; **SHOULD NOT block or throw**.
+- **Enabled** (optional) — filtering hook taking context/instrumentation-scope/severity/event-name,
+  returns bool.
+- **Shutdown**, **ForceFlush** — as usual for OTel pipeline components.
+
+#### Simple Processor
+
+Passes each finished `LogRecord` to its configured `exporter` **immediately**, synchronized so
+`Export` is never called concurrently on the same exporter instance.
+
+#### Batching Processor
+
+Buffers records into batches before handing them to the exporter. Configurable parameters and
+**their environment variables** (general SDK env var spec):
+
+| Parameter | Env var | Default | Notes |
+|---|---|---|---|
+| Max queue size | `OTEL_BLRP_MAX_QUEUE_SIZE` | `2048` | Maximum number of `LogRecord`s buffered before drop. |
+| Scheduled delay | `OTEL_BLRP_SCHEDULE_DELAY` | `1000` (ms) | Delay between consecutive batch exports. |
+| Export timeout | `OTEL_BLRP_EXPORT_TIMEOUT` | `30000` (ms) | Max time allowed for a single export call. |
+| Max export batch size | `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` | `512` | Must be `<=` max queue size. |
+
+All numeric values must be positive. (`BLRP` = **B**atch **L**og**R**ecord **P**rocessor — same
+naming pattern as `BSP` for spans.)
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/sdk/#batching-processor and
+https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md
+(§ "Batch LogRecord Processor")
+
+### 4.4 LogRecordExporter
+
+- **Export(batch of `ReadableLogRecord`s)** → `Success` | `Failure`. **Must not be called
+  concurrently** with other `Export` calls on the same exporter instance (the processor guarantees
+  serialization).
+- **ForceFlush** — completes pending exports within a timeout.
+- **Shutdown** — releases resources; any subsequent `Export` call **MUST** return `Failure`.
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordexporter
+
+### 4.5 LogRecord limits
+
+The SDK enforces the same family of attribute limits used for spans, applied to `LogRecord.Attributes`:
+
+| Parameter | Env var | Default | Notes |
+|---|---|---|---|
+| Attribute count limit | `OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT` | `128` | Non-negative integer; extra attributes past this count are dropped (and counted in `dropped_attributes_count` on the wire). |
+| Attribute value length limit | `OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT` | no limit | Non-negative integer; truncates attribute values longer than this. |
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecord-limits and
+https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md
+(§ "Attribute Limits" / "LogRecord Limits")
+
+### 4.6 Exporter selection
+
+| Env var | Default | Known values |
+|---|---|---|
+| `OTEL_LOGS_EXPORTER` | `otlp` | `otlp`, `console`, `logging` (deprecated alias for `console`), `none`. Implementations may accept a comma-separated list to configure multiple exporters simultaneously. |
+
+Source: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md
+(§ "Exporter Selection")
+
+### 4.7 Concurrency
+
+- `LoggerProvider`: creation of `Logger`s, `ForceFlush`, `Shutdown` must be thread-safe.
+- `Logger`: all methods thread-safe.
+- `LogRecordExporter`: `ForceFlush`/`Shutdown` thread-safe; `Export` itself is explicitly **not**
+  required to be concurrency-safe against itself (the processor serializes calls instead).
+
+Source: https://opentelemetry.io/docs/specs/otel/logs/sdk/#concurrency-requirements
+
+---
+
+## 5. Events
+
+**Stability: Development / actively changing (2026).** This is the area of the spec most in flux
+— report here reflects the *current* normative direction, not a settled long-term API.
+
+### 5.1 Current model: Events are log-based, not a separate signal
+
+As of the current spec, there is **no separate Event API/SDK**. The historical
+`specification/logs/event-api.md` document (a standalone Event API layered on top of the Logs API,
+present in older spec versions such as
+[v1.35.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.35.0/specification/logs/event-api.md))
+**no longer exists on `main`** (confirmed 404 against the current `main` branch tree at time of
+writing). Events have been folded directly into the log data model:
+
+- An **Event** is defined as **a `LogRecord` with a non-empty `EventName`** — not a distinct
+  message type. The proto wire representation is `LogRecord.event_name` (field 12,
+  `opentelemetry/proto/logs/v1/logs.proto`), sitting alongside `time_unix_nano`,
+  `severity_number`, `body`, `attributes`, `trace_id`, `span_id`, etc. There is no separate
+  `EventRecord` proto message.
+- All Events sharing the same `EventName` **MUST** conform to the same schema for both their
+  `Attributes` and their `Body` — i.e. `EventName` acts like a schema/type discriminator.
+- Per the events semantic-conventions page: Events **MUST** have `Timestamp` set to when the event
+  actually occurred, and semantic conventions **MUST NOT** define a value for `ObservedTimestamp`
+  (that field stays purely about when the observability pipeline itself observed/received the
+  record — SDK/collector populated, never spec'd by convention authors).
+- Event semantic conventions **MUST NOT** define a `Body` value except to hold a plain string
+  display message — structured/queryable data belongs in `Attributes`, preferably flat rather than
+  deeply nested.
+- Event semantic conventions **MUST** document the event name so that querying by `event.name`
+  reliably returns records conforming to that convention's schema.
+
+Source: https://opentelemetry.io/docs/specs/semconv/general/events/ and
+https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-eventname
+
+### 5.2 Deprecation of Span Events in favor of log-based events
+
+A significant, currently-in-progress spec direction (tracked as an accepted OTEP, referenced as
+**OTEP 4430** in the announcement): OpenTelemetry is **deprecating the Span Events API**
+(`Span.AddEvent()` and `Span.RecordException()`) in favor of emitting **log-based events** through
+the Logs API/SDK, correlated back to the active trace/span via `Context` (the same mechanism
+described in [§3.3](#33-logger--emit-a-logrecord)) rather than being attached directly to the span
+object.
+
+Rationale given: maintaining two overlapping event mechanisms (span events vs. log-based events)
+produced inconsistent guidance for library authors, duplicated concepts for operators to learn, and
+slowed spec evolution since every improvement had to be designed/implemented twice.
+
+Migration posture (no exact version/date commitments found in the source):
+
+- New instrumentation should prefer log-based events **now**.
+- Existing instrumentation's current major version stays behaviorally compatible (no breaking
+  removal yet).
+- Next major versions of instrumentation libraries and semantic conventions are expected to
+  migrate from span events to log-based events.
+- Language SDKs are expected to offer compatibility/transform shims during the transition.
+
+**Practical implication for Maple:** if our self-instrumentation (or any vendored instrumentation
+we depend on) currently uses `span.addEvent(...)` for things like exception recording, expect
+upstream libraries to eventually shift that data into log-based Events (`LogRecord` with
+`EventName` set) instead of `SpanEvent`s on the span. Our ingest/consumption path should already
+handle both shapes since both arrive as normal OTLP signals (span events inside
+`Span.events`, log-based events inside the Logs OTLP stream) — but any dashboard logic that reads
+"events" **only** from span data (e.g. `Span.events`) will miss log-based events, and vice versa,
+until this migration is complete across the ecosystem.
+
+Source: https://opentelemetry.io/blog/2026/deprecating-span-events/
+
+---
+
+## 6. Stability summary
+
+| Area | Stability (as stated by spec) | Source |
+|---|---|---|
+| Logs Data Model | Stable | https://opentelemetry.io/docs/specs/otel/logs/data-model/ |
+| Data Model Appendix (mappings) | Stable | https://opentelemetry.io/docs/specs/otel/logs/data-model-appendix/ |
+| Logs API ("Bridge API") | Stable, except Ergonomic API (Development) | https://opentelemetry.io/docs/specs/otel/logs/api/ |
+| Logs SDK | Stable, except `LoggerConfigurator`/`LoggerConfig`/`Enabled`-filtering/event-to-span-event-bridge processor (Development) | https://opentelemetry.io/docs/specs/otel/logs/sdk/ |
+| OTLP Logs wire format (`logs.proto`) | Stable (part of OTLP) | https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto |
+| Events (semantic-convention layer, `EventName`) | **Development** | https://opentelemetry.io/docs/specs/semconv/general/events/ |
+| Span Events API (`Span.AddEvent`) | **Deprecated** (transition to log-based events in progress) | https://opentelemetry.io/blog/2026/deprecating-span-events/ |
+| Standalone Event API/SDK (`logs/event-api.md`) | **Removed** — folded into Logs Data Model / API | (confirmed absent on `main`; last present at tag [v1.35.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.35.0/specification/logs/event-api.md)) |
+
+---
+
+## Key references
+
+- Logs specification overview — https://opentelemetry.io/docs/specs/otel/logs/
+- Logs Data Model — https://opentelemetry.io/docs/specs/otel/logs/data-model/
+- Data Model Appendix (format mappings) — https://opentelemetry.io/docs/specs/otel/logs/data-model-appendix/
+- Logs API (Bridge API) — https://opentelemetry.io/docs/specs/otel/logs/api/
+- Logs SDK — https://opentelemetry.io/docs/specs/otel/logs/sdk/
+- SDK environment variables (Batch LogRecord Processor, LogRecord Limits, `OTEL_LOGS_EXPORTER`) — https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md
+- Events semantic conventions (general) — https://opentelemetry.io/docs/specs/semconv/general/events/
+- Deprecating Span Events API (blog, 2026) — https://opentelemetry.io/blog/2026/deprecating-span-events/
+- OTLP `logs.proto` (wire format, `LogRecord`/`SeverityNumber`/`ResourceLogs`/`ScopeLogs`) — https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto
+- Specification status summary — https://opentelemetry.io/docs/specs/status/
+- Historical Event API (pre-removal, v1.35.0 snapshot, for context only — not current) — https://github.com/open-telemetry/opentelemetry-specification/blob/v1.35.0/specification/logs/event-api.md

--- a/docs/otel-spec/metrics.md
+++ b/docs/otel-spec/metrics.md
@@ -1,0 +1,559 @@
+# Metrics (API, SDK & Data Model)
+
+This page is a compliance-oriented reference for the OpenTelemetry **Metrics** signal: the client-facing
+**API** (instrument creation and recording), the **SDK** (Views, Aggregations, MetricReader/Exporter
+config), and the **Data Model** that defines what actually goes over OTLP (point kinds, temporality,
+exemplars, resets). It exists to support spec-compliance checks and a best-practices skill — every claim
+below is sourced from the fetched spec pages, not from memory.
+
+> Source pages fetched for this document:
+> - API: https://opentelemetry.io/docs/specs/otel/metrics/api/
+> - SDK: https://opentelemetry.io/docs/specs/otel/metrics/sdk/
+> - Data model: https://opentelemetry.io/docs/specs/otel/metrics/data-model/
+> - Overview: https://opentelemetry.io/docs/specs/otel/metrics/
+> - OTLP exporter env vars: https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/
+> - General SDK env vars: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+> - Canonical repo (raw): `specification/metrics/data-model.md`, `specification/metrics/sdk.md` on
+>   [open-telemetry/opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification)
+
+## Relevance to Maple
+
+Maple is primarily a **consumer/backend** for OTel metrics (Rust ingest gateway → collector →
+ClickHouse/Tinybird), plus we self-instrument our own services (see the ingest gateway's own OTLP
+metrics export described in the root `CLAUDE.md`). The parts of this spec that matter most to us:
+
+- **Data model correctness** when ingesting/storing OTLP metric points: point kinds, temporality
+  (delta vs cumulative), `start_time_unix_nano` semantics for reset/gap detection, and the
+  `NoRecordedValue` staleness flag — these directly affect how we aggregate and query stored metrics.
+- **Single-writer principle & overlap handling** — as a backend, we're a "receiver" under the spec's
+  terminology; the normative guidance on deduplicating overlapping streams and detecting resets applies
+  to any rollup/materialized-view logic we build over ingested metrics.
+- **Exponential histograms** — we may need to render/aggregate these (scale/bucket mapping), so the
+  mapping-function details are captured at a working level.
+- **OTLP exporter env vars** (temporality preference, default histogram aggregation) — relevant when
+  documenting expected behavior of instrumented clients sending to our ingest gateway, and for our own
+  self-instrumentation config.
+- Metrics are **not yet a primary product surface** in Maple's dashboard (traces/logs are further along
+  per `docs/otel-coverage-roadmap.md`), so SDK-side view/aggregation configuration is lower priority than
+  data-model fidelity, but is included here for completeness since we may need to validate producer
+  behavior during spec-compliance checks.
+
+---
+
+## 1. Metrics API
+
+**Stability: Stable**, except where individually marked *(Development)* below (the `Bind` operation and
+the `Attributes` advisory parameter).
+Source: https://opentelemetry.io/docs/specs/otel/metrics/api/
+
+### 1.1 Core architecture
+
+| Concept | Role | Source anchor |
+|---|---|---|
+| `MeterProvider` | Entry point; owns config (exporters, readers, views). "The API SHOULD provide a way to set/register and access a global default `MeterProvider`." | `#meterprovider` |
+| `Meter` | Created from a `MeterProvider`; "Responsible for creating `Instruments`." Meter MUST NOT hold configuration — that's the MeterProvider's job. | `#meter` |
+| `Instrument` | Identified by `name`, `kind`, `unit`, `description` (plus language-level value-type distinction, e.g. integer vs floating point) | `#instrument` |
+
+`Meter` creation parameters (`Get a Meter`):
+
+- `name` (required) — instrumentation scope name, e.g. `io.opentelemetry.contrib.mongodb`
+- `version` (optional) — e.g. `1.0.0`
+- `schema_url` (optional, since spec v1.4.0)
+- instrumentation scope `attributes` (optional, since spec v1.13.0)
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/api/#meter
+
+### 1.2 Instruments
+
+All instruments are namespaced under a `Meter`; "MUST NOT be any API for creating [an instrument] other
+than with Meter" (normative MUST) — i.e., no free-standing instrument construction outside the Meter.
+
+#### Synchronous instruments
+
+| Instrument | Semantics | Monotonic? | Recording op | Valid values |
+|---|---|---|---|---|
+| **Counter** | Non-negative increments | Yes (non-decreasing) | `Add(value, attributes)` | Non-negative; API "SHOULD be documented" as non-negative but "SHOULD NOT validate" |
+| **UpDownCounter** | Increments and decrements | No | `Add(value, attributes)` (accepts negative) | Any; used "when the absolute values are not pre-calculated, or fetching the 'current value' requires extra effort" |
+| **Histogram** | Arbitrary, statistically-meaningful values | N/A | `Record(value, attributes)` | Non-negative (documented, not validated); advisory `ExplicitBucketBoundaries: double[]` *(Stable)* |
+| **Gauge** | Non-additive value(s), recorded via subscription to change events | N/A | `Record(value, attributes)` | Absolute current value at time of recording |
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/api/#counter ,
+`#updowncounter`, `#histogram`, `#gauge`
+
+#### Asynchronous (observable) instruments
+
+All use **callback functions**, registered at creation or afterward, "called only when the Meter is
+being observed."
+
+| Instrument | Semantics | Monotonic? | Value reported |
+|---|---|---|---|
+| **Asynchronous Counter** | Monotonically increasing | Yes | Absolute (not delta) — SDK derives rate from successive differences |
+| **Asynchronous UpDownCounter** | Additive, can increase or decrease | No | Absolute — SDK calculates deltas |
+| **Asynchronous Gauge** | Non-additive | N/A | Absolute, from an accessor/poll (contrast with sync Gauge's subscription model) |
+
+Callback normative requirements:
+- "Callback functions SHOULD be reentrant safe"
+- "SHOULD NOT take an indefinite amount of time"
+- "SHOULD NOT make duplicate observations across all registered callbacks"
+- Observations from a single callback invocation "MUST be reported with identical timestamps"
+- API "SHOULD support registration of `callback` functions after asynchronous instrumentation creation";
+  the user "MUST be able to undo registration ... by some means"
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/api/#asynchronous-instrument-api ,
+`#asynchronous-counter`, `#asynchronous-updowncounter`, `#asynchronous-gauge`
+
+### 1.3 Instruments × default aggregation (cross-reference to SDK §2.2)
+
+See the table in [§2.2](#22-aggregations--default-per-instrument) — the API doesn't define aggregation,
+but it's the natural pairing readers need.
+
+### 1.4 Naming rules
+
+**Instrument name syntax** — Source: https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-name-syntax
+
+```
+instrument-name = ALPHA 0*254 ("_" / "." / "-" / "/" / ALPHA / DIGIT)
+```
+
+- Not null/empty; case-insensitive ASCII
+- First character: alphabetic (A–Z, a–z)
+- Subsequent characters: alphanumeric, `_`, `.`, `-`, `/`
+- **Max length: 255 characters**
+- "The API SHOULD NOT validate the `name`; that is left to implementations."
+
+**Unit** — Source: `#instrument-unit`
+- Case-sensitive ASCII string, opaque
+- **Max length: 63 characters** (chosen to allow fixed-size array storage)
+- "The API SHOULD NOT validate the `unit`"
+
+**Description** — Source: `#instrument-description`
+- Must support BMP (Unicode Plane 0); minimum guaranteed support **1023 characters**
+- Opaque string
+
+### 1.5 Instrument identity, duplicate registration, and concurrency
+
+- **Identical instruments**: all identifying parameters equal (name, kind, unit, description, and the
+  language-level value-type distinction).
+- **Distinct instruments**: differ in at least one identifying parameter.
+- The Metrics **API spec itself does not define behavior for duplicate/conflicting registration** — that
+  is left to the SDK. (See Data Model §3.6 below for the *data-model*-level normative handling of
+  conflicting `Metric` identities once they reach OTLP.)
+- **Concurrency**: `MeterProvider`, `Meter`, and `Instrument` — "All methods MUST be documented that
+  implementations need to be safe for concurrent use by default."
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/api/#concurrency-requirements
+
+### 1.6 Attributes
+
+"Users can provide attributes to associate with ... values, but it is up to their discretion. Therefore,
+this API MUST be structured to accept a variable number of attributes, including none." For multiple
+observations in one async callback: "User code is recommended not to provide more than one `Measurement`
+with the same `attributes` in a single callback."
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/api/#measurement
+
+---
+
+## 2. Metrics SDK
+
+**Stability: Mixed** — most areas below are Stable; a few are explicitly Development (noted inline).
+Source: https://opentelemetry.io/docs/specs/otel/metrics/sdk/
+
+### 2.1 Views
+
+Views let the SDK owner customize how instruments are turned into metric streams without touching
+instrumentation code.
+
+**Instrument selection criteria** (all optional; user picks any subset):
+
+| Criterion | Matching |
+|---|---|
+| `name` | Exact match or wildcard (`*` = any sequence, `?` = single char) |
+| `type` | Instrument kind |
+| `unit` | Exact unit value |
+| `meter_name`, `meter_version`, `meter_schema_url` | Meter identity metadata |
+
+**Stream configuration** applied to matched instruments:
+
+| Parameter | Effect |
+|---|---|
+| `name` | Override output stream name (not re-validated against instrument-name syntax) |
+| `description` | Override description |
+| `attribute_keys` | Allow-list/exclude-list of attribute keys; View takes precedence over the instrument's `Attributes` advisory parameter |
+| `aggregation` | Override the default aggregation (see §2.2) |
+| `exemplar_reservoir` | Custom exemplar sampling strategy |
+| `aggregation_cardinality_limit` | Max data points emitted per collection cycle for this stream |
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#instrument-selection-criteria ,
+`#stream-configuration`
+
+### 2.2 Aggregations — default per instrument
+
+| Instrument | Default aggregation |
+|---|---|
+| Counter, Asynchronous Counter | Sum |
+| UpDownCounter, Asynchronous UpDownCounter | Sum |
+| Gauge, Asynchronous Gauge | Last Value |
+| Histogram | Explicit Bucket Histogram (honoring the `ExplicitBucketBoundaries` advisory if given) |
+
+**Explicit Bucket Histogram** *(Stable)* default boundaries:
+
+```
+[0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000]
+```
+
+`RecordMinMax` defaults to `true`.
+
+**Base2 Exponential Histogram** *(Recommended default config when this aggregation is selected)*:
+`MaxSize = 160` buckets, `MaxScale = 20`, `RecordMinMax = true`.
+
+**Drop aggregation**: discards all measurements for the instrument (emits nothing).
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#aggregation ,
+raw spec `specification/metrics/sdk.md` (boundary list + MaxSize/MaxScale defaults confirmed verbatim).
+
+### 2.3 MetricReader / MetricExporter
+
+**Periodic Exporting MetricReader** *(Stable)*:
+- Collects at a configurable interval — default **60,000 ms**
+- Export timeout — default **30,000 ms**
+- *(Development)* `maxExportBatchSize` splits large batches while preserving order across collections
+
+**Collect operation**: triggers async-instrument callbacks, invokes `Produce` on registered
+`MetricProducer`s, and ensures the configured aggregation temporality is applied (performing
+delta↔cumulative conversion for synchronous instruments as needed).
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader-operations ,
+`#periodic-exporting-metricreader`
+
+### 2.4 Exemplars (SDK side)
+
+**ExemplarFilter** *(Stable)*:
+
+| Filter | Behavior |
+|---|---|
+| `TraceBased` (default) | Eligible only if recorded within a sampled span context |
+| `AlwaysOn` | All measurements eligible |
+| `AlwaysOff` | No measurements eligible |
+
+**ExemplarReservoir** *(Stable)* — one per timeseries; `Offer(value, attributes, context, timestamp)`;
+`Collect()` returns accumulated exemplars respecting the stream's aggregation temporality.
+
+Default reservoir selection:
+
+| Aggregation | Default reservoir |
+|---|---|
+| Explicit bucket histogram (>1 bucket) | `AlignedHistogramBucketExemplarReservoir` |
+| Exponential histogram | `SimpleFixedSizeExemplarReservoir` (size = `min(20, max_buckets)`) |
+| Everything else | `SimpleFixedSizeExemplarReservoir` |
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#exemplar
+
+### 2.5 Cardinality limits
+
+**Status: Stable.**
+
+- Enforced **after** attribute filtering (i.e., after Views' `attribute_keys` allow/exclude list is
+  applied).
+- Resolution order: (1) View's `aggregation_cardinality_limit` → (2) MetricReader default for that
+  instrument kind → (3) **global default of 2000**.
+- **Overflow attribute**: measurements beyond the limit are aggregated into a single synthetic series
+  tagged `otel.metric.overflow = true` (boolean).
+- **Cumulative streams**: "continue to export all attribute sets that were observed prior to the
+  beginning of overflow" (pre-overflow series are retained individually).
+- **Delta streams**: "MAY choose an arbitrary subset of attribute sets to output to maintain the stated
+  cardinality limit" — no guaranteed stability of which series survive.
+- **Asynchronous instruments**: prefer first-observed attribute sets when trimming.
+
+There is **no dedicated global env var** for the default cardinality limit documented on the general SDK
+environment-variables page fetched for this doc (only the View-level `aggregation_cardinality_limit`
+stream-config parameter and the built-in 2000 default are spec-defined). Verify per-SDK docs (language
+implementations may expose their own env var) before treating any specific name as normative.
+
+Source: raw spec `specification/metrics/sdk.md` (Cardinality limits section, doc status "Mixed" at file
+top — the specific cardinality-limits subsection content quoted above is Stable per the rendered site).
+
+### 2.6 MeterProvider / MeterConfigurator (Development)
+
+*(Development)* `MeterConfigurator`: a function computing `MeterConfig` from an `InstrumentationScope`,
+returning either a configuration or a signal to use defaults; SDKs may provide helpers for common
+patterns (e.g., select meters by name, disable specific meters).
+*(Development)* `MeterConfig`: `enabled: boolean` (default `true`); disabled meters behave as no-ops.
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#meterprovider
+
+---
+
+## 3. Metrics Data Model
+
+**Stability: Stable** for all point kinds, temporality, exemplars, data point flags, and the
+single-writer principle. **Development** for the "Resets and Gaps" mechanics and "Overlap"/out-of-order
+handling sections specifically (noted inline below).
+Source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/
+
+### 3.1 Point kinds
+
+| Point kind | Temporality? | Key fields | Status |
+|---|---|---|---|
+| **Sum** | delta or cumulative | attributes, `(start, end]` window, `monotonic: bool`, exemplars, flags | Stable |
+| **Gauge** | n/a (no aggregation temporality) | attributes, sampled value, `time_unix_nano`, optional `start_time_unix_nano`, exemplars, flags | Stable |
+| **Histogram** | delta or cumulative | attributes, window, `count`, `sum`, optional `min`/`max`, explicit bucket boundaries + per-bucket counts, exemplars, flags | Stable |
+| **ExponentialHistogram** | delta or cumulative | same as Histogram but exponential bucket structure (`scale`, `zero_count`, `zero_threshold`, positive/negative bucket index ranges) | Stable |
+| **Summary (legacy)** | n/a | attributes, `time_unix_nano`, `count`, `sum`, strictly-increasing quantile set `[0.0, 1.0]` | Stable, but "not recommended for new applications" — points "cannot always be merged in a meaningful way" |
+
+**Sum monotonicity note**: "Delta monotonic: reader SHOULD expect non-negative values" / "Cumulative
+monotonic: reader SHOULD expect values that are not less than the previous value."
+
+**Histogram bucket inclusivity** (normative): "Bucket upper-bounds are inclusive (except for the case
+where the upper-bound is +Inf) while bucket lower-bounds are exclusive. That is, buckets express the
+number of values that are greater than their lower bound and less than or equal to their upper bound."
+
+**Gauge semantics**: "a point within a Gauge stream represents the last-sampled event for a given time
+window" — no aggregation semantic; "last sample value" wins when temporally aligning or resampling.
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums , `#gauge`, `#histogram`,
+`#exponentialhistogram`, `#summary-legacy`
+
+### 3.2 Temporality — delta vs cumulative
+
+| | Delta | Cumulative |
+|---|---|---|
+| Start timestamp behavior | "successive data points **advance** the starting timestamp" — `(T0,T1], (T1,T2], (T2,T3]` | "successive data points **repeat** the starting timestamp" — `(T0,T1], (T0,T2], (T0,T3]` |
+| Typical origin | Statsd-style metrics; "enables sampling and supports shifting the cost of cardinality outside of the process" | Prometheus-style; "naturally simpler ... in terms of cost of adding reliability. When collection fails intermittently, gaps ... are naturally averaged" |
+| Sender-side memory cost | Lower (no need to remember all-time totals) | Higher — sender must retain "all previous measurements, an 'up-front' memory cost proportional to cardinality" |
+| Validity rule | intervals must be contiguous — no gaps/overlaps in a well-formed stream | repeats the same start; validity tracked via reset detection (§3.3) |
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality
+
+**OTLP exporter default & env var** (producer-side preference, not the wire temporality itself — see
+§4 for the table):
+`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` default = `cumulative`.
+
+### 3.3 `start_time_unix_nano`, resets, and gaps
+
+*(Status: Development for this subsection's mechanics.)*
+Source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#resets-and-gaps
+
+> "When the `StartTimeUnixNano` field is present, it allows the consumer to observe when there are gaps
+> and overlapping writers in a stream. Correctly used, the consumer can observe both transient and
+> ongoing violations of the single-writer principle as well as reset events."
+
+| Case | Condition | Meaning |
+|---|---|---|
+| **True reset (known start)** | `StartTimeUnixNano < TimeUnixNano` | "a new unbroken sequence of observations begins with a 'true' reset at a known start time. The zero value is implicit, it is not necessary to record the starting point." |
+| **Reset, unknown start** | `StartTimeUnixNano == TimeUnixNano` | "a new unbroken sequence of observations begins with a reset at an unknown start time. The initial observed value is recorded ... These points have zero duration." |
+| **Subsequent point, delta** | — | `StartTimeUnixNano` of each point matches the `TimeUnixNano` of the *preceding* point |
+| **Subsequent point, cumulative/other** | — | `StartTimeUnixNano` of each point matches the `StartTimeUnixNano` of the *initial* observation in the sequence |
+
+**Gap definition**: "A metric stream has a gap, where it is implicitly undefined, anywhere there is a
+range of time such that no point covers that range with its `StartTimeUnixNano` and `TimeUnixNano`
+fields."
+
+### 3.4 Exemplars
+
+**Status: Stable.** Source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exemplars
+
+Fields:
+
+| Field | Description |
+|---|---|
+| `trace_id` (optional) | Trace associated with the recording |
+| `span_id` (optional) | Span associated with the recording |
+| `time_unix_nano` | Time of the observation |
+| `value` | The recorded value |
+| `filtered_attributes` | Attributes present on the measurement but filtered out of the point's own attribute set — "provide additional insight into the Context when the observation was made" |
+
+Value participation in the parent point:
+- **Histogram**: exemplar's value "already participates in `bucket_counts`, `count` and `sum`"
+- **Sum**: exemplar's value "is already included in the overall sum"
+- **Gauge**: exemplar's value "was seen at some point within the gauge interval for the same source"
+
+### 3.5 Data point flags — staleness marker
+
+**Status: Stable.** Source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#data-point-flags
+
+**`NoRecordedValue`** flag (default `false`):
+> "this data point reflects explicitly missing data in a series. It serves as an indicator that a
+> previously present timeseries was removed and that this timeseries SHOULD NOT be returned in queries
+> after such an indicator was received."
+
+Equivalent to the [Prometheus staleness marker](https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness).
+When set: "all other data point properties except attributes, time stamps, or time windows, SHOULD be
+ignored."
+
+### 3.6 Single-writer principle & conflicting metric identities
+
+**Status: Stable.** Source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#single-writer
+
+> "All metric data streams within OTLP MUST have one logical writer. This means, conceptually, that any
+> Timeseries created from the Protocol MUST have one originating source of truth."
+
+- "All metric data streams produced by OTel SDKs SHOULD have globally unique identity at any given point
+  in time."
+- "Aggregations of metric streams MUST only be written from a single logical source at any given point
+  time. **Note: This implies aggregated metric streams must reach one destination**."
+- "Multiple writers for a metric stream is considered an error state, or misbehaving system. Receivers
+  SHOULD presume a single writer was intended and eliminate overlap / deduplicate."
+- Distinguished from semantic errors: single-writer violations are usually **misconfiguration**
+  (fixable by differentiating `Resource` or ensuring non-overlapping time ranges), whereas semantic
+  errors are sometimes fixable via Views.
+
+**Conflicting `Metric` identity** for the same `name` + `Resource` + `Scope` — producer recommendations
+*(Stable)*, source: `#opentelemetry-protocol-data-model-producer-recommendations`:
+
+| Conflict | Producer recommendation |
+|---|---|
+| Non-identifying field differs (e.g. `description`) | "producer SHOULD choose the longer string" |
+| `unit` mismatch (e.g. `ms` vs `s`) | MAY convert units to avoid a semantic error; otherwise SHOULD inform the user of a semantic error |
+| `AggregationTemporality` conflict | MAY convert via Cumulative→Delta or Delta→Cumulative transform; otherwise SHOULD inform the user of a semantic error |
+| Other identifying-property conflict | SHOULD inform the user of a semantic error and pass through the conflicting data |
+
+"Consumers MAY reject OpenTelemetry Metrics data containing semantic errors (i.e., more than one
+`Metric` identity for a given `name`, `Resource`, and `Scope`)." — **relevant to Maple as an ingest
+consumer**: we are within spec to reject/flag such payloads rather than silently merge them.
+
+### 3.7 Overlap & out-of-order handling
+
+*(Status: Development for this subsection.)*
+Source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#overlap
+
+- "When more than one process writes the same metric data stream, OTLP data points may appear to
+  overlap. This condition typically results from misconfiguration ... When there are overlapping points,
+  receivers SHOULD eliminate points so that there are no overlaps. Which data to select in overlapping
+  cases is not specified."
+- "OpenTelemetry collectors SHOULD export telemetry when they observe overlapping points in data
+  streams, so that the user can monitor for erroneous configurations."
+- Expected-overlap interpolation: "When one process starts just as another exits, the appearance of
+  overlapping points may be expected ... collectors SHOULD modify points at the change-over using
+  interpolation for Sum data points, to reduce gaps to zero width in these cases, without any overlap."
+
+**Delta-to-cumulative conversion algorithm** (out-of-order / restart detection), source:
+`#sums-detecting-alignment-issues`:
+- "if the current point precedes the start time, then drop this point. Note: there are algorithms which
+  can deal with late arriving points."
+- "if the next point does NOT align with the expected next-time window, then reset the counter following
+  the same steps performed as if the current point was the first point seen."
+- Two triggers: (1) significant **overlap** with the previous interval → assume single-writer-principle
+  violation, recommend elimination/dedup or resource differentiation; (2) significant **gap** from the
+  last-seen time → assume a reboot/restart and reset the cumulative counter.
+- Degenerate case: if timestamps are missing entirely from data points (can happen when adapting
+  non-OTel metric formats into OTLP), "the algorithm resets on every point."
+
+---
+
+## 4. Exponential histograms — mapping rules (working-level detail)
+
+**Status: Stable** (data model fields); the mapping-function reference math below is drawn from the
+canonical spec markdown (`specification/metrics/data-model.md`, ExponentialHistogram section).
+
+- **Base formula**: `base = 2**(2**(-scale))`. At `scale = 0`, `base = 2`.
+- **Bucket definition**: "bucket identified by `index`, a signed integer, represents values in the
+  population that are greater than `base**index` and less than or equal to `base**(index+1)`."
+- **Index constraint**: producers must ensure "the bucket index of any encoded bucket falls within the
+  range of a signed 32-bit integer."
+- **Scale = 0 mapping ("extract exponent")**: "the index of a value equals its normalized base-2
+  exponent" — derived directly from the IEEE-754 bit layout (no logarithm needed).
+- **Scale ≤ 0 mapping ("extract and shift")**: equals the scale-0 mapping "shifted to the right by
+  `-scale`".
+- **General (any scale) mapping via logarithm**: `index == Ceiling(log(value)/log(base)) - 1`, computed
+  in practice via a scaling factor `2**scale / log(2)` (e.g. `math.Ldexp(math.Log2E, scale)` in Go-style
+  pseudocode) for numerical stability instead of naively dividing by `log(base)` each time.
+- **Negative values**: "mapped by their absolute value into the negative range using the same scale as
+  the positive range" — i.e., symmetric positive/negative bucket sets sharing one `scale`.
+- **Zero handling**: a dedicated `zero_count` bucket, with optional `zero_threshold`; "`zero_count`
+  contains the count of values whose absolute value is less than or equal to `zero_threshold`." When
+  `zero_threshold` is unset, the zero bucket also "stores values that cannot be expressed using the
+  standard exponential formula as well as values that have been rounded to zero."
+- **Downscaling (resolution reduction)**: "Buckets of an exponential Histogram with a given scale map
+  exactly into buckets of exponential Histograms with lesser scales, which allows consumers to lower the
+  resolution of a histogram (i.e., downscale) without introducing error" — i.e., merging is lossless when
+  reducing scale, which is how implementations reconcile a too-large bucket count against `MaxSize`
+  (default 160, see §2.2) by repeatedly halving resolution until the active index range fits.
+
+Source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram (rendered) and
+`specification/metrics/data-model.md` (raw, for verbatim formula quotes).
+
+---
+
+## 5. Enumerated reference tables
+
+### 5.1 Instrument → default aggregation → point kind produced
+
+| Instrument | Sync/Async | Monotonic | Default aggregation | Point kind on wire |
+|---|---|---|---|---|
+| Counter | Sync | Yes | Sum | Sum (`monotonic=true`) |
+| UpDownCounter | Sync | No | Sum | Sum (`monotonic=false`) |
+| Histogram | Sync | n/a | Explicit Bucket Histogram | Histogram |
+| Gauge | Sync | n/a | Last Value | Gauge |
+| Asynchronous Counter | Async | Yes | Sum | Sum (`monotonic=true`) |
+| Asynchronous UpDownCounter | Async | No | Sum | Sum (`monotonic=false`) |
+| Asynchronous Gauge | Async | n/a | Last Value | Gauge |
+
+### 5.2 Temporality preference matrix (`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`)
+
+**Status: Stable.** Default: `cumulative`.
+Source: https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/
+
+| Preference value | Counter (sync) | Async Counter | Histogram | UpDownCounter (sync) | Async UpDownCounter |
+|---|---|---|---|---|---|
+| `cumulative` (default) | Cumulative | Cumulative | Cumulative | Cumulative | Cumulative |
+| `delta` | Delta | Delta | Delta | Cumulative | Cumulative |
+| `lowmemory` | Delta | Cumulative | Delta | Cumulative | Cumulative |
+
+Notes verbatim:
+- `delta`: "Choose Delta aggregation temporality for Counter, Asynchronous Counter and Histogram
+  instrument kinds, choose Cumulative aggregation for UpDownCounter and Asynchronous UpDownCounter
+  instrument kinds."
+- `lowmemory`: "uses Delta aggregation temporality for Synchronous Counter and Histogram and uses
+  Cumulative aggregation temporality for Synchronous UpDownCounter, Asynchronous Counter, and
+  Asynchronous UpDownCounter instrument kinds" — the distinguishing difference from `delta` is that
+  Asynchronous Counter stays Cumulative under `lowmemory` (avoids the SDK having to retain prior
+  async-counter state to compute deltas).
+
+### 5.3 Environment variables (Metrics)
+
+| Variable | Default | Values | Scope | Status |
+|---|---|---|---|---|
+| `OTEL_METRICS_EXPORTER` | `otlp` | `otlp`, `prometheus`, `console`, `logging` (deprecated), `none`, `otlp/stdout` (dev) | General SDK config | Stable (mixed per value) |
+| `OTEL_METRIC_EXPORT_INTERVAL` | `60000` (ms) | duration | Periodic Exporting MetricReader | Stable |
+| `OTEL_METRIC_EXPORT_TIMEOUT` | `30000` (ms) | duration | Periodic Exporting MetricReader | Stable |
+| `OTEL_METRICS_EXEMPLAR_FILTER` | `trace_based` | `always_on`, `always_off`, `trace_based` | Exemplar filter | Stable |
+| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | `cumulative` | `cumulative`, `delta`, `lowmemory` (case-insensitive) | OTLP metrics exporter | Stable |
+| `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION` | `explicit_bucket_histogram` | `explicit_bucket_histogram`, `base2_exponential_bucket_histogram` (case-insensitive) | OTLP metrics exporter | Stable |
+
+No dedicated global env var for the cardinality-limit default (2000) was found on the fetched general
+SDK env-vars page; the limit is a spec-defined constant applied via View/Reader config precedence (see
+§2.5), not (per the pages fetched) an environment variable. Treat this as **unverified-absence** rather
+than confirmed non-existence — some individual language SDKs may add their own env var; check
+language-specific SDK docs if this matters for a specific client.
+
+Source: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/ ,
+https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/
+
+### 5.4 Point kind × temporality applicability
+
+| Point kind | Delta valid? | Cumulative valid? | Notes |
+|---|---|---|---|
+| Sum | Yes | Yes | `monotonic` flag independent of temporality |
+| Gauge | n/a | n/a | No aggregation temporality field at all — last-sample semantics only |
+| Histogram | Yes | Yes | `min`/`max` "more useful for Delta temporality, since ... Cumulative min and max will stabilize as more events are recorded" |
+| ExponentialHistogram | Yes | Yes | Same temporality semantics as Histogram |
+| Summary (legacy) | n/a | n/a | No temporality field; compatibility-only point kind |
+
+---
+
+## Key references
+
+- Metrics API: https://opentelemetry.io/docs/specs/otel/metrics/api/
+- Metrics SDK: https://opentelemetry.io/docs/specs/otel/metrics/sdk/
+- Metrics Data Model: https://opentelemetry.io/docs/specs/otel/metrics/data-model/
+- Metrics overview: https://opentelemetry.io/docs/specs/otel/metrics/
+- OTLP metrics exporter config: https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/
+- General SDK environment variables: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+- Canonical spec repo (source of truth for raw markdown): https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/metrics
+  - `data-model.md` (point kinds, temporality, resets/gaps, exemplars, flags, single-writer, overlap)
+  - `sdk.md` (Views, Aggregation, MetricReader, cardinality limits, exemplar filter/reservoir)
+  - `api.md` (instrument definitions, naming rules)
+- Prometheus staleness marker (referenced by the `NoRecordedValue` flag): https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness
+- OTEP 0113 (Exemplars design): https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/metrics/0113-exemplars.md
+- OTEP 0049 (Metric LabelSet): https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/metrics/0049-metric-label-set.md

--- a/docs/otel-spec/otlp.md
+++ b/docs/otel-spec/otlp.md
@@ -1,0 +1,385 @@
+# OTLP (Protocol, Encodings & Exporter Config)
+
+OTLP (OpenTelemetry Protocol) is the wire format OpenTelemetry SDKs and collectors use to send traces, metrics, and logs. It defines the transports (gRPC, HTTP/protobuf, HTTP/JSON), the protobuf message schemas (`Resource` → `Scope*` → `Span`/`Metric`/`LogRecord`), the request/response contract (including partial-success semantics), and retry/backpressure rules a compliant server must implement.
+
+> **Relevance to Maple:** Maple's Rust ingest gateway (`apps/ingest`) is an **OTLP server** — it receives OTLP/HTTP (binary protobuf and JSON) from customer SDKs/collectors and must implement the server-side MUSTs below: correct status codes, partial-success vs full-failure semantics, `Retry-After`/throttling signals, and JSON encoding rules (hex trace/span IDs, camelCase, numeric enums, stringified int64). Getting these wrong causes silent data loss or client retry storms. Maple is also an OTLP **client** for self-observability (`apps/ingest` and the API self-instrument via `@effect/opentelemetry`/OTLP exporters) — the exporter env-var section governs that config. Our dummy-data script (`scripts/ingest-dummy.ts`, `bun run ingest:dummy`) hand-constructs OTLP/JSON and depends on the JSON encoding rules (camelCase + hex IDs); see also the root `CLAUDE.md` self-observability section for the loop-prevention rules layered on top of this transport.
+
+---
+
+## Stability
+
+Per the OTLP spec (v1.10.0): OTLP is **Stable** for the **trace, metric, and log** signals. The **profiles** signal is **Development** status (entered public Alpha in March 2026 per the OpenTelemetry blog); its default HTTP path is versioned accordingly (`/v1development/profiles`, not `/v1/profiles`), and its proto messages/fields are explicitly excluded from stability guarantees until promoted.
+
+Source: https://opentelemetry.io/docs/specs/otlp/ · https://opentelemetry.io/blog/2026/profiles-alpha/
+
+---
+
+## Transports: gRPC vs HTTP
+
+| Transport | Default port | Encoding | Notes |
+|---|---|---|---|
+| OTLP/gRPC | **4317** | Protobuf (unary calls) | HTTP/2-based; server MAY multiplex gRPC and HTTP on the same port |
+| OTLP/HTTP | **4318** | Protobuf (binary) or JSON | Implementations MAY use HTTP/1.1 or HTTP/2 |
+
+### Default URL paths (OTLP/HTTP)
+
+| Signal | Path | Stability |
+|---|---|---|
+| Traces | `/v1/traces` | Stable |
+| Metrics | `/v1/metrics` | Stable |
+| Logs | `/v1/logs` | Stable |
+| Profiles | `/v1development/profiles` | Development |
+
+### Content types
+
+| Encoding | `Content-Type` |
+|---|---|
+| Binary protobuf | `application/x-protobuf` |
+| JSON | `application/json` |
+
+### Compression
+
+- **MUST support:** "All server components MUST support the following transport compression options: No compression, denoted by `none`. Gzip compression, denoted by `gzip`."
+- Client: "The client MAY gzip the content and in that case MUST include `Content-Encoding: gzip` request header."
+
+### Concurrency
+
+- gRPC: "The implementations that need to achieve high throughput SHOULD support concurrent Unary calls to achieve higher throughput," and "the number of concurrent requests SHOULD be configurable."
+- HTTP: "the client MAY send requests using several parallel HTTP connections. In that case, the maximum number of parallel connections SHOULD be configurable."
+
+### Connection management
+
+- "The client SHOULD keep the connection alive between requests."
+- "If the client cannot connect to the server, the client SHOULD retry the connection using an exponential backoff strategy between retries. The interval between retries must have a random jitter."
+- "If the server disconnects without returning a response, the client SHOULD retry and send the same request."
+
+Source: https://opentelemetry.io/docs/specs/otlp/
+
+---
+
+## Request/response shapes
+
+Each signal has its own collector service with one RPC method:
+
+```protobuf
+service TraceService {
+  rpc Export(ExportTraceServiceRequest) returns (ExportTraceServiceResponse) {}
+}
+```
+
+(Analogous `MetricsService`/`LogsService`/`ProfilesService`, each with one `Export` unary RPC.)
+
+```protobuf
+message ExportTraceServiceRequest {
+  repeated opentelemetry.proto.trace.v1.ResourceSpans resource_spans = 1;
+}
+
+message ExportTraceServiceResponse {
+  ExportTracePartialSuccess partial_success = 1;
+}
+
+message ExportTracePartialSuccess {
+  int64 rejected_spans = 1;   // 0 == fully accepted
+  string error_message = 2;   // human-readable, English
+}
+```
+
+Metrics/logs mirror this exactly: `ExportMetricsServiceRequest{resource_metrics}` / `ExportMetricsServiceResponse{partial_success: ExportMetricsPartialSuccess{rejected_data_points, error_message}}`, and `ExportLogsServiceRequest{resource_logs}` / `ExportLogsServiceResponse{partial_success: ExportLogsPartialSuccess{rejected_log_records, error_message}}`. Profiles: `rejected_profiles`.
+
+Source: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto
+
+### Full success
+
+- **gRPC:** server responds with the appropriate `Export<Signal>ServiceResponse` and **"MUST leave the `partial_success` field unset in case of a successful response."**
+- **HTTP:** **"On success, the server MUST respond with `HTTP 200 OK`."** The response body **"MUST be a Protobuf-encoded `Export<signal>ServiceResponse` message"** (even for a JSON request — response encoding for HTTP is always the ordinary protobuf-JSON/binary mapping, matching the request's encoding).
+
+### Partial success (server MUST rules)
+
+Applicability: **"If the request is only partially accepted (i.e. when the server accepts only parts of the data and rejects the rest)…"** the server:
+
+- **MUST** initialize the `partial_success` field.
+- **MUST** set the respective `rejected_spans` / `rejected_data_points` / `rejected_log_records` / `rejected_profiles` field to the count of rejected items.
+- **SHOULD** populate `error_message` with a human-readable (English) explanation.
+
+Warnings-only case: **"Servers MAY also use the `partial_success` field to convey warnings/suggestions to clients even when the server fully accepts the request. In such cases, the `rejected_<signal>` field MUST have a value of `0`."**
+
+Client behavior: **"The client MUST NOT retry the request when it receives a partial success response where the `partial_success` is populated"** — partial success is a terminal outcome, not a retry signal, regardless of which items were rejected.
+
+Degenerate case: a `partial_success` with `rejected_* == 0` and empty `error_message` is defined as equivalent to the field being unset (full success).
+
+Source: https://opentelemetry.io/docs/specs/otlp/ · https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto
+
+### When to use partial success vs full failure (server MUST)
+
+- If **any** part of the request is decodable and acceptable, respond `200 OK` + partial success describing what was rejected and why — do not fail the whole request just because some items were bad.
+- If the request **cannot be decoded at all**, or is invalid such that nothing in it can be processed, and the failure is permanent: **"the server MUST respond with `HTTP 400 Bad Request`"** (full failure, no partial success). The client **"MUST NOT retry"** on a 400.
+
+---
+
+## Failure handling
+
+### gRPC status codes — retryable matrix
+
+| gRPC code | Retryable? |
+|---|---|
+| CANCELLED | Yes |
+| UNKNOWN | No |
+| INVALID_ARGUMENT | No |
+| DEADLINE_EXCEEDED | Yes |
+| NOT_FOUND | No |
+| ALREADY_EXISTS | No |
+| PERMISSION_DENIED | No |
+| UNAUTHENTICATED | No |
+| RESOURCE_EXHAUSTED | Only if server signals recoverability (via `RetryInfo`) |
+| FAILED_PRECONDITION | No |
+| ABORTED | Yes |
+| OUT_OF_RANGE | Yes |
+| UNIMPLEMENTED | No |
+| INTERNAL | No |
+| UNAVAILABLE | Yes |
+| DATA_LOSS | Yes |
+
+- Retryable: **"indicate that telemetry data processing failed, and the client SHOULD record the error and may retry exporting the same data."**
+- Non-retryable: **"indicate that telemetry data processing failed, and the client MUST NOT retry sending the same telemetry data."**
+- `RESOURCE_EXHAUSTED` special case: **"The client SHOULD interpret `RESOURCE_EXHAUSTED` code as retryable only if the server signals that the recovery from resource exhaustion is possible. This is signaled by the server by returning a status containing `RetryInfo`."**
+- Backoff: **"When retrying, the client SHOULD implement an exponential backoff strategy."**
+- gRPC backpressure signal: **"To signal backpressure when using gRPC transport, the server SHOULD return an error with code `Unavailable` and MAY supply additional details via status using `RetryInfo`."**
+
+### HTTP status codes — retryable matrix
+
+| HTTP status | Retryable? | Notes |
+|---|---|---|
+| 200 | n/a | Success (full or partial) |
+| 400 Bad Request | **No** | Undecodable/permanently invalid request; client MUST NOT retry |
+| 429 Too Many Requests | **Yes** | Throttling; MAY carry `Retry-After` |
+| 502 Bad Gateway | **Yes** | |
+| 503 Service Unavailable | **Yes** | Overload; MAY carry `Retry-After` |
+| 504 Gateway Timeout | **Yes** | |
+| other 4xx/5xx | **No** | **"All other `4xx` or `5xx` response status codes MUST NOT be retried."** |
+
+- Error body: **"The response body for all `HTTP 4xx` and `HTTP 5xx` responses MUST be a Protobuf-encoded `Status` message that describes the problem."** — this applies regardless of whether the request was binary or JSON encoded.
+- Bad data: **"If the processing of the request fails because the request contains data that cannot be decoded or is otherwise invalid and such failure is permanent, then the server MUST respond with `HTTP 400 Bad Request`."**
+
+### Throttling / backpressure (server SHOULD)
+
+- **"If the server is unable to keep up with the pace of data it receives from the client then it SHOULD signal that fact to the client."**
+- HTTP: **"the server SHOULD respond with `HTTP 429 Too Many Requests` or `HTTP 503 Service Unavailable` and MAY include a `Retry-After` header with a recommended time interval in seconds."**
+- Client honoring: **"The client SHOULD honour the waiting interval specified in the `Retry-After` header if it is present. If the client receives a retryable error code and the `Retry-After` header is not present in the response, then the client SHOULD implement an exponential backoff strategy."**
+
+### Duplicate data (known limitation, informational)
+
+**"In edge cases (e.g. on reconnections, network interruptions, etc) the client has no way of knowing if recently sent data was delivered if no acknowledgement was received yet. The client will typically choose to re-send such data to guarantee delivery, which may result in duplicate data on the server side."** — downstream consumers (Tinybird MVs, dashboards) should tolerate duplicate spans/log records/data points; OTLP does not guarantee exactly-once delivery.
+
+### Empty envelopes
+
+**"Senders SHOULD NOT create empty envelopes (OTLP payloads that contain zero spans, zero metric points or zero log records), receivers MAY ignore empty envelopes, and implementations that receive and send (forward) OTLP payloads MAY drop empty envelopes."**
+
+Source: https://opentelemetry.io/docs/specs/otlp/
+
+---
+
+## JSON encoding (OTLP/HTTP JSON) — deviations from standard protobuf JSON
+
+OTLP/HTTP JSON starts from the proto3 standard JSON mapping but overrides it in ways that matter for anyone hand-constructing or parsing OTLP JSON (e.g. Maple's ingest-dummy script):
+
+| Aspect | Standard protobuf JSON | **OTLP/JSON rule** |
+|---|---|---|
+| `trace_id`/`span_id` (`bytes`) | base64 | **Case-insensitive hex-encoded string.** Example: `{"traceId": "5B8EFFF798038103D269B633813FC60C"}` |
+| Field names | configurable | **lowerCamelCase only** — original (snake_case) field names are **not valid**. Example: `droppedAttributesCount`, not `dropped_attributes_count` |
+| Enums | name string OR number, receiver's choice | **Numbers only — enum name strings MUST NOT be used.** Example: `{"kind": 2}`, not `{"kind": "SPAN_KIND_SERVER"}` |
+| `int64`/`uint64` | string | Same as standard: **encoded as decimal strings**; **"either numbers or strings are accepted when decoding"** |
+| Unknown fields | mapping-defined | **"OTLP/JSON receivers MUST ignore message fields with unknown names and MUST unmarshal the message as if the unknown field was not present"** (forward compatibility) |
+
+These are normative MUSTs for any OTLP/JSON server, including Maple's ingest gateway when it accepts `Content-Type: application/json`.
+
+Source: https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
+
+---
+
+## Proto schema essentials
+
+All three stable signals share the same `Resource → Scope<Signal> → <Item>` hierarchy, each level carrying its own `schema_url`:
+
+```
+Export<Signal>ServiceRequest
+└── repeated Resource<Signal>          (resource = 1, scope_<signal> = 2, schema_url = 3)
+    └── repeated Scope<Signal>         (scope = 1, <items> = 2, schema_url = 3)
+        └── repeated <Span|Metric|LogRecord>
+```
+
+- `ResourceSpans{resource, scope_spans[], schema_url}`, `ScopeSpans{scope, spans[], schema_url}`
+- `ResourceMetrics{resource, scope_metrics[], schema_url}`, `ScopeMetrics{scope, metrics[], schema_url}`
+- `ResourceLogs{resource, scope_logs[], schema_url}`, `ScopeLogs{scope, log_records[], schema_url}`
+
+`schema_url` at the **resource** level versions the resource's attribute schema; at the **scope** level it versions the schema of the scope and everything nested under it (spans/metrics/log records in that `Scope*` block).
+
+### `Resource`
+
+```protobuf
+message Resource {
+  repeated KeyValue attributes = 1;       // keys MUST be unique
+  uint32 dropped_attributes_count = 2;    // 0 == none dropped
+  repeated EntityRef entity_refs = 3;     // Development status; keys must exist in attributes
+}
+```
+
+### `InstrumentationScope` (common.proto)
+
+```protobuf
+message InstrumentationScope {
+  string name = 1;
+  string version = 2;
+  repeated KeyValue attributes = 3;
+  uint32 dropped_attributes_count = 4;
+}
+```
+
+### `AnyValue` / `KeyValue` recursion (attribute value model)
+
+```protobuf
+message AnyValue {
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+    int32 string_value_strindex = 8;   // Alpha, profiling-exclusive
+  }
+}
+message ArrayValue    { repeated AnyValue values = 1; }
+message KeyValueList  { repeated KeyValue values = 1; }   // keys must be unique
+message KeyValue {
+  string key = 1;
+  AnyValue value = 2;
+  int32 key_strindex = 3;  // Alpha, profiling-exclusive; mutually exclusive with key
+}
+```
+
+`ArrayValue`/`KeyValueList` let `AnyValue` recurse arbitrarily (arrays of any value, maps of any value), which is how OTel represents nested/structured attributes over a flat protobuf wire format.
+
+### `Span` (trace.proto)
+
+```protobuf
+message Span {
+  bytes  trace_id = 1;                 // 16 bytes
+  bytes  span_id = 2;                  // 8 bytes
+  string trace_state = 3;
+  bytes  parent_span_id = 4;           // 8 bytes
+  fixed32 flags = 16;                  // low 8 bits = W3C trace-context flags; bits 8-9 = remote span/link markers
+  string name = 5;
+  SpanKind kind = 6;
+  fixed64 start_time_unix_nano = 7;
+  fixed64 end_time_unix_nano = 8;
+  repeated KeyValue attributes = 9;
+  uint32 dropped_attributes_count = 10;
+  repeated Event events = 11;
+  uint32 dropped_events_count = 12;
+  repeated Link links = 13;
+  uint32 dropped_links_count = 14;
+  Status status = 15;
+}
+enum SpanKind {
+  SPAN_KIND_UNSPECIFIED = 0;
+  SPAN_KIND_INTERNAL = 1;
+  SPAN_KIND_SERVER = 2;
+  SPAN_KIND_CLIENT = 3;
+  SPAN_KIND_PRODUCER = 4;
+  SPAN_KIND_CONSUMER = 5;
+}
+message Status {
+  reserved 1;
+  string message = 2;
+  StatusCode code = 3;
+  enum StatusCode {
+    STATUS_CODE_UNSET = 0;
+    STATUS_CODE_OK = 1;
+    STATUS_CODE_ERROR = 2;
+  }
+}
+```
+
+> Note for Maple: `Status.code` on the wire is the numeric enum (`0`/`1`/`2` — `Unset`/`Ok`/`Error`); the project's own data convention (per root `CLAUDE.md`) renders these as title-case strings (`"Ok"`, `"Error"`, `"Unset"`) once ingested — that's a Maple display/storage convention, not an OTLP wire rule.
+
+### `LogRecord` (logs.proto)
+
+```protobuf
+message LogRecord {
+  fixed64 time_unix_nano = 1;
+  fixed64 observed_time_unix_nano = 11;
+  SeverityNumber severity_number = 2;
+  string severity_text = 3;
+  AnyValue body = 5;
+  repeated KeyValue attributes = 6;
+  uint32 dropped_attributes_count = 7;
+  fixed32 flags = 8;                 // low 8 bits = W3C trace flags
+  bytes trace_id = 9;                // 16 bytes, correlates log to a trace
+  bytes span_id = 10;                // 8 bytes, correlates log to a span
+  string event_name = 12;            // identifies the record as a named event
+}
+```
+
+`SeverityNumber` is a 1–24 numeric scale (`UNSPECIFIED=0`, then `TRACE`(1-4)/`DEBUG`(5-8)/`INFO`(9-12)/`WARN`(13-16)/`ERROR`(17-20)/`FATAL`(21-24) tiers, each tier having 4 numbered sub-levels e.g. `TRACE2`).
+
+### Dropped-count fields (uniform pattern across all signals)
+
+Every repeated collection that the SDK may have truncated carries a paired `dropped_*_count: uint32` sibling — `dropped_attributes_count` (Resource, InstrumentationScope, Span, LogRecord, metric data points), `dropped_events_count`/`dropped_links_count` (Span only). `0` always means "nothing was dropped," never "field not applicable."
+
+### `flags` fields
+
+Both `Span.flags` (field 16) and `LogRecord.flags` (field 8) are `fixed32`, with the low 8 bits reserved for the W3C Trace Context trace-flags byte (e.g. sampled bit); `Span.flags` additionally uses bits 8-9 to mark whether the span's parent or a link is remote.
+
+Source: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto · https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto · https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto · https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/common/v1/common.proto · https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/resource/v1/resource.proto
+
+---
+
+## Exporter configuration (`OTEL_EXPORTER_OTLP_*`)
+
+All options are defined generically and per-signal (`TRACES`/`METRICS`/`LOGS`); **"Each configuration option MUST be overridable by a signal specific option"** — signal-specific always wins over the generic one.
+
+| Env var (generic → per-signal suffix pattern) | Default | Values / format |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` → `_TRACES_ENDPOINT` / `_METRICS_ENDPOINT` / `_LOGS_ENDPOINT` | `http://localhost:4318` (HTTP), `http://localhost:4317` (gRPC) | URL (scheme+host+port[+path]) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` → `_TRACES_PROTOCOL` / etc. | `http/protobuf` | `grpc`, `http/protobuf`, `http/json` |
+| `OTEL_EXPORTER_OTLP_HEADERS` → `_TRACES_HEADERS` / etc. | none | W3C Baggage-style `key1=value1,key2=value2` (no `;`); values always strings |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` → `_TRACES_TIMEOUT` / etc. | `10s` | duration |
+| `OTEL_EXPORTER_OTLP_COMPRESSION` → `_TRACES_COMPRESSION` / etc. | none specified (SIG picks a sensible default) | `none`, `gzip` |
+| `OTEL_EXPORTER_OTLP_INSECURE` → `_TRACES_INSECURE` / etc. | `false` | bool; gRPC-only (HTTP uses the endpoint's scheme). Legacy `OTEL_EXPORTER_OTLP_SPAN_INSECURE`/`_METRIC_INSECURE` SHOULD still be supported |
+| `OTEL_EXPORTER_OTLP_CERTIFICATE` → `_TRACES_CERTIFICATE` / etc. | none | PEM file path (trusted server cert) |
+| `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` → `_TRACES_CLIENT_CERTIFICATE` / etc. | none | PEM file path (mTLS client cert/chain) |
+| `OTEL_EXPORTER_OTLP_CLIENT_KEY` → `_TRACES_CLIENT_KEY` / etc. | none | PEM file path (mTLS client private key) |
+
+### Endpoint path-appending rule — generic vs per-signal
+
+- **Generic `OTEL_EXPORTER_OTLP_ENDPOINT` (HTTP):** the base URL, with the signal path appended: `v1/traces`, `v1/metrics`, `v1/logs`.
+- **Per-signal endpoint (e.g. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`):** **"the URL MUST be used as-is without any modification. The only exception is that if a URL contains no path part, the root path `/` MUST be used."** — i.e. per-signal endpoints are NOT auto-suffixed with `/v1/traces`; you must include the full path yourself, or the request goes to `/`.
+- **Precedence:** **"The per-signal endpoint configuration options take precedence and can be used to override this behavior (the URL is used as-is for them, without any modifications)."**
+
+### Protocol defaults / SDK requirements
+
+**"SDKs SHOULD support both `grpc` and `http/protobuf` transports and MUST support at least one. If they support only one, it SHOULD be `http/protobuf`."** Default protocol value is `http/protobuf` unless a language SIG documents otherwise.
+
+### Retry requirement on the client/exporter
+
+**"Transient errors MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered."** ("Transient" = the retryable gRPC/HTTP codes above.)
+
+Source: https://opentelemetry.io/docs/specs/otel/protocol/exporter/
+
+---
+
+## Key references
+
+- OTLP specification (main spec — transports, request/response, retries, throttling): https://opentelemetry.io/docs/specs/otlp/
+- OTLP/JSON encoding deviations: https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
+- Exporter configuration (env vars): https://opentelemetry.io/docs/specs/otel/protocol/exporter/
+- opentelemetry-proto repo (all `.proto` sources): https://github.com/open-telemetry/opentelemetry-proto
+  - Trace: `opentelemetry/proto/trace/v1/trace.proto`
+  - Logs: `opentelemetry/proto/logs/v1/logs.proto`
+  - Metrics: `opentelemetry/proto/metrics/v1/metrics.proto`
+  - Common (`AnyValue`/`KeyValue`/`InstrumentationScope`): `opentelemetry/proto/common/v1/common.proto`
+  - Resource: `opentelemetry/proto/resource/v1/resource.proto`
+  - Collector services (`Export` RPCs, partial-success messages): `opentelemetry/proto/collector/{trace,metrics,logs}/v1/*_service.proto`
+- Profiles (Development/Alpha, separate proto fork for active WG work): https://github.com/open-telemetry/opentelemetry-proto-profile · https://opentelemetry.io/blog/2026/profiles-alpha/
+- opentelemetry-proto stability policy (Development/Alpha/Beta/RC grades): https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md

--- a/docs/otel-spec/resource-and-config.md
+++ b/docs/otel-spec/resource-and-config.md
@@ -1,0 +1,237 @@
+# Resource, Entities & SDK Configuration
+
+This page is a compliance reference for the OpenTelemetry **Resource** model (what a "resource" is, how it's built and merged), the **resource semantic conventions** that matter most to Maple (`service.*`, `deployment.environment.name`, `telemetry.sdk.*`, plus summary-level `host.*`/`k8s.*`/`cloud.*`), the **SDK environment-variable spec** (the consolidated table is the centerpiece), the emerging **declarative/file configuration** mechanism, and the current **Entities** data model effort. It exists for spec-compliance checks and to back a best-practices skill — every non-obvious claim below carries an inline `Source:` link to the fetched spec page it was verified against.
+
+## Relevance to Maple
+
+- Maple is primarily a **consumer/backend** of OTel data (Rust `ingest` gateway → collector → ClickHouse/Tinybird → web dashboard), plus we **self-instrument** our own services (`apps/ingest`, the API, etc.) — so we need to both parse resources correctly from arbitrary SDKs *and* emit spec-correct resources ourselves.
+- **Dashboards key off `service.name` + `deployment.environment.name`.** The legacy `deployment.environment` attribute is deprecated (replaced by `deployment.environment.name`); our ingest gateway dual-emits both today because downstream Tinybird materialized views (`service_overview_spans_mv` et al.) still pre-extract the legacy key — see `CLAUDE.md`. This doc's deprecation citation below is the spec basis for eventually dropping the legacy emission once those MVs coalesce both.
+- Our ingest gateway stamps a **vendor-namespaced** `maple_org_id` (and `maple.*` span attributes) — this is intentionally outside semconv (no `maple.*` resource semantic convention exists upstream), so it must never collide with a real OTel resource attribute name.
+- We do not currently consume declarative/file configuration or the Entities data model, but both are tracked here because they affect how upstream SDKs will emit resources in the near future (Entities) and how our own self-instrumentation could be configured (file config).
+
+---
+
+## 1. Resource: definition, immutability, merge rules
+
+**Stability: Stable** (the Resource SDK spec is stable except where individual parts are marked otherwise — resource *detector names* are explicitly called out as Development).
+Source: https://opentelemetry.io/docs/specs/otel/resource/sdk/
+
+- **Definition:** a Resource is "an immutable representation of the observed entity for which telemetry is being produced, expressed as Attributes." Once created, a Resource cannot be modified.
+- **Creation:** SDKs expose a `Create(attributes, schema_url)` factory. `schema_url` is optional and records the Schema URL associated with the emitted attributes.
+- **Merge rule — critical for compliance checks:** when merging an *old* resource with an *updating* resource, "the value of the updating resource MUST be picked (even if the updated value is empty)." I.e., **the updating side always wins**, including overwriting a populated attribute with an empty one. Merge is not "fill in only missing keys."
+- **Schema URL on merge:** combining two resources that carry **different, non-empty** schema URLs is a merging error — schema URLs must match (or one/both must be empty) for a clean merge.
+- **`OTEL_RESOURCE_ATTRIBUTES`:** "The SDK MUST extract information from the `OTEL_RESOURCE_ATTRIBUTES` environment variable and merge this, as the secondary resource, with any resource information provided by the user." Format is `key1=value1,key2=value2`, percent-encoded for special characters — i.e. user-supplied/programmatic resource attributes win over the env var per the merge rule above (env var is the "old"/secondary side).
+- **`OTEL_SERVICE_NAME`:** the `service` resource detector populates `service.name` from this env var; per the SDK environment variable spec (below), `OTEL_SERVICE_NAME` takes precedence over any `service.name` key set via `OTEL_RESOURCE_ATTRIBUTES`.
+- **Default `service.name`:** if `service.name` is not otherwise specified, "SDKs MUST fallback to `unknown_service:` concatenated with the process executable name, e.g. `unknown_service:bash`." If the executable name is unavailable, the value degrades to plain `unknown_service`. (Note: many SDKs/docs colloquially write this as `unknown_service[:process]"`, which is what this pattern means in practice — the colon-joined executable name is included whenever known.)
+  Source: https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/
+
+## 2. Resource data model (Entities-aware)
+
+**Stability: Development.**
+Source: https://opentelemetry.io/docs/specs/otel/resource/data-model/
+
+The current logical Resource data model has two fields:
+
+- `attributes` — the flat map of resource attribute key/values, which "MUST not change during the lifetime of the resource."
+- `entities` — (newer, Development) a set of Entity objects the resource is composed of, per the Entities data model (§7). Resources also carry a `schema_url`, derived during entity merging: shared across all entities' schema URLs when they agree, left blank on conflict.
+
+This model is the forward-looking replacement for "resource = flat attribute bag"; see §7 for the Entities effort itself.
+
+## 3. Key resource semantic conventions
+
+### 3.1 `service.*`
+
+**Stability: Stable** for all four attributes below.
+Source: https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| `service.name` | Recommended | "MUST be the same for all instances of horizontally scaled services." Falls back to `unknown_service:<process-executable-name>` if unset (see §1). Configurable via `OTEL_SERVICE_NAME` (SDK env var spec) or provided as a default by the SDK (Resource SDK spec). |
+| `service.namespace` | Optional | Logical grouping for a set of services; service names are expected to be unique **within** the same namespace. "Zero-length namespace string is assumed equal to unspecified namespace." |
+| `service.version` | Optional | Version string of the service; format is undefined (examples: `2.0.0`, `a01dbef8a`). |
+| `service.instance.id` | Optional | "MUST be unique for each instance of the same `service.namespace`, `service.name` pair." Recommendation: generate a random **UUID v1 or v4** (RFC 4122), or derive a **UUID v5** from a stable namespace UUID (`4d63009a-8d0f-11ee-aad7-4c796ed8e320`) when a stable seed exists. Treat data like pod names, used as input to instance IDs, as potentially confidential. |
+
+### 3.2 `deployment.environment.name` (and the legacy `deployment.environment` rename)
+
+Source: https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/ and https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/
+
+- **`deployment.environment.name`** — **Stable**, Recommended, type `string`. "Name of the deployment environment (aka deployment tier)." Well-known values (all Stable): `development`, `production`, `staging`, `test` — a well-known value MUST be used when it applies; otherwise a custom value MAY be used.
+- Explicit note: this attribute "does not affect the uniqueness constraints defined through the `service.namespace`, `service.name` and `service.instance.id` attributes" — i.e. the same logical service running in two environments is still considered the same service identity for uniqueness purposes; the environment is an orthogonal dimension.
+- **Legacy `deployment.environment`** (no `.name`) is registered as **Deprecated**, with the exact registry note: **"Replaced by `deployment.environment.name`."** This is the citable spec basis for the rename Maple's ingest gateway currently works around by dual-emitting both keys (see `CLAUDE.md` self-observability section) — compliant new code should emit only `deployment.environment.name`.
+- The broader "Deployment" resource/entity group itself is at **Development** status overall (per the resource semconv landing page), even though the two attributes above are individually Stable — Development status here reflects unfinished entity-role modeling, not attribute-level instability.
+
+### 3.3 `telemetry.sdk.*` / `telemetry.distro.*`
+
+**Stability: Stable** (both groups).
+Source: https://opentelemetry.io/docs/specs/semconv/resource/
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| `telemetry.sdk.name` | Required (by SDKs) | "The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to `opentelemetry`." A non-OTel SDK claiming these attributes MUST instead use its own fully-qualified class/module name. |
+| `telemetry.sdk.language` | Required | e.g. `cpp`, `dotnet`, `go`, `java`, `nodejs`, `python`, `rust`, `webjs`. |
+| `telemetry.sdk.version` | Required | SDK version string, e.g. `1.2.3`. |
+| `telemetry.distro.name` | Recommended | Name of the auto-instrumentation agent/distro, if used. |
+| `telemetry.distro.version` | Recommended | Distro version string. |
+
+### 3.4 `host.*`, `k8s.*`, `cloud.*` — summary level
+
+Full definitions: https://opentelemetry.io/docs/specs/semconv/resource/ (index; links to each group's registry page). Per-group stability below reflects each attribute's individual maturity badge, independent of the overall resource page's blanket "Development" note for these groups.
+
+**`host.*`** — Source: https://opentelemetry.io/docs/specs/semconv/registry/attributes/host/ — all listed attributes currently **Development**: `host.name`, `host.id` (mandatory shape for cloud: provider's `instance_id`), `host.type` (cloud machine type), `host.arch`, `host.image.id`/`host.image.name`/`host.image.version`.
+
+**`k8s.*`** — Source: https://opentelemetry.io/docs/specs/semconv/registry/attributes/k8s/ — the widely-used identity attributes are **Stable**: `k8s.cluster.name`, `k8s.cluster.uid`, `k8s.node.name`/`k8s.node.uid`, `k8s.namespace.name`, `k8s.pod.name`/`k8s.pod.uid`, `k8s.container.name`, `k8s.deployment.name`, `k8s.statefulset.name`, `k8s.daemonset.name`, `k8s.job.name`, `k8s.cronjob.name`. Newer additions are **Development**: `k8s.persistentvolume.name`, `k8s.persistentvolumeclaim.name`, `k8s.service.name`, `k8s.service.type`.
+
+**`cloud.*`** — Source: https://opentelemetry.io/docs/specs/semconv/registry/attributes/cloud/ — all currently **Development**: `cloud.provider` (well-known values incl. `aws`/`azure`/`gcp`/`alibaba_cloud`, must use a well-known value when applicable), `cloud.platform` (e.g. `aws_lambda`, `gcp_cloud_run`), `cloud.region`, `cloud.account.id`, `cloud.availability_zone`, `cloud.resource_id` (provider-specific full identifier — ARN, etc.).
+
+## 4. Common attribute spec (applies to resource *and* span/log/metric attributes)
+
+**Stability: Stable** (except where individually marked otherwise).
+Source: https://opentelemetry.io/docs/specs/otel/common/
+
+- **Permitted value types** for an attribute (`AnyValue`): primitive `string`, `boolean`, `double` (IEEE 754-1985), signed 64-bit `integer`; **homogeneous arrays** of those primitives; byte arrays; arrays of `AnyValue`; and `map<string, AnyValue>`.
+- **Homogeneity rule (exact wording):** "A homogeneous array MUST NOT contain values of different types."
+- **Empty values are meaningful:** empty strings, zero numbers, and empty arrays must be preserved through processors/exporters — they are not treated as "unset."
+- **Null handling (exact wording):** "While `null` is a valid attribute value, its use within homogeneous arrays SHOULD generally be avoided unless language constraints make this impossible." If nulls do occur, "they MUST be preserved as-is (i.e., passed on to processors / exporters as `null`)" — nulls must not be silently dropped or coerced.
+- **Attribute limits** (defaults, enforced by SDKs):
+  - `AttributeCountLimit` — default **128** (max attributes per record).
+  - `AttributeValueLengthLimit` — default **Infinity/no limit** (max length of string/byte-array values).
+  - The count limit "applies only to top-level attributes, not to nested key-value pairs within maps."
+  - **Resource attributes and metric attributes are explicitly exempt** from these SDK-enforced limits (relevant: don't assume `OTEL_ATTRIBUTE_COUNT_LIMIT` truncates a resource — it doesn't, per this spec section, though exporters/backends may impose their own caps).
+
+## 5. SDK environment-variable spec (consolidated table)
+
+**Stability: Stable, except where individually marked otherwise** (e.g. some newer/experimental vars).
+Source: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/ (OTLP-exporter-specific vars: https://opentelemetry.io/docs/specs/otel/protocol/exporter/, status **Stable**)
+
+### General SDK
+
+| Variable | Default | Notes |
+|---|---|---|
+| `OTEL_SDK_DISABLED` | `false` | Disables the SDK (all signals become no-ops) when `true`. |
+| `OTEL_LOG_LEVEL` | `info` | Controls the SDK's own internal diagnostic logging. |
+| `OTEL_RESOURCE_ATTRIBUTES` | *(unset)* | `key1=value1,key2=value2`, percent-encoded; merged as the "secondary"/old resource (user-supplied wins per merge rule). |
+| `OTEL_SERVICE_NAME` | *(unset)* | Sets `service.name`; takes precedence over a `service.name` set via `OTEL_RESOURCE_ATTRIBUTES`. |
+| `OTEL_PROPAGATORS` | `tracecontext,baggage` | Comma-separated, deduplicated propagator list. |
+
+### Exporter selection
+
+| Variable | Default |
+|---|---|
+| `OTEL_TRACES_EXPORTER` | `otlp` |
+| `OTEL_METRICS_EXPORTER` | `otlp` |
+| `OTEL_LOGS_EXPORTER` | `otlp` |
+
+### Sampling
+
+| Variable | Default | Notes |
+|---|---|---|
+| `OTEL_TRACES_SAMPLER` | `parentbased_always_on` | e.g. `parentbased_traceidratio`, `always_on`, `always_off`, `traceidratio`. |
+| `OTEL_TRACES_SAMPLER_ARG` | *(unset)* | Argument shape depends on the chosen sampler (e.g. a ratio `0.1` for `traceidratio`/`parentbased_traceidratio` — used at high QPS by `apps/ingest`, per `CLAUDE.md`). |
+
+### Batch Span Processor (BSP)
+
+| Variable | Default |
+|---|---|
+| `OTEL_BSP_SCHEDULE_DELAY` | 5000 ms |
+| `OTEL_BSP_EXPORT_TIMEOUT` | 30000 ms |
+| `OTEL_BSP_MAX_QUEUE_SIZE` | 2048 |
+| `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | 512 |
+
+### Batch LogRecord Processor (BLRP)
+
+| Variable | Default |
+|---|---|
+| `OTEL_BLRP_SCHEDULE_DELAY` | 1000 ms |
+| `OTEL_BLRP_EXPORT_TIMEOUT` | 30000 ms |
+| `OTEL_BLRP_MAX_QUEUE_SIZE` | 2048 |
+| `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` | 512 |
+
+### Periodic Metric Reader
+
+| Variable | Default |
+|---|---|
+| `OTEL_METRIC_EXPORT_INTERVAL` | 60000 ms |
+| `OTEL_METRIC_EXPORT_TIMEOUT` | 30000 ms |
+
+### Attribute / span / log-record limits
+
+| Variable | Default | Scope |
+|---|---|---|
+| `OTEL_ATTRIBUTE_COUNT_LIMIT` | 128 | General fallback attribute count limit |
+| `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` | no limit | General fallback value length limit |
+| `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` | 128 | Per-span override of the general count limit |
+| `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` | no limit | Per-span override of the general length limit |
+| `OTEL_SPAN_EVENT_COUNT_LIMIT` | 128 | Max span events |
+| `OTEL_SPAN_LINK_COUNT_LIMIT` | 128 | Max span links |
+| `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT` | 128 | Max attributes per span event |
+| `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT` | 128 | Max attributes per span link |
+| `OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT` | 128 | Per-log-record override of the general count limit |
+| `OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT` | no limit | Per-log-record override of the general length limit |
+
+Recall from §4: resource attributes and metric attributes are exempt from all count/length limits above.
+
+### OTLP exporter configuration (base + per-signal `TRACES`/`METRICS`/`LOGS` variants)
+
+Base variable applies to all signals unless a signal-specific variant overrides it. Signal-specific endpoint variables are used **as-is** (no path suffix appended); the base endpoint variable gets `/v1/traces`, `/v1/metrics`, or `/v1/logs` appended automatically per signal.
+
+| Variable (base; suffix each with `_TRACES_`/`_METRICS_`/`_LOGS_` for per-signal override) | Default |
+|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` (HTTP) / `http://localhost:4317` (gRPC) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | *(unset)*; W3C Baggage-style `key=value` pairs |
+| `OTEL_EXPORTER_OTLP_COMPRESSION` | *(unset)*; `none` or `gzip` |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | 10 s |
+| `OTEL_EXPORTER_OTLP_INSECURE` | `false` (gRPC only) |
+| `OTEL_EXPORTER_OTLP_CERTIFICATE` | *(unset)* — trusted server cert for TLS verification |
+| `OTEL_EXPORTER_OTLP_CLIENT_KEY` | *(unset)* — client private key (PEM), mTLS |
+| `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` | *(unset)* — client cert/chain (PEM), mTLS |
+
+Note: "SDKs SHOULD default endpoint variables to use `http` scheme unless they have good reasons to choose `https` scheme."
+
+## 6. Declarative / file configuration
+
+**Stability: the core schema is now Stable** (JSON schema, YAML file representation, in-memory representation, `ConfigProperties`, `PluginComponentProvider`, and the SDK `Parse`/`Create` operations were stabilized alongside an `opentelemetry-configuration` `1.0.0` release, announced 2026). Portions still evolving are explicitly namespaced `.../development` in the schema so stable and experimental parts can coexist.
+Sources: https://opentelemetry.io/blog/2026/stable-declarative-config/ , https://opentelemetry.io/docs/specs/otel/configuration/sdk/ , https://opentelemetry.io/docs/specs/otel/configuration/
+
+- **Mechanism:** the SDK exposes a two-step `Parse` (reads/validates a YAML file, performs env-var substitution, returns an in-memory config model) → `Create` (instantiates `TracerProvider`/`MeterProvider`/`LoggerProvider`/propagators from that model) flow.
+- **File format:** YAML, validated against the `opentelemetry-configuration` JSON Schema.
+- **Env var to opt in / point at a file:** **`OTEL_CONFIG_FILE`** (the stabilized name — treat any reference to `OTEL_EXPERIMENTAL_CONFIG_FILE` as the older/language-specific pre-stabilization spelling; some SDKs may still only support the experimental name until they finish adopting `1.0.0`).
+- **Positioning vs. env vars:** declarative config is described as "more expressive and full-featured than the environment variable based scheme." The spec's own stated direction is to eventually "deprecate environment variables which don't interoperate well" with file config, but the pages fetched do **not** spell out a precise precedence/merge rule for the case where both an env-var-based and a file-based configuration are present simultaneously — treat that as unverified/TBD rather than assume a specific precedence.
+- **Language implementation status (as of the stabilization blog post):** C++, Go, Java, JavaScript, and PHP have implementations; .NET and Python are in progress. The Go implementation is also reused by the Collector for its own internal telemetry configuration.
+- **Maple relevance:** not currently used anywhere in this repo; noted here so future self-instrumentation config changes can cite the correct stable env var (`OTEL_CONFIG_FILE`) rather than the deprecated experimental name.
+
+## 7. Entities
+
+**Stability: Development** (the whole effort — overview and data model pages both carry an explicit `Status: Development` marker).
+Sources: https://opentelemetry.io/docs/specs/otel/entities/ , https://opentelemetry.io/docs/specs/otel/entities/data-model/
+
+- **Purpose:** a common data model for "entities" — objects of interest associated with produced telemetry (e.g. a `service`, `host`, `k8s.pod`, `k8s.cluster`) — so multiple distinct-but-related components can be represented within the same signal's resource, each with its own identity and metadata, rather than flattening everything into one undifferentiated attribute bag.
+- **Data model fields:**
+  - `type` — required, immutable string category (e.g. `"service"`, `"host"`).
+  - `id` — a map of identifying attributes; "must contain at least one attribute" and should be the minimal attribute set sufficient to uniquely identify the entity.
+  - `description` — a map of descriptive, non-identifying attributes that may change over time and may be empty.
+- **Relationship to Resource:** entities are attached in the resource section of a signal and reference the same shared attribute pool defined by Resource — this preserves backward compatibility with existing Resource-attribute consumers while avoiding duplicating identifying data across multiple entities on the same signal.
+- **Instantiation models:** *pull-based* (an entity discovers itself from the current runtime/environment — analogous to today's resource detectors) and *push-based* (entity info supplied externally, typically via environment variables or declarative configuration).
+- **Practical takeaway for Maple:** this is not yet something ClickHouse/Tinybird ingestion needs to model explicitly (Development stability, not yet emitted by mainstream SDKs by default), but the ingest gateway's resource-attribute parsing should not assume the Resource model stays a flat attribute-only bag forever — the `entities` field on the Resource data model (§2) is the forward path.
+
+---
+
+## Key references
+
+- Resource SDK spec: https://opentelemetry.io/docs/specs/otel/resource/sdk/
+- Resource data model: https://opentelemetry.io/docs/specs/otel/resource/data-model/
+- Resource semantic conventions (index): https://opentelemetry.io/docs/specs/semconv/resource/
+- Service attributes registry: https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/
+- Deployment environment semconv: https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/
+- Deployment attributes registry (deprecation note source): https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/
+- Host attributes registry: https://opentelemetry.io/docs/specs/semconv/registry/attributes/host/
+- Kubernetes attributes registry: https://opentelemetry.io/docs/specs/semconv/registry/attributes/k8s/
+- Cloud attributes registry: https://opentelemetry.io/docs/specs/semconv/registry/attributes/cloud/
+- Common (attribute) spec: https://opentelemetry.io/docs/specs/otel/common/
+- SDK environment variables spec: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+- OTLP exporter configuration (env vars): https://opentelemetry.io/docs/specs/otel/protocol/exporter/
+- Configuration overview (declarative config positioning): https://opentelemetry.io/docs/specs/otel/configuration/
+- Configuration SDK (Parse/Create, `OTEL_CONFIG_FILE`): https://opentelemetry.io/docs/specs/otel/configuration/sdk/
+- Declarative configuration stabilization announcement: https://opentelemetry.io/blog/2026/stable-declarative-config/
+- Entities overview: https://opentelemetry.io/docs/specs/otel/entities/
+- Entities data model: https://opentelemetry.io/docs/specs/otel/entities/data-model/

--- a/docs/otel-spec/semantic-conventions.md
+++ b/docs/otel-spec/semantic-conventions.md
@@ -1,0 +1,389 @@
+# Semantic Conventions
+
+OpenTelemetry Semantic Conventions ("semconv") define the common attribute names, span/metric naming rules, and per-domain required/recommended fields that give telemetry consistent meaning across languages, libraries, and vendors. They live in a single spec (currently **v1.43.0**) covering traces, metrics, logs, resources, and profiles, published from `github.com/open-telemetry/semantic-conventions` and rendered at `https://opentelemetry.io/docs/specs/semconv/`.
+
+> **Relevance to Maple:** Maple is primarily a **consumer/backend** for OTel data — our ClickHouse/Tinybird schemas, dashboard UI, and query engine all key on semconv attribute names, so drift between "what the spec says" and "what our ingest/query layers expect" causes silent breakage (missing facets, wrong span-status coloring, unmatched filters). Our trace UI keys on `http.request.method`/`http.route`/`http.response.status_code`; our Rust ingest gateway (`apps/ingest`) emits new-semconv HTTP attributes and self-instruments per `service.name="ingest"` (see root `CLAUDE.md`); warehouse read paths alias legacy `db.statement`/`db.system` to `db.query.text`/`db.system.name` for spans recorded before the DB semconv stability migration; and per project convention our own span status values use **title case** (`"Ok"`, `"Error"`, `"Unset"`), matching the OTel API enum names rather than the lowercase wire values some SDKs historically emitted.
+
+---
+
+## General rules
+
+### Attribute naming
+
+Source: https://opentelemetry.io/docs/specs/semconv/general/naming/
+
+- "Names SHOULD be lowercase" and use **namespacing**, delimited by a dot character (e.g. `http.response.status_code` is the `status_code` attribute in the `http` namespace, itself nested under `http.response`).
+- Multi-word components within a dot-delimited segment use **snake_case** (`status_code`, not `statusCode` or `status-code`).
+- Character rules: names must be a valid Unicode sequence restricted to printable Basic Latin; tooling further limits to lowercase Latin letters, digits, underscore, and dot; names **must start with a letter, end with an alphanumeric character**, and must not contain two or more consecutive delimiters.
+- Pluralization: singular for single-valued attributes (`host.name`), plural for array-valued attributes (`process.command_args`).
+- Custom/vendor attributes outside the registry should be namespaced under a reverse-DNS-style prefix (e.g. `com.acme.shopname.*`) to avoid collisions with future registry additions.
+- Metric names additionally: namespaces and metric names generally **SHOULD NOT be pluralized** (`system.process.count`, not `system.processes`); counters/up-down counters **SHOULD NOT** append `_total`; units follow UCUM (Unified Code for Units of Measure), preferring un-prefixed units (`By` not `MiBy`) and `s` for durations, with bracketed annotations matching grammatical number (`{request}` not `{requests}`).
+
+### Attribute requirement levels
+
+Source: https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/
+
+| Level | Definition |
+|---|---|
+| **Required** | "All instrumentations MUST populate the attribute." Expected to be efficiently available in the vast majority of cases. |
+| **Conditionally Required** | "All instrumentations MUST populate the attribute when the given condition is satisfied." The convention must spell out the triggering condition. |
+| **Recommended** | "Instrumentations SHOULD add the attribute by default if it's readily available and can be efficiently populated." May be disabled for perf/security/privacy reasons. |
+| **Opt-In** | "Instrumentations SHOULD populate the attribute if and only if the user configures the instrumentation to do so." Reserved for expensive-to-collect or privacy/security-sensitive fields. |
+
+### Span naming
+
+Source: https://opentelemetry.io/docs/specs/otel/trace/api/ (core span-naming rule, part of the tracing API spec that semconv domains implement against)
+
+- "The span name SHOULD be the most general string that identifies a (statistically) interesting class of Spans, rather than individual Span instances" — i.e. **low cardinality is mandatory**. `get_user` is a good name; `get_user/314159` (embedding a user ID) is not.
+- Generality is prioritized over human-readability when the two conflict.
+- Each domain gives its own concrete template (e.g. HTTP: `{method} {route}`; DB: `{db.query.summary}` or `{db.operation.name} {target}`; see domain sections below) — always built from low-cardinality attribute values, never from raw high-cardinality identifiers (full URLs, raw SQL literals, IDs).
+
+### Recording errors / span status
+
+Source: https://opentelemetry.io/docs/specs/semconv/general/recording-errors/
+
+- "Span Status Code MUST be left unset if the instrumented operation has ended without any errors." Only set `Error` on genuine failures.
+- When an operation fails: set span status to `Error` and set `error.type`; an optional status description can add detail but shouldn't just repeat the status code or error type.
+- `error.type` must be applied **consistently** between a span and its corresponding metric for the same operation: same value if failed, absent if succeeded.
+- Errors that were retried/handled internally (the operation still completes successfully) **SHOULD NOT** be recorded as errors on the span/metric describing that operation.
+
+### Stability levels
+
+Source: https://opentelemetry.io/docs/specs/otel/versioning-and-stability/
+
+OpenTelemetry signals (including semconv domains) move through a lifecycle:
+
+| Level | Meaning |
+|---|---|
+| **Development** | May have breaking changes; "Long-term dependencies SHOULD NOT be taken against signals in Development." |
+| **Stable** | Backward compatibility guaranteed; safe to build long-term dependencies against. |
+| **Deprecated** | Being phased out; "Signals MUST NOT be marked as deprecated unless the replacement is stable." Same support guarantees as stable until removed. |
+| **Removed** | No longer supported; removal requires a major version bump. |
+
+Per-domain stability (see each section below): **HTTP is Stable**; **Database is Stable** (as of the v1.30-era stability migration); **Messaging is Development**; **RPC is Release Candidate**; **Exceptions**-as-span-events is **Deprecated** in favor of exceptions-on-logs; **Code attributes are Stable**; **General attributes (`server.*`, `client.*`, `network.*`, `url.*`) are Stable** (a handful of derived `url.*` sub-attributes remain Development); **Gen-AI is Development** and has moved to a separate spec repo.
+
+### The `OTEL_SEMCONV_STABILITY_OPT_IN` migration pattern
+
+Source: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/ · https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/
+
+When a domain graduates from experimental to stable, its attribute names/values often change (e.g. `http.method` → `http.request.method`). Because this breaks dashboards/alerts built on the old names, instrumentations expose an env var so users can migrate on their own schedule instead of the instrumentation silently flipping conventions:
+
+- **HTTP** (`OTEL_SEMCONV_STABILITY_OPT_IN`): `http` = emit only the new stable HTTP/network conventions; `http/dup` = emit **both** old and new (phased rollout); unset/default = keep emitting whatever the instrumentation emitted before.
+- **Database**: same three-way shape with values `database` / `database/dup` / default.
+- **Gen-AI**: `gen_ai_latest_experimental` opts into the newest experimental gen-ai shape instead of the pre-1.36.0 one; default keeps emitting whatever version was previously emitted.
+- Constraint: this variable is "only intended to be used when migrating from an experimental semantic convention to its initial stable version" — not a general-purpose versioning knob. Instrumentations must support the `/dup` dual-emit mode for **at least six months** after introducing it, within their current major version, before dropping the old shape in a subsequent major version.
+- Exceptions have an analogous but distinct variable, `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN` (`logs` / `logs/dup` / default) — see the Exceptions section.
+
+### Schema URLs & telemetry schemas
+
+Source: https://opentelemetry.io/docs/specs/otel/schemas/
+
+- A **Schema URL** identifies a specific version of a telemetry schema and is the address from which the schema file can be fetched: `http[s]://server[:port]/path/<version>`. The portion before the version is the **Schema Family** identifier, stable across all versions in that family.
+- OTLP carries `schema_url` at the `Resource*` message level and at the `InstrumentationScope`/instrumentation-library level; when both are present, the scope-level one takes precedence for that scope's data.
+- Purpose: semantic conventions evolve (attributes get renamed, e.g. `http.method` → `http.request.method`, or `deployment.environment` → `deployment.environment.name`); a schema file formally declares the transformation rules needed to convert telemetry between schema versions, so a consumer that knows the schema version of incoming data (via `schema_url`) can mechanically rewrite it to the version its dashboards/alerts expect, instead of every consumer hand-rolling compatibility shims.
+- The schema file format itself is versioned separately (`file_format_v1.0.0`, `file_format_v1.1.0`) from the schema content it describes.
+
+### The semconv registry
+
+Source: https://opentelemetry.io/docs/specs/semconv/registry/attributes/ · https://github.com/open-telemetry/semantic-conventions
+
+- The **attribute registry** (`/docs/specs/semconv/registry/attributes/`) is an auto-generated, searchable/browsable catalog of every registered attribute, organized by namespace (`http.*`, `db.*`, `network.*`, `code.*`, …), each with type, stability, and description — this is the fastest way to check an attribute's current name/stability without reading the full domain spec.
+- The registry and all domain specs are generated from YAML model definitions in `github.com/open-telemetry/semantic-conventions` (the source of truth); the rendered docs on opentelemetry.io are a build artifact of that repo. Gen-AI conventions have since split out into their own sibling repo, `github.com/open-telemetry/semantic-conventions-genai` (see Gen-AI section).
+
+---
+
+## HTTP
+
+**Stability: Stable** (both client and server spans/metrics).
+Source: https://opentelemetry.io/docs/specs/semconv/http/http-spans/ · https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
+
+### Span name
+
+`{method} {target}` when a low-cardinality target is known, else just `{method}`. `{method}` is `http.request.method` if known, else the literal string `HTTP`. Server spans use `http.route` as `{target}`; client spans may use `url.template`. **"Instrumentation MUST NOT default to using URI path as a `{target}`"** (path segments are high-cardinality).
+
+### Required / Conditionally Required attributes
+
+| Attribute | Level | Client / Server | Notes |
+|---|---|---|---|
+| `http.request.method` | Required | Both | GET, POST, HEAD, … |
+| `server.address` | Required | Client | Domain/IP/socket the request targets |
+| `server.port` | Required | Client | — |
+| `url.full` | Required | Client | Absolute URL, RFC3986; credentials MUST be redacted |
+| `url.path` | Required | Server | URI path component |
+| `url.scheme` | Required | Server | `http`/`https` |
+| `http.response.status_code` | Cond. Required | Both | If a response was received/sent |
+| `error.type` | Cond. Required | Both | If the request ended in error |
+| `network.protocol.name` | Cond. Required | Both | If not `http` and version is set |
+| `http.route` | Cond. Required | Server | If available; must be low-cardinality (static segments + placeholders) |
+| `server.port` | Cond. Required | Server | If available and `server.address` set |
+| `url.query` | Cond. Required | Server | If a query string was present |
+
+### Span status mapping (the important compliance rule)
+
+- **1xx/2xx/3xx**: leave span status **unset**, unless another error occurred (network failure, redirect-limit exceeded) — then `Error`.
+- **4xx**: **SERVER** spans leave status **unset** (client errors aren't the server's fault); **CLIENT** spans **SHOULD** be set to `Error`.
+- **5xx**: `Error` for **both** client and server spans, plus `error.type` set.
+- Intentionally cancelled client requests (caller-initiated) should **not** be treated as errors.
+
+This asymmetry (4xx = Ok for SERVER, Error for CLIENT) is the single most load-bearing rule for anyone building error-rate dashboards — filtering `StatusCode = 'Error'` on server spans will correctly exclude client 4xx noise, but the same filter on client spans will correctly include it.
+
+### Retries/resends
+
+Each client resend (redirect, auth failure, 5xx, network error — cause doesn't matter) increments `http.request.resend_count`, set to the ordinal number of the resend attempt.
+
+### Metrics (Stable)
+
+| Metric | Type | Unit | Stability | Required attrs |
+|---|---|---|---|---|
+| `http.server.request.duration` | Histogram | `s` | Stable | `http.request.method`, `url.scheme` |
+| `http.client.request.duration` | Histogram | `s` | Stable | `http.request.method`, `server.address`, `server.port` |
+| `http.server.active_requests` | UpDownCounter | `{request}` | Development | Opt-in |
+| `http.{server,client}.{request,response}.body.size` | Histogram | `By` | Development | Opt-in |
+
+When reported alongside a span, the duration metric value **SHOULD** equal the span's duration.
+
+> **Maple hook:** our trace UI keys directly on `http.request.method` / `http.route` / `http.response.status_code`; the SERVER-4xx-is-Ok rule above is exactly what our error-rate widgets assume when they filter on span status.
+
+---
+
+## Database
+
+**Stability: Stable** (as of the DB semconv stability migration; pre-migration instrumentations used `OTEL_SEMCONV_STABILITY_OPT_IN=database`/`database/dup` to move over — see General rules above).
+Source: https://opentelemetry.io/docs/specs/semconv/db/database-spans/ · https://opentelemetry.io/docs/specs/semconv/db/database-metrics/ · https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/
+
+The stable migration renamed `db.system` → `db.system.name` (and `db.statement` → `db.query.text`), and changed many enum values to a `<vendor>.<product>` pattern.
+
+### Span name
+
+Priority order:
+1. `{db.query.summary}` if available
+2. `{db.operation.name} {target}` if a low-cardinality operation name is available
+3. `{target}` alone
+4. `{db.system.name}` as the final fallback
+
+Where `{target}` prefers, in order: `db.collection.name` → `db.stored_procedure.name` → `db.namespace` → `server.address:server.port`.
+
+### Required / Conditionally Required attributes
+
+| Attribute | Level | Notes |
+|---|---|---|
+| `db.system.name` | Required | DBMS product identifier (e.g. `postgresql`, `clickhouse`) |
+| `db.collection.name` | Cond. Required | If readily available and the operation targets a single collection |
+| `db.namespace` | Cond. Required | If available |
+| `db.operation.name` | Cond. Required | If readily available and describes a single operation |
+| `db.response.status_code` | Cond. Required | If the operation failed and a code is available |
+| `error.type` | Cond. Required | If and only if the operation failed |
+| `server.port` | Cond. Required | If a non-default port is used and `server.address` is set |
+
+### `db.query.text` sanitization
+
+- Raw (non-parameterized) query text should only be collected **if sanitized to exclude sensitive info** — literals replaced with a placeholder (e.g. `?`).
+- **"Parameterized query text SHOULD NOT be sanitized."** Using parameters is itself a strong signal from the application that sensitive values are passed out-of-band as parameters, not embedded in the query text.
+- IN-clauses may be collapsed for cardinality control (`IN (?, ?, ?, ?)` → `IN (?)`).
+
+### Span status
+
+Follows the general Recording Errors doc; each system-specific DB convention should specify which `db.response.status_code` values count as errors.
+
+### Metrics
+
+| Metric | Type | Unit | Stability |
+|---|---|---|---|
+| `db.client.operation.duration` | Histogram | `s` | **Stable** |
+| `db.client.response.returned_rows` | Histogram | `{row}` | Development |
+| `db.client.connection.*` (pool size, idle, pending, timeouts, create/wait/use time) | Counter/UpDownCounter/Histogram | varies | Development |
+
+Batch operations **SHOULD** be recorded as a single operation (not one metric event per row/statement).
+
+> **Maple hook:** warehouse read paths in `WarehouseQueryService` coalesce both the legacy (`db.statement`, `db.system`) and stable (`db.query.text`, `db.system.name`) spellings, since spans recorded before our own migration still carry the legacy names — mirrors exactly the dual-emit window the spec expects instrumentations to support.
+
+---
+
+## Messaging
+
+**Stability: Development** (not yet stable — per the spec, existing instrumentations on v1.24.0-era conventions should not change what they emit by default until this stabilizes).
+Source: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+
+### Span name
+
+`{messaging.operation.name} {destination}`, where `{destination}` prefers `messaging.destination.template` (low-cardinality template) → `messaging.destination.name` (for known, non-temporary destinations) → `server.address:server.port` (only when no specific destination is targeted).
+
+### Required / Conditionally Required attributes
+
+| Attribute | Level | Notes |
+|---|---|---|
+| `messaging.system` | Required | e.g. `kafka`, `rabbitmq`, `aws_sqs` |
+| `messaging.operation.name` | Required | System-specific operation name (`send`, `publish`, `poll`, …) |
+| `messaging.operation.type` | Cond. Required | One of `create`/`send`/`receive`/`process`/`settle` |
+| `messaging.destination.name` | Cond. Required | Single-message ops, or batch ops with a uniform destination |
+| `messaging.batch.message_count` | Cond. Required | Batch operations |
+| `messaging.consumer.group.name` | Cond. Required | If applicable to the system |
+| `error.type` | Cond. Required | If the operation failed |
+
+### Span kind by operation type
+
+| Operation | Span kind |
+|---|---|
+| `create` | PRODUCER |
+| `send` | PRODUCER (if the created context is used) or CLIENT |
+| `receive` | CLIENT |
+| `process` | CONSUMER |
+| `settle` | CLIENT |
+
+Status follows the general Recording Errors doc; don't set `error.type` on success.
+
+---
+
+## RPC
+
+**Stability: Release Candidate** (near-stable; minor changes possible before final release).
+Source: https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/
+
+### Span name
+
+`{rpc.method}` if known and not `_OTHER`; else falls back to `{rpc.system.name}`.
+
+### Required / Conditionally Required attributes
+
+| Attribute | Level | Notes |
+|---|---|---|
+| `rpc.system.name` | Required | `grpc`, `dubbo`, `connectrpc`, `jsonrpc`, … (client/server systems may legitimately differ for the same call) |
+| `rpc.method` | Cond. Required | If available; unrecognized methods **MUST** be set to `_OTHER`, with the original value preserved in `rpc.method_original` |
+| `error.type` | Cond. Required | On failure |
+| `rpc.response.status_code` | Cond. Required | If available (supersedes the old `rpc.grpc.status_code`) |
+| `server.address` / `server.port` | Cond. Required | If available |
+
+---
+
+## Exceptions
+
+**Stability: the span-event form is Deprecated; the log-record form is the current Stable recommendation.**
+Source: https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/ · https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-logs/
+
+- Recording exceptions as **span events** (event name `exception`) is deprecated: "Use Semantic conventions for exceptions in logs instead." `exception.escaped` is likewise deprecated — "It's no longer recommended to record exceptions that are handled and do not escape the scope of a span."
+- The current guidance: exceptions **SHOULD be recorded as attributes on the LogRecord** passed to `Logger` emit operations, not as span events.
+- Migration is gated by `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN`: `logs` = emit as logs only; `logs/dup` = emit both span events and logs during a phased rollout; default = keep emitting span events. Even after an instrumentation moves to logs-only emission, "users will still have the option to route those to span events at the SDK layer."
+- Attributes (same names/semantics in both forms):
+
+| Attribute | Level | Notes |
+|---|---|---|
+| `exception.type` | Cond. Required | Fully-qualified exception class name; required if `exception.message` unset |
+| `exception.message` | Cond. Required | Required if `exception.type` unset; may contain sensitive data |
+| `exception.stacktrace` | Recommended | Natural stack-trace string for the language runtime |
+
+- Instrumentations **should not** record artificial/synthetic exceptions manufactured by a framework purely to represent an error status code.
+
+---
+
+## Code
+
+**Stability: Stable.**
+Source: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/ · https://opentelemetry.io/docs/specs/semconv/non-normative/code-attrs-migration/
+
+| Attribute | Description |
+|---|---|
+| `code.function.name` | Fully-qualified function/method name **without arguments**, in the natural representation for the language runtime |
+| `code.file.path` | Source file identifying the code unit as uniquely as possible (prefer absolute path) |
+| `code.line.number` | Line in `code.file.path` best representing the operation; should point within the unit named by `code.function.name` |
+| `code.column.number` | Column in `code.file.path`, same "should point within" constraint |
+| `code.stacktrace` | Stack trace string in the language's natural representation; identical semantics to `exception.stacktrace` |
+
+Note: as of the v1.29.0 → v1.33.0 migration, the older separate `code.namespace` and `code.function` attributes were folded into the single `code.function.name` (which now carries the fully-qualified name). All `code.*` attributes are disallowed on Profile signals (redundant with data profiling already captures).
+
+---
+
+## Network, URL, Server, Client (general attributes)
+
+**Stability: Stable** for the attributes below (a few derived `url.*` sub-attributes are still Development, noted inline).
+Source: https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/ · https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/ · general attribute registry
+
+### `server.*` / `client.*`
+
+| Attribute | Description |
+|---|---|
+| `server.address` | Server domain name if resolvable without a reverse DNS lookup, else IP/socket. When observed client-side through an intermediary (proxy), **SHOULD** represent the real server behind it, if known |
+| `server.port` | Server port; same "behind the intermediary" preference as `server.address` |
+| `client.address` | Client address as observed by the server (may itself be a proxy) |
+| `client.port` | Client port as observed by the server |
+
+### `network.*`
+
+| Attribute | Description |
+|---|---|
+| `network.protocol.name` | OSI application layer or non-OSI equivalent (e.g. `http`, `amqp`); lowercase-normalized |
+| `network.protocol.version` | Actual (post-negotiation) protocol version in use |
+| `network.transport` | OSI transport layer / IPC method; lowercase-normalized |
+| `network.type` | OSI network layer or non-OSI equivalent; lowercase-normalized |
+| `network.peer.address` / `network.peer.port` | Peer (remote) address/port of the connection |
+| `network.local.address` / `network.local.port` | Local address/port of the connection |
+| `network.io.direction` | `transmit`/`receive`, from the observing host's perspective (Release Candidate) |
+
+Guidance: "Consider always setting the transport when setting a port number, since a port number is ambiguous without knowing the transport."
+
+### `url.*`
+
+| Attribute | Stability | Description |
+|---|---|---|
+| `url.scheme` | Stable | `https`, `ftp`, … |
+| `url.full` | Stable | Absolute URL (RFC3986); **MUST NOT** contain credentials; sensitive query params (`X-Amz-Signature`, `sig`, `X-Goog-Signature`, …) should be redacted |
+| `url.path` | Stable | URI path component; scrub sensitive content |
+| `url.query` | Stable | URI query component; same default redaction list as `url.full` |
+| `url.fragment` | Stable | URI fragment |
+| `url.template` | Development | Low-cardinality path template, e.g. `/users/{id}` |
+| `url.domain`, `url.port`, `url.registered_domain`, `url.subdomain`, `url.top_level_domain`, `url.extension` | Development | Derived sub-components parsed out of `url.full` |
+| `url.original` | Development | Unmodified original URL as seen at the source; may retain credentials (unlike `url.full`) |
+
+> **Maple hook:** these are the backbone of the HTTP domain above — our trace UI and ingest gateway's "new-semconv HTTP attributes" are built directly on `server.address`/`server.port`/`network.protocol.*`/`url.*` alongside `http.*`.
+
+---
+
+## Gen-AI
+
+**Stability: Development.** Note: gen-ai semantic conventions **moved out of the main spec** into a dedicated repository, `github.com/open-telemetry/semantic-conventions-genai` (the `opentelemetry.io/docs/specs/semconv/gen-ai/` pages now redirect/point there).
+Source: https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-spans.md
+
+### Span name
+
+- Inference spans: `{gen_ai.operation.name} {gen_ai.request.model}`
+- Retrieval spans: `{gen_ai.operation.name} {gen_ai.data_source.id}`
+- Individual GenAI systems/frameworks may define their own span-name format.
+
+### Required / Conditionally Required attributes
+
+| Attribute | Level | Notes |
+|---|---|---|
+| `gen_ai.operation.name` | Required | e.g. `chat`, `embeddings`, `retrieval` |
+| `gen_ai.provider.name` | Required | Provider identifier, e.g. `openai`, `anthropic`, `gcp.vertex_ai` (supersedes the deprecated `gen_ai.system`) |
+| `gen_ai.request.model` | Cond. Required | If available |
+| `gen_ai.response.model` | Cond. Required | If available; the actual model that served the response (may differ from the requested one) |
+| `gen_ai.usage.input_tokens` | Recommended | — |
+| `gen_ai.usage.output_tokens` | Recommended | — |
+| `error.type` | Cond. Required | Should match the provider's/client library's error code |
+
+Span kinds covered by the spec include Inference, Embeddings, Retrieval, Memory, and Execute-Tool spans. Migration is gated by `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` (opt into the newest experimental shape) vs. default (keep emitting whatever pre-1.36.0 shape was already in use) — the spec notes this transition plan will gain a genuine stable value once gen-ai conventions themselves stabilize.
+
+> **Maple hook:** relevant to our AI features — treat `gen_ai.*` as Development/pre-stable, expect attribute churn (`gen_ai.system` → `gen_ai.provider.name` already happened), and don't hard-code assumptions about the current attribute set without checking the genai repo for the version in use.
+
+---
+
+## Key references
+
+- Semconv spec home (v1.43.0): https://opentelemetry.io/docs/specs/semconv/
+- Attribute registry (searchable): https://opentelemetry.io/docs/specs/semconv/registry/attributes/
+- Naming rules: https://opentelemetry.io/docs/specs/semconv/general/naming/
+- Attribute requirement levels: https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/
+- Recording errors (span status): https://opentelemetry.io/docs/specs/semconv/general/recording-errors/
+- Tracing API span-naming rule: https://opentelemetry.io/docs/specs/otel/trace/api/
+- Versioning & stability levels: https://opentelemetry.io/docs/specs/otel/versioning-and-stability/
+- Telemetry schemas: https://opentelemetry.io/docs/specs/otel/schemas/
+- HTTP spans: https://opentelemetry.io/docs/specs/semconv/http/http-spans/ · HTTP metrics: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
+- HTTP stability migration guide: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/
+- Database spans: https://opentelemetry.io/docs/specs/semconv/db/database-spans/ · DB metrics: https://opentelemetry.io/docs/specs/semconv/db/database-metrics/
+- DB stability migration guide: https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/
+- Messaging spans: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+- RPC spans: https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/
+- Exceptions (spans, deprecated form): https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/ · Exceptions (logs, current form): https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-logs/
+- Code attributes: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/
+- Network attributes: https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/ · URL attributes: https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/
+- Gen-AI spans (moved repo): https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-spans.md
+- Source of truth (YAML model + all specs): https://github.com/open-telemetry/semantic-conventions

--- a/docs/otel-spec/stability-and-compliance.md
+++ b/docs/otel-spec/stability-and-compliance.md
@@ -1,0 +1,558 @@
+# Versioning, Stability & Compliance
+
+This document is the meta-spec reference: it covers how the OpenTelemetry
+specification itself defines maturity/stability, what "stable" legally forbids
+implementations from doing, the error-handling and performance principles
+every SDK/instrumentation must follow, and how to read the cross-language
+compliance matrix. Everything else in `docs/otel-spec/` (semconv, OTLP, etc.)
+inherits its stability guarantees from the concepts defined here.
+
+> **Spec version referenced:** OpenTelemetry Specification **v1.58.0**
+> (released 2026-06-22, per the
+> [specification CHANGELOG](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md)).
+> Stability language quoted below is current as of that release; re-check the
+> CHANGELOG's "Unreleased" section when bumping this doc.
+
+> [!NOTE] Relevance to Maple
+> Maple is primarily a **consumer/backend** of OTel data (Rust ingest gateway →
+> collector → ClickHouse/Tinybird → web dashboard), plus a **self-instrumented
+> emitter** of its own telemetry via `@effect/opentelemetry`. That means three
+> of the four stability domains below (API, SDK, telemetry/semconv) matter to
+> us mostly as *producers* (our own services) and the fourth (OTLP wire format)
+> matters as a *server implementor* (`apps/ingest` accepting arbitrary
+> upstream OTLP). We do not ship an OTel API/SDK for others to depend on, so
+> the API/SDK LTS clauses are not obligations we owe — they're read as
+> "what guarantees can we assume from the SDKs instrumenting the services that
+> send us data."
+
+---
+
+## 1. Four stability domains, disentangled
+
+The spec deliberately separates stability into independent domains that
+version and evolve on their own schedules. Conflating them is the most common
+compliance mistake.
+
+| Domain | What it governs | Governing doc | Versioning |
+|---|---|---|---|
+| **API stability** | Method signatures in `opentelemetry-api` packages (Tracer, Meter, Logger, Context, Propagators) | [Versioning and stability](https://opentelemetry.io/docs/specs/otel/versioning-and-stability/) | All stable API packages across all signals version together, one number, SemVer 2.0.0 |
+| **SDK stability** | Public SDK surface: plugin interfaces (`SpanProcessor`, `Exporter`, `Sampler`) and constructors/config/builders | Same doc, "SDK" sections | SDK packages for all signals version together, independently from API |
+| **Telemetry/semconv stability** | The *shape* of emitted telemetry (span/metric/log names, attribute keys) that a stable instrumentation produces | [Telemetry Stability](https://opentelemetry.io/docs/specs/otel/telemetry-stability/) | Semantic Conventions have their own single version number, independent of API/SDK |
+| **Wire (OTLP) stability** | The protobuf/JSON wire protocol between SDKs, collectors, and backends | OTLP protocol spec (see `docs/otel-spec` OTLP page if present) | Its own protocol version field, independent again |
+
+Each of these can be at a different maturity level simultaneously. For
+example, the Trace **API** has been Stable since v1.0.0, but a given
+**instrumentation library's telemetry** (e.g., HTTP semconv attribute names)
+can still be in `Development`/`Alpha` even while riding on top of a fully
+stable API and SDK. Maple's ingest gateway sees this directly: many spans
+we accept still carry `http.method`/`net.peer.name` (old semconv) alongside
+`http.request.method`/`server.address` (new semconv) because instrumentation
+libraries move through telemetry-stability transitions independently of their
+host language's API/SDK version.
+
+Source: https://opentelemetry.io/docs/specs/otel/versioning-and-stability/, https://opentelemetry.io/docs/specs/otel/telemetry-stability/
+
+---
+
+## 2. Signal lifecycle levels (spec-wide)
+
+The specification's versioning-and-stability doc defines the lifecycle a
+**signal** (Traces, Metrics, Logs, Profiles, Baggage) or a spec **feature**
+moves through:
+
+| Level | Guarantee | Notes |
+|---|---|---|
+| **Development** | None. "While signals are in development, breaking changes and performance issues MAY occur." | Not feature-complete; may be discarded entirely. Long-term dependencies discouraged. |
+| **Stable** | Backward compatible going forward. "Once a signal in Development has gone through rigorous testing, it MAY transition to Stable." | Long-term dependencies now permissible. Transition itself must not break existing users: "OpenTelemetry clients MUST NOT be designed in a manner that breaks existing users when a signal transitions from Development to Stable." |
+| **Deprecated** | Same support guarantees as Stable, but scheduled for removal. Requires a stable replacement to exist first. | |
+| **Removed** | Gone. "Support is ended by the removal of a signal from the release. The release MUST make a major version bump when this happens." | |
+
+Source: https://opentelemetry.io/docs/specs/otel/versioning-and-stability/
+
+### Document-level status markers (separate taxonomy)
+
+Individual **specification documents** (not signals) carry their own,
+more granular maturity marker at the top of the page — this is the taxonomy
+most relevant to reading any given spec page correctly:
+
+| Status | Guarantee | Exact language |
+|---|---|---|
+| **Development** | None; may be incomplete or unavailable. | "Bugs and performance issues are expected to be reported." Should not be used in production; may be removed without notice. |
+| **Alpha** | Usable for "limited non-critical production workloads." | Interfaces/config "can change often without backward compatibility." Component may be dropped anytime without warning. |
+| **Beta** | Interfaces "treated as stable whenever possible." | Breaking changes should be minimized between releases (still possible). |
+| **Release Candidate** | Feature-complete. | "Breaking changes, including configuration options and the component's output, are only allowed under special circumstances." |
+| **Stable** | General availability. | "Breaking changes ... are only allowed under special circumstances," with prior notice when possible. |
+| **Deprecated** | Frozen, sunset scheduled. | "Components that are included in distributions are expected to exist for at least two minor releases or six months." |
+| **Unmaintained** | No active code owner. | After six months in this state, may transition to Deprecated. |
+| *(no marker)* | Treated as **Alpha**. | Absence of a status is not "stable by default." |
+
+Documents whose sections carry differing statuses are labeled **"Mixed"** at
+the top — always check the per-section status inline, not just the doc
+banner, before treating any single paragraph as a stability guarantee.
+
+Source: https://opentelemetry.io/docs/specs/otel/document-status/
+
+**Practical rule for our compliance checks:** when citing a spec page as
+justification for a design decision, always record the status banner (and,
+for Mixed docs, the section-level status) alongside the citation — a
+"Development"-status paragraph is not a compliance requirement, it's a
+preview.
+
+---
+
+## 3. What "Stable" forbids — breaking-change policy
+
+### API packages
+
+> "Backward-incompatible changes to API packages MUST NOT be made unless the
+> major version number is incremented."
+>
+> "All existing API calls MUST continue to compile and function against all
+> future minor versions of the same major version."
+
+Languages that ship binaries should additionally provide **ABI compatibility**
+for API packages across minor versions.
+
+### SDK packages
+
+> "Public portions of SDK packages MUST remain backward compatible."
+
+"Public" is scoped to two categories:
+
+1. **Plugin interfaces** — `SpanProcessor`, `Exporter`, `Sampler`, and
+   equivalents. New methods may be *added* to these interfaces without a
+   major bump only if the host language allows it in a backward-compatible
+   way (e.g., default interface methods).
+2. **Constructors** — configuration objects, environment variables, builder
+   APIs.
+
+### Semantic conventions
+
+Semconv defines a *breaking change* as one that breaks "common usage of
+tooling written against the telemetry it produces" — a narrower, more
+practical bar than pure API compatibility. Two tiers:
+
+- **Allowed only via a published schema file** (so old→new transforms are
+  mechanical): renaming span/metric/log/resource attributes; renaming
+  metrics and span events.
+- **Always allowed, no schema needed**: adding new attributes to an existing
+  convention; adding entirely new conventions for resource/span/metric types
+  that didn't exist before.
+- **Prohibited outright**: anything else that would require inventing a new
+  schema transform format.
+
+### Deprecation process
+
+A signal/feature can only be marked Deprecated once a Stable replacement
+exists. Deprecated code retains full Stable-level support guarantees (no
+extra breakage) until formally Removed, which itself requires a major version
+bump.
+
+Source: https://opentelemetry.io/docs/specs/otel/versioning-and-stability/, https://opentelemetry.io/docs/specs/otel/telemetry-stability/
+
+---
+
+## 4. Versioning scheme
+
+- Follows **Semantic Versioning 2.0.0**.
+- **Independent version tracks:** all stable API packages (across every
+  signal) share one version number; all SDK packages share a separate one;
+  Semantic Conventions have their own single version number; contrib
+  packages version independently again. A major bump in one track does not
+  imply a bump in another.
+- **Major bump** required for: any breaking change to a stable interface, or
+  removal of a deprecated signal.
+- **Minor bump**: backward-compatible additions, changes to Development-level
+  signals, or a signal's maturity transition (e.g., Development → Stable).
+- **Patch bump**: "Make no changes which would require recompilation or
+  potentially break application code" — bug fixes, security fixes, docs only.
+
+### Long-term support (LTS)
+
+| Track | Minimum support window after next major release |
+|---|---|
+| API | 3 years |
+| SDK | 1 year |
+| Contrib | 1 year |
+
+During the API LTS window, the latest SDK minor version keeps receiving
+bug/security fixes, and contrib packages from that era keep receiving fixes
+too.
+
+Source: https://opentelemetry.io/docs/specs/otel/versioning-and-stability/
+
+---
+
+## 5. Error-handling principles (fail-safe requirements)
+
+These are the rules that should drive our best-practices skill's "never let
+telemetry take down the host app" checks — both for our own
+`@effect/opentelemetry` self-instrumentation and for anything we tell users
+to expect from well-behaved upstream SDKs sending us data.
+
+- **No unhandled exceptions, ever, at runtime:**
+  > "OpenTelemetry implementations MUST NOT throw unhandled exceptions at
+  > runtime." / "API methods MUST NOT throw unhandled exceptions when used
+  > incorrectly by end users."
+- **Fail-safe defaults over runtime failure:** implementations must "provide
+  safe defaults for missing or invalid arguments" instead of failing.
+- **Init-time failure is the one allowed exception:** libraries "MAY fail
+  fast and cause the application to fail on initialization" but "MUST NOT
+  cause the application to fail later at runtime." (I.e., blow up at startup
+  if misconfigured — never mid-request.)
+- **SDK internal errors are isolated:** SDKs "MUST NOT throw unhandled
+  exceptions for errors in their own operations" — e.g. an exporter's
+  connection to the collector dropping must not propagate into user code.
+- **Callback safety:** "API methods that accept external callbacks MUST
+  handle all errors" raised by those callbacks.
+- **No-op over null:** on suppressed error, implementations "MUST return a
+  'no-op' or any other 'default' object" rather than `null`/an exception.
+- **Self-diagnostics instead of silent failure:** "Whenever the library
+  suppresses an error that would otherwise have been exposed to the user,
+  the library SHOULD log the error using language-specific conventions."
+  Libraries are further "encouraged to expose self-troubleshooting metrics,
+  spans, and other telemetry that can be easily enabled and filtered out by
+  default."
+- **User override:** "SDK implementations MUST allow end users to change the
+  library's default error handling behavior for relevant errors."
+
+Source: https://opentelemetry.io/docs/specs/otel/error-handling/
+
+**Best-practice-skill translation:** any span/metric/log emission path we
+write (in `apps/api`, `apps/ingest`, or client SDKs we recommend) must never
+be able to throw past its call site into request-handling code; it should
+swallow-and-self-log instead. This is exactly the shape of our own
+`withTracerDisabledWhen` / OTLP-export-is-async design already documented in
+CLAUDE.md's Self-Observability section — that design *is* spec compliance
+with error-handling, not just an internal safety measure.
+
+---
+
+## 6. Performance / blocking guidance
+
+- **Non-blocking by default:** "Library should not block end user
+  application by default."
+- **Bounded memory:** "Library should not consume unbounded memory
+  resource." The spec explicitly frames overhead as a trade-off the
+  implementation must actively manage, not ignore: instrumentation "should
+  not degrade the end user application as possible."
+- **Under load, choose consciously between two failure modes:**
+  1. *Preserve everything, risk memory pressure* — "Preserve all information
+     but possible to consume many resources", or
+  2. *Bound memory, drop data* — "Dropping some information under
+     overwhelming load and show warning log to inform when information loss
+     starts and when recovered." This mode should have configurable
+     thresholds and ideally expose a metric approximating the effective
+     sampling ratio caused by the drops.
+- **Logs need their own filter valve:** "Logging could consume much memory
+  by default if the end user application emits too many logs" — the spec
+  says implementations should "provide a way to filter logs to capture by
+  OpenTelemetry" independent of the application's own logging volume.
+- **Shutdown/flush must be boundedly blocking:** "The OpenTelemetry client
+  could block the end user application when it shut down." Both `shutdown()`
+  and explicit `flush()` should "support user-configurable timeout."
+
+No concrete numeric overhead/allocation targets are specified — this is
+qualitative guidance only, left to each SDK's own benchmarking.
+
+Source: https://opentelemetry.io/docs/specs/otel/performance/
+
+**Maple-specific read:** `apps/ingest`'s WAL + async OTLP forward and its
+startup loopback guard are the kind of bounded-blocking / configurable-drop
+behavior this section calls for. Any new self-instrumentation on hot paths
+(e.g. per-request auth token validation, per-span-batch processing) should be
+checked against "does this block the request" and "is memory bounded under
+burst," not just "does it produce useful telemetry."
+
+---
+
+## 7. Library / instrumentation guidelines
+
+Two source documents cover this, one on general client design principles and
+one specifically on native instrumentation practice.
+
+### General client design (spec: library-guidelines)
+
+- **Depend on API only, never SDK:** "Libraries, frameworks, and applications
+  that want to be instrumented with OpenTelemetry take a dependency only on
+  the API packages." This is what lets a library be instrumented without
+  forcing a specific backend on its consumers.
+- **Negligible overhead is a design constraint, not an afterthought:** "It is
+  also important that minimal implementation incurs as little performance
+  penalty as possible, so that third-party frameworks and libraries that are
+  instrumented with OpenTelemetry impose negligible overheads..."
+- **Exporter package naming:** separately-published exporters should be
+  named with the `opentelemetry-exporter-{vendor_name}` pattern (prefixed
+  with "OpenTelemetry" and "Exporter").
+- This document explicitly does *not* cover span-granularity or attribute
+  hygiene — it defers to other spec sections (semantic conventions, API spec)
+  for that level of detail.
+
+Source: https://opentelemetry.io/docs/specs/otel/library-guidelines/
+
+### Native instrumentation practice (concepts: instrumentation/libraries)
+
+- **Why native over external hooks:** "Native library instrumentation with
+  OpenTelemetry provides better observability and developer experience for
+  users, removing the need for libraries to expose and document hooks."
+  Custom logging hooks get replaced by the common OTel API, and
+  traces/logs/metrics from library and application code end up "correlated
+  and coherent."
+- **Scope naming when you call `getTracer`/`getMeter`/`getLogger`:** "When
+  obtaining the tracer, provide your library (or tracing plugin) name and
+  version: they show up on the telemetry and help users process and filter
+  telemetry." Example: `getTracer("demo-db-client", "0.1.0-beta1")`.
+- **Pin to the earliest stable API:** "Use the earliest stable OpenTelemetry
+  API (1.0.*) and avoid updating it unless you have to use new features" —
+  minimizes forced version churn for consumers of the instrumented library.
+- **Register it:** "Add your instrumentation library to the OpenTelemetry
+  registry so users can find it."
+
+### Instrumentation Scope — identity and naming (concepts: instrumentation-scope)
+
+An Instrumentation Scope is "a logical unit of software with which emitted
+telemetry is associated. It can represent a module, package, class, library,
+or framework." It is identified by a `(name, version, schema_url,
+attributes)` tuple — only `name` is required, and "the `name` should uniquely
+identify the logical unit of software — for example, the fully qualified name
+of a library, class, or module."
+
+Naming guidance by situation:
+
+| Situation | Convention | Example |
+|---|---|---|
+| Library/framework with native instrumentation | Library's own fully qualified name + version | — |
+| Third-party library, no native support (external instrumentation library) | Fully qualified name/version of the *instrumentation* library itself, often reverse-DNS | `io.opentelemetry.contrib.mongodb`, `io.opentelemetry.instrumentation.flask` |
+| OpenTelemetry-hosted contrib instrumentation | `opentelemetry-instrumentation-<instrumented-lib>` package-name prefix | `opentelemetry-instrumentation-flask` |
+| Application-level code (not a library) | Class or module name | `CheckoutService` |
+
+Every span/metric/log record produced by a given tracer/meter/logger
+instance is tagged with that instance's scope — this is what lets backends
+group/filter telemetry by originating component and compare across library
+versions.
+
+Source: https://opentelemetry.io/docs/specs/otel/library-guidelines/, https://opentelemetry.io/docs/concepts/instrumentation/libraries/, https://opentelemetry.io/docs/concepts/instrumentation-scope/
+
+**Maple-specific read:** our own service names already follow the spec's
+identity model at the *Resource* level (`service.name="ingest"`,
+`service.version`, `service.instance.id` — see CLAUDE.md's
+Self-Observability section). Instrumentation Scope is the finer-grained
+sibling of that: if we ever split internal tracer usage across modules
+inside `apps/api` (e.g. a distinct tracer for the alerting service vs. the
+query engine), each should get its own scope name (e.g.
+`maple.alerting`, `maple.query-engine`) and version, not one blanket
+service-wide tracer — so dashboard users can filter by component the same
+way they filter by service.
+
+---
+
+## 8. Telemetry stability guarantees (semconv-adjacent, distinct from API/SDK)
+
+This document governs **the shape of telemetry emitted by instrumentations**
+specifically — a different axis from API/SDK code stability.
+
+- **Unstable instrumentations:** no guarantees at all. "Unstable
+  instrumentations provide no guarantees about the shape of the telemetry
+  they produce and how that shape changes over time."
+- **Stable instrumentations** split into two sub-cases:
+  - **Fixed-schema producers** (stable, but no Schema URL attached to their
+    telemetry): "Such instrumentations are prohibited from changing any
+    produced telemetry" — full stop, even to adopt a newer semconv release,
+    unless they migrate to schema-file-driven status.
+  - **Schema-file-driven producers** (stable, Schema URL attached): as of the
+    fetched page, this path is **under moratorium** — currently held to the
+    same no-change restriction as fixed-schema producers. Once the
+    moratorium lifts, changes become allowed only if they (a) match a
+    released OTel semconv version, (b) ship a corresponding published schema
+    file, and (c) correctly update the Schema URL.
+- **Universally allowed regardless of tier:** "Adding of new metrics, spans,
+  span events or log records and adding of new attributes."
+
+Source: https://opentelemetry.io/docs/specs/otel/telemetry-stability/
+
+**Why this matters for our ingest gateway specifically:** because
+telemetry-shape stability is decoupled from API/SDK stability, a
+long-since-1.0 SDK can still be emitting spans whose attribute names are
+mid-migration (old vs. new HTTP semconv, for instance). Maple's ingest path
+and ClickHouse materialized views (`service_overview_spans_mv`, etc.) already
+coalesce legacy and current attribute spellings for this exact reason — see
+CLAUDE.md's note on dual-emitting `deployment.environment.name`/
+`deployment.environment`. That coalescing logic is not a hack; it's the
+correct way to consume telemetry from instrumentations that are Stable at the
+API level but still transitioning at the telemetry-shape level.
+
+### Schema URL / Telemetry Schema mechanics
+
+A **Schema URL** identifies a **Schema File** — a YAML document describing
+one version of a Schema Family, plus the transforms needed to convert older
+compatible telemetry in that family up to this version. Mechanically:
+
+- The URL's last path segment is the schema version; everything before it is
+  the **Schema Family identifier** — all schema versions in one family share
+  that prefix.
+- Fetchers **must** follow HTTP redirects when resolving a Schema URL.
+- In OTLP, `schema_url` on `ResourceSpans`/`ResourceMetrics`/`ResourceLogs`
+  applies to the contained `Resource` and its spans/metrics/logs; a
+  scope-level `schema_url` (on `ScopeSpans`/`ScopeMetrics`/`ScopeLogs`, the
+  successor to the deprecated `InstrumentationLibrarySpans` etc.) applies
+  only to the contained telemetry items for that scope.
+- The whole mechanism exists for one narrow purpose: "to allow OpenTelemetry
+  Semantic Conventions to evolve over time" without breaking consumers who
+  pin to an older schema version.
+
+Source: https://opentelemetry.io/docs/specs/otel/schemas/, https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/schemas/README.md
+
+---
+
+## 9. Glossary — terms load-bearing for this doc
+
+| Term | Definition | Source |
+|---|---|---|
+| **Signal** | "OpenTelemetry is structured around signals, or categories of telemetry. Metrics, logs, traces, profiles, and baggage are examples of signals." | [Glossary](https://opentelemetry.io/docs/specs/otel/glossary/) |
+| **Instrumented Library** | "The library for which the telemetry signals (traces, metrics, logs) are gathered." | [Glossary](https://opentelemetry.io/docs/specs/otel/glossary/) |
+| **Instrumentation Library** | "The library that provides the instrumentation for a given Instrumented Library. Instrumented Library and Instrumentation Library may be the same library if it has built-in OpenTelemetry instrumentation." | [Glossary](https://opentelemetry.io/docs/specs/otel/glossary/) |
+| **Instrumentation Scope** | "A logical unit of software with which emitted telemetry is associated. It can represent a module, package, class, library, or framework." Identified by `(name, version, schema_url, attributes)`. | [Instrumentation Scope concept](https://opentelemetry.io/docs/concepts/instrumentation-scope/) |
+| **Telemetry SDK** | "The library that implements the OpenTelemetry API." | [Glossary](https://opentelemetry.io/docs/specs/otel/glossary/) |
+| **Manual Instrumentation** | "Coding against the OpenTelemetry API to collect telemetry from end user code or shared frameworks." | [Glossary](https://opentelemetry.io/docs/specs/otel/glossary/) |
+| **Automatic Instrumentation** | "Telemetry collection methods that do not require the end user to modify application's source code." | [Glossary](https://opentelemetry.io/docs/specs/otel/glossary/) |
+| **Schema URL** | Identifier for a Schema File; last path segment is the version, the prefix is the Schema Family identifier; resolution must follow redirects. | [Telemetry Schemas](https://opentelemetry.io/docs/specs/otel/schemas/) |
+| **Telemetry Schema** | "The expected shape and composition of emitted telemetry data," versioned so Semantic Conventions can evolve without breaking pinned consumers. | [Telemetry Schemas](https://opentelemetry.io/docs/specs/otel/schemas/) |
+
+Note: the canonical glossary page does not itself define Resource, Baggage,
+Sampler, or Context Propagation with standalone entries — those are defined
+in their respective spec sections (Resource SDK spec, Baggage API spec,
+Trace SDK spec, Context API spec) rather than the glossary. Treat the
+glossary as authoritative only for the terms actually listed on it.
+
+Source: https://opentelemetry.io/docs/specs/otel/glossary/
+
+---
+
+## 10. The spec compliance matrix — how to read it
+
+The living source of truth for "does implementation X support feature Y" is:
+
+**https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md**
+
+Structure (do not copy the matrix itself — it changes frequently; always
+link and re-fetch):
+
+- **Rows** are individual spec requirements/features, grouped under section
+  headers for the major component areas:
+  1. **Traces** — TracerProvider ops, context interaction, Tracer ops,
+     SpanContext, span creation/lifecycle, attributes, links, events,
+     exceptions, sampling, ID generation.
+  2. **Baggage** — basic support, header naming.
+  3. **Metrics** — MeterProvider, Meter ops, instrument types, Views,
+     aggregations, exemplars, cardinality limits.
+  4. **Logs** — LoggerProvider, Logger ops, LogRecord handling, processors.
+  5. **Resource** — creation, merging, detection.
+  6. **Context Propagation** — Context management, composite propagators,
+     standard propagators (TraceContext, B3, Jaeger, OpenCensus).
+  7. **Environment Variables** — `OTEL_*` configuration knobs.
+  8. **Declarative Configuration** — YAML-based SDK setup.
+  9. **Exporters** — stdout, in-memory, OTLP, Zipkin, Prometheus
+     compatibility.
+- **Columns** are per-language implementations: Go, Java, JavaScript, Python,
+  Ruby, Erlang, PHP, **Rust**, C++, .NET, Swift, Kotlin.
+- **Legend:** `+` supported, `-` unsupported, `N/A` not applicable, blank =
+  unknown/unreported. An **Optional** column marks features with `X` when a
+  feature is optional rather than required — unmarked rows are required for
+  a language to claim compliance.
+
+**Caveats relevant to Maple's stack:**
+- **Rust** has its own column (relevant to `apps/ingest`) — but note the
+  matrix tracks *SDK/client* conformance (an implementation emitting
+  telemetry), not *server/collector* conformance (accepting OTLP). Our
+  ingest gateway is architecturally closer to an OTLP *receiver* than to any
+  row in this matrix — the matrix doesn't directly grade us, but it's the
+  right place to check what guarantees we can assume from Rust-instrumented
+  services sending us data.
+- **JavaScript** is the column that governs `@effect/opentelemetry`'s
+  underlying `@opentelemetry/sdk-*` dependencies (apps/web, apps/api on
+  Workers). There is no separate "Bun" column — Bun is a JS runtime, so it
+  inherits the JavaScript column's conformance status; any Bun-specific gaps
+  (e.g. Workers-runtime clock/timer quirks — see the `workerd-trace-timestamp-bug`
+  memory entry) are Bun/workerd runtime bugs, not spec non-compliance, and
+  won't show up in this matrix.
+- The matrix is **self-reported per language SIG** and updated
+  asynchronously from actual releases — treat a blank cell as "unverified,"
+  not "unsupported."
+
+Source: https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md
+
+---
+
+## 11. How Maple should use this spec
+
+**(a) The ingest gateway as an OTLP server.** `apps/ingest` is not a client
+SDK, so most of Sections 1–4 (API/SDK versioning obligations) don't bind us
+directly. What does bind us:
+- **Error-handling principles (Section 5) apply symmetrically to servers.**
+  A malformed/oversized/undecodable payload from a misbehaving client must
+  never crash the gateway — this is already implemented via the documented
+  4xx-vs-5xx `otel_status_for_rejection` split (only 5xx sets span status to
+  `Error`; auth/billing/throttle/payload 4xx rejections stay `Ok` but fully
+  observable via `http.response.status_code`/`error.type`). That design *is*
+  the fail-safe-defaults principle applied to a receiver role.
+- **Performance/blocking guidance (Section 6)** governs the WAL + async
+  forward design and the startup loopback guard — bounded memory and
+  non-blocking behavior under load are exactly what the spec calls out.
+- **Telemetry-shape stability (Section 8)** is why we must tolerate mixed
+  old/new semantic conventions in inbound payloads indefinitely — clients
+  are never obligated to be on the latest semconv, and "Stable" telemetry
+  producers are largely frozen at whatever shape they shipped. Schema-URL
+  coalescing (Section 8's mechanism) is the spec-sanctioned way to handle
+  this, and is exactly what our materialized views already do by convention
+  even though we don't yet key off literal `schema_url` values.
+
+**(b) Our self-instrumentation.** When `apps/ingest`, `apps/api`, or any new
+service adds tracing:
+- Use **Instrumentation Scope naming** (Section 7) deliberately — one scope
+  per logical component (e.g. `maple.ingest`, `maple.alerting`), not one
+  global tracer, so the scope tuple is actually useful for filtering.
+- New spans on hot/high-frequency paths must be justified against the
+  performance guidance (Section 6) — non-blocking, bounded memory, and ideally
+  covered by the existing `withTracerDisabledWhen` pattern for noisy paths.
+  CLAUDE.md's explicit warning not to remove that filter, and to be careful
+  adding spans to auth-token validation, is a direct application of Section 6.
+- Any place we might swallow/re-throw telemetry-related errors should follow
+  Section 5 exactly: log-and-continue, never propagate into request handling,
+  never let OTLP export failures affect the response to the end user (already
+  true today since export is async and bypasses the API entirely per
+  CLAUDE.md).
+
+**(c) The UI's interpretation of data.** The dashboard trusts specific
+semconv-adjacent contracts as if they were part of the wire stability
+guarantee (Section 1's fourth domain) — e.g., **span status codes** should be
+title case (`"Ok"`, `"Error"`, `"Unset"`) per Maple's own data convention, and
+error-rate dashboards filter strictly on `StatusCode='Error'`. Per Section 5's
+"only 5xx is Error" SERVER-span rule, the UI's error dashboards are implicitly
+depending on upstream instrumentations following that exact OTEL HTTP
+semconv status-mapping rule. If an upstream SDK sets status to `Error` for a
+4xx (a spec violation, or simply an older/nonconforming instrumentation), our
+dashboards will over-count errors — this is a real spec-compliance risk
+surface worth a validation/lint pass on ingest, not just a UI concern. More
+generally: any dashboard heuristic that assumes "stable telemetry never
+changes shape" (Section 8) is safe **only** for genuinely Stable, fixed-schema
+producers — Alpha/Beta/Development-status instrumentations (the document
+status ladder in Section 2) can and will change attribute names under us
+without notice, and the UI/query layer should degrade gracefully (missing
+attribute → omit facet, not crash) rather than assume presence.
+
+---
+
+## Key references
+
+- Versioning and stability — https://opentelemetry.io/docs/specs/otel/versioning-and-stability/
+- Document status (Development/Alpha/Beta/RC/Stable/Deprecated/Unmaintained) — https://opentelemetry.io/docs/specs/otel/document-status/
+- Telemetry stability guarantees — https://opentelemetry.io/docs/specs/otel/telemetry-stability/
+- Error handling principles — https://opentelemetry.io/docs/specs/otel/error-handling/
+- Performance and blocking guidance — https://opentelemetry.io/docs/specs/otel/performance/
+- Library guidelines (client design principles) — https://opentelemetry.io/docs/specs/otel/library-guidelines/
+- Native instrumentation for libraries — https://opentelemetry.io/docs/concepts/instrumentation/libraries/
+- Instrumentation Scope concept — https://opentelemetry.io/docs/concepts/instrumentation-scope/
+- Telemetry Schemas — https://opentelemetry.io/docs/specs/otel/schemas/ and https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/schemas/README.md
+- Glossary — https://opentelemetry.io/docs/specs/otel/glossary/
+- Spec compliance matrix (living source, re-fetch before relying on cell values) — https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md
+- Specification CHANGELOG (version history) — https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md

--- a/docs/otel-spec/traces.md
+++ b/docs/otel-spec/traces.md
@@ -1,0 +1,801 @@
+# Tracing (API & SDK)
+
+This page documents the OpenTelemetry **Tracing** specification: the Trace API (`TracerProvider`,
+`Tracer`, `Span`, `SpanContext`), the Trace SDK (samplers, span processors, span limits, ID
+generators, the `SpanExporter` interface), and the normative rules a spec-compliant tracing
+implementation (or a backend that consumes its output) must honor. Every claim below is sourced
+from the official specification — see inline `Source:` links — and each section states the
+stability level the spec itself declares (Stable / Development / Deprecated), because normative
+strength differs materially by level (only Stable sections are locked against breaking change).
+
+## Relevance to Maple
+
+> Maple is primarily a **consumer/backend** of OTel trace data (Rust `apps/ingest` OTLP gateway →
+> collector → ClickHouse/Tinybird → web dashboard), plus a **self-instrumented emitter** of its own
+> traces (`@effect/opentelemetry` in the API/alerting/chat-agent workers, and `apps/ingest`'s own
+> Rust OTLP self-instrumentation — see CLAUDE.md "Self-Observability"). Both angles are why this
+> spec matters:
+>
+> - **As a consumer/backend:** we must defensively parse whatever a compliant (or non-compliant)
+>   SDK emits. Key invariants to enforce or tolerate: `TraceId`/`SpanId` validity (all-zero = invalid,
+>   §[SpanContext](#spancontext)), the `Sampled`/`IsRecording` combination that must never reach us
+>   (`Sampled=true, IsRecording=false` is spec-forbidden — §[Sampling](#sampling-sdk)), `StatusCode`
+>   ordering (`Ok > Error > Unset`, and `Description` is only meaningful on `Error` —
+>   §[Status](#set-status)), and the 5 `SpanKind` values that drive our service-map/flamegraph
+>   parent-child inference (§[SpanKind](#spankind)). Maple stores span status as title-case
+>   `"Ok"`/`"Error"`/`"Unset"` strings (see CLAUDE.md "Data Conventions"), which matches the spec's
+>   enum spelling directly — but the OTLP wire encoding uses a different, uppercase enum
+>   (`STATUS_CODE_OK` / `STATUS_CODE_ERROR` / `STATUS_CODE_UNSET`); our ingest/collector mapping
+>   layer is the one place that translation must stay correct.
+> - **As a self-instrumented emitter:** our own services configure `BatchSpanProcessor` knobs,
+>   samplers (`OTEL_TRACES_SAMPLER` / `_ARG`), and span limits via the env vars in
+>   §[Span Limits](#span-limits) and §[Span Processor](#span-processor-sdk). The
+>   `withTracerDisabledWhen` health-check filter and the `workerd` monotonic-clock timestamp bug
+>   (see MEMORY.md) are both examples of us needing to reason precisely about `Span` start/end
+>   timestamp semantics (§[Span](#span)) and `OnStart`/`OnEnd` processor timing
+>   (§[Span Processor](#span-processor-sdk)).
+> - **Links added after span start** (§[Add Link](#add-link)) and **attributes preferred at
+>   creation** (§[Span Creation](#span-creation)) matter for our own instrumentation code review:
+>   sampling can only ever see what was present at span-start time.
+
+---
+
+## 1. Scope and stability
+
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/ ,
+https://opentelemetry.io/docs/specs/otel/trace/sdk/
+
+Both the Trace API spec and the Trace SDK spec carry the document-level banner:
+
+> "**Status**: Stable, except where otherwise specified"
+
+This means: unless a specific subsection is explicitly marked otherwise, treat it as **Stable**
+(locked against breaking changes). A number of subsections — mostly newer extension points — are
+explicitly marked **Development** (pre-release, can still change) inline; these are called out
+throughout this doc. `TraceIdRatioBased`'s *configuration/creation* API is Stable, but its
+*algorithm* compatibility is separately flagged (see §[Samplers](#samplers)). No section in either
+document is marked **Experimental** or **Deprecated** at time of writing (2026), though
+`TraceIdRatioBased` is textually described as "deprecated in favor of" `ProbabilitySampler` (a
+**Development**-status component) — see §[Samplers](#samplers) for the exact deprecation timeline
+language.
+
+---
+
+## 2. SpanContext
+
+**Stability: Stable.**
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#spancontext
+
+A `SpanContext` is the serializable portion of a `Span` — the part that must be propagated across
+process boundaries. `SpanContext`s are **immutable**. The representation conforms to the
+[W3C TraceContext spec](https://www.w3.org/TR/trace-context/).
+
+| Field | Rule |
+| --- | --- |
+| `TraceId` | 16-byte array; **valid** iff it has at least one non-zero byte (all-zero = invalid) |
+| `SpanId` | 8-byte array; **valid** iff it has at least one non-zero byte (all-zero = invalid) |
+| `TraceFlags` | Present on every span context (unlike `TraceState`). Currently defines two flags: `Sampled` ([W3C sampled flag](https://www.w3.org/TR/trace-context-2/#sampled-flag)) and `Random` ([W3C random-trace-id flag](https://www.w3.org/TR/trace-context-2/#random-trace-id-flag)) |
+| `TraceState` | List of tracing-system-specific key-value pairs; lets multiple tracing systems co-participate in one trace; fully defined by [W3C `tracestate`](https://www.w3.org/TR/trace-context-2/#tracestate-header) |
+| `IsRemote` | Boolean — was this `SpanContext` received from another process, or locally generated? |
+
+Normative rules:
+
+- The API **MUST** implement methods to create a `SpanContext`, and these **SHOULD** be the only
+  way to create one; this "MUST be fully implemented in the API, and SHOULD NOT be overridable."
+- **Retrieving TraceId/SpanId:** the API **MUST** allow retrieval in hex (32-hex-char lowercase
+  string for `TraceId`, 16-hex-char lowercase for `SpanId`) and binary (16-byte / 8-byte array)
+  forms. The API **SHOULD NOT** expose how they are stored internally.
+- **`IsValid`**: "MUST be provided," returns `true` iff both `TraceId` and `SpanId` are non-zero.
+- **`IsRemote`**: "MUST be provided." When a `SpanContext` is extracted via the Propagators API,
+  `IsRemote` **MUST** return `true`; for any child span's own context it **MUST** return `false`.
+- **`TraceState` operations** — the API **MUST** provide: get value for key, add key-value pair,
+  update existing value, delete pair. All mutating operations **MUST** return a new immutable
+  `TraceState`; all must validate their inputs and **MUST NOT** return a `TraceState` containing
+  invalid data on invalid input (follow "general error handling guidelines" instead). Because
+  `SpanContext` is immutable, a new `TraceState` can only take effect at
+  [propagation](https://opentelemetry.io/docs/specs/otel/context/api-propagators/) or
+  [export](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-exporter) time — propagators
+  and exporters may create a modified copy right before serializing to the wire.
+
+---
+
+## 3. Span
+
+**Stability: Stable** (see §[Span Creation](#span-creation) for one Development-status nuance
+inherited from the SDK's `TracerConfig`).
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#span
+
+A `Span` represents a single operation within a trace; spans nest into a trace tree with one root
+span per trace. A `Span` encapsulates: name, an immutable `SpanContext`, a parent (`Span` /
+`SpanContext` / null), `SpanKind`, start/end timestamps, `Attributes`, a list of `Link`s, a list of
+timestamped `Event`s, and a `Status`.
+
+**Span name:** "the most general string that identifies a (statistically) interesting *class of
+Spans*" rather than a per-instance identifier — generality is prioritized over human-readability
+(e.g. `get_account` is good; `get_account/42` is not, due to cardinality; `get_account/{accountId}`
+is also acceptable using the HTTP-route form).
+
+**Timestamps:** "A `Span`'s start and end timestamps reflect the elapsed real time of the
+operation." Start time **SHOULD** default to span-creation time. After creation it **SHOULD** be
+possible to change the name, set attributes, add events, and set status — but none of these
+**MUST** be changed after the end timestamp has been set.
+
+**Isolation from application logic:** Spans are not meant to propagate information within a
+process; implementations **SHOULD NOT** expose a `Span`'s own attributes/events/etc. back to the
+user (only its `SpanContext` is retrievable). Vendors may implement `Span` for vendor-specific
+logic, but alternative implementations **MUST NOT** allow callers to create `Span`s directly — all
+`Span`s **MUST** be created via a `Tracer`.
+
+### Span Creation
+
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#span-creation
+
+- There **MUST NOT** be any API for creating a `Span` other than via a `Tracer`.
+- In languages with implicit context propagation, span creation **MUST NOT** set the new span as
+  the active span in the current `Context` by default (MAY be offered as a separate operation).
+- Required/accepted parameters:
+  - **Name** — required.
+  - **Parent `Context`** or an explicit "root span" indication. The API **MUST NOT** accept a
+    `Span` or `SpanContext` directly as parent — only a full `Context`. (See
+    [Determining the Parent Span from a Context](#determining-the-parent-span-from-a-context).)
+  - **`SpanKind`** — defaults to `SpanKind.Internal` if unspecified.
+  - **`Attributes`** — empty collection assumed if not given. "The API documentation MUST state
+    that adding attributes at span creation is preferred to calling `SetAttribute` later, as
+    samplers can only consider information already present during span creation."
+  - **`Link`s** — an ordered sequence, see §[Link](#link).
+  - **Start timestamp** — defaults to current time; "SHOULD only be set when span creation time
+    has already passed" (i.e. don't pass "now" explicitly).
+- Root spans: "Implementations MUST provide an option to create a `Span` as a root span, and MUST
+  generate a new `TraceId` for each root span created." For a non-root span, `TraceId` **MUST**
+  match the parent's, and the child **MUST** inherit all of the parent's `TraceState` values by
+  default.
+- A `Span` is said to have a **remote parent** if it's a child of a span created in another
+  process; each propagator's deserialization must set `IsRemote=true` on that parent `SpanContext`.
+- "Any span that is created MUST also be ended. This is the responsibility of the user." (Failing
+  to end a span MAY leak memory/resources in the implementation.)
+
+#### Determining the Parent Span from a Context
+
+If the input `Context` contains a `Span`, that is the parent; if not, the new span is a root span.
+A bare `SpanContext` cannot be set active in a `Context` directly — it must first be
+[wrapped in a (non-recording) Span](#wrapping-a-spancontext-in-a-span).
+
+#### Specifying links
+
+"During Span creation, a user MUST have the ability to record links to other Spans" (same or
+different trace). "Links added at Span creation may be considered by Samplers to make a sampling
+decision" — a capability links added later do not have (see §[Add Link](#add-link)).
+
+### Span operations
+
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#span-operations
+
+"With the exception of the function to retrieve the Span's SpanContext and `IsRecording`, none of
+the below may be called after the Span is finished."
+
+| Operation | Key normative rule |
+| --- | --- |
+| **Get Context** | MUST return the `SpanContext`; usable even after the span ends; MUST be the same value for the entire span lifetime. MAY be called `GetContext`. |
+| **IsRecording** | See dedicated subsection below. |
+| **Set Attributes** | MUST provide a single-attribute setter (`SetAttribute`); MAY provide a batch setter. Duplicate keys overwrite. Samplers only ever see attributes present at creation time — later changes can't affect their decision. |
+| **Add Events** | MUST provide `AddEvent(name, attributes?, timestamp?)`; timestamp defaults to call time if omitted. Events SHOULD preserve recording order (may differ from timestamp order if custom timestamps are used out-of-order). An event's timestamp may legally fall before span start / after span end — no normalization is required. |
+| **Add Link** | MUST support adding links post-creation (see §[Add Link](#add-link)) — but these "may not be considered by Samplers." |
+| **Set Status** | See §[Set Status](#set-status). |
+| **UpdateName** | Changes span name post-creation; sampling behavior thereafter is implementation-defined, since samplers can't retroactively reconsider. |
+| **End** | See dedicated subsection below. |
+| **Record Exception** | Language-specific specialization of `AddEvent` for exceptions (see below). |
+
+#### IsRecording
+
+"A `Span` is recording (`IsRecording` returns `true`) when the data provided to it via functions
+like `SetAttributes`, `AddEvent`, `SetStatus` is captured in some form (e.g. in memory). When a
+`Span` is not recording ... all this data is discarded right away." Further calls become no-ops.
+
+Critically: **"This flag may be `true` despite the entire trace not being sampled."** This lets a
+system record/process all spans locally (e.g. for SLA/SLO latency charts) while only exporting a
+sampled subset to the backend — see §[Sampling](#sampling-sdk) for the full `IsRecording` ×
+`Sampled` matrix.
+
+"After a `Span` is ended, it SHOULD become non-recording and `IsRecording` SHOULD always return
+`false`" (streaming implementations without local state are the one documented exception).
+`IsRecording` **SHOULD NOT** take parameters and **SHOULD** be used to skip expensive attribute/event
+computation when a span isn't recording. A child span's own recording state is independent of its
+parent's `IsRecording` value (it's driven by the `Sampled` flag on `SpanContext` instead).
+"Users of the API should only access the `IsRecording` property when instrumenting code and never
+access `SampledFlag` unless used in context propagators."
+
+#### Set Status
+
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#set-status
+
+Overrides the default `Unset` status. `Status` = `{ StatusCode, Description? }`.
+`Description` **MUST** only be used with `StatusCode=Error` (an empty description is treated as
+absent); it **MUST be ignored** for `Ok`/`Unset`.
+
+| `StatusCode` | Meaning |
+| --- | --- |
+| `Unset` | The default status. |
+| `Ok` | "The operation has been validated by an Application developer or Operator to have completed successfully." |
+| `Error` | The operation contains an error. |
+
+These "form a total order: `Ok > Error > Unset`" — setting `Ok` overrides any prior *or future*
+attempt to set `Error`/`Unset`. Additional rules:
+
+- An attempt to set `Unset` explicitly **SHOULD** be ignored.
+- When Instrumentation Libraries set `Error`, the `Description` **SHOULD** be documented and
+  predictable, and the decision to set `Error` at all **should only follow semantic-convention
+  rules** (or the library's own published conventions if none exist for that operation).
+- "Generally, Instrumentation Libraries SHOULD NOT set the status code to `Ok`, unless explicitly
+  configured to do so." They **SHOULD** leave status `Unset` absent an error.
+- Only **Application developers and Operators** (i.e., end-user code, not instrumentation
+  libraries) are expected to set `Ok`.
+- Once `Ok` is set it **SHOULD** be considered final; further changes **SHOULD** be ignored.
+- "Analysis tools SHOULD respond to an `Ok` status by suppressing any errors they would otherwise
+  generate" (e.g. suppressing a noisy 404-as-error).
+- "Only the value of the last call will be recorded" — implementations are free to ignore earlier
+  `SetStatus` calls when a later, permitted one arrives.
+
+> **Maple note:** the spec's enum spelling (`Unset`/`Ok`/`Error`) is exactly the title-case string
+> Maple stores (CLAUDE.md: "Span Status Codes: Use title case"). The OTLP wire proto uses a
+> *different*, uppercase, prefixed spelling — `STATUS_CODE_UNSET` / `STATUS_CODE_OK` /
+> `STATUS_CODE_ERROR` (see the
+> [OTLP trace.proto `Status.StatusCode`](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto)).
+> The API spec explicitly notes the OTLP proto refers to `Description` as `message`. Any ingest
+> mapping code translating OTLP → Maple's internal representation is the seam where this spelling
+> difference must be handled once and consistently.
+
+#### End
+
+"Signals that the operation described by this span has now (or at the time optionally specified)
+ended." Implementations **SHOULD** ignore subsequent calls to `End` or any other span method — the
+span becomes non-recording once ended (streaming exceptions noted above). Other end-triggering
+language sugar (e.g. Python `with`) **MUST** internally call `End` and be documented as such.
+
+- **`End` MUST NOT affect child spans** — they may still be running and end later independently.
+- **`End` MUST NOT inactivate the span in any `Context`** it's active in — an ended span remains
+  usable as a parent via that context, and any Context-attachment mechanism must keep working.
+- Optional parameter: explicit end timestamp; if omitted, treated as "now."
+- Performance: "Expect this operation to be called in the hot path of production applications. It
+  needs to be designed to complete fast, if not immediately." `End` itself **MUST NOT** perform
+  blocking I/O on the calling thread, and locking should be minimized/eliminated where possible
+  (downstream test/debug-only processors/exporters are explicitly out of scope for this
+  requirement).
+
+#### Record Exception
+
+Languages that use exceptions **SHOULD** provide `RecordException` as a specialized `AddEvent` —
+same requirements as `AddEvent` apply except where overridden here. The minimum required argument
+**SHOULD** be just the exception object; an optional parameter for additional attributes **MUST**
+be accepted if the method exists (existing conventional attributes take precedence over duplicates
+supplied this way).
+
+### Span lifetime
+
+"Start and end time as well as Event's timestamps MUST be recorded at [the] time of ... calling of
+[the] corresponding API" — i.e., timestamps reflect the moment the API call happens (or an
+explicit override), not some other clock.
+
+### Wrapping a SpanContext in a Span
+
+The API **MUST** provide an operation wrapping a bare `SpanContext` as a `Span` (for in-process
+propagation scenarios, e.g. propagator extraction). If a new type is needed for this, it **SHOULD
+NOT** be publicly exposed if avoidable; if it must be, it **SHOULD** be named `NonRecordingSpan`.
+Behavior:
+
+- `GetContext` **MUST** return the wrapped `SpanContext`.
+- `IsRecording` **MUST** return `false`.
+- All remaining `Span` methods **MUST** be no-ops — including `End` (so, as the one exception to
+  "every span must be ended," it's not required, or even useful, to end a wrapped context).
+
+This "MUST be fully implemented in the API, and SHOULD NOT be overridable."
+
+---
+
+## 4. SpanKind
+
+**Stability: Stable.**
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#spankind
+
+`SpanKind` communicates two independent properties for analysis tooling: (1) outgoing-remote-call
+vs. incoming-external-request, and (2) request/response vs. deferred execution. "In order for
+`SpanKind` to be meaningful, callers SHOULD arrange that a single Span does not serve more than one
+purpose" — e.g. a server-handling span should not double as the span for an outgoing RPC it makes;
+instrumentation should start a *new* span before injecting `SpanContext` for an outgoing call.
+
+| `SpanKind` | Call direction | Communication style | Definition |
+| --- | --- | --- | --- |
+| `SERVER` | incoming | request/response | Covers server-side handling of a remote request while the client awaits a response. |
+| `CLIENT` | outgoing | request/response | Describes a request to a remote service where the client awaits a response. When propagated, a `CLIENT` span usually becomes the parent of a remote `SERVER` span. |
+| `PRODUCER` | outgoing | deferred execution | Initiation/scheduling of a local or remote operation; often ends before the correlated `CONSUMER` span even starts. In batched messaging, each individual message needs its own `PRODUCER` span. |
+| `CONSUMER` | incoming | deferred execution | Processing of an operation initiated by a producer that does not wait for the outcome. |
+| `INTERNAL` | (n/a) | (n/a) | **Default value.** An internal operation, as opposed to one with remote parents/children. |
+
+Notes: a `CLIENT` span may have a `CLIENT` child, or a `PRODUCER` may have a local `CLIENT` child —
+kind describes the *edge*, not a strict alternating pattern. Technology-specific semantic
+conventions document the expected kind per operation type (e.g. DB client calls use `CLIENT`; if a
+DB client itself talks HTTP, the nested HTTP instrumentation creates its own nested `CLIENT` spans).
+
+> **Maple relevance:** these 5 kinds (plus `PRODUCER`/`CONSUMER` pairing rules) drive service-map
+> edge direction and any parent/child inference Maple's flamegraph or trace-topology code performs
+> — a `PRODUCER` span legitimately ending before its `CONSUMER` starts is expected, not a data bug.
+
+---
+
+## 5. Link
+
+**Stability: Stable.**
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#link ,
+https://opentelemetry.io/docs/specs/otel/trace/api/#add-link
+
+"A user MUST have the ability to record links to other `SpanContext`s. Linked `SpanContext`s can
+be from the same or a different trace." A `Link` = `{ SpanContext, Attributes? }`.
+
+- The API **MUST** provide a single-link recorder (e.g. `AddLink`) taking the target `SpanContext`
+  plus optional attributes; **MAY** provide a batch-add variant.
+- "Implementations SHOULD record links containing `SpanContext` with empty `TraceId` or `SpanId`
+  (all zeros) as long as either the attribute set or `TraceState` is non-empty" — i.e., a link can
+  legitimately carry an invalid ID pair if it's only there to smuggle attributes/tracestate.
+- Order of links **SHOULD** be preserved as set.
+- **Links added at span creation** are preferred and documented as such: "because head sampling
+  decisions can only consider information present during span creation."
+- **Links added after creation** (`AddLink` post-start) are explicitly allowed by the API — "A
+  `Span` MUST have the ability to add `Link`s associated with it after its creation" — but "Links
+  added after `Span` creation may not be considered by Samplers."
+
+**Concurrency:** Links are immutable and **SHOULD** be safe for concurrent use by default (Events
+are immutable and **MUST** be safe for concurrent use — a slightly stronger requirement than for
+Links).
+
+---
+
+## 6. TracerProvider / Tracer
+
+**Stability: Stable** for the core API-level operations described here; **Development** for
+`TracerConfigurator`/`TracerConfig` (SDK-level dynamic enable/disable) — see
+§[TracerProvider / Tracer (SDK)](#tracerprovider--tracer-sdk).
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#tracerprovider ,
+https://opentelemetry.io/docs/specs/otel/trace/api/#tracer
+
+`TracerProvider` is the API's entry point and the stateful object holding configuration. The API
+**SHOULD** provide a way to set/register and access a global default instance, and implementations
+**SHOULD** allow creating an arbitrary number of independent `TracerProvider` instances (e.g. for
+per-dependency-injection-scope configuration).
+
+**Get a Tracer** — `TracerProvider` **MUST** provide this. Accepted parameters:
+
+| Param | Required? | Notes |
+| --- | --- | --- |
+| `name` | required | "SHOULD uniquely identify the instrumentation scope" (library/package/module/class name). Invalid (null/empty) input **MUST** still return a working no-op-free `Tracer`, not null/an exception — its `name` **SHOULD** be set to empty string and an invalid-input message **SHOULD** be logged. Implementations *may* ignore `name` entirely if "named" tracers aren't supported. |
+| `version` | optional | Instrumentation scope version, e.g. `"1.0.0"`. |
+| `schema_url` | optional, since 1.4.0 | Schema URL recorded in emitted telemetry. |
+| `attributes` | optional, since 1.13.0 | Instrumentation scope attributes to associate with emitted telemetry. |
+
+Two `Tracer`s are *identical* if all params match, *distinct* otherwise. "Implementations MUST NOT
+require users to repeatedly obtain a `Tracer` again with the same identity to pick up configuration
+changes" — either the old `Tracer` picks up new config live, or it keeps working with stale config;
+either is compliant as long as re-acquisition isn't *required*.
+
+**Tracer operations:** `Tracer` **MUST** provide span creation; **SHOULD** provide an `Enabled()`
+check (see §[Tracer (SDK)](#tracerprovider--tracer-sdk) for the SDK-level semantics driving its
+return value) so callers can skip expensive work when tracing is off. `Enabled`'s return value can
+change over time — the API **SHOULD** document that instrumentation must re-check it per span, not
+cache it.
+
+**Concurrency:** all `TracerProvider`, `Tracer`, and `Span` methods **MUST** be documented as safe
+for concurrent use by default.
+
+---
+
+## 7. Context interaction
+
+**Stability: Stable.**
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#context-interaction
+
+The API **MUST** provide, against the generic
+[`Context`](https://opentelemetry.io/docs/specs/otel/context/): (1) extracting the `Span` from a
+`Context`, (2) combining a `Span` with a `Context` to produce a new `Context`. These exist because
+API users **SHOULD NOT** have direct access to the Context Key the tracing API uses internally.
+
+If the language supports **implicit** context propagation, the API **SHOULD** additionally provide:
+getting the currently-active span (equivalent to get-implicit-context-then-extract-span), and
+setting the active span (equivalent to combine-then-make-implicit). These may be exposed as static
+module-level functions and **SHOULD** be fully implemented at the API layer where possible.
+
+---
+
+## 8. Behavior of the API without an installed SDK
+
+**Stability: Stable.**
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#behavior-of-the-api-in-the-absence-of-an-installed-sdk
+
+"In general, in the absence of an installed SDK, the Trace API is a no-op API" — operations on a
+`Tracer` or `Span` have no side effects. The one carve-out is `SpanContext` propagation continuity:
+the API **MUST** return a non-recording `Span` wrapping whatever `SpanContext` was in the parent
+`Context` (explicit or current-implicit). If that parent context's span is already non-recording,
+it **SHOULD** be returned directly (no new object). If the parent context has no span at all, an
+**empty** non-recording span **MUST** be returned — all-zero `SpanContext`, empty `TraceState`,
+unsampled flags. Net effect: a `SpanContext` supplied by a configured `Propagator` still flows
+through to children and eventually `Inject`, but no *new* `SpanContext` gets created without an SDK.
+
+---
+
+## 9. Concurrency requirements (API)
+
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/api/#concurrency-requirements
+
+- **TracerProvider / Tracer / Span** — all methods **MUST** be documented safe for concurrent use
+  by default.
+- **Event** — immutable, **MUST** be safe for concurrent use by default.
+- **Link** — immutable, **SHOULD** be safe for concurrent use by default.
+
+---
+
+## 10. SDK: TracerProvider / Tracer (SDK)
+
+**Stability: mixed.** Core `TracerProvider` responsibilities (owning config, `Shutdown`,
+`ForceFlush`) are **Stable**; per-tracer dynamic enable/disable via `TracerConfigurator` /
+`TracerConfig` is explicitly **Development**.
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/sdk/#tracer-provider
+
+The SDK's `TracerProvider` **MUST** implement the API's Get-a-Tracer operation and **MUST** build
+the `InstrumentationScope` from the caller-supplied name/version/schema_url/attributes, storing it
+on the returned `Tracer`. Configuration ownership — `SpanProcessor`s, `IdGenerator`, `SpanLimits`,
+`Sampler`, and (Development) `TracerConfigurator` — belongs to the `TracerProvider`; it MAY be
+applied at construction time and the provider MAY expose update methods, but any update **MUST**
+retroactively apply to already-returned `Tracer`s (implementations typically achieve this by having
+`Tracer`s hold a reference back to the provider rather than caching config directly).
+
+**Shutdown** — MUST be called only once per `TracerProvider`; subsequent `GetTracer` calls after
+Shutdown are disallowed (SDKs **SHOULD** return a working no-op `Tracer` if possible instead of
+erroring). **MUST** be implemented by invoking `Shutdown` on all internal processors. **SHOULD**
+report success/failure/timeout to the caller and **SHOULD** complete or abort within some timeout
+(sync or async, implementation's choice).
+
+**ForceFlush** — immediately exports all not-yet-exported spans across all internal processors.
+**MUST** invoke `ForceFlush` on every registered `SpanProcessor`. Same SHOULD-report-outcome /
+SHOULD-timeout guidance as Shutdown.
+
+**`TracerConfigurator` (Development):** a function `tracer_scope -> TracerConfig` (or a
+"use-default" sentinel) that the `TracerProvider` calls per-`Tracer`, both at first creation and
+(if updating is supported) for every outstanding `Tracer` when the configurator itself is updated —
+so it "is important that it returns quickly." Modeled as a function for flexibility; SDKs MAY offer
+shorthand helpers (select tracers by name/pattern, disable specific tracers, disable-all-then-allow­list).
+
+**`TracerConfig` (Development):** currently one field, `enabled` (default `true`). A disabled
+`Tracer` **MUST** behave like the API's no-op/no-SDK `Tracer`. `enabled` directly determines
+`Enabled()`'s return value (`false` → `Enabled()` returns `false`; `true` → returns `true`).
+Implementations don't need config changes to be *immediately* visible to `Enabled()` callers, but
+they **MUST** be eventually visible.
+
+**`Enabled` (SDK semantics, Development flag inside a Stable-by-default method):** **MUST** return
+`false` when there are no registered `SpanProcessor`s, or (Development) when
+`TracerConfig.enabled == false`. Otherwise it **SHOULD** return `true`, and MAY return `false` for
+other optimization reasons.
+
+---
+
+## 11. SDK: Additional span interfaces (readable / read-write span)
+
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/sdk/#additional-span-interfaces
+
+The API only defines write access to a `Span`; the SDK needs to read data back out for processors
+and exporters, so it defines two SDK-internal contracts:
+
+- **Readable span** — MUST expose everything added via the API-level `Span` interface (that spec
+  section is authoritative for the full list), MUST expose `InstrumentationScope` (since 1.10.0)
+  and `Resource`, MUST (for back-compat) also expose the deprecated `InstrumentationLibrary` view
+  with matching name/version, MUST let callers reliably determine whether the span has ended, and
+  MUST expose attribute/event/link **dropped counts** (for exporters, per the
+  [non-OTLP mapping spec](https://opentelemetry.io/docs/specs/otel/common/mapping-to-non-otlp/#dropped-attributes-count)).
+  Implementations MAY choose not to expose the full parent `Context`, but MUST expose at least the
+  full parent `SpanContext`. May or may not be mutable.
+- **Read/write span** — everything a readable span has, plus the full write API, and callers
+  **MUST** be able to obtain the *same* `Span` instance/type that span-creation returned to the user
+  (e.g. passed as a parameter, or via a getter).
+
+---
+
+## 12. Sampling (SDK) {#sampling-sdk}
+
+**Stability: mixed** — the core `Sampler`/`ShouldSample` contract, `AlwaysOn`/`AlwaysOff`, and
+`TraceIdRatioBased`'s *configuration/creation* surface are **Stable**; `ProbabilitySampler`,
+`CompositeSampler`/`ComposableSampler` and the whole explicit-randomness / `Random`-flag apparatus
+are **Development**; `TraceIdRatioBased`'s *algorithm compatibility* note is separately flagged
+**Development** even though the sampler itself is Stable.
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/sdk/#sampling
+
+Sampling controls collection noise/overhead. Two API-level signals govern it:
+
+- **`IsRecording`** on `Span` — if `false`, all data is discarded. `SpanProcessor`s **MUST** only
+  receive spans with `IsRecording == true`; `SpanExporter`s **SHOULD NOT** receive them unless
+  `Sampled` is *also* set.
+- **`Sampled`** flag in `TraceFlags` on `SpanContext` — propagates to children via `SpanContext`;
+  indicates the span *has been* sampled and will be exported. Exporters **MUST** receive spans with
+  `Sampled == true` and **SHOULD NOT** receive ones without it.
+
+### Recording × Sampled reaction table
+
+| `IsRecording` | `Sampled` | Processor receives? | Exporter receives? |
+| --- | --- | --- | --- |
+| true | true | true | true |
+| true | false | true | false |
+| false | true | **Not allowed** | **Not allowed** |
+| false | false | false | false |
+
+`IsRecording=false, Sampled=true` is a forbidden combination: "the OpenTelemetry SDK MUST NOT allow
+this combination" because it would create gaps in the distributed trace. `IsRecording=true,
+Sampled=false` is legal and means "this span records data but its children likely won't."
+
+> **Maple relevance:** a spec-compliant SDK will never emit the forbidden combination, but
+> defensive ingest code should treat `Sampled=true` + missing/absent span data as a signal of a
+> non-compliant producer or transport-layer data loss, not assume it can't happen.
+
+### SDK span creation order
+
+When creating a span, the SDK **MUST** act as if, in order: (1) use the parent's trace ID if valid,
+else generate a new one — *before* calling `ShouldSample`, which requires a valid trace ID as
+input; (2) call the `Sampler`'s `ShouldSample`; (3) generate a new span ID regardless of the
+sampling decision (so other components — logs, exception handling — can rely on a unique span ID
+even for a non-recording span); (4) construct the span per the `ShouldSample` decision (a
+non-recording result MAY reuse the same "wrap a SpanContext" mechanism as the no-SDK API path).
+
+### Sampler interface
+
+**`ShouldSample`** — required inputs: parent `Context` (its `SpanContext` may be invalid → root
+span), the new span's `TraceId` (MUST match the parent's if parent has a valid trace ID), span
+name, `SpanKind`, initial `Attributes`, and the collection of `Link`s. Returns a `SamplingResult`:
+
+| `SamplingResult` field | Meaning |
+| --- | --- |
+| `Decision` | One of `DROP` / `RECORD_ONLY` / `RECORD_AND_SAMPLE` — see table below. |
+| Attributes | Additional span attributes to add; the returned object MUST be immutable. |
+| `Tracestate` | The `TraceState` for the new `SpanContext`. If the sampler returns an *empty* `Tracestate`, the existing one is cleared — so samplers that don't intend to change it SHOULD pass through the incoming value unmodified. |
+
+| `Decision` | `IsRecording` | `Sampled` flag |
+| --- | --- | --- |
+| `DROP` | `false` — span not recorded, all events/attributes dropped | not set |
+| `RECORD_ONLY` | `true` | **MUST NOT** be set |
+| `RECORD_AND_SAMPLE` | `true` | **MUST** be set |
+
+**`GetDescription`** — returns the sampler's name/config as a debug string (e.g.
+`"TraceIdRatioBased{0.000100}"`); MAY change over time (e.g. under dynamic reconfiguration);
+callers **SHOULD NOT** cache it.
+
+### Built-in samplers
+
+**Default sampler: `ParentBased(root=AlwaysOn)`.**
+
+| Sampler | Status | Behavior |
+| --- | --- | --- |
+| `AlwaysOn` | Stable | Always returns `RECORD_AND_SAMPLE`. Description MUST be `AlwaysOnSampler`. |
+| `AlwaysOff` | Stable | Always returns `DROP`. Description MUST be `AlwaysOffSampler`. |
+| `TraceIdRatioBased` | Stable (config/creation API); algorithm compatibility notes are Development | Deterministic hash of `TraceId` decides sampling; ignores parent `Sampled` flag (compose with `ParentBased` to respect it). A given ratio MUST sample a superset of what any lower-ratio instance would sample (monotonic — lets a backend sample at a higher rate than the frontend safely). **Deprecation note:** being phased out in favor of `ProbabilitySampler`; "OpenTelemetry SDK implementors SHALL NOT remove or modify the behavior of the original `TraceIdRatioBased` sampler until at least January 1, 2027," after which they're encouraged to silently swap in an equally-configured `ProbabilitySampler`. Exact hash algorithm was never specified — cross-SDK/cross-version results may differ, so it's recommended only as a *root* sampler. |
+| `ProbabilitySampler` | Development | Composable-style ratio sampler built on W3C Trace Context Level 2's 56 bits of randomness (see [Probability Sampling in TraceState](https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/)). Ignores parent `Sampled` flag (compose with `ParentBased`). Configured with a ratio in `[2^-56, 1.0]`; on `ShouldSample`, compares randomness value `R` against rejection threshold `T` derived from the ratio — `R >= T` ⇒ `RECORD_AND_SAMPLE`, sets `ot=th:T` in tracestate; else `DROP`. |
+| `ParentBased` | Stable | Decorator dispatching on parent shape — see table below. |
+| `JaegerRemoteSampler` | Stable | Periodically pulls sampling config from a remote endpoint (Jaeger Collector or OTel Collector implementing the [Remote Sampling API](https://www.jaegertracing.io/docs/2.14/architecture/apis/#remote-sampling-configuration)); can assign different strategies per span name (e.g. `/product` at 10%, `/admin` at 100%, never `/metrics`). Configurable: `endpoint`, `polling interval`, `initial sampler` (used before first fetch). |
+| `AlwaysRecord` | Stable | Decorator: converts a wrapped sampler's `DROP` into `RECORD_ONLY` (all other decisions pass through unchanged) so every span reaches processors (e.g. for span-to-metrics) without necessarily being exported. |
+| `CompositeSampler` / `ComposableSampler` | Development | Implements `Sampler` by delegating to a `ComposableSampler.GetSamplingIntent` (threshold + `adjusted_count_reliable` + optional attribute/tracestate providers), then deriving/compares a randomness value `R` against the returned threshold to reach the final decision. Built-in composables: `ComposableAlwaysOn`, `ComposableAlwaysOff`, `ComposableProbability` (ratio `[2^-56, 1.0]`), `ComposableParentThreshold` (propagate parent's decision/threshold), `ComposableRuleBased` (predicate → sampler rule list, first match wins), `ComposableAnnotating` (delegate + extra attributes on sampled spans). |
+
+**`ParentBased` dispatch table** — required param `root(Sampler)`; optional params
+`remoteParentSampled` (default `AlwaysOn`), `remoteParentNotSampled` (default `AlwaysOff`),
+`localParentSampled` (default `AlwaysOn`), `localParentNotSampled` (default `AlwaysOff`):
+
+| Parent | `IsRemote()` | `IsSampled()` | Delegate invoked |
+| --- | --- | --- | --- |
+| absent | n/a | n/a | `root()` |
+| present | true | true | `remoteParentSampled()` |
+| present | true | false | `remoteParentNotSampled()` |
+| present | false | true | `localParentSampled()` |
+| present | false | false | `localParentNotSampled()` |
+
+### Sampling requirements — TraceID randomness (Development)
+
+The [W3C Trace Context Level 2](https://www.w3.org/TR/trace-context-2/) CR defines a `Random` trace
+flag meaning "the rightmost 7 bytes / 56 bits of the TraceID are random." SDKs **SHOULD** set this
+`Random` flag on root spans when they generate TraceIDs meeting that randomness bar. SDKs and
+Samplers **MUST NOT** overwrite an explicit randomness value (the `rv` sub-key of OTel's
+`tracestate`, see
+[TraceState Handling](https://opentelemetry.io/docs/specs/otel/trace/tracestate-handling/#explicit-randomness-value-rv))
+once a user has set one; root samplers MAY insert an `rv` value themselves when the generated
+TraceID doesn't meet the randomness bar and no `rv` is already present. Absent an explicit
+randomness value, samplers **SHOULD** presume TraceIDs are W3C-Level-2-random. Custom
+`IdGenerator`s **SHOULD** self-identify when all their generated TraceIDs meet the randomness bar so
+the SDK can correctly set the `Random` flag.
+
+---
+
+## 13. Span Limits
+
+**Stability: Stable** (attribute-limit portions are defined once, in the common spec, and inherited
+here).
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-limits
+
+Span attributes **MUST** follow the common
+[attribute-limits](https://opentelemetry.io/docs/specs/otel/common/#attribute-limits) rules. The
+SDK MAY additionally discard links/events beyond a configured per-collection limit. If a limit is
+implemented, the SDK **MUST** expose a way to change it via `TracerProvider` configuration.
+Discarding an attribute/event/link due to a limit **SHOULD** log a message — but **MUST** be logged
+**at most once per span** (not once per discarded item) to avoid log spam.
+
+| Limit | Default | Env var | Notes |
+| --- | --- | --- | --- |
+| `AttributeCountLimit` (common) | 128 | `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` (falls back to `OTEL_ATTRIBUTE_COUNT_LIMIT`) | Max attributes per span. |
+| `AttributeValueLengthLimit` (common) | no limit | `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` (falls back to `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`) | Max attribute value length; strings/byte-arrays MUST be truncated to the limit; for arrays of strings/AnyValue, the limit applies per-element; all other value shapes MUST NOT be truncated. |
+| `EventCountLimit` | 128 | `OTEL_SPAN_EVENT_COUNT_LIMIT` | Max events per span. |
+| `LinkCountLimit` | 128 | `OTEL_SPAN_LINK_COUNT_LIMIT` | Max links per span. |
+| `AttributePerEventCountLimit` | 128 | `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT` | Max attributes per event. |
+| `AttributePerLinkCountLimit` | 128 | `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT` | Max attributes per link. |
+
+**Source (env vars):** https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor
+and the neighboring "Span limits" / "Attribute limits" tables on that same page.
+
+**Attribute value types** (common spec, inherited by span attributes) — Source:
+https://opentelemetry.io/docs/specs/otel/common/#attribute — attribute keys **MUST** be non-null,
+non-empty strings; key casing is preserved and case-sensitive (differently-cased keys are distinct
+keys). Attribute values **MUST** be one of the types defined by `AnyValue` (string, boolean,
+double-precision float, signed 64-bit integer, byte array, homogeneous/nested arrays, maps, and
+empty). Verified against the raw spec source (`specification/common/README.md` on `main`,
+2026-07): "The attribute value MUST be one of types defined in AnyValue." *Note:* earlier spec
+versions restricted plain `Attribute` values to only primitives and homogeneous primitive arrays
+(no maps/nesting); the current spec unifies `Attribute` with the broader `AnyValue` definition
+used by log bodies. When validating third-party producers instrumented with older SDKs, expect
+the stricter, pre-unification subset in practice.
+
+---
+
+## 14. ID Generators
+
+**Stability: Stable** for the core requirement; **Development** for the self-identifying-randomness
+extension.
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/sdk/#id-generators
+
+"The SDK MUST by default randomly generate both the `TraceId` and the `SpanId`." The SDK **MUST**
+provide a mechanism to customize ID generation for both (typically via an `IdGenerator`-style
+interface exposing `generateSpanIdBytes()` / `generateTraceIdBytes()`). Vendor-specific ID
+generators (e.g. AWS X-Ray's ID format) **MUST NOT** be maintained/distributed as part of
+OpenTelemetry's own core packages.
+
+**(Development)** Custom `IdGenerator`s **SHOULD** self-identify when *all* generated TraceIDs meet
+the W3C Trace Context Level 2 randomness bar, so the SDK can set the `Random` trace flag
+accordingly — typically inferred statically via a marker interface rather than per-call.
+
+---
+
+## 15. Span Processor {#span-processor-sdk}
+
+**Stability: Stable**, except `OnEnding` which is explicitly **Development**.
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor
+
+A `SpanProcessor` hooks span start/end. Processors are invoked **only** when `IsRecording` is true.
+Built-in processors handle batching + conversion to an export-friendly representation before
+handing off to exporters. Multiple processors register directly on the `TracerProvider` and run **in
+registration order**; each forms the head of its own pipeline (processor + optional exporter), and
+the SDK **MUST** allow each pipeline to end with an individual exporter. The SDK **MUST** allow
+users to implement and register custom processors.
+
+### Interface
+
+The `SpanProcessor` interface **MUST** declare `OnStart`, `OnEnd`, `Shutdown`, `ForceFlush`, and
+**SHOULD** declare `OnEnding`.
+
+| Method | Timing / threading | Contract |
+| --- | --- | --- |
+| `OnStart(span, parentContext)` | Synchronous, on the span-starting thread | MUST NOT block/throw. Multiple processors' `OnStart` run in registration order. `span` is a read/write span; keeping a reference and observing live updates SHOULD work (e.g. a processor that periodically inspects all active spans from a background thread). `parentContext` is the SDK-determined parent (explicit / current / empty, per what was requested). Returns void. |
+| `OnEnding(span)` — **Development** | Synchronous, inside `Span.End()`, *before* `OnEnd` | Called once the end timestamp is computed (its own duration is excluded from span duration) but while the span is **still mutable** (`SetAttribute`/`AddLink`/`AddEvent` still legal). MUST NOT block/throw. Multiple processors' `OnEnding` run in registration order; the SDK MUST guarantee no other thread can modify the span once the first `OnEnding` starts — only synchronous in-callback modification is allowed from that point. **All** registered `OnEnding` callbacks run before **any** `OnEnd` callback runs. |
+| `OnEnd(span)` | Synchronous, inside `Span.End()`, after end timestamp is set | MUST NOT block/throw. `span` is a readable span; even if technically mutable, modifying it here is not allowed (already ended). |
+| `Shutdown()` | — | SHOULD be called only once; subsequent `OnStart`/`OnEnd`/`ForceFlush` calls SHOULD be gracefully ignored. MUST include the effects of `ForceFlush`. SHOULD report success/failure/timeout and SHOULD complete/abort within some timeout. |
+| `ForceFlush()` | — | Hint to complete any in-flight span work "as soon as possible, preferably before returning." If the processor has an exporter, it SHOULD `Export` everything not yet exported, then call the exporter's `ForceFlush` — built-in processors **MUST** do so. If a timeout is set, the processor MUST prioritize the timeout over completeness (may abort/skip calls). SHOULD report outcome; SHOULD only be called when "absolutely necessary" (e.g. FaaS suspend-after-invocation risk). |
+
+### Built-in processors
+
+The standard SDK **MUST** implement both. (Other cross-cutting processing scenarios are steered
+toward the out-of-process [Collector](https://opentelemetry.io/docs/specs/otel/overview/#collector)
+instead of more built-in processors.)
+
+**Simple processor** — passes each finished span to the configured exporter immediately as it
+finishes. MUST synchronize `Export` calls so they're never invoked concurrently. Configurable:
+`exporter`.
+
+**Batching processor** — batches finished spans before handing them to the exporter; also MUST
+synchronize `Export` calls. Exports a batch when (previous export has returned AND) any of:
+`scheduledDelayMillis` since construction / since first span in a new window, `scheduledDelayMillis`
+since previous export timer ended/completed, the queue reaches `maxExportBatchSize`, or
+`ForceFlush()` is called. An empty queue at export time MAY export an empty batch or skip export
+entirely (implementation's choice).
+
+| Parameter | Default | Env var | Meaning |
+| --- | --- | --- | --- |
+| `maxQueueSize` | 2048 | `OTEL_BSP_MAX_QUEUE_SIZE` | Spans beyond this are dropped once the queue is full. |
+| `scheduledDelayMillis` | 5000 | `OTEL_BSP_SCHEDULE_DELAY` | Max delay between consecutive exports. |
+| `exportTimeoutMillis` | 30000 | `OTEL_BSP_EXPORT_TIMEOUT` | How long a single export may run before being cancelled. |
+| `maxExportBatchSize` | 512 | `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | Max spans per export call; must be ≤ `maxQueueSize`; reaching this triggers an export even before `scheduledDelayMillis` elapses. |
+
+**Source (env vars):** https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor
+
+### Concurrency
+
+`Span processor` — all methods **MUST** be safe for concurrent calls.
+
+---
+
+## 16. Span Exporter
+
+**Stability: Stable.**
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-exporter
+
+The `SpanExporter` interface is what protocol-specific exporters implement to plug into the SDK; it
+minimizes exporter implementation burden — an exporter is meant to be "primarily a simple telemetry
+data encoder and transmitter." Each implementation **MUST** document its own concurrency
+requirements.
+
+**Interface:** MUST support `Export`, `Shutdown`, `ForceFlush` (typically one interface per signal,
+e.g. `SpanExporter`).
+
+| Method | Contract |
+| --- | --- |
+| `Export(batch)` | Exports a batch of readable spans (serialize + transmit, typically). "should not be called concurrently with other Export calls for the same exporter instance" — but the underlying transmission work MAY still happen concurrently under the hood (language-specific). **MUST NOT block indefinitely** — must time out with `Failure` after a reasonable upper limit. Retry logic is the **exporter's** responsibility, not the built-in processors' — "The default SDK's Span Processors SHOULD NOT implement retry logic" since it's protocol/backend-specific (e.g. [OTLP](https://opentelemetry.io/docs/specs/otlp/) defines its own send/retry logic). Returns an `ExportResult`: `Success` ("the batch has been successfully exported" — e.g. delivered over the wire) or `Failure` ("exporting failed. The batch must be dropped," e.g. unserializable data). |
+| `Shutdown()` | Opportunity for exporter cleanup; called on SDK shutdown. Should be called only once; after it, subsequent `Export` calls are disallowed and **should return `Failure`**. Should not block indefinitely even if flushing to an unavailable destination. |
+| `ForceFlush()` | Hint that any spans already received prior to the call should be exported "as soon as possible, preferably before returning." SHOULD report success/failure/timeout; SHOULD only be called when "absolutely necessary" (same FaaS-suspend rationale as the processor's `ForceFlush`); SHOULD complete/abort within some timeout. |
+
+**Concurrency:** `ForceFlush` and `Shutdown` **MUST** be safe to call concurrently on a `SpanExporter`.
+
+---
+
+## 17. SDK Concurrency requirements (summary)
+
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/sdk/#concurrency-requirements
+
+| Component | Requirement |
+| --- | --- |
+| TracerProvider | Tracer creation, `ForceFlush`, `Shutdown` MUST be safe for concurrent calls. |
+| Sampler | `ShouldSample` and `GetDescription` MUST be safe for concurrent calls. |
+| Span processor | All methods MUST be safe for concurrent calls. |
+| Span Exporter | `ForceFlush` and `Shutdown` MUST be safe for concurrent calls (per-instance `Export` itself must NOT be called concurrently — see above). |
+
+---
+
+## 18. Self-observability (SDK)
+
+**Stability: Development.**
+**Source:** https://opentelemetry.io/docs/specs/otel/trace/sdk/#self-observability
+
+"The Tracing SDK SHOULD support
+[SDK self-observability](https://opentelemetry.io/docs/specs/otel/self-observability/)" — i.e. the
+SDK itself emitting metrics/logs about its own internal health (queue depth, export failures,
+etc.), distinct from the application's own OTel-instrumented telemetry. This is the spec-level
+counterpart to what Maple's own `apps/ingest` does manually today (its `PeriodicReader`-pushed
+operational metrics — see CLAUDE.md "Self-Observability" — mirror the shape this section describes
+for SDKs generally).
+
+---
+
+## 19. Environment variable reference (sampler & exporter selection)
+
+**Stability: Stable.**
+**Source:** https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration
+(Trace Sampler / Trace Exporter subsections)
+
+| Env var | Default | Accepted values / meaning |
+| --- | --- | --- |
+| `OTEL_TRACES_SAMPLER` | `parentbased_always_on` | `always_on` (`AlwaysOnSampler`), `always_off` (`AlwaysOffSampler`), `traceidratio` (`TraceIdRatioBased`), `parentbased_always_on` (`ParentBased(root=AlwaysOnSampler)`), `parentbased_always_off` (`ParentBased(root=AlwaysOffSampler)`), `parentbased_traceidratio` (`ParentBased(root=TraceIdRatioBased)`), `parentbased_jaeger_remote` (`ParentBased(root=JaegerRemoteSampler)`), `jaeger_remote` (`JaegerRemoteSampler`), `xray` (AWS X-Ray centralized sampling — third-party). |
+| `OTEL_TRACES_SAMPLER_ARG` | unset | Meaning depends on the selected sampler. For `traceidratio` / `parentbased_traceidratio`: "Sampling probability, a number in the [0..1] range, e.g. '0.25'. Default is 1.0 if unset." For `jaeger_remote` / `parentbased_jaeger_remote`: a comma-separated list of `endpoint`, `pollingIntervalMs`, `initialSamplingRate`. |
+| `OTEL_TRACES_EXPORTER` | `otlp` | `otlp`, `zipkin`, `console`, `logging` (deprecated alias), `none`. |
+| `OTEL_PROPAGATORS` | `tracecontext,baggage` | Ordered list of propagators to install globally (not trace-specific, but governs how `SpanContext`/`Baggage` cross process boundaries). |
+
+---
+
+## Key references
+
+- Trace API spec: https://opentelemetry.io/docs/specs/otel/trace/api/
+  (raw: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md)
+- Trace SDK spec: https://opentelemetry.io/docs/specs/otel/trace/sdk/
+  (raw: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md)
+- Trace spec overview / index: https://opentelemetry.io/docs/specs/otel/trace/
+- TraceState handling: https://opentelemetry.io/docs/specs/otel/trace/tracestate-handling/
+- Probability sampling in TraceState (`th`/`rv` sub-keys, consistent sampling math): https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/
+- Common attribute & attribute-limits spec (`AnyValue`, `AttributeCountLimit`, `AttributeValueLengthLimit`): https://opentelemetry.io/docs/specs/otel/common/
+- SDK environment variables (batch span processor, span/attribute limits, sampler & exporter selection, propagators): https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+- SDK self-observability: https://opentelemetry.io/docs/specs/otel/self-observability/
+- Context & Propagators API: https://opentelemetry.io/docs/specs/otel/context/ , https://opentelemetry.io/docs/specs/otel/context/api-propagators/
+- OTLP trace proto (wire-level `Status.StatusCode` enum spelling, `Span` message shape): https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
+- Document status / stability-level definitions: https://opentelemetry.io/docs/specs/otel/document-status/


### PR DESCRIPTION
## Summary

Adds `docs/otel-spec/` — an internal, source-linked map of the OpenTelemetry specifications, snapshotted at **spec v1.58.0** (2026-06-22), researched against the live official sources (opentelemetry.io/docs/specs, the specification/semconv/proto repos, W3C trace-context & baggage TRs). Every section carries inline `Source:` deep links so claims can be re-verified as the spec moves.

Nine reference files + an index README:

- **otlp.md** — the OTLP server contract our ingest gateway must honor: partial-success MUSTs, retryable set {429, 502, 503, 504}, protobuf `Status` error bodies, gzip MUST, OTLP/JSON encoding deviations
- **traces.md / metrics.md / logs.md** — full signal specs with defaults tables (span limits, batch processors, samplers, temporality, severity bands, exponential-histogram mapping)
- **context-propagation.md** — W3C traceparent/tracestate/baggage grammars + limits, B3/Jaeger interop
- **resource-and-config.md** — resource merge rules, consolidated SDK env-var table, declarative config (`OTEL_CONFIG_FILE`, now Stable), entities
- **semantic-conventions.md** — naming rules, requirement levels, HTTP/DB/messaging/RPC/exceptions/gen-ai domains + stability, schema-URL migrations
- **stability-and-compliance.md** — the four independent stability domains, compliance matrix, error-handling/performance principles
- **emerging-and-compat.md** — profiles (Alpha), telemetry schemas deep-dive, Prometheus interop, deprecated OpenTracing/OpenCensus shims

The README frames Maple's three compliance surfaces (ingest gateway as OTLP server, self-instrumentation, UI data-consumer semantics) and honestly lists the few low-confidence items to re-verify. Also registers the directory in CLAUDE.md's docs list.

## Notable findings for Maple

- Our SERVER-span 5xx-only Error rule and title-case `"Ok"/"Error"/"Unset"` storage match spec exactly; the `db.statement`→`db.query.text` and `deployment.environment`→`deployment.environment.name` coalescing mirror official deprecations
- Log error classification should key on `SeverityNumber >= 17`, not `SeverityText` matching
- Events are now LogRecords with `EventName`; span events / `RecordException()` are on a deprecation path
- Our ingest never reads `schema_url` today — telemetry-schema transforms are the principled version of our manual attribute coalescing

## Verification

- Docs-only change (plus one CLAUDE.md index line); no code paths touched
- Spot-checked flagged ambiguities against raw spec markdown (e.g., attribute values are now full `AnyValue` per `specification/common/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->