### PR TITLE
feat(mcp): filter browser sessions by user in search_sessions

### DIFF
--- a/apps/api/src/mcp/tools/search-sessions.ts
+++ b/apps/api/src/mcp/tools/search-sessions.ts
@@ -51,15 +51,17 @@ export function registerSearchSessionsTool(server: McpToolRegistrar) {
 			const off = clampOffset(params.offset, { max: 10_000 })
 
 			// Whether any in-session event predicate is active — drives the Matches
-			// column and the "narrowed by event" note.
-			const hasEventFilter = Boolean(
-				params.event_type ||
-					params.level ||
-					params.http_status_min ||
-					params.url_contains ||
-					params.message_contains ||
-					params.trace_id,
-			)
+			// column and the "narrowed by event" note. Uses `!= null` (not truthiness)
+			// to match the query layer's `needsEventFilter` in session-replays.ts:
+			// otherwise a zero-valued predicate like `http_status_min=0` would apply the
+			// INNER JOIN in SQL while the display silently dropped the Matches column.
+			const hasEventFilter =
+				params.event_type != null ||
+				params.level != null ||
+				params.http_status_min != null ||
+				params.url_contains != null ||
+				params.message_contains != null ||
+				params.trace_id != null
 
 			const tenant = yield* resolveTenant
 			yield* Effect.annotateCurrentSpan({

--- a/apps/api/src/mcp/tools/search-sessions.ts
+++ b/apps/api/src/mcp/tools/search-sessions.ts
@@ -1,4 +1,9 @@
-import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from "./types"
+import {
+	optionalBooleanParam,
+	optionalNumberParam,
+	optionalStringParam,
+	type McpToolRegistrar,
+} from "./types"
 import { warehouseToMcpHandlers } from "../lib/map-warehouse-error"
 import { withTenantExecutor, resolveTenant } from "../lib/query-warehouse"
 import { resolveTimeRange, formatClampNote } from "../lib/time"
@@ -12,17 +17,29 @@ import { searchSessions } from "@maple/query-engine/observability"
 export function registerSearchSessionsTool(server: McpToolRegistrar) {
 	server.tool(
 		"search_sessions",
-		"Find browser session replays by what happened inside them — errors, failed network requests, console messages, or visited URLs. Returns matching sessions; follow up with `get_session_transcript` to read one. Filters are combined (a single event must match all of them), so pass a coherent set (e.g. event_type=network + http_status_min=500).",
+		"List and filter browser session replays. Filter by WHO (user_id — the app's end-user id), by client (browser, country, device_type), by whether the session errored (has_errors), by how long it lasted (duration/active bounds), and/or by WHAT HAPPENED inside it (event_type, level, http_status_min, url_contains, message_contains, trace_id). Returns each session's metadata including the end-user id. All filters are ANDed. Follow up with `get_session_transcript` to read a session's events or `get_session_traces` to see the backend traces it produced.",
 		Schema.Struct({
 			start_time: optionalStringParam("Start of time range (YYYY-MM-DD HH:mm:ss)"),
 			end_time: optionalStringParam("End of time range (YYYY-MM-DD HH:mm:ss)"),
+			// Session metadata filters (who / where / how long)
+			user_id: optionalStringParam("Exact match on the session's end-user id (e.g. 4632)"),
+			service: optionalStringParam("Exact match on the session's service name"),
+			browser: optionalStringParam("Exact match on browser name (e.g. Chrome)"),
+			country: optionalStringParam("Exact match on country"),
+			device_type: optionalStringParam("Exact match on device type (e.g. desktop, mobile)"),
+			has_errors: optionalBooleanParam("Only sessions with at least one recorded error"),
+			duration_min_ms: optionalNumberParam("Only sessions at least this long (ms)"),
+			duration_max_ms: optionalNumberParam("Only sessions at most this long (ms)"),
+			active_min_ms: optionalNumberParam("Only sessions with at least this much active (non-idle) time (ms)"),
+			active_max_ms: optionalNumberParam("Only sessions with at most this much active time (ms)"),
+			// In-session event refinement (what happened)
 			event_type: optionalStringParam(
-				"Event type to match: navigation, click, input, console, network, or error",
+				"Match sessions that contain this event type: navigation, click, input, console, network, or error",
 			),
-			level: optionalStringParam("Console/error level (e.g. error, warn)"),
-			http_status_min: optionalNumberParam("Match network requests with status >= this (e.g. 500)"),
-			url_contains: optionalStringParam("Substring match on the event/page URL"),
-			message_contains: optionalStringParam("Substring match on console/error message text"),
+			level: optionalStringParam("Console/error level to match (e.g. error, warn)"),
+			http_status_min: optionalNumberParam("Match sessions with a network request status >= this (e.g. 500)"),
+			url_contains: optionalStringParam("Substring match on an in-session event/page URL"),
+			message_contains: optionalStringParam("Substring match on an in-session console/error message"),
 			trace_id: optionalStringParam("Only sessions that observed this trace id"),
 			offset: optionalNumberParam("Offset for pagination (default 0)"),
 			limit: optionalNumberParam("Max results (default 25)"),
@@ -33,9 +50,21 @@ export function registerSearchSessionsTool(server: McpToolRegistrar) {
 			const lim = clampLimit(params.limit, { defaultValue: 25, max: 200 })
 			const off = clampOffset(params.offset, { max: 10_000 })
 
+			// Whether any in-session event predicate is active — drives the Matches
+			// column and the "narrowed by event" note.
+			const hasEventFilter = Boolean(
+				params.event_type ||
+					params.level ||
+					params.http_status_min ||
+					params.url_contains ||
+					params.message_contains ||
+					params.trace_id,
+			)
+
 			const tenant = yield* resolveTenant
 			yield* Effect.annotateCurrentSpan({
 				orgId: tenant.orgId,
+				userId: params.user_id ?? "any",
 				eventType: params.event_type ?? "any",
 				limit: lim,
 				offset: off,
@@ -45,12 +74,22 @@ export function registerSearchSessionsTool(server: McpToolRegistrar) {
 				searchSessions({
 					startTime: st,
 					endTime: et,
-					type: params.event_type ?? undefined,
-					level: params.level ?? undefined,
-					minStatus: params.http_status_min ?? undefined,
-					urlSearch: params.url_contains ?? undefined,
-					messageSearch: params.message_contains ?? undefined,
-					traceId: params.trace_id ?? undefined,
+					userId: params.user_id ?? undefined,
+					serviceName: params.service ?? undefined,
+					browser: params.browser ?? undefined,
+					country: params.country ?? undefined,
+					deviceType: params.device_type ?? undefined,
+					hasErrors: params.has_errors ?? undefined,
+					durationMinMs: params.duration_min_ms ?? undefined,
+					durationMaxMs: params.duration_max_ms ?? undefined,
+					activeTimeMinMs: params.active_min_ms ?? undefined,
+					activeTimeMaxMs: params.active_max_ms ?? undefined,
+					eventType: params.event_type ?? undefined,
+					eventLevel: params.level ?? undefined,
+					eventMinStatus: params.http_status_min ?? undefined,
+					eventUrlSearch: params.url_contains ?? undefined,
+					eventMessageSearch: params.message_contains ?? undefined,
+					eventTraceId: params.trace_id ?? undefined,
 					limit: lim,
 					offset: off,
 				}),
@@ -65,26 +104,45 @@ export function registerSearchSessionsTool(server: McpToolRegistrar) {
 				}
 			}
 
+			// ClickHouse serializes 64-bit integer aggregates (`length()`, `count()`)
+			// as JSON strings while the Tinybird path returns numbers; coerce every
+			// numeric at the edge (same as get_session_traces / the http handler).
+			const headers = ["User", "Started", "Duration", "Browser", "Device", "Country", "Errors", "Entry URL"]
+			if (hasEventFilter) headers.push("Matches")
+
+			const rows = sessions.map((s) => {
+				const errorCount = Number(s.errorCount)
+				const device = [s.osName, s.deviceType].filter(Boolean).join(" / ")
+				const row = [
+					s.userId || "Anonymous",
+					s.startTime,
+					s.durationMs != null ? `${Math.round(Number(s.durationMs))}ms` : "—",
+					s.browserName || "—",
+					device || "—",
+					s.country || "—",
+					errorCount > 0 ? String(errorCount) : "",
+					truncate(s.urlInitial, 60),
+				]
+				if (hasEventFilter) row.push(String(Number(s.matchCount ?? 0)))
+				return row
+			})
+
 			const lines: string[] = [
-				`## Matching sessions (showing ${off + 1}–${off + sessions.length})`,
+				`## Sessions (showing ${off + 1}–${off + sessions.length})`,
 				`Time range: ${st} — ${et}${formatClampNote(range)}`,
 				``,
-				formatTable(
-					["Session ID", "Matches", "First", "Last", "First URL"],
-					sessions.map((s) => [
-						s.sessionId,
-						String(s.matchCount),
-						s.firstTimestamp,
-						s.lastTimestamp,
-						truncate(s.firstUrl, 80),
-					]),
-				),
+				formatTable(headers, rows),
 			]
 
 			const nextSteps = pipe(
 				sessions,
 				Arr.take(3),
-				Arr.map((s) => `\`get_session_transcript session_id="${s.sessionId}"\` — read the session`),
+				Arr.map(
+					(s) =>
+						`\`get_session_transcript session_id="${s.sessionId}"\` — read ${
+							s.userId ? `${s.userId}'s` : "the"
+						} session`,
+				),
 			)
 			lines.push(formatNextSteps(nextSteps))
 
@@ -97,10 +155,21 @@ export function registerSearchSessionsTool(server: McpToolRegistrar) {
 							sessions,
 							Arr.map((s) => ({
 								sessionId: s.sessionId,
-								matchCount: s.matchCount,
-								firstTimestamp: s.firstTimestamp,
-								lastTimestamp: s.lastTimestamp,
-								firstUrl: s.firstUrl,
+								userId: s.userId,
+								startTime: s.startTime,
+								durationMs: s.durationMs != null ? Number(s.durationMs) : null,
+								status: s.status,
+								browserName: s.browserName,
+								osName: s.osName,
+								deviceType: s.deviceType,
+								country: s.country,
+								serviceName: s.serviceName,
+								pageViews: Number(s.pageViews),
+								clickCount: Number(s.clickCount),
+								errorCount: Number(s.errorCount),
+								traceCount: Number(s.traceCount),
+								urlInitial: truncate(s.urlInitial, 256),
+								...(hasEventFilter ? { matchCount: Number(s.matchCount ?? 0) } : {}),
 							})),
 						),
 					},

--- a/packages/domain/src/mcp-structured-types.ts
+++ b/packages/domain/src/mcp-structured-types.ts
@@ -785,10 +785,25 @@ export interface SearchSessionsData {
 	timeRange: { start: string; end: string }
 	sessions: ReadonlyArray<{
 		sessionId: string
-		matchCount: number
-		firstTimestamp: string
-		lastTimestamp: string
-		firstUrl: string
+		/** The session's end-user id, or "" for an anonymous session. */
+		userId: string
+		startTime: string
+		durationMs: number | null
+		status: string
+		browserName: string
+		osName: string
+		deviceType: string
+		country: string
+		serviceName: string
+		pageViews: number
+		clickCount: number
+		errorCount: number
+		traceCount: number
+		urlInitial: string
+		/** Count of in-session events matching the event predicates. Present only when
+		 *  an event filter (event_type / level / http_status_min / url / message /
+		 *  trace_id) was applied. */
+		matchCount?: number
 	}>
 }
 

--- a/packages/query-engine/src/ch/index.ts
+++ b/packages/query-engine/src/ch/index.ts
@@ -121,13 +121,12 @@ export {
 // Queries — Session Events (distilled stream)
 export {
 	sessionTranscriptQuery,
-	searchSessionsByEventQuery,
+	sessionEventMatchQuery,
 	sessionActivityQuery,
 	sessionActivityAggregateQuery,
 	IDLE_GAP_THRESHOLD_MS,
 	type SessionTranscriptOutput,
-	type SearchSessionsByEventOpts,
-	type SearchSessionsByEventOutput,
+	type SessionEventMatchOpts,
 	type SessionActivityOpts,
 	type SessionActivityOutput,
 } from "./queries/session-events"

--- a/packages/query-engine/src/ch/queries/session-events.ts
+++ b/packages/query-engine/src/ch/queries/session-events.ts
@@ -19,19 +19,6 @@ function count(): CH.Expr<number> {
 	return compileFnCall<number>("count")
 }
 
-function minExpr<T>(value: CH.Expr<T>): CH.Expr<T> {
-	return compileFnCall<T>("min", value)
-}
-
-function maxExpr<T>(value: CH.Expr<T>): CH.Expr<T> {
-	return compileFnCall<T>("max", value)
-}
-
-/** `argMin(value, ordering)` — the value of `value` at the row with the smallest `ordering`. */
-function argMinExpr<T>(value: CH.Expr<T>, ordering: CH.Expr<unknown>): CH.Expr<T> {
-	return compileFnCall<T>("argMin", value, ordering)
-}
-
 // ---------------------------------------------------------------------------
 // Transcript: every event for one session, in order
 //
@@ -114,15 +101,19 @@ export function sessionTranscriptQuery(opts: SessionTranscriptOpts = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Search: sessions containing events that match the given predicates
+// Event-match semi-join: sessions whose distilled events match the predicates
 //
 // Row-level filters are ANDed, so callers pass a coherent predicate set (e.g.
 // type="network" + minStatus=500, or messageSearch="…"). Returns one row per
-// session with a match, plus the match count and time bounds, ordered by most
-// recent. The MCP / UI layer joins these session ids back to session metadata.
+// matching session with the match count — an UNFORMATTED grouped builder used as
+// an INNER JOIN by `sessionReplaysListQuery` to refine the (session_replays)
+// session list by what happened inside each session. Binds the same
+// orgId/startTime/endTime params as the list query (same pattern as
+// `sessionActivityAggregateQuery`), so they resolve to one window when compiled
+// together. No limit/offset/format — those belong to the outer list query.
 // ---------------------------------------------------------------------------
 
-export interface SearchSessionsByEventOpts {
+export interface SessionEventMatchOpts {
 	type?: string
 	level?: string
 	/** Network status >= this (e.g. 500 for server errors). */
@@ -132,29 +123,13 @@ export interface SearchSessionsByEventOpts {
 	/** Substring match on console/error message text. */
 	messageSearch?: string
 	traceId?: string
-	limit?: number
-	offset?: number
 }
 
-export interface SearchSessionsByEventOutput {
-	readonly sessionId: string
-	readonly matchCount: number
-	readonly firstTimestamp: string
-	readonly lastTimestamp: string
-	/** Page URL of the earliest matching event — helps an agent pick which session to read. */
-	readonly firstUrl: string
-}
-
-export function searchSessionsByEventQuery(opts: SearchSessionsByEventOpts) {
-	const limit = opts.limit ?? 50
-
+export function sessionEventMatchQuery(opts: SessionEventMatchOpts) {
 	return from(SessionEvents)
 		.select(($) => ({
 			sessionId: $.SessionId,
 			matchCount: count(),
-			firstTimestamp: minExpr($.Timestamp),
-			lastTimestamp: maxExpr($.Timestamp),
-			firstUrl: argMinExpr($.Url, $.Timestamp),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
@@ -168,10 +143,6 @@ export function searchSessionsByEventQuery(opts: SearchSessionsByEventOpts) {
 			CH.when(opts.traceId, (v: string) => $.TraceId.eq(v)),
 		])
 		.groupBy("sessionId")
-		.orderBy(["lastTimestamp", "desc"])
-		.limit(limit)
-		.offset(opts.offset ?? 0)
-		.format("JSON")
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/query-engine/src/ch/queries/session-replays.test.ts
+++ b/packages/query-engine/src/ch/queries/session-replays.test.ts
@@ -203,3 +203,61 @@ describe("sessionReplaysListQuery session-time filters", () => {
 		expect(sql).toContain("Timestamp >= '2026-06-24 04:00:00'")
 	})
 })
+
+// ---------------------------------------------------------------------------
+// Event refinement — INNER JOIN the distilled session_events match subquery
+//
+// Powers the search_sessions MCP tool's "by what happened inside" filtering.
+// Only an event predicate triggers the join; metadata-only filters (including
+// the web listReplays path) must never read session_events.
+// ---------------------------------------------------------------------------
+
+describe("sessionReplaysListQuery event refinement", () => {
+	it("INNER JOINs the session_events match subquery and selects matchCount", () => {
+		const { sql } = compileCH(
+			sessionReplaysListQuery({ eventType: "network", eventMinStatus: 500 }),
+			{ ...baseParams, ...WINDOW },
+		)
+		expect(sql).toContain("INNER JOIN")
+		expect(sql).toContain("FROM session_events")
+		expect(sql).toContain("ON s.sessionId = e.sessionId")
+		expect(sql).toContain("AS matchCount")
+		// The event predicates land in the joined subquery.
+		expect(sql).toContain("Type = 'network'")
+		expect(sql).toContain("NetStatus >= 500")
+	})
+
+	it("keeps session-metadata filters on the base while the event predicate joins", () => {
+		const { sql } = compileCH(sessionReplaysListQuery({ userId: "4632", eventType: "error" }), {
+			...baseParams,
+			...WINDOW,
+		})
+		// user filter stays on the session_replays base…
+		expect(sql).toContain("UserId = '4632'")
+		// …and the event predicate rides the joined session_events subquery.
+		expect(sql).toContain("INNER JOIN")
+		expect(sql).toContain("Type = 'error'")
+	})
+
+	it("chains the event INNER JOIN with the active-time LEFT JOIN", () => {
+		const { sql } = compileCH(
+			sessionReplaysListQuery({ eventType: "network", activeTimeMinMs: 1000 }),
+			{ ...baseParams, ...WINDOW },
+		)
+		expect(sql).toContain("INNER JOIN")
+		expect(sql).toContain("LEFT JOIN")
+		expect(sql).toContain("ON s.sessionId = e.sessionId")
+		expect(sql).toContain("ON s.sessionId = a.sessionId")
+		expect(sql).toContain("coalesce(a.activeTimeMs, 0) >= 1000")
+	})
+
+	it("never joins session_events for metadata-only filters (web listReplays path)", () => {
+		const { sql } = compileCH(
+			sessionReplaysListQuery({ userId: "4632", browser: "Chrome", hasErrors: true }),
+			{ ...baseParams, ...WINDOW },
+		)
+		expect(sql).not.toContain("JOIN")
+		expect(sql).not.toContain("session_events")
+		expect(sql).not.toContain("matchCount")
+	})
+})

--- a/packages/query-engine/src/ch/queries/session-replays.ts
+++ b/packages/query-engine/src/ch/queries/session-replays.ts
@@ -24,7 +24,7 @@ import { param } from "@maple-dev/clickhouse-builder"
 import { from, fromQuery, type ColumnAccessor, type CHQuery } from "@maple-dev/clickhouse-builder"
 import { unionAll, type CHUnionQuery } from "@maple-dev/clickhouse-builder"
 import { SessionReplays, SessionReplayEvents, TraceDetailSpans } from "../tables"
-import { sessionActivityAggregateQuery } from "./session-events"
+import { sessionActivityAggregateQuery, sessionEventMatchQuery } from "./session-events"
 
 // argMax(value, ordering) — finalize a ReplacingMergeTree column to its latest
 // version. Generic per call site, so declared here rather than via defineFn.
@@ -70,6 +70,24 @@ export interface SessionReplaysListOpts {
 	 *  scans session_events — the default list never does). */
 	activeTimeMinMs?: number
 	activeTimeMaxMs?: number
+	// Event refinement: narrow the list to sessions whose distilled `session_events`
+	// match these predicates (INNER JOIN semi-join via `sessionEventMatchQuery`).
+	// Setting any of these is what powers the `search_sessions` MCP tool's "by what
+	// happened inside" filtering; when all are unset the query never touches
+	// session_events (the web `listReplays` path is unchanged). `matchCount` on the
+	// output is populated only when an event predicate is present.
+	/** Event type: navigation / click / input / console / network / error. */
+	eventType?: string
+	/** Console/error level (e.g. "error", "warn"). */
+	eventLevel?: string
+	/** Match network events with status >= this (e.g. 500). */
+	eventMinStatus?: number
+	/** Substring match on the event URL (page or request). */
+	eventUrlSearch?: string
+	/** Substring match on console/error message text. */
+	eventMessageSearch?: string
+	/** Only sessions that observed this trace id in an event. */
+	eventTraceId?: string
 	limit?: number
 	offset?: number
 }
@@ -91,6 +109,9 @@ export interface SessionReplaysListOutput {
 	readonly clickCount: number
 	readonly errorCount: number
 	readonly traceCount: number
+	/** Count of distilled events matching the event predicates. Present only when an
+	 *  `event*` filter is set (the event INNER JOIN selects it); absent otherwise. */
+	readonly matchCount?: number
 }
 
 // Return type is annotated (not inferred) because the duration/active filters
@@ -104,6 +125,13 @@ export function sessionReplaysListQuery(
 	const limit = opts.limit ?? 50
 	const needsDurationFilter = opts.durationMinMs != null || opts.durationMaxMs != null
 	const needsActiveFilter = opts.activeTimeMinMs != null || opts.activeTimeMaxMs != null
+	const needsEventFilter =
+		opts.eventType != null ||
+		opts.eventLevel != null ||
+		opts.eventMinStatus != null ||
+		opts.eventUrlSearch != null ||
+		opts.eventMessageSearch != null ||
+		opts.eventTraceId != null
 
 	const base = from(SessionReplays)
 		.select(($) => ({
@@ -142,6 +170,75 @@ export function sessionReplaysListQuery(
 			CH.when(opts.cursor, (v: string) => $.StartTime.lt(v)),
 		])
 		.groupBy("sessionId")
+
+	// Event refinement path. When any `event*` predicate is set, INNER JOIN the
+	// grouped session_events match subquery onto the session list — narrowing to
+	// sessions that contain a matching event and surfacing its `matchCount` — and,
+	// if active-time bounds are set, additionally LEFT JOIN the activity aggregate.
+	// Handled entirely here (and returning) so the no-event branches below keep
+	// their exact compiled SQL: the web `listReplays` path never sets event filters,
+	// so it is byte-for-byte unchanged.
+	if (needsEventFilter) {
+		const eventMatch = sessionEventMatchQuery({
+			type: opts.eventType,
+			level: opts.eventLevel,
+			minStatus: opts.eventMinStatus,
+			urlSearch: opts.eventUrlSearch,
+			messageSearch: opts.eventMessageSearch,
+			traceId: opts.eventTraceId,
+		})
+		// The accumulator is typed `any` because each conditional join widens the
+		// builder's Join type, which TS can't thread through the `if (needsActiveFilter)`
+		// re-assignment. The public return type is annotated on the function signature.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		let joined: any = fromQuery(base, "s").innerJoinQuery(eventMatch, "e", (s: any, e: any) =>
+			s.sessionId.eq(e.sessionId),
+		)
+		if (needsActiveFilter) {
+			joined = joined.leftJoinQuery(
+				sessionActivityAggregateQuery(),
+				"a",
+				(s: any, a: any) => s.sessionId.eq(a.sessionId),
+			)
+		}
+		return joined
+			.select(($: any) => ({
+				sessionId: $.sessionId,
+				startTime: $.startTime,
+				endTime: $.endTime,
+				durationMs: $.durationMs,
+				status: $.status,
+				userId: $.userId,
+				urlInitial: $.urlInitial,
+				browserName: $.browserName,
+				osName: $.osName,
+				deviceType: $.deviceType,
+				country: $.country,
+				serviceName: $.serviceName,
+				pageViews: $.pageViews,
+				clickCount: $.clickCount,
+				errorCount: $.errorCount,
+				traceCount: $.traceCount,
+				matchCount: $.e.matchCount,
+			}))
+			.where(($: any) => {
+				const conds = [
+					opts.durationMinMs != null ? $.durationMs.gte(opts.durationMinMs) : undefined,
+					opts.durationMaxMs != null ? $.durationMs.lte(opts.durationMaxMs) : undefined,
+				]
+				if (needsActiveFilter) {
+					// See the active-only branch below for why NULL activity coalesces to 0.
+					const activeMs = CH.coalesce($.a.activeTimeMs, CH.lit(0))
+					if (opts.activeTimeMinMs != null) conds.push(activeMs.gte(opts.activeTimeMinMs))
+					if (opts.activeTimeMaxMs != null) conds.push(activeMs.lte(opts.activeTimeMaxMs))
+				}
+				return conds
+			})
+			.orderBy(["startTime", "desc"])
+			.limit(limit)
+			.offset(opts.offset ?? 0)
+			.format("JSON")
+	}
 
 	// Fast path: no post-aggregate filters → the original grouped query, untouched
 	// (never reads session_events).

--- a/packages/query-engine/src/observability/index.ts
+++ b/packages/query-engine/src/observability/index.ts
@@ -27,6 +27,7 @@ export {
 	getSessionTranscript,
 	type SearchSessionsInput,
 	type SessionTranscriptOutput,
+	type SessionReplaysListOutput,
 } from "./session-events"
 export {
 	getSessionTraces,

--- a/packages/query-engine/src/observability/session-events.ts
+++ b/packages/query-engine/src/observability/session-events.ts
@@ -3,22 +3,39 @@ import * as CH from "../ch"
 import { WarehouseExecutor } from "./WarehouseExecutor"
 
 export type { SessionTranscriptOutput } from "../ch/queries/session-events"
+export type { SessionReplaysListOutput } from "../ch/queries/session-replays"
 
 /**
- * Search for sessions whose distilled events match the given predicates
- * (errors, network status, console/url text, trace id). Returns one row per
- * matching session with the match count and time bounds — the MCP / UI layer
- * joins these back to session metadata.
+ * List browser session replays, filtered by session metadata (end-user id,
+ * service, browser, country, device, errors, duration, active time) and/or by
+ * what happened inside them (event predicates: type / console-error level /
+ * network status / url / message / trace id). Reads `session_replays` — the
+ * table that carries the end-user id and client metadata — and INNER JOINs the
+ * distilled `session_events` stream only when an event predicate is set. Returns
+ * one row per session with its full metadata (and `matchCount` when filtered by
+ * event). Mirrors the web dashboard's replays list.
  */
 export interface SearchSessionsInput {
 	readonly startTime: string
 	readonly endTime: string
-	readonly type?: string
-	readonly level?: string
-	readonly minStatus?: number
-	readonly urlSearch?: string
-	readonly messageSearch?: string
-	readonly traceId?: string
+	// Session metadata filters (session_replays)
+	readonly userId?: string
+	readonly serviceName?: string
+	readonly browser?: string
+	readonly country?: string
+	readonly deviceType?: string
+	readonly hasErrors?: boolean
+	readonly durationMinMs?: number
+	readonly durationMaxMs?: number
+	readonly activeTimeMinMs?: number
+	readonly activeTimeMaxMs?: number
+	// In-session event refinement (session_events)
+	readonly eventType?: string
+	readonly eventLevel?: string
+	readonly eventMinStatus?: number
+	readonly eventUrlSearch?: string
+	readonly eventMessageSearch?: string
+	readonly eventTraceId?: string
 	readonly limit?: number
 	readonly offset?: number
 }
@@ -29,13 +46,23 @@ export const searchSessions = Effect.fn("Observability.searchSessions")(function
 	const executor = yield* WarehouseExecutor
 	yield* Effect.annotateCurrentSpan("orgId", executor.orgId)
 	const compiled = CH.compile(
-		CH.searchSessionsByEventQuery({
-			type: input.type,
-			level: input.level,
-			minStatus: input.minStatus,
-			urlSearch: input.urlSearch,
-			messageSearch: input.messageSearch,
-			traceId: input.traceId,
+		CH.sessionReplaysListQuery({
+			userId: input.userId,
+			serviceName: input.serviceName,
+			browser: input.browser,
+			country: input.country,
+			deviceType: input.deviceType,
+			hasErrors: input.hasErrors,
+			durationMinMs: input.durationMinMs,
+			durationMaxMs: input.durationMaxMs,
+			activeTimeMinMs: input.activeTimeMinMs,
+			activeTimeMaxMs: input.activeTimeMaxMs,
+			eventType: input.eventType,
+			eventLevel: input.eventLevel,
+			eventMinStatus: input.eventMinStatus,
+			eventUrlSearch: input.eventUrlSearch,
+			eventMessageSearch: input.eventMessageSearch,
+			eventTraceId: input.eventTraceId,
 			limit: input.limit,
 			offset: input.offset,
 		}),


### PR DESCRIPTION
## What & why

An agent using the Maple MCP server couldn't find a specific end-user's browser sessions: `search_sessions` had no user filter and didn't return the user. Root cause — `search_sessions` queried the `session_events` table (the distilled click/nav/network/error stream), which **has no user column at all**. The end-user id and client metadata (browser, OS, device, country, duration, errors) live in a different table, `session_replays`, whose query (`sessionReplaysListQuery`) already powers the web dashboard's replays list — but that query was never reachable from MCP.

This gives `search_sessions` a **`session_replays` spine** (reusing the existing, battle-tested list query) and keeps the old event predicates as an **optional refinement**. A `user_id`-only search now returns *all* of that user's sessions — matching the web UI — instead of only ones that happen to have distilled events.

## Changes

- **`sessionReplaysListQuery`** (`packages/query-engine/src/ch/queries/session-replays.ts`) — gains opt-in `event*` predicates. When any is set, it INNER JOINs a grouped `session_events` match subquery and surfaces `matchCount`. **Gated behind `needsEventFilter`** so the no-event path — the web `listReplays` query — compiles byte-for-byte unchanged.
- **`session-events.ts`** — replaced `searchSessionsByEventQuery` with the unformatted semi-join `sessionEventMatchQuery` (one row per matching session + `matchCount`).
- **Observability `searchSessions`** — now compiles the list query; input widened with `userId` / `serviceName` / `browser` / `country` / `deviceType` / `hasErrors` / duration + active bounds / event predicates.
- **`search_sessions` tool** (`apps/api/src/mcp/tools/search-sessions.ts`) — adds `user_id`, `service`, `browser`, `country`, `device_type`, `has_errors`, `duration_min/max_ms`, `active_min/max_ms`; returns session metadata incl. `userId`; session-centric output table. Coerces `traceCount`/`matchCount` with `Number()` at the edge (UInt64 → JSON string on BYO-ClickHouse).
- **`SearchSessionsData`** structured type widened; `matchCount` now optional.

## Reviewer notes

- **Web path is provably unchanged:** the event join/`matchCount` only appear when an `event*` predicate is set, and the web `listReplays` handler never passes one. A test asserts metadata-only filters produce no JOIN and never read `session_events`.
- **Pagination correctness:** the event refinement is a SQL INNER JOIN (not two paginated queries intersected in app code), so `limit`/`offset` line up.
- **Verification:** `bun typecheck` (27/27 packages) and `session-replays.test.ts` (21/21, incl. 4 new cases: event join, event+metadata, event+active chaining, metadata-only guardrail). The live `mcp__maple__*` tools hit the **deployed** server, so `search_sessions user_id="4632"` can only be confirmed end-to-end after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->