### PR TITLE
fix(cloudflare): make poller skips observable + recover state on reconnect

### DIFF
--- a/apps/alerting/src/worker.ts
+++ b/apps/alerting/src/worker.ts
@@ -304,7 +304,13 @@ const cloudflareAnalyticsTick = Effect.gen(function* () {
 	const analytics = yield* CloudflareAnalyticsService
 	const result = yield* analytics.pollAllOrgs()
 	yield* Effect.logInfo("Cloudflare analytics tick complete").pipe(
-		Effect.annotateLogs({ orgs: result.orgs, rowsIngested: result.rowsIngested }),
+		Effect.annotateLogs({
+			orgs: result.orgs,
+			rowsIngested: result.rowsIngested,
+			skipped: result.skipped,
+			failures: result.failures,
+			perOrg: result.perOrg,
+		}),
 	)
 }).pipe(
 	Effect.withSpan("alerting.cloudflare_analytics_tick"),

--- a/apps/api/src/routes/integrations.http.ts
+++ b/apps/api/src/routes/integrations.http.ts
@@ -21,7 +21,7 @@ import {
 	UserId,
 	VcsCommitDetailResponse,
 } from "@maple/domain/http"
-import { Effect, Option, Schema } from "effect"
+import { Cause, Effect, Option, Schema } from "effect"
 import { Env } from "../lib/Env"
 import { CloudflareAnalyticsService } from "../services/CloudflareAnalyticsService"
 import { CloudflareOAuthService } from "../services/CloudflareOAuthService"
@@ -436,6 +436,7 @@ export const IntegrationsCallbackRouter = HttpRouter.use((router) =>
 		const hazel = yield* HazelOAuthService
 		const github = yield* GithubConnectService
 		const cloudflare = yield* CloudflareOAuthService
+		const cloudflareAnalytics = yield* CloudflareAnalyticsService
 		const env = yield* Env
 
 		const dashboardTargetOrigin = resolveDashboardTargetOrigin(env.MAPLE_APP_BASE_URL)
@@ -713,6 +714,21 @@ export const IntegrationsCallbackRouter = HttpRouter.use((router) =>
 							tag: error._tag,
 							message: error.message,
 						}),
+					),
+					// Reconnect writes fresh tokens, but rows a prior revoked-token error disabled
+					// (`recordOrgError(..., { disable: true })`) have no other re-enable path for the
+					// account-scoped workers anchor row — clear that state now so polling resumes
+					// immediately instead of staying dead until something else touches the rows. This
+					// must never fail the callback page: the connection itself already succeeded.
+					Effect.tap((result) =>
+						cloudflareAnalytics.resetOrgState(result.orgId).pipe(
+							Effect.catchCause((cause) =>
+								Effect.logWarning("cloudflare post-connect state reset failed", {
+									orgId: result.orgId,
+									error: Cause.pretty(cause),
+								}),
+							),
+						),
 					),
 					Effect.map((result) =>
 						htmlResponse(

--- a/apps/api/src/services/CloudflareAnalyticsService.test.ts
+++ b/apps/api/src/services/CloudflareAnalyticsService.test.ts
@@ -623,6 +623,77 @@ describe("CloudflareAnalyticsService", () => {
 		}).pipe(Effect.provide(makeLayer(testDb, captured)))
 	})
 
+	it.effect("pollOrg reclaims a far-future (corrupt) lease instead of skipping forever", () => {
+		const testDb = createTestDb(trackedDbs)
+		const captured: CapturedIngest[] = []
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(T0)
+			yield* seedConnection()
+			// A live lease is always bounded by now+LEASE_MS (4min); anything beyond 2x that (8min)
+			// can't come from normal operation — e.g. a crashed writer left a bogus far-future value
+			// — so it must be treated as corrupt and reclaimed rather than wedging the org forever.
+			yield* seedStateRow({ dataset: "workers_invocations", leaseUntil: new Date(T0 + 60 * MIN) })
+			const service = yield* CloudflareAnalyticsService
+			const summary = yield* service.pollOrg(ORG)
+			assert.isNull(summary.skipped)
+			assert.isAbove(summary.rowsIngested, 0)
+		}).pipe(Effect.provide(makeLayer(testDb, captured)))
+	})
+
+	it.effect("pollAllOrgs rollup reports skip counts and per-org reasons", () => {
+		const testDb = createTestDb(trackedDbs)
+		const captured: CapturedIngest[] = []
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(T0)
+			yield* seedConnection()
+			// Reuse the lease-held skip scenario: a live 3min lease means this tick's pollOrg call
+			// skips instead of polling.
+			yield* seedStateRow({ dataset: "workers_invocations", leaseUntil: new Date(T0 + 3 * MIN) })
+			const service = yield* CloudflareAnalyticsService
+			const result = yield* service.pollAllOrgs()
+			assert.strictEqual(result.rowsIngested, 0)
+			assert.strictEqual(result.skipped, 1)
+			assert.strictEqual(result.perOrg.length, 1)
+			assert.strictEqual(result.perOrg[0]!.skipped, "lease held by another tick")
+		}).pipe(Effect.provide(makeLayer(testDb, captured)))
+	})
+
+	it.effect("resetOrgState re-enables disabled rows and clears error/discovery state", () => {
+		const testDb = createTestDb(trackedDbs)
+		const captured: CapturedIngest[] = []
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(T0)
+			yield* seedConnection()
+			yield* seedStateRow({
+				dataset: "workers_invocations",
+				enabled: false,
+				lastError: "token revoked",
+				lastErrorAt: new Date(T0 - 10 * MIN),
+				discoveredAt: new Date(T0 - 10 * MIN),
+			})
+			yield* seedStateRow({
+				dataset: "http_requests",
+				zoneId: ZONE_ID,
+				zoneName: ZONE_NAME,
+				enabled: false,
+				lastError: "token revoked",
+				lastErrorAt: new Date(T0 - 10 * MIN),
+			})
+			const service = yield* CloudflareAnalyticsService
+			yield* service.resetOrgState(ORG)
+
+			const rows = yield* loadStateRows
+			assert.strictEqual(rows.length, 2)
+			for (const row of rows) {
+				assert.isTrue(row.enabled)
+				assert.isNull(row.lastError)
+				assert.isNull(row.lastErrorAt)
+			}
+			const anchor = rows.find((row) => row.dataset === "workers_invocations")
+			assert.isNull(anchor!.discoveredAt)
+		}).pipe(Effect.provide(makeLayer(testDb, captured)))
+	})
+
 	it.effect("pollOrg records GraphQL errors without advancing watermarks", () => {
 		const testDb = createTestDb(trackedDbs)
 		const captured: CapturedIngest[] = []

--- a/apps/api/src/services/CloudflareAnalyticsService.ts
+++ b/apps/api/src/services/CloudflareAnalyticsService.ts
@@ -44,7 +44,7 @@ import {
 	type CloudflareAnalyticsStateInsert,
 	type CloudflareAnalyticsStateRow,
 } from "@maple/db"
-import { and, eq, inArray, isNull, lt, or } from "drizzle-orm"
+import { and, eq, gt, inArray, isNull, lt, or } from "drizzle-orm"
 import {
 	Array as Arr,
 	Cause,
@@ -599,6 +599,14 @@ interface PollAllOrgsSummary {
 	readonly orgs: number
 	readonly rowsIngested: number
 	readonly failures: number
+	readonly skipped: number
+	readonly perOrg: ReadonlyArray<{
+		readonly orgId: OrgId
+		readonly skipped: string | null
+		readonly callsMade: number
+		readonly rowsIngested: number
+		readonly failures: number
+	}>
 }
 
 export interface CloudflareAnalyticsServiceShape {
@@ -611,6 +619,8 @@ export interface CloudflareAnalyticsServiceShape {
 		orgId: OrgId,
 	) => Effect.Effect<CloudflareIntegrationStatus, IntegrationsPersistenceError>
 	readonly getUsage: (orgId: OrgId) => Effect.Effect<CloudflareUsageResponse, IntegrationsPersistenceError>
+	/** Recovery hook for reconnect — see the implementation below for why this exists. */
+	readonly resetOrgState: (orgId: OrgId) => Effect.Effect<void, IntegrationsPersistenceError>
 }
 
 export class CloudflareAnalyticsService extends Context.Service<
@@ -771,6 +781,11 @@ export class CloudflareAnalyticsService extends Context.Service<
 							or(
 								isNull(cloudflareAnalyticsState.leaseUntil),
 								lt(cloudflareAnalyticsState.leaseUntil, new Date(now)),
+								// Corrupt-lease escape hatch: a live lease is always bounded by now+LEASE_MS,
+								// so anything beyond 2x that is impossible under normal operation (e.g. a
+								// clock jump or a crashed writer that left a bogus far-future value) and is
+								// safe to reclaim rather than let it wedge the org forever.
+								gt(cloudflareAnalyticsState.leaseUntil, new Date(now + 2 * LEASE_MS)),
 							),
 						),
 					)
@@ -1110,13 +1125,23 @@ export class CloudflareAnalyticsService extends Context.Service<
 
 		const pollOrg = Effect.fn("CloudflareAnalyticsService.pollOrg")(function* (orgId: OrgId) {
 			yield* Effect.annotateCurrentSpan("orgId", orgId)
-			const skip = (reason: string): PollOrgSummary => ({
-				orgId,
-				skipped: reason,
-				callsMade: 0,
-				rowsIngested: 0,
-				failures: [],
-			})
+			// A skip used to be silent — the reason only ever landed in the returned summary, which
+			// nothing read for a plain tick. Annotating pollOrg's own span means every skip is now
+			// visible on the trace even when the tick rollup below doesn't (yet) escalate it.
+			const skip = (reason: string) =>
+				Effect.annotateCurrentSpan({
+					"maple.cloudflare.skip_reason": reason,
+					"maple.cloudflare.calls": 0,
+					"maple.cloudflare.rows_ingested": 0,
+				}).pipe(
+					Effect.as({
+						orgId,
+						skipped: reason,
+						callsMade: 0,
+						rowsIngested: 0,
+						failures: [],
+					} satisfies PollOrgSummary),
+				)
 
 			const now = yield* Clock.currentTimeMillis
 
@@ -1126,7 +1151,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 				Result.isFailure(tokenResult) &&
 				tokenResult.failure instanceof IntegrationsNotConnectedError
 			) {
-				return skip("not connected")
+				return yield* skip("not connected")
 			}
 
 			// Claim the tick lease; the anchor row is created lazily the first time an org is polled.
@@ -1135,7 +1160,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 				yield* ensureWorkersRow(orgId, now)
 				claimed = yield* claimLease(orgId, now)
 			}
-			if (claimed == null) return skip("lease held by another tick")
+			if (claimed == null) return yield* skip("lease held by another tick")
 			const anchor = claimed
 
 			return yield* Effect.gen(function* () {
@@ -1146,13 +1171,13 @@ export class CloudflareAnalyticsService extends Context.Service<
 					yield* recordOrgError(orgId, error.message, now, {
 						disable: error instanceof IntegrationsRevokedError,
 					})
-					return skip(`token unavailable: ${error._tag}`)
+					return yield* skip(`token unavailable: ${error._tag}`)
 				}
 				const { accessToken, accountId, scope } = tokenResult.success
 
 				if (!hasAnalyticsScopes(scope)) {
 					yield* recordOrgError(orgId, MISSING_SCOPES_ERROR, now)
-					return skip("missing analytics scopes")
+					return yield* skip("missing analytics scopes")
 				}
 
 				// Zone discovery (REST pagination) is hourly-TTL'd on the anchor row; ticks in
@@ -1165,7 +1190,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 						yield* recordOrgError(orgId, error.message, now, {
 							disable: error instanceof IntegrationsRevokedError,
 						})
-						return skip(`zone discovery failed: ${error._tag}`)
+						return yield* skip(`zone discovery failed: ${error._tag}`)
 					}
 					rows = yield* reconcileZones(orgId, zonesResult.success, anchor.id, now)
 				} else {
@@ -1184,7 +1209,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 						`Cloudflare ingest key unavailable: ${keyResult.failure.message}`,
 						now,
 					)
-					return skip("ingest key unavailable")
+					return yield* skip("ingest key unavailable")
 				}
 				const ingestKey = keyResult.success
 
@@ -1310,7 +1335,20 @@ export class CloudflareAnalyticsService extends Context.Service<
 			}).pipe(
 				Effect.ensuring(
 					Clock.currentTimeMillis.pipe(
-						Effect.flatMap((end) => releaseLease(orgId, end).pipe(Effect.ignore)),
+						Effect.flatMap((end) =>
+							releaseLease(orgId, end).pipe(
+								// The ensuring must never fail (that would mask whatever this tick actually
+								// did), but a lease release failure is not nothing — it silently wedges the
+								// org behind a lease until the corrupt-lease escape hatch reclaims it, so log
+								// loudly instead of swallowing it via Effect.ignore.
+								Effect.catchCause((cause) =>
+									Effect.logWarning("cloudflare-analytics lease release failed", {
+										orgId,
+										error: Cause.pretty(cause),
+									}),
+								),
+							),
+						),
 					),
 				),
 			)
@@ -1334,6 +1372,11 @@ export class CloudflareAnalyticsService extends Context.Service<
 			// Concurrent fan-out below — must be a Ref rather than a mutable closure variable.
 			const rowsIngestedRef = yield* Ref.make(0)
 			const failuresRef = yield* Ref.make(0)
+			// Every org's full summary, including skips — the outage that motivated this had 100%
+			// of ticks skip silently for 31 hours because nothing outside pollOrg ever looked at
+			// `summary.skipped`. Keeping the whole summary (not just counters) lets the rollup below
+			// name which orgs are stuck and why.
+			const summariesRef = yield* Ref.make<Array<PollOrgSummary>>([])
 			yield* Effect.forEach(
 				capable,
 				(row) =>
@@ -1343,6 +1386,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 								[
 									Ref.update(rowsIngestedRef, (count) => count + summary.rowsIngested),
 									Ref.update(failuresRef, (count) => count + summary.failures.length),
+									Ref.update(summariesRef, (list) => [...list, summary]),
 								],
 								{ discard: true },
 							),
@@ -1365,6 +1409,15 @@ export class CloudflareAnalyticsService extends Context.Service<
 			)
 			const rowsIngested = yield* Ref.get(rowsIngestedRef)
 			const failures = yield* Ref.get(failuresRef)
+			const summaries = yield* Ref.get(summariesRef)
+			const skipped = summaries.filter((summary) => summary.skipped != null).length
+			const perOrg = summaries.map((summary) => ({
+				orgId: summary.orgId,
+				skipped: summary.skipped,
+				callsMade: summary.callsMade,
+				rowsIngested: summary.rowsIngested,
+				failures: summary.failures.length,
+			}))
 			// Per-failure exception events + ERROR logs already fired in the seam; this is the
 			// at-a-glance rollup so a failing tick doesn't read as a healthy "complete".
 			if (failures > 0) {
@@ -1373,7 +1426,25 @@ export class CloudflareAnalyticsService extends Context.Service<
 					orgs: capable.length,
 				})
 			}
-			return { orgs: capable.length, rowsIngested, failures } satisfies PollAllOrgsSummary
+			// The outage that motivated this: every capable org skipped every tick, so rowsIngested
+			// stayed 0 with no failures either — a tick that "completed" while doing nothing at all.
+			// Surface that shape explicitly instead of relying on someone noticing a flat graph.
+			if (capable.length > 0 && rowsIngested === 0) {
+				yield* Effect.logWarning("cloudflare-analytics tick ingested zero rows", {
+					orgs: capable.length,
+					skipped,
+					reasons: summaries
+						.filter((summary) => summary.skipped != null)
+						.map((summary) => ({ orgId: summary.orgId, reason: summary.skipped })),
+				})
+			}
+			return {
+				orgs: capable.length,
+				rowsIngested,
+				failures,
+				skipped,
+				perOrg,
+			} satisfies PollAllOrgsSummary
 		})
 
 		const getStatus = Effect.fn("CloudflareAnalyticsService.getStatus")(function* (orgId: OrgId) {
@@ -1568,12 +1639,40 @@ export class CloudflareAnalyticsService extends Context.Service<
 			})
 		})
 
+		/**
+		 * Recovery hook for reconnect: clears the disabled/error state a revoked-token error left
+		 * behind and forces zone re-discovery on the next tick (so any zone that vanished while
+		 * disconnected is immediately re-disabled again by the reconcile, rather than reappearing
+		 * as falsely healthy). Reconnecting writes fresh tokens, but rows disabled by
+		 * `recordOrgError(..., { disable: true })` would otherwise stay dead forever — zone rows
+		 * recover via the discovery reconcile once polling resumes, but the account-scoped workers
+		 * anchor row has no other re-enable path.
+		 */
+		const resetOrgState = Effect.fn("CloudflareAnalyticsService.resetOrgState")(function* (orgId: OrgId) {
+			yield* Effect.annotateCurrentSpan("orgId", orgId)
+			const now = yield* Clock.currentTimeMillis
+			yield* dbExecute((db) =>
+				db
+					.update(cloudflareAnalyticsState)
+					.set({
+						enabled: true,
+						lastError: null,
+						lastErrorAt: null,
+						discoveredAt: null,
+						leaseUntil: null,
+						updatedAt: new Date(now),
+					})
+					.where(eq(cloudflareAnalyticsState.orgId, orgId)),
+			)
+		})
+
 		return {
 			pollAllOrgs,
 			pollOrg,
 			getStatus,
 			getIntegrationStatus,
 			getUsage,
+			resetOrgState,
 		} satisfies CloudflareAnalyticsServiceShape
 	}),
 }) {

--- a/apps/api/src/services/CloudflareAnalyticsService.ts
+++ b/apps/api/src/services/CloudflareAnalyticsService.ts
@@ -1402,7 +1402,23 @@ export class CloudflareAnalyticsService extends Context.Service<
 								: Effect.logWarning("cloudflare-analytics org poll failed", {
 										orgId: row.orgId,
 										error: Cause.pretty(cause),
-									}),
+									}).pipe(
+										// A crashed org must still appear in the rollup — otherwise perOrg
+										// silently omits it, `skipped` undercounts, and the zero-rows warning
+										// below can't see a crash-storm at all.
+										Effect.andThen(
+											Ref.update(summariesRef, (list) => [
+												...list,
+												{
+													orgId: decodeOrgId(row.orgId),
+													skipped: "org poll failed — see the warning log for the cause",
+													callsMade: 0,
+													rowsIngested: 0,
+													failures: [],
+												} satisfies PollOrgSummary,
+											]),
+										),
+									),
 						),
 					),
 				{ concurrency: ORG_CONCURRENCY, discard: true },
@@ -1429,7 +1445,10 @@ export class CloudflareAnalyticsService extends Context.Service<
 			// The outage that motivated this: every capable org skipped every tick, so rowsIngested
 			// stayed 0 with no failures either — a tick that "completed" while doing nothing at all.
 			// Surface that shape explicitly instead of relying on someone noticing a flat graph.
-			if (capable.length > 0 && rowsIngested === 0) {
+			// Gated on `skipped > 0` so a genuinely idle tick (orgs caught up / zero traffic —
+			// zero rows with zero skips) stays quiet; crashed orgs count as skipped via the
+			// synthetic summary above, and pure dataset failures already warn just before this.
+			if (capable.length > 0 && rowsIngested === 0 && skipped > 0) {
 				yield* Effect.logWarning("cloudflare-analytics tick ingested zero rows", {
 					orgs: capable.length,
 					skipped,

--- a/apps/api/src/services/CloudflareOAuthService.ts
+++ b/apps/api/src/services/CloudflareOAuthService.ts
@@ -242,6 +242,17 @@ export class CloudflareOAuthService extends Context.Service<
 			const orgId = decodeOrgId(stateRow.orgId)
 			yield* Effect.annotateCurrentSpan({ orgId })
 
+			// This is exactly the condition that caused a 31h silent outage: without a refresh
+			// token, the connection can only ever renew by the access token still being valid, so
+			// once it expires every poll tick starts skipping with no other signal. The registered
+			// OAuth client must have the refresh-token grant enabled on the Cloudflare side.
+			if (!tokenResponse.refresh_token) {
+				yield* Effect.logWarning(
+					"Cloudflare OAuth token exchange returned no refresh token — connection will expire without renewal",
+					{ orgId, expiresAt },
+				)
+			}
+
 			yield* oauth.upsertConnection(orgId, currentTime, {
 				externalUserId: account.id,
 				// Cloudflare has no user email in this flow; the account name is a display label.


### PR DESCRIPTION
## What happened

The Cloudflare analytics poller stopped ingesting at **2026-07-04 11:50 UTC** and stayed dead for 31+ hours with zero errors anywhere. Root cause: both orgs' OAuth access tokens expired (~16h TTL) and **no refresh token was stored** — Cloudflare only returns `refresh_token` when the registered OAuth client has the refresh-token grant type enabled (see the `offline_access` note in `apps/api/src/lib/Env.ts`). Every tick since skipped with `token unavailable: IntegrationsRevokedError`, recorded only to `cloudflare_analytics_state.last_error` (which nothing watches), while the tick logged `"Cloudflare analytics tick complete" {orgs: 2, rowsIngested: 0}` at Info.

Fallout: the revoked-token handling set `enabled = false` on all state rows, and the account-scoped workers anchor row had **no re-enable path** — a reconnect alone would have left the Workers dataset dead forever.

## What changed

- **`pollOrg` skips are now visible on the trace**: every skip annotates `maple.cloudflare.skip_reason` (+ zeroed `maple.cloudflare.calls` / `rows_ingested`) on the span.
- **`pollAllOrgs` rollup**: now returns `skipped` + a per-org breakdown, and logs a **WARN when capable orgs exist but zero rows were ingested** — the exact failure shape that was silent.
- **`resetOrgState(orgId)`** (new): re-enables all state rows, clears `lastError`, forces zone re-discovery; wired into the OAuth callback so a successful reconnect recovers polling within one tick. Reset failures never fail the callback page.
- **Connect-time warning** when the token exchange returns no `refresh_token` — surfaced immediately instead of ~16h later.
- **`claimLease` corrupt-lease escape hatch**: leases beyond `now + 2×LEASE_MS` are reclaimable (a live lease is bounded by `now + LEASE_MS`, so this can't steal a real one).
- **`releaseLease` failures are logged** instead of `Effect.ignore`'d.
- Alerting worker tick log includes `skipped` / `failures` / `perOrg`.

## Reviewer notes

- Diagnosis was done against prod telemetry + a read-only PlanetScale query: last good tick 11:45:42 (548 rows), first dead tick 11:50:37; `oauth_connections.expires_at` = 11:50/11:51 for both orgs; `last_error` = "access token expired and no refresh token is stored".
- The skip helper changed from a pure factory to an Effect (`return yield* skip(...)` at all 6 sites) so it can annotate the current span.
- Tests: 3 new cases (corrupt-lease reclaim, rollup skip counts, `resetOrgState`) — `vitest` 23/23, `bun typecheck` 27/27 packages.

## Deploy follow-ups (not in this PR)

1. Enable the **refresh-token grant type** on the registered Cloudflare OAuth client — without it, reconnected integrations break again ~16h later (the new connect-time WARN will confirm).
2. After deploy, reconnect the Cloudflare integration for both affected orgs; polling resumes within one 5-min tick (`resetOrgState` clears the disabled rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->