### PR TITLE
fix(alerts): evaluate every group of draft-grouped builder_query rules

### DIFF
--- a/apps/api/src/services/AlertsService.test.ts
+++ b/apps/api/src/services/AlertsService.test.ts
@@ -1607,6 +1607,301 @@ describe("AlertsService", () => {
 		)
 	})
 
+	// Regression: the web form persists rule-level groupBy as null for
+	// builder_query rules — the grouping lives only in the draft. The scheduler
+	// must derive groupedness from the compiled plan, not rule.groupBy, or it
+	// evaluates only the first group under "__total__".
+	it.effect("fans out per group for builder_query rules grouped only via the draft", () => {
+		const testDb = createTestDb(trackedDbs)
+
+		const groupedLogsDraft = (groupBy: string[]) => ({
+			id: "q",
+			name: "A",
+			dataSource: "logs" as const,
+			aggregation: "count" as const,
+			whereClause: 'severity = "error"',
+			groupBy,
+			addOns: { groupBy: true, having: false, orderBy: false, limit: false, legend: false },
+		})
+
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
+			const alerts = yield* AlertsService
+			const orgId = asOrgId("org_draft_grouped")
+			const userId = asUserId("user_draft_grouped")
+			const destination = yield* createWebhookDestination(alerts, orgId, userId)
+
+			const rule = yield* alerts.createRule(
+				orgId,
+				userId,
+				adminRoles,
+				new AlertRuleUpsertRequest({
+					name: "Error logs by service (draft grouping)",
+					severity: "critical",
+					enabled: true,
+					signalType: "builder_query",
+					queryBuilderDraft: groupedLogsDraft(["service.name"]),
+					// Deliberately NO rule-level groupBy — matches what the web form sends.
+					comparator: "gt",
+					threshold: 10,
+					windowMinutes: 5,
+					minimumSampleCount: 1,
+					consecutiveBreachesRequired: 2,
+					consecutiveHealthyRequired: 2,
+					renotifyIntervalMinutes: 30,
+					destinationIds: [destination.id],
+				}),
+			)
+
+			// Simulate the prod failure mode: a stale "__total__" state row left
+			// behind from when this rule evaluated ungrouped.
+			yield* Effect.promise(() =>
+				executeSql(
+					testDb,
+					`insert into alert_rule_states (org_id, rule_id, group_key, consecutive_breaches, consecutive_healthy, last_status, updated_at)
+					 values ($1, $2, '__total__', 0, 2, 'healthy', now())`,
+					[orgId, rule.id],
+				),
+			)
+
+			yield* alerts.runSchedulerTick()
+			yield* TestClock.adjust(Duration.minutes(1))
+			yield* alerts.runSchedulerTick()
+
+			// The breaching group fires even though the healthy group sorts first.
+			const incidents = yield* alerts.listIncidents(orgId)
+			assert.lengthOf(incidents.incidents, 1)
+			assert.strictEqual(incidents.incidents[0]?.groupKey, "zzz-breach")
+			assert.strictEqual(incidents.incidents[0]?.status, "open")
+
+			// Per-group state rows exist; the stale "__total__" row self-healed away.
+			const stateCounts = yield* Effect.promise(() =>
+				queryFirstRow<{ total_rows: number; grouped_rows: number }>(
+					testDb,
+					`select
+						count(*) filter (where group_key = '__total__')::int as total_rows,
+						count(*) filter (where group_key <> '__total__')::int as grouped_rows
+					 from alert_rule_states where rule_id = $1`,
+					[rule.id],
+				),
+			)
+			assert.strictEqual(stateCounts?.total_rows, 0)
+			assert.strictEqual(stateCounts?.grouped_rows, 2)
+		}).pipe(
+			Effect.provide(
+				makeLayer(
+					testDb,
+					makeWarehouseStub({
+						logsAggregateByServiceRows: [
+							{ bucket: "2026-01-01 00:00:00", groupName: "aaa-healthy", count: 3 },
+							{ bucket: "2026-01-01 00:00:00", groupName: "zzz-breach", count: 14 },
+						],
+					}),
+					{ fetch: okFetch },
+				),
+			),
+		)
+	})
+
+	it.effect("deletes stale per-group state rows once a rule evaluates ungrouped", () => {
+		const testDb = createTestDb(trackedDbs)
+
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
+			const alerts = yield* AlertsService
+			const orgId = asOrgId("org_ungrouped_heal")
+			const userId = asUserId("user_ungrouped_heal")
+			const destination = yield* createWebhookDestination(alerts, orgId, userId)
+			const rule = yield* createErrorRateRule(alerts, orgId, userId, destination.id)
+
+			// Leftover from a previous grouped configuration.
+			yield* Effect.promise(() =>
+				executeSql(
+					testDb,
+					`insert into alert_rule_states (org_id, rule_id, group_key, consecutive_breaches, consecutive_healthy, last_status, updated_at)
+					 values ($1, $2, 'svc-stale', 1, 0, 'breached', now())`,
+					[orgId, rule.id],
+				),
+			)
+
+			yield* alerts.runSchedulerTick()
+
+			const staleCount = yield* Effect.promise(() =>
+				queryFirstRow<{ stale: number }>(
+					testDb,
+					`select count(*)::int as stale from alert_rule_states where rule_id = $1 and group_key <> '__total__'`,
+					[rule.id],
+				),
+			)
+			assert.strictEqual(staleCount?.stale, 0)
+		}).pipe(
+			Effect.provide(
+				makeLayer(
+					testDb,
+					makeWarehouseStub({
+						tracesAggregateRows: [
+							{
+								count: 200,
+								avgDuration: 20,
+								p50Duration: 10,
+								p95Duration: 80,
+								p99Duration: 160,
+								errorRate: 1,
+								satisfiedCount: 195,
+								toleratingCount: 3,
+								apdexScore: 0.9825,
+							},
+						],
+					}),
+					{ fetch: okFetch },
+				),
+			),
+		)
+	})
+
+	it.effect("treats a draft-only grouping change as structural and resets state", () => {
+		const testDb = createTestDb(trackedDbs)
+
+		const draft = (groupBy: string[]) => ({
+			id: "q",
+			name: "A",
+			dataSource: "logs" as const,
+			aggregation: "count" as const,
+			whereClause: 'severity = "error"',
+			groupBy,
+			addOns: { groupBy: true, having: false, orderBy: false, limit: false, legend: false },
+		})
+		const request = (overrides: Partial<{ threshold: number; groupBy: string[] }>) =>
+			new AlertRuleUpsertRequest({
+				name: "Error logs grouping change",
+				severity: "critical",
+				enabled: true,
+				signalType: "builder_query",
+				queryBuilderDraft: draft(overrides.groupBy ?? ["service.name"]),
+				comparator: "gt",
+				threshold: overrides.threshold ?? 10,
+				windowMinutes: 5,
+				minimumSampleCount: 1,
+				consecutiveBreachesRequired: 2,
+				consecutiveHealthyRequired: 2,
+				renotifyIntervalMinutes: 30,
+				destinationIds: [],
+			})
+
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
+			const alerts = yield* AlertsService
+			const orgId = asOrgId("org_draft_group_change")
+			const userId = asUserId("user_draft_group_change")
+			const destination = yield* createWebhookDestination(alerts, orgId, userId)
+			const withDestination = (overrides: Partial<{ threshold: number; groupBy: string[] }>) =>
+				new AlertRuleUpsertRequest({ ...request(overrides), destinationIds: [destination.id] })
+
+			const rule = yield* alerts.createRule(orgId, userId, adminRoles, withDestination({}))
+
+			yield* alerts.runSchedulerTick()
+			yield* TestClock.adjust(Duration.minutes(1))
+			yield* alerts.runSchedulerTick()
+
+			const open = yield* alerts.listIncidents(orgId)
+			assert.strictEqual(open.incidents[0]?.status, "open")
+
+			// A non-structural edit (threshold) keeps the incident open.
+			yield* alerts.updateRule(orgId, userId, adminRoles, rule.id, withDestination({ threshold: 12 }))
+			const afterThreshold = yield* alerts.listIncidents(orgId)
+			assert.strictEqual(afterThreshold.incidents[0]?.status, "open")
+
+			// Changing only the draft's grouping is structural: incidents resolve
+			// and all state rows reset.
+			yield* alerts.updateRule(
+				orgId,
+				userId,
+				adminRoles,
+				rule.id,
+				withDestination({ threshold: 12, groupBy: ["severity"] }),
+			)
+			const afterGrouping = yield* alerts.listIncidents(orgId)
+			assert.strictEqual(afterGrouping.incidents[0]?.status, "resolved")
+			const stateCount = yield* Effect.promise(() =>
+				queryFirstRow<{ remaining: number }>(
+					testDb,
+					`select count(*)::int as remaining from alert_rule_states where rule_id = $1`,
+					[rule.id],
+				),
+			)
+			assert.strictEqual(stateCount?.remaining, 0)
+		}).pipe(
+			Effect.provide(
+				makeLayer(
+					testDb,
+					makeWarehouseStub({
+						logsAggregateByServiceRows: [
+							{ bucket: "2026-01-01 00:00:00", groupName: "zzz-breach", count: 14 },
+						],
+					}),
+					{ fetch: okFetch },
+				),
+			),
+		)
+	})
+
+	it.effect("testRule surfaces a breaching non-first group for draft-grouped rules", () => {
+		const testDb = createTestDb(trackedDbs)
+
+		return Effect.gen(function* () {
+			const result = yield* Effect.gen(function* () {
+				const alerts = yield* AlertsService
+				const orgId = asOrgId("org_test_draft_grouped")
+				const userId = asUserId("user_test_draft_grouped")
+				const destination = yield* createWebhookDestination(alerts, orgId, userId)
+
+				return yield* alerts.testRule(
+					orgId,
+					userId,
+					adminRoles,
+					new AlertRuleUpsertRequest({
+						name: "Grouped test rule",
+						severity: "critical",
+						enabled: true,
+						signalType: "builder_query",
+						queryBuilderDraft: {
+							id: "q",
+							name: "A",
+							dataSource: "logs",
+							aggregation: "count",
+							whereClause: 'severity = "error"',
+							groupBy: ["service.name"],
+							addOns: { groupBy: true, having: false, orderBy: false, limit: false, legend: false },
+						},
+						comparator: "gt",
+						threshold: 10,
+						windowMinutes: 5,
+						minimumSampleCount: 1,
+						consecutiveBreachesRequired: 2,
+						consecutiveHealthyRequired: 2,
+						renotifyIntervalMinutes: 30,
+						destinationIds: [destination.id],
+					}),
+				)
+			}).pipe(
+				Effect.provide(
+					makeLayer(
+						testDb,
+						makeWarehouseStub({
+							logsAggregateByServiceRows: [
+								{ bucket: "2026-01-01 00:00:00", groupName: "aaa-healthy", count: 3 },
+								{ bucket: "2026-01-01 00:00:00", groupName: "zzz-breach", count: 14 },
+							],
+						}),
+					),
+				),
+			)
+
+			assert.strictEqual(result.status, "breached")
+			assert.strictEqual(result.value, 14)
+		})
+	})
+
 	it.effect("blocks destination deletion when rules still reference it", () => {
 		const testDb = createTestDb(trackedDbs)
 

--- a/apps/api/src/services/AlertsService.ts
+++ b/apps/api/src/services/AlertsService.ts
@@ -84,7 +84,7 @@ import {
 	type AlertRuleRow,
 	alertRuleStates,
 } from "@maple/db"
-import { and, asc, desc, eq, inArray, isNotNull, isNull, lt, lte, or } from "drizzle-orm"
+import { and, asc, desc, eq, inArray, isNotNull, isNull, lt, lte, ne, or } from "drizzle-orm"
 import {
 	Array as Arr,
 	Cause,
@@ -315,6 +315,25 @@ const parseStoredGroupBy = (raw: string | null): AlertGroupBy | null =>
 
 const isServiceGroupBy = (groupBy: AlertGroupBy | null): boolean =>
 	groupBy != null && groupBy.length === 1 && groupBy[0] === "service.name"
+
+/**
+ * The compiled plan is the single authority on whether a rule evaluates
+ * grouped. Rule-level `groupBy` and a builder draft's `groupBy` both funnel
+ * into the compiled spec's tokens (`["none"]` when ungrouped), so evaluation
+ * code must never consult those source representations — a builder_query rule
+ * stores its grouping only in the draft and keeps rule-level `groupBy` null.
+ */
+const planGroupingTokens = (
+	plan: Schema.Schema.Type<typeof CompiledAlertQueryPlan>,
+): ReadonlyArray<string> | null => {
+	if (plan.kind !== "spec" || plan.query == null || plan.query.kind !== "timeseries") return null
+	const groupBy = plan.query.groupBy
+	if (groupBy == null || groupBy.length === 0 || groupBy.includes("none")) return null
+	return groupBy
+}
+
+const isGroupedPlan = (plan: Schema.Schema.Type<typeof CompiledAlertQueryPlan>): boolean =>
+	planGroupingTokens(plan) != null
 
 const resolveServiceLinkName = (
 	rule: Pick<NormalizedRule, "serviceNames" | "groupBy">,
@@ -2501,22 +2520,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				yield* requireDestinationIds(orgId, normalized.destinationIds)
 
 				let evaluation: EvaluatedRule
-				if (normalized.groupBy != null && normalized.serviceNames.length === 0) {
-					const allResults = yield* evaluateRule(orgId, normalized)
-					const excludeSet = new Set(normalized.excludeServiceNames)
-					const results = allResults.filter((r) => !excludeSet.has(r.groupKey))
-					const breached = results.find((r) => r.evaluation.status === "breached")
-					evaluation = breached?.evaluation ??
-						results[0]?.evaluation ?? {
-							status: "skipped" as const,
-							value: null,
-							sampleCount: 0,
-							threshold: normalized.threshold,
-							thresholdUpper: normalized.thresholdUpper,
-							comparator: normalized.comparator,
-							reason: "No groups found",
-						}
-				} else if (normalized.serviceNames.length > 1) {
+				if (normalized.serviceNames.length > 1) {
 					const results = yield* Effect.forEach(
 						normalized.serviceNames,
 						(svcName) =>
@@ -2555,16 +2559,25 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 							reason: "No data",
 						}
 				} else {
-					const observations = yield* evaluateRule(orgId, normalized)
-					evaluation = observations[0]?.evaluation ?? {
-						status: "skipped" as const,
-						value: null,
-						sampleCount: 0,
-						threshold: normalized.threshold,
-						thresholdUpper: normalized.thresholdUpper,
-						comparator: normalized.comparator,
-						reason: "No data",
-					}
+					// Uniform grouped/ungrouped path — mirrors runSchedulerTick: the
+					// compiled plan decides groupedness, and a breaching group (if any)
+					// wins so the test reflects what the scheduler would fire on.
+					const allResults = yield* evaluateRule(orgId, normalized)
+					const excludeSet = new Set(normalized.excludeServiceNames)
+					const results = isGroupedPlan(normalized.compiledPlan)
+						? allResults.filter((r) => !excludeSet.has(r.groupKey))
+						: allResults
+					const breached = results.find((r) => r.evaluation.status === "breached")
+					evaluation = breached?.evaluation ??
+						results[0]?.evaluation ?? {
+							status: "skipped" as const,
+							value: null,
+							sampleCount: 0,
+							threshold: normalized.threshold,
+							thresholdUpper: normalized.thresholdUpper,
+							comparator: normalized.comparator,
+							reason: "No data",
+						}
 				}
 
 				if (sendNotification) {
@@ -2786,7 +2799,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				// a series even when the whole range is empty.
 				if (
 					obsByGroup.size === 0 &&
-					normalized.groupBy == null &&
+					!isGroupedPlan(normalized.compiledPlan) &&
 					normalized.serviceNames.length <= 1
 				) {
 					obsByGroup.set("all", new Map())
@@ -3773,7 +3786,10 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				return HashSet.union(removedServices, newlyExcluded)
 			}
 
-			const groupByEqual = (a: AlertGroupBy | null, b: AlertGroupBy | null): boolean => {
+			const groupByEqual = (
+				a: ReadonlyArray<string> | null,
+				b: ReadonlyArray<string> | null,
+			): boolean => {
 				if (a == null || b == null) return a == null && b == null
 				if (a.length !== b.length) return false
 				for (let i = 0; i < a.length; i++) {
@@ -3782,11 +3798,32 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				return true
 			}
 
+			/**
+			 * The user-facing grouping keys a rule evaluates by — rule-level groupBy,
+			 * or the builder draft's groupBy for builder_query rules (which always
+			 * persist rule-level groupBy as null). Compared at key level because
+			 * different attribute keys (attr.http.route vs attr.http.method) compile
+			 * to the same spec token ("attribute").
+			 */
+			const effectiveGroupByKeys = (rule: NormalizedRule): ReadonlyArray<string> | null => {
+				if (rule.groupBy != null && rule.groupBy.length > 0) return rule.groupBy
+				const draft = rule.queryBuilderDraft
+				if (
+					rule.signalType === "builder_query" &&
+					draft?.addOns?.groupBy === true &&
+					draft.groupBy != null &&
+					draft.groupBy.length > 0
+				) {
+					return draft.groupBy
+				}
+				return null
+			}
+
 			const ruleStructureChanged = (oldRule: NormalizedRule, newRule: NormalizedRule): boolean => {
-				if (!groupByEqual(oldRule.groupBy, newRule.groupBy)) return true
+				if (!groupByEqual(effectiveGroupByKeys(oldRule), effectiveGroupByKeys(newRule))) return true
 				if (oldRule.signalType !== newRule.signalType) return true
 				const mode = (r: NormalizedRule) =>
-					r.groupBy != null ? "grouped" : r.serviceNames.length > 1 ? "multi" : "single"
+					isGroupedPlan(r.compiledPlan) ? "grouped" : r.serviceNames.length > 1 ? "multi" : "single"
 				return mode(oldRule) !== mode(newRule)
 			}
 
@@ -4170,46 +4207,6 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 								const ruleStart = yield* now
 								const normalized = yield* normalizeRuleRow(row)
 
-								if (normalized.groupBy != null && normalized.serviceNames.length === 0) {
-									const results = yield* evaluateRule(row.orgId, normalized)
-									const excludeSet = HashSet.fromIterable(normalized.excludeServiceNames)
-									const eligible = Arr.filter(
-										results,
-										(r) => !HashSet.has(excludeSet, r.groupKey),
-									)
-
-									yield* Effect.forEach(eligible, ({ evaluation, groupKey }) =>
-										Effect.gen(function* () {
-											yield* recordEvaluationStatus(evaluation)
-											yield* processEvaluation(
-												row,
-												normalized,
-												evaluation,
-												groupKey,
-												timestamp,
-												pendingChecks,
-												issueBudget,
-											)
-										}),
-									)
-
-									const evaluatedGroups = HashSet.fromIterable(
-										Arr.map(eligible, (r) => r.groupKey),
-									)
-									yield* resolveOrphanedGroupIncidents(
-										row.orgId,
-										normalized.id,
-										normalized,
-										evaluatedGroups,
-										timestamp,
-									)
-									yield* Metric.update(
-										AlertingMetrics.ruleEvaluationDurationMs,
-										(yield* now) - ruleStart,
-									)
-									return
-								}
-
 								if (normalized.serviceNames.length > 1) {
 									yield* Effect.forEach(normalized.serviceNames, (svcName) =>
 										Effect.gen(function* () {
@@ -4252,20 +4249,64 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 									return
 								}
 
-								const observations = yield* evaluateRule(row.orgId, normalized)
-								const evaluation = observations[0]?.evaluation
-								if (evaluation != null) {
-									yield* recordEvaluationStatus(evaluation)
-									yield* processEvaluation(
-										row,
-										normalized,
-										evaluation,
-										"__total__",
-										timestamp,
-										pendingChecks,
-										issueBudget,
-									)
-								}
+								// Uniform grouped/ungrouped path. The engine always returns one
+								// observation per group — a single "all" observation (with a
+								// no-data fallback) when the compiled plan is ungrouped — so both
+								// shapes flow through the same loop; ungrouped rules keep their
+								// historical "__total__" storage key at this boundary.
+								const grouped = isGroupedPlan(normalized.compiledPlan)
+								const results = yield* evaluateRule(row.orgId, normalized)
+								const excludeSet = HashSet.fromIterable(normalized.excludeServiceNames)
+								const eligible = grouped
+									? Arr.filter(results, (r) => !HashSet.has(excludeSet, r.groupKey))
+									: results
+
+								yield* Effect.forEach(eligible, ({ evaluation, groupKey }) =>
+									Effect.gen(function* () {
+										yield* recordEvaluationStatus(evaluation)
+										yield* processEvaluation(
+											row,
+											normalized,
+											evaluation,
+											grouped ? groupKey : "__total__",
+											timestamp,
+											pendingChecks,
+											issueBudget,
+										)
+									}),
+								)
+
+								const evaluatedGroups = grouped
+									? HashSet.fromIterable(Arr.map(eligible, (r) => r.groupKey))
+									: HashSet.fromIterable(["__total__"])
+								yield* resolveOrphanedGroupIncidents(
+									row.orgId,
+									normalized.id,
+									normalized,
+									evaluatedGroups,
+									timestamp,
+								)
+
+								// Self-heal state rows whose key shape contradicts the rule's
+								// groupedness: a grouped rule can never legitimately own a
+								// "__total__" row (left behind when this rule evaluated ungrouped,
+								// or by recordEvaluationFailure), and vice versa. Orphan resolution
+								// above only deletes incident-backed rows. Zero rows touched in
+								// steady state, so the Electric shape stays quiet.
+								yield* dbExecute((db) =>
+									db
+										.delete(alertRuleStates)
+										.where(
+											and(
+												eq(alertRuleStates.orgId, row.orgId),
+												eq(alertRuleStates.ruleId, row.id),
+												grouped
+													? eq(alertRuleStates.groupKey, "__total__")
+													: ne(alertRuleStates.groupKey, "__total__"),
+											),
+										),
+								)
+
 								yield* Metric.update(
 									AlertingMetrics.ruleEvaluationDurationMs,
 									(yield* now) - ruleStart,


### PR DESCRIPTION
## What

A prod `builder_query` alert stopped meaningfully evaluating after its grouping was changed: the chart showed a group ~20x over the threshold while the rule sat healthy/OK.

**Root cause:** "is this rule grouped?" was answered from two representations that can disagree. The web form persists rule-level `groupBy: null` for query-builder rules (the grouping lives only in `queryBuilderDraft.groupBy`), but the scheduler gated its grouped fan-out on rule-level `groupBy != null`. A grouped builder rule therefore fell into the ungrouped path, which takes `observations[0]` only — evaluating one arbitrary group under `"__total__"` and silently dropping the rest (including the breaching one). `testRule` had the same shortcut, and `ruleStructureChanged` missed draft-grouping changes, so state was never reset either.

## How

- **Single authority on groupedness:** `planGroupingTokens` / `isGroupedPlan` derive grouping from the compiled QuerySpec (`["none"]` = ungrouped). Rule-level and draft grouping both already funnel into the compiled plan, so evaluation code no longer consults either source representation.
- **One uniform evaluation loop:** the scheduler's grouped + single paths are collapsed; every observation the engine returns is processed per group (ungrouped = the degenerate single-`"all"` case, keeping its historical `"__total__"` storage key, so existing data is untouched). Any future signal type returning grouped observations fans out automatically. The multi-service branch is unchanged.
- **`testRule` / `previewRule`:** share the same authority; a rule test now surfaces a breaching non-first group.
- **`ruleStructureChanged`:** compares effective grouping *keys* (rule-level or draft; key-level because `attr.x` and `attr.y` compile to the same spec token), so a draft-only grouping change resolves stale incidents and resets state like any structural change.
- **Self-heal:** each clean tick deletes state rows whose key shape contradicts the rule's groupedness (grouped rules can never own `"__total__"`, and vice versa). Zero rows touched in steady state (no Electric shape churn), and already-affected prod rules fix themselves on the first tick after deploy — no re-save needed.

## Reviewer notes

- `raw_query` rules keep single-observation semantics unless their SQL emits a `group` column, which the uniform loop now also handles instead of dropping.
- The two remaining `rule.groupBy` reads (delivery enrichment, issue-hub service link) are display-only service-link concerns and intentionally untouched.
- The pre-existing "grouped logs query alerts" test only passed because it set rule-level `groupBy` — something the web form never sends. New tests cover the realistic shape: draft-only grouping fan-out (breaching non-first group fires, stale `"__total__"` row self-heals), the inverse ungrouped cleanup, draft-grouping change resetting state (threshold-only edit doesn't), and `testRule` on a grouped draft.
- Verified with `bun run test` (719 passing in apps/api) and `bun typecheck`.

Deploy: api + alerting worker together (worker imports `@maple/api/alerting`). If the prod group is still over threshold, the incident fires after the usual consecutive-breach count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)