### PR TITLE
fix(alerts): stop rule chart lines dying before the right edge

### DIFF
--- a/apps/api/src/services/AlertsService.test.ts
+++ b/apps/api/src/services/AlertsService.test.ts
@@ -4,6 +4,7 @@ import { TestClock } from "effect/testing"
 import {
 	AlertDestinationInUseError,
 	AlertForbiddenError,
+	AlertValidationError,
 	type AlertDestinationId,
 	AlertRulePreviewRequest,
 	AlertRuleUpsertRequest,
@@ -52,7 +53,7 @@ const makeConfig = () =>
 		}),
 	)
 
-const emptyWarehouseRows = [] as ReadonlyArray<Record<string, unknown>>
+const emptyWarehouseRows: ReadonlyArray<Record<string, unknown>> = []
 
 function makeWarehouseStub(state: {
 	tracesAggregateRows?: ReadonlyArray<Record<string, unknown>>
@@ -61,7 +62,7 @@ function makeWarehouseStub(state: {
 	logsAggregateByServiceRows?: ReadonlyArray<Record<string, unknown>>
 	rawQueryRows?: ReadonlyArray<Record<string, unknown>>
 }): WarehouseQueryServiceShape {
-	const succeedRows = (rows: ReadonlyArray<Record<string, unknown>>) => Effect.succeed(rows as never)
+	const succeedRows = (rows: ReadonlyArray<Record<string, unknown>>) => Effect.succeed(rows)
 
 	// All alert queries now go through sqlQuery (raw SQL via CH query engine).
 	// Route the response based on what data is configured in the test state.
@@ -76,7 +77,7 @@ function makeWarehouseStub(state: {
 	}
 
 	return {
-		query: (_tenant, payload) => Effect.fail(new Error(`Unexpected pipe ${payload.pipeName}`)) as never,
+		query: (_tenant, payload) => Effect.die(new Error(`Unexpected pipe ${payload.pipeName}`)),
 		sqlQuery: sqlQueryStub,
 		compiledQuery: (_tenant, compiled) =>
 			sqlQueryStub().pipe(Effect.flatMap((rows) => compiled.decodeRows(rows).pipe(Effect.orDie))),
@@ -138,7 +139,7 @@ const makeLayer = (
 				hazelOAuthLive,
 			),
 		),
-	) as Layer.Layer<AlertsService, never, never>
+	)
 }
 
 const asOrgId = Schema.decodeUnknownSync(OrgId)
@@ -1372,10 +1373,8 @@ describe("AlertsService", () => {
 			const failure = getError(exit)
 
 			assert.isTrue(Exit.isFailure(exit))
-			assert.strictEqual(
-				(failure as { message: string }).message,
-				"Metrics alerts support at most one attr.* groupBy dimension",
-			)
+			assert.instanceOf(failure, AlertValidationError)
+			assert.strictEqual(failure.message, "Metrics alerts support at most one attr.* groupBy dimension")
 		})
 	})
 
@@ -1410,7 +1409,9 @@ describe("AlertsService", () => {
 				.pipe(Effect.exit)
 
 			assert.isTrue(Exit.isFailure(exit))
-			assert.include((getError(exit) as { message: string }).message, "32-character Events API v2 routing key")
+			const failure = getError(exit)
+			assert.instanceOf(failure, AlertValidationError)
+			assert.include(failure.message, "32-character Events API v2 routing key")
 			// Format check short-circuits before any network call.
 			assert.lengthOf(requests, 0)
 		})
@@ -1451,7 +1452,9 @@ describe("AlertsService", () => {
 				.pipe(Effect.exit)
 
 			assert.isTrue(Exit.isFailure(exit))
-			assert.include((getError(exit) as { message: string }).message, "Invalid routing key")
+			const failure = getError(exit)
+			assert.instanceOf(failure, AlertValidationError)
+			assert.include(failure.message, "Invalid routing key")
 			assert.lengthOf(requests, 1)
 			assert.strictEqual(requests[0]?.url, "https://events.pagerduty.com/v2/enqueue")
 			// Validation uses a no-op resolve so it never creates an incident.
@@ -2176,13 +2179,12 @@ describe("AlertsService", () => {
 			estimatedSpanCount: 200,
 		}
 
-		const alertRows = [breachingRow, healthyRow] as ReadonlyArray<Record<string, unknown>>
+		const alertRows: ReadonlyArray<Record<string, unknown>> = [breachingRow, healthyRow]
 		const stub: WarehouseQueryServiceShape = {
 			...makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }),
-			sqlQuery: () => Effect.succeed(alertRows) as never,
-			compiledQuery: (_tenant, compiled) => compiled.decodeRows(alertRows).pipe(Effect.orDie) as never,
-			compiledQueryFirst: (_tenant, compiled) =>
-				compiled.decodeFirstRow(alertRows).pipe(Effect.orDie) as never,
+			sqlQuery: () => Effect.succeed(alertRows),
+			compiledQuery: (_tenant, compiled) => compiled.decodeRows(alertRows).pipe(Effect.orDie),
+			compiledQueryFirst: (_tenant, compiled) => compiled.decodeFirstRow(alertRows).pipe(Effect.orDie),
 		}
 
 		return Effect.gen(function* () {
@@ -2233,15 +2235,15 @@ describe("AlertsService evaluation error persistence", () => {
 	}): WarehouseQueryServiceShape => {
 		const sqlQueryStub = () =>
 			state.failing
-				? (Effect.fail(
+				? Effect.fail(
 						new WarehouseQueryError({
 							message: "Unknown column FooBar in traces",
 							pipeName: "tracesAlertEval",
 						}),
-					) as never)
-				: (Effect.succeed(state.rows as never) as never)
+					)
+				: Effect.succeed(state.rows)
 		return {
-			query: () => Effect.fail(new Error("Unexpected pipe query")) as never,
+			query: () => Effect.die(new Error("Unexpected pipe query")),
 			sqlQuery: sqlQueryStub,
 			compiledQuery: (_tenant, compiled) =>
 				sqlQueryStub().pipe(Effect.flatMap((rows) => compiled.decodeRows(rows).pipe(Effect.orDie))),
@@ -2408,6 +2410,63 @@ describe("AlertsService.previewRule", () => {
 			// (which freezes counters), so no close within the window either way.
 			assert.lengthOf(response.wouldFire, 1)
 			assert.strictEqual(response.wouldFire[0]?.start, "2026-01-01T00:00:00.000Z")
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: okFetch })))
+	})
+
+	it.effect("adds a provisional point for the trailing partial window", () => {
+		const testDb = createTestDb(trackedDbs)
+		const state = {
+			tracesAggregateRows: [
+				bucketRow("2026-01-01 00:00:00", 10),
+				bucketRow("2026-01-01 00:05:00", 12),
+				bucketRow("2026-01-01 00:30:00", 8),
+			],
+		}
+
+		return Effect.gen(function* () {
+			const alerts = yield* AlertsService
+			const orgId = asOrgId("org_preview_partial")
+
+			const request = decodePreviewRequest({
+				rule: {
+					name: "Preview rule",
+					severity: "critical",
+					enabled: true,
+					serviceNames: ["checkout"],
+					signalType: "error_rate",
+					comparator: "gt",
+					threshold: 5,
+					windowMinutes: 5,
+					minimumSampleCount: 10,
+					consecutiveBreachesRequired: 2,
+					consecutiveHealthyRequired: 2,
+					renotifyIntervalMinutes: 30,
+					destinationIds: [],
+				},
+				startTime: "2026-01-01T00:00:00.000Z",
+				// 2.5 minutes past the last complete 5-minute boundary.
+				endTime: "2026-01-01T00:32:30.000Z",
+			})
+
+			const response = yield* alerts.previewRule(orgId, request)
+
+			assert.lengthOf(response.series, 1)
+			const points = response.series[0]!.points
+			// 6 complete windows plus the in-progress [00:30, 00:32:30) one.
+			assert.lengthOf(points, 7)
+			assert.isUndefined(points[5]?.provisional)
+			const last = points[6]!
+			assert.strictEqual(last.bucket, "2026-01-01T00:30:00.000Z")
+			assert.strictEqual(last.provisional, true)
+			assert.strictEqual(last.status, "breached")
+			assert.strictEqual(last.value, 8)
+
+			// The provisional window charts but must not extend the would-fire
+			// simulation: the span from the two opening breaches stays the only one,
+			// closed at the last complete boundary.
+			assert.lengthOf(response.wouldFire, 1)
+			assert.strictEqual(response.wouldFire[0]?.start, "2026-01-01T00:00:00.000Z")
+			assert.strictEqual(response.wouldFire[0]?.end, "2026-01-01T00:30:00.000Z")
 		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: okFetch })))
 	})
 

--- a/apps/api/src/services/AlertsService.ts
+++ b/apps/api/src/services/AlertsService.ts
@@ -441,10 +441,11 @@ const makePersistenceError = (error: unknown) => {
 const makeValidationError = (message: string, details: ReadonlyArray<string> = [], cause?: unknown) =>
 	new AlertValidationError({ message, details, ...(cause === undefined ? {} : { cause }) })
 
-const makeDeliveryError = (message: string, destinationType?: AlertDestinationType) =>
+const makeDeliveryError = (message: string, destinationType?: AlertDestinationType, cause?: unknown) =>
 	new AlertDeliveryError({
 		message,
 		destinationType,
+		...(cause === undefined ? {} : { cause }),
 	})
 
 const isAdmin = (roles: ReadonlyArray<RoleName>) => roles.some((role) => adminRoles.includes(role))
@@ -452,7 +453,7 @@ const isAdmin = (roles: ReadonlyArray<RoleName>) => roles.some((role) => adminRo
 const validateDestinationUrl = (rawUrl: string, field: string): Effect.Effect<string, AlertValidationError> =>
 	validateExternalUrl(rawUrl).pipe(
 		Effect.as(rawUrl.trim()),
-		Effect.mapError((error) => makeValidationError(`${field}: ${error.message}`)),
+		Effect.mapError((error) => makeValidationError(`${field}: ${error.message}`, [], error)),
 	)
 
 const parseEncryptionKey = (raw: string): Effect.Effect<Buffer, AlertValidationError> =>
@@ -552,7 +553,12 @@ const buildPublicConfig = (request: AlertDestinationCreateRequest): DestinationP
 		}),
 	)
 
-const buildSecretConfig = (request: AlertDestinationCreateRequest): DestinationSecretConfig =>
+// Hazel-OAuth requires provisioning a channel webhook on Hazel first, so its
+// secret config is built inline after that side effect — the type excludes it
+// here so this stays a pure, total function over the remaining variants.
+const buildSecretConfig = (
+	request: Exclude<AlertDestinationCreateRequest, { readonly type: "hazel-oauth" }>,
+): DestinationSecretConfig =>
 	Match.value(request).pipe(
 		Match.discriminatorsExhaustive("type")({
 			slack: (r) => ({
@@ -573,13 +579,6 @@ const buildSecretConfig = (request: AlertDestinationCreateRequest): DestinationS
 				webhookUrl: r.webhookUrl.trim(),
 				signingSecret: normalizeOptionalString(r.signingSecret),
 			}),
-			// Hazel-OAuth requires provisioning a channel webhook on Hazel; we build
-			// the secret config inline after that side effect, not here.
-			"hazel-oauth": () => {
-				throw new Error(
-					"Hazel-OAuth secret config must be built via the channel-webhook provisioning path",
-				)
-			},
 			discord: (r) => ({
 				type: "discord" as const,
 				webhookUrl: r.webhookUrl.trim(),
@@ -1424,9 +1423,9 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 						"@maple/http/errors/QueryEngineValidationError": (e) =>
 							Effect.fail(makeValidationError(e.message, e.details)),
 						"@maple/http/errors/QueryEngineExecutionError": (e) =>
-							Effect.fail(makeDeliveryError(e.message)),
+							Effect.fail(makeDeliveryError(e.message, undefined, e)),
 						"@maple/http/errors/QueryEngineTimeoutError": (e) =>
-							Effect.fail(makeDeliveryError(e.message ?? "Alert evaluation timed out")),
+							Effect.fail(makeDeliveryError(e.message ?? "Alert evaluation timed out", undefined, e)),
 					}),
 				)
 
@@ -2688,6 +2687,22 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					bucketStarts.push(t)
 				}
 
+				// The trailing in-progress window [endMs, requestedEndMs) — evaluated as a
+				// provisional bucket keyed at endMs so the chart reaches "now" instead of
+				// dropping up to a full window of the freshest data. Its rows land in the
+				// epoch-aligned bucket starting at endMs, so the series query just extends.
+				const hasPartialBucket = requestedEndMs - endMs >= 60_000
+				const queryEndMs = hasPartialBucket ? requestedEndMs : endMs
+				const pointBuckets = hasPartialBucket ? Arr.append(bucketStarts, endMs) : bucketStarts
+
+				yield* Effect.annotateCurrentSpan({
+					orgId,
+					"alert.plan_kind": plan.kind,
+					"alert.window_minutes": normalized.windowMinutes,
+					"alert.preview.buckets": pointBuckets.length,
+					"alert.preview.has_partial_bucket": hasPartialBucket,
+				})
+
 				// Raw per-(group, bucket) observations; buckets missing here are
 				// no-data windows and get filled from the grid below.
 				interface PreviewObs {
@@ -2728,7 +2743,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 									const observations = yield* queryEngine
 										.evaluateSeries(systemTenant(orgId), {
 											startTime: toTinybirdDateTime(startMs),
-											endTime: toTinybirdDateTime(endMs),
+											endTime: toTinybirdDateTime(queryEndMs),
 											query: perServicePlan.query,
 											reducer: perServicePlan.reducer,
 											sampleCountStrategy: perServicePlan.sampleCountStrategy,
@@ -2748,7 +2763,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 						const observations = yield* queryEngine
 							.evaluateSeries(systemTenant(orgId), {
 								startTime: toTinybirdDateTime(startMs),
-								endTime: toTinybirdDateTime(endMs),
+								endTime: toTinybirdDateTime(queryEndMs),
 								query: plan.query,
 								reducer: plan.reducer,
 								sampleCountStrategy: plan.sampleCountStrategy,
@@ -2766,15 +2781,16 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					}
 				} else {
 					// Raw SQL: the reducer runs INSIDE one evaluation window, so replay
-					// the evaluator over each historical window. Bounded by
-					// MAX_RAW_PREVIEW_WINDOWS via the range clamp above.
+					// the evaluator over each historical window (plus the trailing
+					// in-progress one). Bounded by MAX_RAW_PREVIEW_WINDOWS via the range
+					// clamp above.
 					yield* Effect.forEach(
-						bucketStarts,
+						pointBuckets,
 						(bucketMs) =>
 							queryEngine
 								.evaluateRawSql(systemTenant(orgId), {
 									startTime: toTinybirdDateTime(bucketMs),
-									endTime: toTinybirdDateTime(bucketMs + windowMs),
+									endTime: toTinybirdDateTime(Math.min(bucketMs + windowMs, queryEndMs)),
 									sql: plan.rawSql ?? "",
 									reducer: plan.reducer,
 									windowMinutes: normalized.windowMinutes,
@@ -2817,17 +2833,22 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					let breaches = 0
 					let healthy = 0
 					let openStart: number | null = null
-					for (const bucketMs of bucketStarts) {
+					for (const bucketMs of pointBuckets) {
 						const obs = buckets.get(bucketMs) ?? NO_DATA
 						const evaluation = applyEvaluationLogic(normalized, obs)
+						const provisional = hasPartialBucket && bucketMs === endMs
 						points.push(
 							new AlertRulePreviewPoint({
 								bucket: iso(bucketMs),
 								value: evaluation.value,
 								sampleCount: obs.sampleCount,
 								status: evaluation.status,
+								...(provisional ? { provisional } : {}),
 							}),
 						)
+						// The in-progress window charts but doesn't feed the incident
+						// simulation — the scheduler hasn't evaluated it yet.
+						if (provisional) continue
 						if (evaluation.status === "breached") {
 							breaches = Math.min(breaches + 1, normalized.consecutiveBreachesRequired)
 							healthy = 0
@@ -2856,6 +2877,11 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					}
 					series.push(new AlertRulePreviewSeries({ groupKey, points }))
 				}
+
+				yield* Effect.annotateCurrentSpan({
+					"result.seriesCount": series.length,
+					"result.wouldFireCount": wouldFire.length,
+				})
 
 				return new AlertRulePreviewResponse({
 					bucketSeconds: windowMs / 1000,

--- a/apps/web/src/components/alerts/alert-rule-chart.tsx
+++ b/apps/web/src/components/alerts/alert-rule-chart.tsx
@@ -109,7 +109,7 @@ export function AlertRuleChart({
 	// The preview series is the preferred source; when it's empty/unavailable the
 	// recorded checks become the series instead, so a rule whose preview fails
 	// still gets a chart from its evaluation history.
-	const { chartData, seriesKeys, isMultiSeries, source, sampleCounts, statuses } =
+	const { chartData, seriesKeys, isMultiSeries, source, sampleCounts, statuses, noDataBands, provisionalTs } =
 		React.useMemo((): {
 			chartData: ChartPoint[]
 			seriesKeys: string[]
@@ -119,22 +119,37 @@ export function AlertRuleChart({
 			sampleCounts: Map<number, number>
 			/** t → worst per-bucket status across groups (tooltip). */
 			statuses: Map<number, string>
+			/** Merged spans where NO group observed data — hatched on the chart. */
+			noDataBands: Array<{ x1: number; x2: number }>
+			/** x-coords of the trailing in-progress window (tooltip). */
+			provisionalTs: Set<number>
 		} => {
 			const sampleCounts = new Map<number, number>()
 			const statuses = new Map<number, string>()
+			const provisionalTs = new Set<number>()
 			const previewSeries = preview?.series ?? []
-			const hasPreviewPoints = previewSeries.some((s) => s.points.length > 0)
+			// An entirely-valueless preview (every window no-data) charts nothing
+			// useful — fall through to checks/placeholder instead of an empty grid.
+			const hasPreviewPoints = previewSeries.some((s) => s.points.some((p) => p.value != null))
 
 			if (hasPreviewPoints) {
 				const keys = previewSeries.map((s) => s.groupKey)
 				const single = keys.length === 1
 				const byT = new Map<number, ChartPoint>()
 				const statusRank: Record<string, number> = { healthy: 0, skipped: 1, breached: 2 }
+				// Points plot at the window CLOSE — the moment the evaluator observes
+				// the window — matching check timestamps and reaching the axis edge.
+				const stepMs = (preview?.bucketSeconds ?? 60) * 1000
+				// t → window bounds + how many of the bucket's points carried data.
+				const buckets = new Map<number, { x1: number; x2: number; points: number; withData: number }>()
 				for (const series of previewSeries) {
 					const key = single ? SINGLE_KEY : series.groupKey
 					for (const point of series.points) {
-						const t = Date.parse(point.bucket)
-						if (!Number.isFinite(t)) continue
+						const open = Date.parse(point.bucket)
+						if (!Number.isFinite(open)) continue
+						// The provisional window is shorter than a full step — close it at
+						// the domain edge instead of overshooting it.
+						const t = point.provisional ? Math.min(open + stepMs, domain.max) : open + stepMs
 						let row = byT.get(t)
 						if (!row) {
 							row = { t }
@@ -146,7 +161,25 @@ export function AlertRuleChart({
 						if (prev == null || (statusRank[point.status] ?? 0) > (statusRank[prev] ?? 0)) {
 							statuses.set(t, point.status)
 						}
+						if (point.provisional) provisionalTs.add(t)
+						let bucket = buckets.get(t)
+						if (!bucket) {
+							bucket = { x1: open, x2: t, points: 0, withData: 0 }
+							buckets.set(t, bucket)
+						}
+						bucket.points += 1
+						if (point.value != null) bucket.withData += 1
 					}
+				}
+				// Runs of windows where every group came back empty → merged hatched bands.
+				const noDataBands: Array<{ x1: number; x2: number }> = []
+				const emptyBuckets = Array.from(buckets.values())
+					.filter((b) => b.points > 0 && b.withData === 0)
+					.sort((a, b) => a.x1 - b.x1)
+				for (const bucket of emptyBuckets) {
+					const last = noDataBands[noDataBands.length - 1]
+					if (last && bucket.x1 <= last.x2 + 1) last.x2 = bucket.x2
+					else noDataBands.push({ x1: bucket.x1, x2: bucket.x2 })
 				}
 				const rows = Array.from(byT.values()).sort((a, b) => a.t - b.t)
 				return {
@@ -156,6 +189,8 @@ export function AlertRuleChart({
 					source: "preview",
 					sampleCounts,
 					statuses,
+					noDataBands,
+					provisionalTs,
 				}
 			}
 
@@ -174,6 +209,8 @@ export function AlertRuleChart({
 					source: "checks",
 					sampleCounts,
 					statuses,
+					noDataBands: [],
+					provisionalTs,
 				}
 			}
 
@@ -184,8 +221,10 @@ export function AlertRuleChart({
 				source: "none",
 				sampleCounts,
 				statuses,
+				noDataBands: [],
+				provisionalTs,
 			}
-		}, [preview, checks])
+		}, [preview, checks, domain.max])
 
 	const hasSignal = chartData.length > 0
 
@@ -360,8 +399,28 @@ export function AlertRuleChart({
 							</>
 						)}
 					</linearGradient>
+					<pattern
+						id="alert-nodata-hatch"
+						patternUnits="userSpaceOnUse"
+						width={6}
+						height={6}
+						patternTransform="rotate(45)"
+					>
+						<line x1={0} y1={0} x2={0} y2={6} stroke="var(--muted-foreground)" strokeOpacity={0.25} strokeWidth={1.5} />
+					</pattern>
 				</defs>
 				<CartesianGrid vertical={false} />
+
+				{noDataBands.map((band, i) => (
+					<ReferenceArea
+						key={`no-data-${i}`}
+						x1={Math.max(band.x1, domain.min)}
+						x2={Math.min(band.x2, domain.max)}
+						fill="url(#alert-nodata-hatch)"
+						stroke="none"
+						ifOverflow="hidden"
+					/>
+				))}
 
 				{incidentBands.map((band, i) => (
 					<ReferenceArea
@@ -422,6 +481,7 @@ export function AlertRuleChart({
 								const extras = [
 									samples != null ? `${samples} samples` : null,
 									status === "skipped" ? "skipped" : null,
+									provisionalTs.has(t) ? "in progress" : null,
 								].filter(Boolean)
 								return extras.length > 0 ? `${label} · ${extras.join(" · ")}` : label
 							}}
@@ -536,6 +596,11 @@ export function AlertRuleChart({
 				<p className="text-[11px] text-muted-foreground">
 					Shaded: rule would have fired (approximate — the live scheduler evaluates every
 					minute).
+				</p>
+			)}
+			{hasSignal && source === "preview" && noDataBands.length > 0 && (
+				<p className="text-[11px] text-muted-foreground">
+					Hatched: no data received in these windows.
 				</p>
 			)}
 			{preview?.truncatedToStart != null && (

--- a/packages/domain/src/http/alerts.ts
+++ b/packages/domain/src/http/alerts.ts
@@ -520,6 +520,11 @@ export class AlertRulePreviewPoint extends Schema.Class<AlertRulePreviewPoint>("
 	value: Schema.NullOr(Schema.Number),
 	sampleCount: Schema.Number,
 	status: AlertEvaluationStatus,
+	/**
+	 * The trailing in-progress window: evaluated over less than a full
+	 * `windowMinutes`, so its value may still move as data arrives.
+	 */
+	provisional: Schema.optionalKey(Schema.Boolean),
 }) {}
 
 export class AlertRulePreviewSeries extends Schema.Class<AlertRulePreviewSeries>("AlertRulePreviewSeries")({
@@ -661,6 +666,7 @@ export class AlertDeliveryError extends Schema.TaggedErrorClass<AlertDeliveryErr
 	{
 		message: Schema.String,
 		destinationType: Schema.optionalKey(AlertDestinationType),
+		cause: Schema.optionalKey(Schema.Defect()),
 	},
 	{ httpApiStatus: 502 },
 ) {}
@@ -713,10 +719,10 @@ export class AlertChecksListResponse extends Schema.Class<AlertChecksListRespons
 ) {}
 
 export const ListRuleChecksQuery = Schema.Struct({
-	groupKey: Schema.optional(Schema.String),
-	since: Schema.optional(IsoDateTimeString),
-	until: Schema.optional(IsoDateTimeString),
-	limit: Schema.optional(
+	groupKey: Schema.optionalKey(Schema.String),
+	since: Schema.optionalKey(IsoDateTimeString),
+	until: Schema.optionalKey(IsoDateTimeString),
+	limit: Schema.optionalKey(
 		Schema.NumberFromString.check(Schema.isInt(), Schema.isBetween({ minimum: 1, maximum: 2000 })),
 	),
 })


### PR DESCRIPTION
## Problem

Alert rule charts routinely showed the series line ending well before the right edge of the window while the incident strip and evaluation rail below spanned the full range — it read as a broken chart. Three stacked causes:

1. **Systematic right-edge dead zone.** Preview points were plotted at the window *start*, and `previewRule` floor-aligned its end, silently dropping the trailing partial window — so even a fully-healthy series ended 1–2 windows (up to 2h with a 60-min window) before the axis edge. The strips below use fixed full-width grids keyed on evaluation time, so they always reach the edge; the mismatch is what looked broken.
2. **Unexplained no-data gaps.** Windows where a group had no rows chart as `null` with `connectNulls=false` (deliberate — connecting across them would fabricate a signal the evaluator never saw). Common by construction for grouped rules over ephemeral groups (pods) and count-style signals, but nothing told the user *why* the line stopped.
3. Open incidents shade to the edge and skipped windows freeze the resolve counter, so a solid red band kept running under a vanished line.

## Changes

- **`AlertsService.previewRule`**: evaluates the trailing in-progress window `[alignedEnd, requestedEnd)` as a `provisional` point — charted, but excluded from the would-fire simulation (the scheduler hasn't evaluated it yet). New optional `provisional` flag on `AlertRulePreviewPoint`.
- **`alert-rule-chart.tsx`**: preview points now plot at the window **close** (matching check timestamps), so the line reaches the axis edge; windows where *no* group observed data render as hatched `ReferenceArea` bands with a footnote ("Hatched: no data received in these windows"); the tooltip marks the trailing window "in progress"; an entirely-valueless preview falls through to the "No data" placeholder instead of an axes-only grid.
- Also threads a `cause` through alert validation/delivery errors and narrows `buildSecretConfig` to non-hazel-oauth variants (the OAuth path provisions its channel webhook first and builds the secret config inline).

## Notes for review

- The gap semantics are unchanged: no-data still breaks the line (evaluator-faithful); it's now labeled instead of silent.
- Bucket-start → bucket-close shift is client-side only; the API `bucket` field still denotes the window start.
- Aligned preview ranges (`requestedEnd` on a window boundary) are byte-for-byte unchanged — no provisional point is emitted.

## Testing

- `AlertsService` suite passes (37 tests), including a new test asserting the provisional point exists, is flagged, lands at the last aligned boundary, and does not extend would-fire spans.
- Verified in the browser against live demo data: line ends exactly at the plot margin on a healthy rule; a window straddling "now" shows the hatched band from where data ends to the edge; a fully-empty window shows the placeholder.
- `bun typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->