### PR TITLE
feat(unitflow): devtools inspector panel + opt-in Msg/Command reducer

### DIFF
--- a/apps/web/src/components/devtools/unitflow-devtools.tsx
+++ b/apps/web/src/components/devtools/unitflow-devtools.tsx
@@ -1,0 +1,291 @@
+/**
+ * A dev-only floating panel over the unitflow debug inspector (attached to the
+ * shared runtime in `@/lib/models/runtime`). Two views:
+ *
+ *  - **Events** — the write/emit/instance log, grouped into causal transactions
+ *    (a root publication and the writes/emits its synchronous dispatch caused,
+ *    indented by depth) so you can see "what caused what". Filter flattens it.
+ *  - **State** — the live snapshot: model instances (with lease counts) and
+ *    every materialized/derived store value.
+ *
+ * Rendered only under `import.meta.env.DEV` (see `AppFrame`); polls the
+ * inspector while open and unpaused. Nothing here runs in production.
+ */
+
+import { useCallback, useRef, useState } from "react"
+import { Badge } from "@maple/ui/components/ui/badge"
+import { Button } from "@maple/ui/components/ui/button"
+import { cn } from "@maple/ui/utils"
+import { useMountEffect } from "@/hooks/use-mount-effect"
+import { getUnitflowInspector } from "@/lib/models/runtime"
+import {
+	buildCausalGroups,
+	type DebugEvent,
+	eventTypeMeta,
+	filterEvents,
+	formatInstanceKey,
+	previewValue,
+	safeStringify,
+	type Snapshot,
+} from "./unitflow-inspector-view"
+
+const EMPTY_SNAPSHOT: Snapshot = { instances: [], stores: [] }
+/** How many recent events to render (the buffer holds far more). */
+const RENDER_LIMIT = 300
+const POLL_MS = 500
+
+const relativeTime = (delta: number): string => {
+	if (delta < 1000) return `${Math.max(0, Math.round(delta))}ms`
+	if (delta < 60_000) return `${(delta / 1000).toFixed(1)}s`
+	return `${Math.floor(delta / 60_000)}m`
+}
+
+export function UnitflowDevtools() {
+	const [open, setOpen] = useState(false)
+	const [tab, setTab] = useState<"events" | "state">("events")
+	const [paused, setPaused] = useState(false)
+	const [filter, setFilter] = useState("")
+	const [events, setEvents] = useState<ReadonlyArray<DebugEvent>>([])
+	const [snapshot, setSnapshot] = useState<Snapshot>(EMPTY_SNAPSHOT)
+	const [expandedEvents, setExpandedEvents] = useState<ReadonlySet<number>>(() => new Set())
+	const [expandedStores, setExpandedStores] = useState<ReadonlySet<string>>(() => new Set())
+
+	// Latest render values mirrored into refs so the mount-time poll closure
+	// reads current open/paused without re-subscribing.
+	const openRef = useRef(open)
+	const pausedRef = useRef(paused)
+	const lastSeqRef = useRef(-1)
+	openRef.current = open
+	pausedRef.current = paused
+
+	const refresh = useCallback((force: boolean) => {
+		const inspector = getUnitflowInspector()
+		if (inspector === undefined) return
+		const next = inspector.events()
+		const newest = next.at(-1)?.seq ?? 0
+		// Re-render only when a new publication landed (or on an explicit force),
+		// so an idle registry doesn't churn React twice a second.
+		if (!force && newest === lastSeqRef.current) return
+		lastSeqRef.current = newest
+		setEvents(next)
+		setSnapshot(inspector.snapshot())
+	}, [])
+
+	useMountEffect(() => {
+		const id = window.setInterval(() => {
+			if (!openRef.current || pausedRef.current) return
+			refresh(false)
+		}, POLL_MS)
+		return () => window.clearInterval(id)
+	})
+
+	const openPanel = () => {
+		setPaused(false)
+		setOpen(true)
+		refresh(true)
+	}
+
+	const clearLog = () => {
+		getUnitflowInspector()?.clear()
+		lastSeqRef.current = -1
+		setExpandedEvents(new Set())
+		refresh(true)
+	}
+
+	const togglePause = () => {
+		if (paused) refresh(true)
+		setPaused(!paused)
+	}
+
+	const toggleEvent = (seq: number) =>
+		setExpandedEvents((prev) => {
+			const next = new Set(prev)
+			if (next.has(seq)) next.delete(seq)
+			else next.add(seq)
+			return next
+		})
+
+	const toggleStore = (id: string) =>
+		setExpandedStores((prev) => {
+			const next = new Set(prev)
+			if (next.has(id)) next.delete(id)
+			else next.add(id)
+			return next
+		})
+
+	if (!open) {
+		return (
+			<button
+				type="button"
+				onClick={openPanel}
+				className="fixed right-3 bottom-3 z-[9999] flex items-center gap-1.5 rounded-full border bg-popover px-3 py-1.5 font-medium text-foreground text-xs shadow-md hover:bg-accent"
+			>
+				<span className="size-1.5 rounded-full bg-success" />
+				unitflow
+			</button>
+		)
+	}
+
+	const now = Date.now()
+	const groups = buildCausalGroups(events, RENDER_LIMIT)
+	const flat = filterEvents(events, filter, RENDER_LIMIT)
+	const filtering = filter.trim() !== ""
+
+	const renderEventRow = (event: DebugEvent, depth: number) => {
+		const meta = eventTypeMeta(event.type)
+		const expanded = expandedEvents.has(event.seq)
+		const hasValue = event.value !== undefined
+		return (
+			<li key={event.seq}>
+				<button
+					type="button"
+					onClick={() => hasValue && toggleEvent(event.seq)}
+					style={{ paddingLeft: `${8 + depth * 14}px` }}
+					className={cn(
+						"flex w-full items-center gap-2 py-1 pr-2 text-left hover:bg-accent/50",
+						hasValue ? "cursor-pointer" : "cursor-default",
+					)}
+				>
+					<span className="w-10 shrink-0 text-right text-muted-foreground tabular-nums">#{event.seq}</span>
+					<Badge variant={meta.variant} size="sm" className="shrink-0">
+						{meta.label}
+					</Badge>
+					<span className="truncate font-mono text-foreground">{event.name}</span>
+					{hasValue && <span className="truncate font-mono text-muted-foreground">{previewValue(event.value)}</span>}
+					<span className="ml-auto shrink-0 text-muted-foreground tabular-nums">{relativeTime(now - event.time)}</span>
+				</button>
+				{expanded && hasValue && (
+					<pre className="mx-2 mb-1 overflow-x-auto rounded border bg-muted/40 p-2 font-mono text-[11px] text-muted-foreground">
+						{safeStringify(event.value)}
+					</pre>
+				)}
+			</li>
+		)
+	}
+
+	return (
+		<div className="fixed right-3 bottom-3 z-[9999] flex h-[70vh] max-h-[640px] w-[460px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-lg border bg-popover text-foreground text-xs shadow-xl">
+			<div className="flex items-center gap-2 border-b px-3 py-2">
+				<span className="size-1.5 rounded-full bg-success" />
+				<span className="font-semibold">unitflow devtools</span>
+				<div className="ml-2 flex gap-1 rounded-md bg-muted p-0.5">
+					{(["events", "state"] as const).map((value) => (
+						<button
+							type="button"
+							key={value}
+							onClick={() => setTab(value)}
+							className={cn(
+								"rounded px-2 py-0.5 font-medium capitalize",
+								tab === value ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
+							)}
+						>
+							{value}
+						</button>
+					))}
+				</div>
+				<Button variant="ghost" size="xs" onClick={() => setOpen(false)} className="ml-auto">
+					Close
+				</Button>
+			</div>
+
+			{tab === "events" ? (
+				<>
+					<div className="flex items-center gap-2 border-b px-3 py-1.5">
+						<input
+							value={filter}
+							onChange={(e) => setFilter(e.target.value)}
+							placeholder="Filter by name or type…"
+							className="h-6 flex-1 rounded border bg-background px-2 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+						/>
+						<Button variant={paused ? "default" : "outline"} size="xs" onClick={togglePause}>
+							{paused ? "Resume" : "Pause"}
+						</Button>
+						<Button variant="outline" size="xs" onClick={clearLog}>
+							Clear
+						</Button>
+					</div>
+					<div className="flex-1 overflow-y-auto">
+						{events.length === 0 ? (
+							<p className="p-4 text-center text-muted-foreground">
+								No events yet. Interact with a model-backed page (e.g. /alerts) to record writes and emits.
+							</p>
+						) : filtering ? (
+							<ul>{flat.map((event) => renderEventRow(event, 0))}</ul>
+						) : (
+							groups.map((group) => (
+								<ul key={group.root} className="border-b border-border/50 last:border-0">
+									{group.items.map(({ event, depth }) => renderEventRow(event, depth))}
+								</ul>
+							))
+						)}
+					</div>
+					<div className="border-t px-3 py-1 text-muted-foreground">
+						{events.length} events {paused && <span className="text-warning-foreground">· paused</span>}
+					</div>
+				</>
+			) : (
+				<div className="flex-1 overflow-y-auto">
+					<section>
+						<h3 className="sticky top-0 border-b bg-muted/60 px-3 py-1 font-semibold text-muted-foreground uppercase tracking-wide">
+							Instances ({snapshot.instances.length})
+						</h3>
+						{snapshot.instances.length === 0 ? (
+							<p className="px-3 py-2 text-muted-foreground">No live model instances.</p>
+						) : (
+							<ul>
+								{snapshot.instances.map((instance) => {
+									const key = formatInstanceKey(instance.key)
+									return (
+										<li key={`${instance.model}:${key}`} className="flex items-center gap-2 px-3 py-1">
+											<span className="truncate font-mono text-foreground">{instance.model}</span>
+											{key !== "" && <span className="truncate font-mono text-muted-foreground">{key}</span>}
+											<Badge variant="secondary" size="sm" className="ml-auto shrink-0">
+												{instance.leases} lease{instance.leases === 1 ? "" : "s"}
+											</Badge>
+										</li>
+									)
+								})}
+							</ul>
+						)}
+					</section>
+					<section>
+						<h3 className="sticky top-0 border-b bg-muted/60 px-3 py-1 font-semibold text-muted-foreground uppercase tracking-wide">
+							Stores ({snapshot.stores.length})
+						</h3>
+						{snapshot.stores.length === 0 ? (
+							<p className="px-3 py-2 text-muted-foreground">No materialized stores.</p>
+						) : (
+							<ul>
+								{snapshot.stores.map((store) => {
+									const expanded = expandedStores.has(store.id)
+									return (
+										<li key={store.id}>
+											<button
+												type="button"
+												onClick={() => toggleStore(store.id)}
+												className="flex w-full items-center gap-2 px-3 py-1 text-left hover:bg-accent/50"
+											>
+												<span className="truncate font-mono text-foreground">{store.name ?? store.id}</span>
+												{store.derived && (
+													<Badge variant="info" size="sm" className="shrink-0">
+														derived
+													</Badge>
+												)}
+												<span className="ml-auto truncate font-mono text-muted-foreground">{previewValue(store.value)}</span>
+											</button>
+											{expanded && (
+												<pre className="mx-3 mb-1 overflow-x-auto rounded border bg-muted/40 p-2 font-mono text-[11px] text-muted-foreground">
+													{safeStringify(store.value)}
+												</pre>
+											)}
+										</li>
+									)
+								})}
+							</ul>
+						)}
+					</section>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/apps/web/src/components/devtools/unitflow-inspector-view.test.ts
+++ b/apps/web/src/components/devtools/unitflow-inspector-view.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+import {
+	buildCausalGroups,
+	type DebugEvent,
+	filterEvents,
+	previewValue,
+	safeStringify,
+} from "./unitflow-inspector-view"
+
+const ev = (seq: number, opts: Partial<DebugEvent> = {}): DebugEvent => ({
+	seq,
+	time: seq,
+	type: "emit",
+	name: `e${seq}`,
+	id: `id${seq}`,
+	...opts,
+})
+
+describe("buildCausalGroups", () => {
+	it("nests events under their root cause, indented by depth", () => {
+		const events: DebugEvent[] = [
+			ev(1, { type: "emit", name: "toggle" }),
+			ev(2, { type: "write", name: "state", cause: 1 }),
+			ev(3, { type: "write", name: "derived", cause: 2 }),
+		]
+		const [group] = buildCausalGroups(events, 100)
+		expect(group?.root).toBe(1)
+		expect(group?.items.map((item) => [item.event.name, item.depth])).toEqual([
+			["toggle", 0],
+			["state", 1],
+			["derived", 2],
+		])
+	})
+
+	it("orders groups newest-root-first and keeps separate transactions apart", () => {
+		const events: DebugEvent[] = [
+			ev(1, { name: "a" }),
+			ev(2, { name: "a-child", cause: 1 }),
+			ev(3, { name: "b" }),
+		]
+		const groups = buildCausalGroups(events, 100)
+		expect(groups.map((group) => group.root)).toEqual([3, 1])
+	})
+
+	it("treats an evicted cause (not in the buffer) as a root", () => {
+		// The parent (#1) has scrolled out of the ring; #2 still references it.
+		const events: DebugEvent[] = [ev(2, { name: "orphan", cause: 1 })]
+		const [group] = buildCausalGroups(events, 100)
+		expect(group?.root).toBe(2)
+		expect(group?.items[0]?.depth).toBe(0)
+	})
+})
+
+describe("filterEvents", () => {
+	const events: DebugEvent[] = [
+		ev(1, { type: "emit", name: "toggleRule" }),
+		ev(2, { type: "write", name: "overview" }),
+		ev(3, { type: "emit", name: "refresh" }),
+	]
+
+	it("matches by name substring, newest-first", () => {
+		expect(filterEvents(events, "toggle", 100).map((e) => e.seq)).toEqual([1])
+	})
+
+	it("matches by event type", () => {
+		expect(filterEvents(events, "emit", 100).map((e) => e.seq)).toEqual([3, 1])
+	})
+
+	it("returns all (newest-first) for an empty query", () => {
+		expect(filterEvents(events, "  ", 100).map((e) => e.seq)).toEqual([3, 2, 1])
+	})
+})
+
+describe("safeStringify / previewValue", () => {
+	it("renders Maps, Sets, bigints and functions instead of throwing or dropping them", () => {
+		const value = {
+			count: 2n,
+			byId: new Map([["a", 1]]),
+			tags: new Set(["x"]),
+			fn: function handler() {},
+		}
+		const text = safeStringify(value, 0)
+		expect(text).toContain("2n")
+		expect(text).toContain("[Map]")
+		expect(text).toContain("[Set]")
+		expect(text).toContain("[Function handler]")
+	})
+
+	it("survives circular references", () => {
+		const a: Record<string, unknown> = {}
+		a.self = a
+		expect(safeStringify(a, 0)).toContain("[Circular]")
+	})
+
+	it("previewValue shows an em dash for undefined and truncates long values", () => {
+		expect(previewValue(undefined)).toBe("—")
+		const long = previewValue({ text: "x".repeat(400) })
+		expect(long.endsWith("…")).toBe(true)
+		expect(long.length).toBeLessThanOrEqual(120)
+	})
+})

--- a/apps/web/src/components/devtools/unitflow-inspector-view.ts
+++ b/apps/web/src/components/devtools/unitflow-inspector-view.ts
@@ -1,0 +1,128 @@
+/**
+ * Pure transforms over the unitflow debug inspector's output, kept out of the
+ * React component so they can be reasoned about (and unit-tested) on their own.
+ * The inspector itself lives in `@maple/unitflow` (`Debug.attach`) and is
+ * attached to the shared runtime in `@/lib/models/runtime` (dev only).
+ */
+
+import type { Debug } from "@maple/unitflow"
+
+export type DebugEvent = Debug.DebugEvent
+export type Snapshot = Debug.Snapshot
+
+/** A causal transaction: a root publication (an event with no live cause) and
+ * the events dispatched inside its synchronous fan-out, each with its depth. */
+export interface CausalGroup {
+	readonly root: number
+	readonly items: ReadonlyArray<{ readonly event: DebugEvent; readonly depth: number }>
+}
+
+const MAX_DEPTH = 16
+
+/** Walk `cause` pointers to the topmost ancestor still present in the buffer (a
+ * cause evicted from the ring is treated as a root). Cycle- and depth-guarded. */
+const climb = (event: DebugEvent, bySeq: Map<number, DebugEvent>): { readonly root: number; readonly depth: number } => {
+	let current = event
+	let depth = 0
+	const seen = new Set<number>([current.seq])
+	while (current.cause !== undefined && depth < MAX_DEPTH) {
+		const parent = bySeq.get(current.cause)
+		if (parent === undefined || seen.has(parent.seq)) break
+		seen.add(parent.seq)
+		current = parent
+		depth += 1
+	}
+	return { root: current.seq, depth }
+}
+
+/**
+ * Groups the most recent `limit` events into causal transactions: each group is
+ * one root publication and the writes/emits its synchronous dispatch caused,
+ * indented by depth. Groups are ordered newest-root-first; within a group,
+ * events keep seq order. This is the "what caused what" view.
+ */
+export const buildCausalGroups = (events: ReadonlyArray<DebugEvent>, limit: number): ReadonlyArray<CausalGroup> => {
+	const bySeq = new Map(events.map((event) => [event.seq, event]))
+	const recent = events.slice(Math.max(0, events.length - limit))
+	const groups = new Map<number, { root: number; items: Array<{ event: DebugEvent; depth: number }> }>()
+	for (const event of recent) {
+		const { root, depth } = climb(event, bySeq)
+		let group = groups.get(root)
+		if (group === undefined) {
+			group = { root, items: [] }
+			groups.set(root, group)
+		}
+		group.items.push({ event, depth })
+	}
+	return [...groups.values()].sort((a, b) => b.root - a.root)
+}
+
+/** Newest-first flat list of events whose name/type matches `query`
+ * (case-insensitive substring). Used when a filter is active. */
+export const filterEvents = (
+	events: ReadonlyArray<DebugEvent>,
+	query: string,
+	limit: number,
+): ReadonlyArray<DebugEvent> => {
+	const needle = query.trim().toLowerCase()
+	const matched =
+		needle === ""
+			? events
+			: events.filter(
+					(event) => event.name.toLowerCase().includes(needle) || event.type.toLowerCase().includes(needle),
+				)
+	return matched.slice(Math.max(0, matched.length - limit)).reverse()
+}
+
+/**
+ * JSON-ish stringify that survives the values flowing through unitflow
+ * stores/events: Maps, Sets, functions, bigints, and cycles. `space` 0 yields a
+ * compact one-liner (for row previews), 2 an indented block (for the expander).
+ */
+export const safeStringify = (value: unknown, space = 2): string => {
+	const seen = new WeakSet<object>()
+	const replacer = (_key: string, val: unknown): unknown => {
+		if (typeof val === "bigint") return `${val.toString()}n`
+		if (typeof val === "function") return `[Function ${val.name || "anonymous"}]`
+		if (val instanceof Map) return { "[Map]": Object.fromEntries([...val.entries()].slice(0, 50)) }
+		if (val instanceof Set) return { "[Set]": [...val.values()].slice(0, 50) }
+		if (typeof val === "object" && val !== null) {
+			if (seen.has(val)) return "[Circular]"
+			seen.add(val)
+		}
+		return val
+	}
+	try {
+		const out = JSON.stringify(value, replacer, space)
+		return out === undefined ? String(value) : out
+	} catch {
+		return String(value)
+	}
+}
+
+/** A compact one-line preview of a value for a row. */
+export const previewValue = (value: unknown): string => {
+	if (value === undefined) return "—"
+	const text = safeStringify(value, 0)
+	return text.length > 120 ? `${text.slice(0, 117)}…` : text
+}
+
+export type EventTypeVariant = "info" | "success" | "secondary" | "warning"
+
+/** Badge styling + label per event type. */
+export const eventTypeMeta = (type: DebugEvent["type"]): { readonly label: string; readonly variant: EventTypeVariant } => {
+	switch (type) {
+		case "emit":
+			return { label: "emit", variant: "info" }
+		case "write":
+			return { label: "write", variant: "success" }
+		case "instance-created":
+			return { label: "created", variant: "secondary" }
+		case "instance-disposed":
+			return { label: "disposed", variant: "warning" }
+	}
+}
+
+/** Render an instance key (primitive or record) compactly. */
+export const formatInstanceKey = (key: unknown): string =>
+	key === undefined ? "" : typeof key === "string" ? key : safeStringify(key, 0)

--- a/apps/web/src/lib/models/error-issues-model.ts
+++ b/apps/web/src/lib/models/error-issues-model.ts
@@ -12,6 +12,7 @@
 import type { ActorDocument, ErrorIssueDocument } from "@maple/domain/http"
 import { Model, Store } from "@maple/unitflow"
 import * as Db from "@maple/unitflow/db"
+import { Reducer } from "@maple/unitflow/reducer"
 import * as Effect from "effect/Effect"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 
@@ -23,6 +24,7 @@ import {
 	rowToIssue,
 } from "@/lib/collections/errors"
 import { getOrgCollections } from "@/lib/collections/org-collections"
+import { initialIssueSelection, updateIssueSelection } from "@/lib/models/issue-selection"
 import { collectionFailureMessage, makeOrgCollectionsKey, orgIdOf } from "@/lib/models/org-collections-key"
 
 /** The server's page cap, mirrored client-side by {@link filterIssues}. */
@@ -153,10 +155,20 @@ export class ErrorIssuesModel extends Model.Service<ErrorIssuesModel>()("maple/e
 				buildIssues({ issues: issuesState, actors: actorsState, openIncidents: incidentsState }),
 			)
 
+			// Row selection (multi-select + shift-range + clear) is model-owned
+			// interactive state — a pure reducer instead of the route's old
+			// useState/useRef tangle. The View drives it through `dispatchSelection`
+			// and reads `selection`; see @/lib/models/issue-selection.
+			const selection = yield* Reducer.make({
+				initial: initialIssueSelection,
+				update: updateIssueSelection,
+				name: "maple/errors/issues.selection",
+			})
+
 			return {
-				inputs: {},
+				inputs: { dispatchSelection: selection.dispatch },
 				outputs: { overview },
-				ui: { overview },
+				ui: { overview, selection: selection.state, dispatchSelection: selection.dispatch },
 			}
 		}),
 }) {}

--- a/apps/web/src/lib/models/issue-selection.test.ts
+++ b/apps/web/src/lib/models/issue-selection.test.ts
@@ -1,0 +1,58 @@
+import { Story } from "@maple/unitflow/reducer"
+import { describe, expect, it } from "vitest"
+import {
+	clearedSelection,
+	initialIssueSelection,
+	toggledSelection,
+	updateIssueSelection,
+} from "./issue-selection"
+
+const ordered = ["a", "b", "c", "d"]
+const selected = (state: { selectedIds: ReadonlySet<string> }) => [...state.selectedIds].sort()
+
+describe("updateIssueSelection (Story)", () => {
+	it("toggles a single row and records it as the anchor, with no commands", () => {
+		const story = Story.make(updateIssueSelection, initialIssueSelection)
+		story.dispatch(toggledSelection("b", false, ordered))
+		expect(selected(story.state)).toEqual(["b"])
+		expect(story.state.anchor).toBe("b")
+		expect(story.commands).toEqual([])
+	})
+
+	it("toggling the same row again deselects it", () => {
+		const story = Story.make(updateIssueSelection, initialIssueSelection)
+		story.dispatch(toggledSelection("b", false, ordered))
+		story.dispatch(toggledSelection("b", false, ordered))
+		expect(selected(story.state)).toEqual([])
+	})
+
+	it("shift+anchor selects the inclusive range and leaves the anchor put", () => {
+		const story = Story.make(updateIssueSelection, initialIssueSelection)
+		story.dispatch(toggledSelection("a", false, ordered)) // anchor = a
+		story.dispatch(toggledSelection("c", true, ordered)) // range a..c
+		expect(selected(story.state)).toEqual(["a", "b", "c"])
+		expect(story.state.anchor).toBe("a")
+	})
+
+	it("shift-range resolves regardless of direction", () => {
+		const story = Story.make(updateIssueSelection, initialIssueSelection)
+		story.dispatch(toggledSelection("d", false, ordered))
+		story.dispatch(toggledSelection("b", true, ordered))
+		expect(selected(story.state)).toEqual(["b", "c", "d"])
+	})
+
+	it("shift with no anchor falls back to a single toggle", () => {
+		const story = Story.make(updateIssueSelection, initialIssueSelection)
+		story.dispatch(toggledSelection("c", true, ordered))
+		expect(selected(story.state)).toEqual(["c"])
+		expect(story.state.anchor).toBe("c")
+	})
+
+	it("Cleared resets selection and anchor", () => {
+		const story = Story.make(updateIssueSelection, initialIssueSelection)
+		story.dispatch(toggledSelection("a", false, ordered))
+		story.dispatch(clearedSelection)
+		expect(selected(story.state)).toEqual([])
+		expect(story.state.anchor).toBeNull()
+	})
+})

--- a/apps/web/src/lib/models/issue-selection.ts
+++ b/apps/web/src/lib/models/issue-selection.ts
@@ -1,0 +1,74 @@
+/**
+ * The issues-list selection state as a pure unitflow reducer — the first real
+ * adoption of `@maple/unitflow/reducer`. Multi-select with shift-range and a
+ * clear action is exactly the "complex interactive local state" a reducer is
+ * for: every transition flows through one exhaustive `update`, so the
+ * shift-anchor logic (the fiddly part) is testable as plain data instead of
+ * living in a `useState` + `useRef` + imperative-handler tangle in the route.
+ *
+ * The reducer lives here (not in `error-issues-model.ts`) so the pure logic is
+ * importable without the model's Electric-collection dependencies. The model
+ * (`ErrorIssuesModel`) wraps it in `Reducer.make` and republishes it through
+ * `ui`; the URL-backed workflow/severity filters stay in the route.
+ */
+
+import { Command, type Reducer } from "@maple/unitflow/reducer"
+
+export interface IssueSelectionState {
+	readonly selectedIds: ReadonlySet<string>
+	/** The last singly-toggled row — the origin of a shift-range select. */
+	readonly anchor: string | null
+}
+
+export type IssueSelectionMsg =
+	| {
+			readonly _tag: "Toggled"
+			readonly id: string
+			readonly shiftKey: boolean
+			/** The visible rows in display order, for resolving a shift-range. */
+			readonly orderedIds: ReadonlyArray<string>
+	  }
+	| { readonly _tag: "Cleared" }
+
+export const initialIssueSelection: IssueSelectionState = { selectedIds: new Set(), anchor: null }
+
+/** Convenience constructors for the route to dispatch. */
+export const toggledSelection = (
+	id: string,
+	shiftKey: boolean,
+	orderedIds: ReadonlyArray<string>,
+): IssueSelectionMsg => ({ _tag: "Toggled", id, shiftKey, orderedIds })
+
+export const clearedSelection: IssueSelectionMsg = { _tag: "Cleared" }
+
+/**
+ * The whole selection state machine. Mirrors the route's previous imperative
+ * handler exactly: a shift+anchor toggle adds the inclusive range (leaving the
+ * anchor put); any other toggle flips the single row and becomes the new
+ * anchor; clear resets both.
+ */
+export const updateIssueSelection: Reducer.Update<IssueSelectionState, IssueSelectionMsg> = (state, msg) => {
+	switch (msg._tag) {
+		case "Cleared":
+			return [initialIssueSelection, Command.none]
+		case "Toggled": {
+			const next = new Set(state.selectedIds)
+			if (msg.shiftKey && state.anchor !== null) {
+				const from = msg.orderedIds.indexOf(state.anchor)
+				const to = msg.orderedIds.indexOf(msg.id)
+				if (from !== -1 && to !== -1) {
+					const [lo, hi] = from < to ? [from, to] : [to, from]
+					for (let i = lo; i <= hi; i++) {
+						const id = msg.orderedIds[i]
+						if (id !== undefined) next.add(id)
+					}
+					// A range select extends from the anchor; the anchor stays put.
+					return [{ selectedIds: next, anchor: state.anchor }, Command.none]
+				}
+			}
+			if (next.has(msg.id)) next.delete(msg.id)
+			else next.add(msg.id)
+			return [{ selectedIds: next, anchor: msg.id }, Command.none]
+		}
+	}
+}

--- a/apps/web/src/lib/models/runtime.ts
+++ b/apps/web/src/lib/models/runtime.ts
@@ -13,8 +13,9 @@
  * own `Reactivity` and the two would be deaf to each other.
  */
 
-import { UnitflowRuntime } from "@maple/unitflow"
+import { Debug, UnitflowRuntime } from "@maple/unitflow"
 import { Layer } from "effect"
+import * as Exit from "effect/Exit"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import { Atom } from "@/lib/effect-atom"
 import { mapleApiClientLayer } from "@/lib/registry"
@@ -28,6 +29,37 @@ export const unitflowRuntime = UnitflowRuntime.make(
 	),
 	{ memoMap: Atom.runtime.memoMap },
 )
+
+// Dev-only: attach the unitflow debug inspector to the shared registry so the
+// devtools panel can read the event/causality log and live store+instance
+// snapshot. Attach eagerly at module load — BEFORE any View mounts and leases a
+// model — so the inspector's port directory is populated at construction. The
+// registry lives inside the runtime's layer; `runSyncExit` builds it and
+// resolves the inspector synchronously when the layer is synchronous (it is),
+// falling back to an async attach if that ever changes. The inspector is a
+// passive tap (one property check on the hot paths), never installed in prod.
+let unitflowInspector: Debug.Inspector | undefined
+if (import.meta.env.DEV && typeof window !== "undefined") {
+	const attach = Debug.attach({ capacity: 5000 })
+	try {
+		const attached = unitflowRuntime.runtime.runSyncExit(attach)
+		if (Exit.isSuccess(attached)) {
+			unitflowInspector = attached.value
+		} else {
+			void unitflowRuntime.runtime.runPromise(attach).then((inspector) => {
+				unitflowInspector = inspector
+			})
+		}
+	} catch {
+		void unitflowRuntime.runtime.runPromise(attach).then((inspector) => {
+			unitflowInspector = inspector
+		})
+	}
+}
+
+/** The unitflow debug inspector, in dev only (undefined in prod or before the
+ * runtime layer finishes building). Read by the devtools panel. */
+export const getUnitflowInspector = (): Debug.Inspector | undefined => unitflowInspector
 
 // Dispose the runtime on page unload so every live model instance runs its
 // finalizers (Electric shape subscriptions, the delivery-events query, the

--- a/apps/web/src/lib/models/runtime.ts
+++ b/apps/web/src/lib/models/runtime.ts
@@ -41,6 +41,13 @@ export const unitflowRuntime = UnitflowRuntime.make(
 let unitflowInspector: Debug.Inspector | undefined
 if (import.meta.env.DEV && typeof window !== "undefined") {
 	const attach = Debug.attach({ capacity: 5000 })
+	// `Debug.attach` resolves the Registry and THEN installs the sink
+	// (`attachTo`), which is idempotent — a repeat attach just replaces the
+	// sink, with no subscription to leak. Because `attachTo` runs only after the
+	// Registry layer is built, a sync attempt that fails on an async layer build
+	// never partially attached, so the async fallback attaches exactly once.
+	// (Today the layer is synchronous, so the sync path wins and the fallback is
+	// purely defensive against a future async layer.)
 	try {
 		const attached = unitflowRuntime.runtime.runSyncExit(attach)
 		if (Exit.isSuccess(attached)) {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -22,6 +22,7 @@ import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 import type { RouterAuthContext } from "@/router"
 import { captureChatReferrer } from "@/components/chat/auto-contexts"
 import { GlobalShortcuts } from "@/components/command-palette/global-shortcuts"
+import { UnitflowDevtools } from "@/components/devtools/unitflow-devtools"
 
 const PUBLIC_PATHS = new Set(["/sign-in", "/sign-up", "/org-required", "/service-map-bench"])
 
@@ -70,6 +71,7 @@ function AppFrame() {
 			<Outlet />
 			<Toaster />
 			{!PUBLIC_PATHS.has(pathname) && <GlobalShortcuts />}
+			{import.meta.env.DEV && <UnitflowDevtools />}
 		</AttributesProvider>
 	)
 }

--- a/apps/web/src/routes/errors/issues/index.tsx
+++ b/apps/web/src/routes/errors/issues/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo } from "react"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { effectRoute } from "@effect-router/core"
 import { Schema } from "effect"
@@ -7,6 +7,7 @@ import { Unitflow, View } from "@maple/unitflow/react"
 
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { useListNavigation } from "@/hooks/use-list-navigation"
+import { useMountEffect } from "@/hooks/use-mount-effect"
 import { IssueGroup } from "@/components/errors/issue-group"
 import { IssuesBulkBar } from "@/components/errors/issues-bulk-bar"
 import { IssuesToolbar } from "@/components/errors/issues-toolbar"
@@ -14,6 +15,12 @@ import { severityRank } from "@/components/errors/severity-badge"
 import { useIssueMutations } from "@/components/errors/use-issue-mutations"
 import type { SelectToggleEvent } from "@/components/errors/issue-row"
 import { ErrorIssuesModel, filterIssues } from "@/lib/models/error-issues-model"
+import {
+	clearedSelection,
+	type IssueSelectionMsg,
+	type IssueSelectionState,
+	toggledSelection,
+} from "@/lib/models/issue-selection"
 import { unitflowRuntime } from "@/lib/models/runtime"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@maple/ui/components/ui/select"
@@ -147,16 +154,12 @@ function IssuesPage() {
 
 	const mutations = useIssueMutations()
 
-	const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
-	const anchorRef = useRef<string | null>(null)
-
 	const toolbar = (totalCount?: number) => (
 		<IssuesToolbar
 			tabs={TOOLBAR_TABS}
 			active={activeFilter}
 			totalCount={totalCount}
 			onChange={(value) => {
-				setSelectedIds(new Set())
 				navigate({
 					search: (prev) => ({
 						...prev,
@@ -169,7 +172,6 @@ function IssuesPage() {
 					<Select
 						value={kindFilter}
 						onValueChange={(value) => {
-							setSelectedIds(new Set())
 							navigate({
 								search: (prev) => ({
 									...prev,
@@ -190,7 +192,6 @@ function IssuesPage() {
 					<Select
 						value={severityFilter}
 						onValueChange={(value) => {
-							setSelectedIds(new Set())
 							navigate({
 								search: (prev) => ({
 									...prev,
@@ -233,9 +234,6 @@ function IssuesPage() {
 					severityFilter={severityFilter}
 					kindFilter={kindFilter}
 					mutations={mutations}
-					selectedIds={selectedIds}
-					setSelectedIds={setSelectedIds}
-					anchorRef={anchorRef}
 				/>
 			)}
 		</Unitflow>
@@ -248,24 +246,55 @@ interface IssuesBodyProps {
 	severityFilter: SeverityFilterValue
 	kindFilter: "all" | "error" | "alert"
 	mutations: ReturnType<typeof useIssueMutations>
-	selectedIds: Set<string>
-	setSelectedIds: React.Dispatch<React.SetStateAction<Set<string>>>
-	anchorRef: React.MutableRefObject<string | null>
 }
 
-const IssuesModelBody = View.make(ErrorIssuesModel, ({ overview }, props: IssuesBodyProps) => {
-	if (overview.phase === "loading") return <IssuesSkeleton toolbar={props.toolbar()} />
-	if (overview.phase === "error") {
-		return <IssuesLoadError toolbar={props.toolbar()} message={overview.message} />
-	}
-	return <IssuesReadyBody allIssues={overview.issues} {...props} />
-})
+/** The model-owned selection state + its dispatcher, bound from the model's
+ * `ui` and threaded down to the rows and the bulk bar. */
+interface SelectionBinding {
+	selection: IssueSelectionState
+	dispatchSelection: (msg: IssueSelectionMsg) => void
+}
 
-interface IssuesReadyBodyProps extends IssuesBodyProps {
+const IssuesModelBody = View.make(
+	ErrorIssuesModel,
+	({ overview, selection, dispatchSelection }, props: IssuesBodyProps) => {
+		if (overview.phase === "loading") return <IssuesSkeleton toolbar={props.toolbar()} />
+		if (overview.phase === "error") {
+			return <IssuesLoadError toolbar={props.toolbar()} message={overview.message} />
+		}
+		return (
+			<IssuesReadyBody
+				allIssues={overview.issues}
+				selection={selection}
+				dispatchSelection={dispatchSelection}
+				{...props}
+			/>
+		)
+	},
+)
+
+/** Clears the model's selection whenever the URL filters change. The filters
+ * live above the `<Unitflow>` provider, so instead of an effect that watches
+ * them, this null component is remounted by its `key` and fires `Cleared` once
+ * on each mount — the sanctioned no-useEffect "re-run via key" pattern. */
+function ClearSelectionOnFilterChange({ dispatchSelection }: { dispatchSelection: (msg: IssueSelectionMsg) => void }) {
+	useMountEffect(() => {
+		dispatchSelection(clearedSelection)
+	})
+	return null
+}
+
+interface IssuesReadyBodyProps extends IssuesBodyProps, SelectionBinding {
 	allIssues: ReadonlyArray<ErrorIssueDocument>
 }
 
-function IssuesReadyBody({ allIssues, activeFilter, severityFilter, kindFilter, ...props }: IssuesReadyBodyProps) {
+function IssuesReadyBody({
+	allIssues,
+	activeFilter,
+	severityFilter,
+	kindFilter,
+	...props
+}: IssuesReadyBodyProps) {
 	const issues = useMemo(
 		() =>
 			filterIssues(allIssues, {
@@ -276,16 +305,21 @@ function IssuesReadyBody({ allIssues, activeFilter, severityFilter, kindFilter, 
 		[allIssues, activeFilter, severityFilter, kindFilter],
 	)
 
-	return <IssuesPageBody issues={issues} activeFilter={activeFilter} {...props} />
+	return (
+		<>
+			<ClearSelectionOnFilterChange
+				key={`${activeFilter}:${severityFilter}:${kindFilter}`}
+				dispatchSelection={props.dispatchSelection}
+			/>
+			<IssuesPageBody issues={issues} activeFilter={activeFilter} {...props} />
+		</>
+	)
 }
 
-interface IssuesPageBodyProps {
+interface IssuesPageBodyProps extends SelectionBinding {
 	issues: ReadonlyArray<ErrorIssueDocument>
 	activeFilter: FilterValue
 	mutations: ReturnType<typeof useIssueMutations>
-	selectedIds: Set<string>
-	setSelectedIds: React.Dispatch<React.SetStateAction<Set<string>>>
-	anchorRef: React.MutableRefObject<string | null>
 	toolbar: (totalCount?: number) => React.ReactNode
 }
 
@@ -293,11 +327,11 @@ function IssuesPageBody({
 	issues,
 	activeFilter,
 	mutations,
-	selectedIds,
-	setSelectedIds,
-	anchorRef,
+	selection,
+	dispatchSelection,
 	toolbar,
 }: IssuesPageBodyProps) {
+	const selectedIds = selection.selectedIds
 	const grouped = useMemo(() => {
 		const map = new Map<WorkflowState, ErrorIssueDocument[]>()
 		for (const issue of issues) {
@@ -337,31 +371,19 @@ function IssuesPageBody({
 
 	const flatIssueIds = useMemo(() => flatIssues.map((i) => i.id as string), [flatIssues])
 
+	// The shift-range/anchor logic now lives in the pure reducer
+	// (updateIssueSelection); the row just reports the toggle + the current
+	// visible order and the model figures out the rest.
 	const toggleSelection = useCallback(
 		(id: string, event: Pick<SelectToggleEvent, "shiftKey">) => {
-			setSelectedIds((prev) => {
-				const next = new Set(prev)
-				if (event.shiftKey && anchorRef.current) {
-					const a = flatIssueIds.indexOf(anchorRef.current)
-					const b = flatIssueIds.indexOf(id)
-					if (a !== -1 && b !== -1) {
-						const [lo, hi] = a < b ? [a, b] : [b, a]
-						for (let i = lo; i <= hi; i++) next.add(flatIssueIds[i]!)
-						return next
-					}
-				}
-				if (next.has(id)) next.delete(id)
-				else next.add(id)
-				anchorRef.current = id
-				return next
-			})
+			dispatchSelection(toggledSelection(id, event.shiftKey, flatIssueIds))
 		},
-		[flatIssueIds, anchorRef, setSelectedIds],
+		[dispatchSelection, flatIssueIds],
 	)
 
 	const clearSelection = useCallback(() => {
-		setSelectedIds(new Set())
-	}, [setSelectedIds])
+		dispatchSelection(clearedSelection)
+	}, [dispatchSelection])
 
 	const navigate = useNavigate({ from: Route.fullPath })
 

--- a/apps/web/src/routes/errors/issues/index.tsx
+++ b/apps/web/src/routes/errors/issues/index.tsx
@@ -273,13 +273,22 @@ const IssuesModelBody = View.make(
 	},
 )
 
-/** Clears the model's selection whenever the URL filters change. The filters
- * live above the `<Unitflow>` provider, so instead of an effect that watches
- * them, this null component is remounted by its `key` and fires `Cleared` once
- * on each mount — the sanctioned no-useEffect "re-run via key" pattern. */
-function ClearSelectionOnFilterChange({ dispatchSelection }: { dispatchSelection: (msg: IssueSelectionMsg) => void }) {
+/** Resets the model-owned selection on page entry and whenever the URL filters
+ * change. The filters live above the `<Unitflow>` provider, so rather than an
+ * effect that watches them, this null component is remounted by its `key` (and
+ * on a fresh page mount, since the whole subtree unmounts on navigation away)
+ * and fires `Cleared` — the sanctioned no-useEffect "re-run via key" pattern.
+ * `hasSelection` gates the dispatch so the common empty-selection case (first
+ * load, or a filter change with nothing selected) doesn't emit a no-op. */
+function ClearSelectionOnFilterChange({
+	dispatchSelection,
+	hasSelection,
+}: {
+	dispatchSelection: (msg: IssueSelectionMsg) => void
+	hasSelection: boolean
+}) {
 	useMountEffect(() => {
-		dispatchSelection(clearedSelection)
+		if (hasSelection) dispatchSelection(clearedSelection)
 	})
 	return null
 }
@@ -310,6 +319,7 @@ function IssuesReadyBody({
 			<ClearSelectionOnFilterChange
 				key={`${activeFilter}:${severityFilter}:${kindFilter}`}
 				dispatchSelection={props.dispatchSelection}
+				hasSelection={props.selection.selectedIds.size > 0}
 			/>
 			<IssuesPageBody issues={issues} activeFilter={activeFilter} {...props} />
 		</>

--- a/packages/unitflow/package.json
+++ b/packages/unitflow/package.json
@@ -13,7 +13,8 @@
 		"./runtime": "./src/core/runtime.ts",
 		"./store": "./src/core/store.ts",
 		"./react": "./src/react/index.ts",
-		"./db": "./src/db/index.ts"
+		"./db": "./src/db/index.ts",
+		"./reducer": "./src/reducer/index.ts"
 	},
 	"scripts": {
 		"typecheck": "tsc --noEmit",

--- a/packages/unitflow/src/reducer/command.ts
+++ b/packages/unitflow/src/reducer/command.ts
@@ -1,0 +1,45 @@
+import type * as Effect from "effect/Effect";
+
+const TypeId = Symbol.for("@maple/unitflow/reducer/Command");
+
+/**
+ * A declarative one-shot side effect returned from a reducer's `update`: an
+ * Effect that resolves to the follow-up message fed back through `dispatch`.
+ * The reducer runtime runs it (forked into the model instance's scope) and
+ * re-dispatches its result, so every asynchronous transition still flows
+ * through the pure `update`. This is foldkit's `Command`, expressed with
+ * unitflow's Event/Store primitives — the reducer never leaves the state
+ * machine to do async work.
+ *
+ * `execute` may not fail (`E = never`): in this discipline a model's failures
+ * are messages. Turn a fallible effect into both-outcomes-as-messages with
+ * `Effect.match`/`Effect.catch*` before wrapping it as a command.
+ */
+export interface Command<out Msg, out R = never> {
+  readonly [TypeId]: typeof TypeId;
+  /** A label for the Story harness and devtools timeline — not an identity key. */
+  readonly name: string;
+  readonly execute: Effect.Effect<Msg, never, R>;
+}
+
+export const isCommand = (value: unknown): value is Command<unknown, unknown> =>
+  typeof value === "object" && value !== null && TypeId in value;
+
+/** Wrap an effect that already produces the follow-up message. */
+export const make = <Msg, R = never>(
+  name: string,
+  execute: Effect.Effect<Msg, never, R>,
+): Command<Msg, R> => ({ [TypeId]: TypeId, name, execute });
+
+/**
+ * A reusable command constructor from a payload — foldkit's
+ * `Command.define('Name', payload => effectProducingMsg)`. The returned
+ * function builds a named command for each payload.
+ */
+export const define =
+  <P, Msg, R = never>(name: string, run: (payload: P) => Effect.Effect<Msg, never, R>) =>
+  (payload: P): Command<Msg, R> =>
+    make(name, run(payload));
+
+/** The empty command list — the common `update` return for a pure transition. */
+export const none: ReadonlyArray<Command<never>> = [];

--- a/packages/unitflow/src/reducer/index.ts
+++ b/packages/unitflow/src/reducer/index.ts
@@ -1,0 +1,3 @@
+export * as Command from "./command.js";
+export * as Reducer from "./reducer.js";
+export * as Story from "./story.js";

--- a/packages/unitflow/src/reducer/reducer.ts
+++ b/packages/unitflow/src/reducer/reducer.ts
@@ -1,0 +1,91 @@
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Event from "../core/event.js";
+import { ownerScope, Registry } from "../core/registry.js";
+import * as Store from "../core/store.js";
+import type { Command } from "./command.js";
+
+/** What one `update` step returns: the next state and the commands to run. */
+export type Transition<State, Msg, R = never> = readonly [State, ReadonlyArray<Command<Msg, R>>];
+
+/** The pure transition function — the whole of a reducer model's behavior. */
+export type Update<State, Msg, R = never> = (state: State, msg: Msg) => Transition<State, Msg, R>;
+
+/**
+ * A reducer unit: the full `state` store and `dispatch` event a model
+ * republishes through its ports. `state` in `outputs`/`ui` narrows to a
+ * read-only source; `dispatch` in `inputs`/`ui` narrows to a write-only sink.
+ */
+export interface Reducer<State, Msg> {
+  readonly state: Store.Store<State>;
+  readonly dispatch: Event.Event<Msg>;
+}
+
+export interface MakeOptions<State, Msg, R> {
+  readonly initial: State;
+  readonly update: Update<State, Msg, R>;
+  /** Names the `state` store and `dispatch` event for the devtools / logs. */
+  readonly name?: string;
+}
+
+/**
+ * Builds a reducer unit inside a model's `make`: every `dispatch` runs the
+ * pure `update`, writes the next state into `state`, and forks each returned
+ * command into the model instance's scope — a command's result message is fed
+ * straight back through `dispatch`, so asynchronous transitions stay inside
+ * the state machine. Dispatches are serialized (unitflow's direct handler
+ * drain), so `update` always sees the latest state; a synchronous command
+ * cascades within the same settle window (so `Registry.allSettled` awaits it),
+ * while a suspending command runs concurrently and re-enters on completion.
+ *
+ * This is The Elm Architecture scoped to ONE model — an opt-in discipline for
+ * units with complex interactive state, not a replacement for the derivation
+ * models `Store.combine` already serves well.
+ */
+export const make = <State, Msg, R = never>(
+  options: MakeOptions<State, Msg, R>,
+): Effect.Effect<Reducer<State, Msg>, never, R | Registry> =>
+  Effect.gen(function* () {
+    const state = Store.make(
+      options.initial,
+      options.name === undefined ? undefined : { name: options.name },
+    );
+    const dispatch = Event.make<Msg>(
+      options.name === undefined ? undefined : { name: `${options.name}.dispatch` },
+    );
+
+    // Commands are forked into the owner scope (the model instance's scope
+    // inside a `make`, the registry scope otherwise) so a long-running command
+    // never blocks the next dispatch. `startImmediately` runs a synchronous
+    // command to completion in place, so its follow-up `dispatch` is counted
+    // in the current settle window — the same reason unitflow's own concurrent
+    // handlers fork this way.
+    const scope = yield* ownerScope;
+    const runCommand = (command: Command<Msg, R>): Effect.Effect<void, never, R | Registry> =>
+      Effect.asVoid(
+        Effect.forkIn(
+          Effect.flatMap(command.execute, (message) => Event.emit(dispatch, message)).pipe(
+            Effect.catchCause((cause) =>
+              Cause.hasInterruptsOnly(cause)
+                ? Effect.void
+                : Effect.logError("Unitflow reducer command terminated unexpectedly", cause),
+            ),
+          ),
+          scope,
+          { startImmediately: true },
+        ),
+      );
+
+    yield* dispatch.pipe(
+      Event.handler((message: Msg) =>
+        Effect.gen(function* () {
+          const current = yield* Store.get(state);
+          const [next, commands] = options.update(current, message);
+          yield* Store.set(state, next);
+          yield* Effect.forEach(commands, runCommand, { discard: true });
+        }),
+      ),
+    );
+
+    return { state, dispatch };
+  });

--- a/packages/unitflow/src/reducer/story.ts
+++ b/packages/unitflow/src/reducer/story.ts
@@ -1,0 +1,59 @@
+import type { Command } from "./command.js";
+import type { Update } from "./reducer.js";
+
+/**
+ * A pure, synchronous driver for a reducer's `update` — the unitflow analogue
+ * of foldkit's Story tests. Feeds messages through `update`, exposing the
+ * resulting state and the commands the last step produced; `resolve` simulates
+ * a command completing by dispatching its follow-up message. No registry, no
+ * React, no timers: `update` is pure, so the whole state machine is testable
+ * as plain data.
+ */
+export interface Story<State, Msg> {
+  /** The current state, after every message dispatched so far. */
+  readonly state: State;
+  /** The commands the most recent `dispatch` returned (empty before the first). */
+  readonly commands: ReadonlyArray<Command<Msg, unknown>>;
+  /** Run one message through `update`, advancing `state` and `commands`. */
+  readonly dispatch: (msg: Msg) => void;
+  /**
+   * Simulate the named command completing: assert one is pending, then
+   * dispatch its follow-up message. Throws if the last dispatch produced no
+   * command of that name — resolving a command the reducer never asked for is
+   * a bug in the test, not a silent no-op.
+   */
+  readonly resolve: (name: string, followup: Msg) => void;
+}
+
+export const make = <State, Msg, R = never>(
+  update: Update<State, Msg, R>,
+  initial: State,
+): Story<State, Msg> => {
+  let state = initial;
+  let commands: ReadonlyArray<Command<Msg, R>> = [];
+
+  const dispatch = (msg: Msg): void => {
+    const [next, produced] = update(state, msg);
+    state = next;
+    commands = produced;
+  };
+
+  const resolve = (name: string, followup: Msg): void => {
+    if (!commands.some((command) => command.name === name)) {
+      const produced = commands.length === 0 ? "none" : commands.map((command) => command.name).join(", ");
+      throw new Error(`Story.resolve: no pending command named "${name}" (last dispatch produced: ${produced}).`);
+    }
+    dispatch(followup);
+  };
+
+  return {
+    get state() {
+      return state;
+    },
+    get commands() {
+      return commands;
+    },
+    dispatch,
+    resolve,
+  };
+};

--- a/packages/unitflow/test/reducer.test.ts
+++ b/packages/unitflow/test/reducer.test.ts
@@ -1,0 +1,115 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { Event, Model, Registry, Store } from "../src/core/index.js";
+import { Command, Reducer, Story } from "../src/reducer/index.js";
+
+// A tiny counter reducer with one command: "reset" requests an async clear
+// that (in the integration test) completes synchronously with `ResetCompleted`.
+interface CounterState {
+  readonly count: number;
+  readonly resetting: boolean;
+}
+
+type CounterMsg =
+  | { readonly _tag: "Increment" }
+  | { readonly _tag: "ResetRequested" }
+  | { readonly _tag: "ResetCompleted" };
+
+const Increment: CounterMsg = { _tag: "Increment" };
+const ResetRequested: CounterMsg = { _tag: "ResetRequested" };
+const ResetCompleted: CounterMsg = { _tag: "ResetCompleted" };
+
+const resetCommand = Command.make<CounterMsg>("Reset", Effect.succeed(ResetCompleted));
+
+const update: Reducer.Update<CounterState, CounterMsg> = (state, msg) => {
+  switch (msg._tag) {
+    case "Increment":
+      return [{ ...state, count: state.count + 1 }, Command.none];
+    case "ResetRequested":
+      return [{ ...state, resetting: true }, [resetCommand]];
+    case "ResetCompleted":
+      return [{ count: 0, resetting: false }, Command.none];
+  }
+};
+
+const initial: CounterState = { count: 0, resetting: false };
+
+describe("Reducer / Story", () => {
+  it("Story drives update as pure data — state, commands, resolve", () => {
+    const story = Story.make(update, initial);
+
+    story.dispatch(Increment);
+    story.dispatch(Increment);
+    assert.strictEqual(story.state.count, 2);
+    assert.deepStrictEqual(
+      story.commands.map((command) => command.name),
+      [],
+    );
+
+    story.dispatch(ResetRequested);
+    assert.isTrue(story.state.resetting);
+    assert.deepStrictEqual(
+      story.commands.map((command) => command.name),
+      ["Reset"],
+    );
+
+    // Simulate the command completing.
+    story.resolve("Reset", ResetCompleted);
+    assert.strictEqual(story.state.count, 0);
+    assert.isFalse(story.state.resetting);
+  });
+
+  it("Story.resolve throws for a command the reducer never produced", () => {
+    const story = Story.make(update, initial);
+    story.dispatch(Increment);
+    assert.throws(() => story.resolve("Reset", ResetCompleted), /no pending command named "Reset"/);
+  });
+
+  it("Command.define builds a named command per payload", () => {
+    const load = Command.define("Load", (_id: number) => Effect.succeed<CounterMsg>(ResetCompleted));
+    const command = load(7);
+    assert.strictEqual(command.name, "Load");
+    assert.isTrue(Command.isCommand(command));
+  });
+
+  it.effect("dispatch runs update, writes the state store, and cascades commands", () =>
+    Effect.gen(function* () {
+      const reducer = yield* Reducer.make({ initial, update, name: "counter" });
+
+      yield* Registry.allSettled(
+        Event.emit(reducer.dispatch, Increment),
+        Event.emit(reducer.dispatch, Increment),
+      );
+      assert.strictEqual((yield* Store.get(reducer.state)).count, 2);
+
+      // ResetRequested flips `resetting`, forks the Reset command, whose
+      // synchronous ResetCompleted cascade lands within the same settle window.
+      yield* Registry.allSettled(Event.emit(reducer.dispatch, ResetRequested));
+      const final = yield* Store.get(reducer.state);
+      assert.strictEqual(final.count, 0);
+      assert.isFalse(final.resetting);
+    }).pipe(Effect.provide(Registry.layer)),
+  );
+
+  it.effect("works through a model's narrowed ports", () =>
+    Effect.gen(function* () {
+      class CounterModel extends Model.Service<CounterModel>()("/test/reducer/CounterModel")({
+        make: () =>
+          Effect.gen(function* () {
+            const counter = yield* Reducer.make({ initial, update, name: "counter" });
+            return {
+              inputs: { dispatch: counter.dispatch },
+              outputs: { state: counter.state },
+              ui: { state: counter.state, dispatch: counter.dispatch },
+            };
+          }),
+      }) {}
+
+      yield* Effect.gen(function* () {
+        const ports = yield* Model.get(CounterModel);
+        yield* Registry.allSettled(Event.emit(ports.inputs.dispatch, Increment));
+        assert.strictEqual((yield* Store.get(ports.outputs.state)).count, 1);
+      }).pipe(Effect.provide(CounterModel.layer));
+    }).pipe(Effect.provide(Registry.layer)),
+  );
+});


### PR DESCRIPTION
## What & why

An exploration of the question "could we get more out of unitflow by borrowing from [foldkit](https://foldkit.dev/)?" The honest conclusion: the two are optimized for opposite things (foldkit is a whole-app single-model TEA framework that explicitly doesn't fit large SSR/React codebases with incremental adoption — which is exactly what Maple is). So this is a **cherry-pick, not a convergence** — two foldkit ideas grafted onto unitflow *without* the god-model rewrite.

## 1. Opt-in Msg/Command reducer helper

New `@maple/unitflow/reducer` subpath (parallel to `./db`, so the vendored `core/` stays untouched and upstream sync stays clean):

- `Reducer.make({ initial, update })` where `update: (state, msg) => [state, Command[]]` is **pure**. Commands fork into the model instance's scope (`startImmediately`, so a synchronous cascade settles within `Registry.allSettled`).
- `Command.make` / `Command.define` — a one-shot effect resolving to a follow-up `Msg`.
- `Story.make(update, initial)` — foldkit's Story analogue: a pure, registry-free, React-free test driver.

This is TEA scoped to **one** model — for interactive-state units only. The derivation pilots stay on `Store.combine`.

**Adopted on the errors-issues row selection** (multi-select + shift-range + clear): the fiddly shift-range/anchor index math moves out of the route's `useState<Set>` + `useRef(anchor)` + imperative-handler tangle into a pure, Story-tested reducer owned by `ErrorIssuesModel`. Clear-on-filter (filters live *above* the `<Unitflow>` provider) uses a `key`ed null component that fires `Cleared` on remount — the sanctioned no-useEffect "re-run via key" pattern.

## 2. DevTools inspector panel (dev-only)

Over the pre-existing-but-unused `Debug` inspector in the package. Attached to the shared runtime; a floating panel with:
- **Events** — the write/emit/instance log grouped into causal transactions (indented via the inspector's `cause` back-pointers), filterable.
- **State** — live model instances with lease counts + every store value (`derived` flagged).

`import.meta.env.DEV` gated, zero prod cost.

## Reviewer notes

- **Honest scope:** the reducer *capability* + devtools are the durable wins. The reducer *adoption on selection specifically* is a demonstration — it improves test coverage of the shift-range logic but adds some indirection (notably the `ClearSelectionOnFilterChange` remount hack, a consequence of state living below the provider while its trigger stays above). It's cleanly reversible. The reducer earns its keep more on a genuinely async surface (wizard / optimistic edit) we haven't hit yet — Commands are currently unused because selection is pure.
- **Not built (deliberate):** full TEA rewrite; global deterministic time-travel replay (decentralized state → only per-reducer replay is free); routing/forms/managed-resources (already covered by TanStack Router / TanStack Form / `InstanceScope`). MCP read surface over the inspector is a natural follow-on.

## Verification

- unitflow **142 tests** green (5 new reducer/Story); web model + devtools tests green (Story tests for selection + pure inspector-view helpers).
- Repo-wide `bun typecheck` **29/29**.
- **Live on `/alerts` and `/errors/issues`:** models construct, the panel records the causal round-trip (`emit Toggled` → `write selectedIds`), and shift-range selection works end-to-end (shift-click selects the inclusive range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->