### PR TITLE
fix(replays): adapt list page to narrow content columns via container queries

### DIFF
--- a/apps/web/src/components/replays/replays-toolbar.tsx
+++ b/apps/web/src/components/replays/replays-toolbar.tsx
@@ -68,15 +68,15 @@ export function ReplaysToolbar({
 			</InputGroup>
 
 			<div
-				className={cn("flex items-center gap-4 text-sm transition-opacity", waiting && "opacity-60")}
+				className={cn("flex flex-wrap items-center gap-x-4 gap-y-1 text-sm transition-opacity", waiting && "opacity-60")}
 			>
 				<Stat label="sessions" value={totalSessions} />
-				<span className="flex items-center gap-1.5">
+				<span className="flex items-center gap-1.5 whitespace-nowrap">
 					<span className="size-1.5 rounded-full bg-success" />
 					<span className="font-medium tabular-nums">{activeSessions.toLocaleString()}</span>
 					<span className="text-muted-foreground">active</span>
 				</span>
-				<span className="flex items-center gap-1.5">
+				<span className="flex items-center gap-1.5 whitespace-nowrap">
 					<span className={cn("font-medium tabular-nums", errorSessions > 0 && "text-destructive")}>
 						{errorSessions.toLocaleString()}
 					</span>
@@ -89,7 +89,7 @@ export function ReplaysToolbar({
 
 function Stat({ label, value }: { label: string; value: number }) {
 	return (
-		<span className="flex items-center gap-1.5">
+		<span className="flex items-center gap-1.5 whitespace-nowrap">
 			<span className="font-medium tabular-nums">{value.toLocaleString()}</span>
 			<span className="text-muted-foreground">{label}</span>
 		</span>

--- a/apps/web/src/components/replays/sessions-list.tsx
+++ b/apps/web/src/components/replays/sessions-list.tsx
@@ -126,7 +126,7 @@ export function SessionsList({ sessions, onReachEnd, hasMore = false, loadingMor
 	}
 
 	return (
-		<div className="space-y-2">
+		<div className="@container space-y-2">
 			{sessions.map((session) => {
 				const id = identity(session)
 				const isActive = session.status === "active"
@@ -142,30 +142,43 @@ export function SessionsList({ sessions, onReachEnd, hasMore = false, loadingMor
 								search: { t: session.startTime },
 							})
 						}
-						className="group flex w-full items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 text-left transition-all hover:-translate-y-px hover:border-primary/40 hover:bg-accent/40 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:gap-4"
+						className="group flex w-full items-center gap-3 rounded-xl border border-border bg-card px-3.5 py-3 text-left transition-all hover:-translate-y-px hover:border-primary/40 hover:bg-accent/40 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring @2xl:gap-4 @2xl:px-4"
 					>
 						<div
-							className={`grid size-10 shrink-0 place-items-center rounded-full bg-gradient-to-br ${id.gradient} text-sm font-semibold text-white shadow-sm`}
+							className={`grid size-9 shrink-0 place-items-center rounded-full bg-gradient-to-br ${id.gradient} text-sm font-semibold text-white shadow-sm @2xl:size-10`}
 						>
 							{id.initial}
 						</div>
 
 						<div className="min-w-0 flex-1">
 							<div className="flex items-center gap-2">
-								<span className="max-w-[16rem] truncate text-sm font-medium">{id.label}</span>
+								<span className="min-w-0 truncate text-sm font-medium @2xl:max-w-[16rem]">
+									{id.label}
+								</span>
 								<StatusDot active={isActive} />
-								<span className="font-mono text-xs text-muted-foreground">
+								<span className="hidden shrink-0 font-mono text-xs text-muted-foreground @2xl:inline">
 									{session.sessionId.slice(0, 8)} · {formatDuration(session.durationMs)}
+								</span>
+								{/* On phones the right-hand columns are gone, so the timestamp
+								    anchors the top-right corner of the stacked row. */}
+								<span
+									className="ml-auto shrink-0 whitespace-nowrap text-xs text-muted-foreground @2xl:hidden"
+									title={absoluteTs(session.startTime)}
+								>
+									{formatRelative(session.startTime)}
 								</span>
 							</div>
 							<div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
+								<span className="shrink-0 font-mono @2xl:hidden">
+									{session.sessionId.slice(0, 8)} · {formatDuration(session.durationMs)}
+								</span>
 								<span className="flex min-w-0 items-center gap-1.5">
 									<GlobeIcon className="size-3.5 shrink-0 opacity-60" />
-									<span className="max-w-[18rem] truncate">
+									<span className="min-w-0 truncate @2xl:max-w-[18rem]">
 										{hostFromUrl(session.urlInitial)}
 									</span>
 								</span>
-								<span className="hidden items-center gap-1.5 sm:flex">
+								<span className="hidden items-center gap-1.5 @2xl:flex">
 									<DeviceIcon className="size-3.5 shrink-0 opacity-60" />
 									<span className="truncate">
 										{session.browserName || "Unknown"}
@@ -173,15 +186,20 @@ export function SessionsList({ sessions, onReachEnd, hasMore = false, loadingMor
 									</span>
 								</span>
 								{session.country && (
-									<span className="hidden truncate md:inline">{session.country}</span>
+									<span className="hidden truncate @3xl:inline">{session.country}</span>
 								)}
 							</div>
+							{(session.traceCount > 0 || session.errorCount > 0) && (
+								<div className="mt-1.5 flex items-center gap-2 @2xl:hidden">
+									<SessionBadges session={session} />
+								</div>
+							)}
 						</div>
 
-						<div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground sm:gap-2.5">
+						<div className="hidden shrink-0 items-center gap-2.5 text-xs text-muted-foreground @2xl:flex">
 							{/* Click/page-view counts are low-signal — drop them on phones and
 							    keep the load-bearing trace/error badges. */}
-							<span className="hidden items-center gap-2.5 sm:flex">
+							<span className="flex items-center gap-2.5">
 								<Stat
 									icon={<PulseIcon className="size-3.5" />}
 									value={session.clickCount}
@@ -193,28 +211,20 @@ export function SessionsList({ sessions, onReachEnd, hasMore = false, loadingMor
 									title="page views"
 								/>
 							</span>
-							{session.traceCount > 0 && (
-								<span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-1.5 py-0.5 font-medium tabular-nums text-primary">
-									{session.traceCount} trace{session.traceCount === 1 ? "" : "s"}
-								</span>
-							)}
-							{session.errorCount > 0 && (
-								<span className="inline-flex items-center gap-1 rounded-full bg-destructive/10 px-1.5 py-0.5 font-medium tabular-nums text-destructive">
-									<CircleWarningIcon className="size-3" />
-									{session.errorCount}
-								</span>
-							)}
+							<SessionBadges session={session} />
 						</div>
 
-						<div className="flex shrink-0 items-center gap-2 sm:gap-3">
+						<div className="hidden shrink-0 items-center gap-3 @2xl:flex">
 							<span
 								className="inline-flex items-center gap-1.5 whitespace-nowrap text-sm text-muted-foreground"
 								title={absoluteTs(session.startTime)}
 							>
-								<ClockIcon className="hidden size-3.5 opacity-60 sm:inline" />
+								<ClockIcon className="size-3.5 opacity-60" />
 								{formatRelative(session.startTime)}
 							</span>
-							{/* Tap affordance: hover-revealed on desktop, always shown on touch. */}
+							{/* Tap affordance: hover-revealed on desktop. Phones skip it —
+							    the whole card is the tap target and the stacked row needs
+							    every horizontal pixel. */}
 							<span className="grid size-7 place-items-center rounded-full bg-primary/10 text-primary opacity-0 transition-opacity group-hover:opacity-100 pointer-coarse:opacity-100">
 								<PlayGlyph />
 							</span>
@@ -232,6 +242,24 @@ export function SessionsList({ sessions, onReachEnd, hasMore = false, loadingMor
 				</div>
 			)}
 		</div>
+	)
+}
+
+function SessionBadges({ session }: { session: SessionRow }) {
+	return (
+		<>
+			{session.traceCount > 0 && (
+				<span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium tabular-nums text-primary">
+					{session.traceCount} trace{session.traceCount === 1 ? "" : "s"}
+				</span>
+			)}
+			{session.errorCount > 0 && (
+				<span className="inline-flex items-center gap-1 rounded-full bg-destructive/10 px-1.5 py-0.5 text-xs font-medium tabular-nums text-destructive">
+					<CircleWarningIcon className="size-3" />
+					{session.errorCount}
+				</span>
+			)}
+		</>
 	)
 }
 

--- a/packages/ui/src/components/ui/page-layout.tsx
+++ b/packages/ui/src/components/ui/page-layout.tsx
@@ -67,7 +67,7 @@ function Header({ children, title, titleContent, description, className }: Heade
 		<div
 			data-slot="page-header"
 			className={cn(
-				"flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4",
+				"flex flex-col gap-2 @2xl/page:flex-row @2xl/page:items-start @2xl/page:justify-between @2xl/page:gap-4",
 				className,
 			)}
 		>
@@ -181,7 +181,7 @@ function Content({ children, className }: { children: React.ReactNode; className
 		<main
 			id="main-content"
 			data-slot="page-content"
-			className={cn("flex min-h-0 min-w-0 flex-1 flex-col", className)}
+			className={cn("@container/page flex min-h-0 min-w-0 flex-1 flex-col", className)}
 		>
 			{children}
 		</main>


### PR DESCRIPTION
## Summary

The `/replays` list page broke at small sizes — on phones the session rows' identity column got crushed (usernames truncated to nothing, URLs showing `sup…`), and on ~800px windows with both sidebars open the page title collapsed to a single letter with a one-word-per-line description. Root cause: rows and the shared page header switched layout on **viewport** breakpoints, but the actual content column can be far narrower than the viewport.

- **`sessions-list.tsx`** — the list is now a `@container`; below ~672px of content width rows stack: name + status with the timestamp anchored top-right, session id · duration · URL on line two, trace/error badges on their own line. The low-signal click/page-view cluster and hover play affordance hide instead of competing for space.
- **`page-layout.tsx`** — `PageLayout.Content` is a named `@container/page` and the shared header switches to its side-by-side layout based on the content column's width, not the viewport. Benefits every page using `DashboardLayout`.
- **`replays-toolbar.tsx`** — each stat wraps as a whole unit, so "0 with errors" no longer splits mid-phrase.

## Verification

Checked live against the dev stack at 375px, ~483px, 800px with both sidebars inline (~300px content column), and 1440px — full-width desktop rendering is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->