### PR TITLE
feat(web): replace sidebar Chat entry with global chat slide-over

### DIFF
--- a/apps/web/src/components/alerts/alert-chat-sheet.tsx
+++ b/apps/web/src/components/alerts/alert-chat-sheet.tsx
@@ -47,9 +47,9 @@ export function AlertChatSheet({ open, onOpenChange, alertContext }: AlertChatSh
 				<SheetPopup
 					side="right"
 					className="w-[calc(100%-(--spacing(12)))] sm:max-w-2xl"
-					closeProps={{ className: "absolute end-12 top-4 z-10" }}
+					closeProps={{ className: "absolute end-3 top-5 z-10" }}
 				>
-					<SheetHeader className="flex flex-row items-start justify-between gap-3 border-b pb-4">
+					<SheetHeader className="flex flex-row items-start justify-between gap-3 border-b pe-14 pb-4">
 						<div className="min-w-0 space-y-1">
 							<SheetTitle className="truncate text-base">{alertContext.ruleName}</SheetTitle>
 							<SheetDescription>

--- a/apps/web/src/components/chat/global-chat-sheet.tsx
+++ b/apps/web/src/components/chat/global-chat-sheet.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react"
+import { Link } from "@tanstack/react-router"
+
+import { Button } from "@maple/ui/components/ui/button"
+import {
+	Sheet,
+	SheetDescription,
+	SheetHeader,
+	SheetPopup,
+	SheetTitle,
+} from "@maple/ui/components/ui/sheet"
+import { ExternalLinkIcon } from "@/components/icons"
+
+import { ChatConversation } from "@/components/chat/chat-conversation"
+import { FlueClientProvider } from "@/components/chat/flue-client-provider"
+import { ensureStoredTab } from "@/hooks/use-chat-tabs"
+import { useAppHotkey } from "@/hooks/use-app-hotkey"
+import { useMapleOrganizationId } from "@/hooks/use-maple-organization"
+
+const OPEN_CHAT_EVENT = "maple:open-chat-sheet"
+
+/** Stable conversation id for the quick chat — one org-scoped thread. */
+export const QUICK_CHAT_TAB_ID = "quick"
+const QUICK_CHAT_TAB_TITLE = "Quick chat"
+
+/** Open the global chat slide-over from anywhere (header button, ⌘K action). */
+export function openGlobalChat() {
+	document.dispatchEvent(new CustomEvent(OPEN_CHAT_EVENT))
+}
+
+/**
+ * App-wide chat surface, mounted once in the root AppFrame: a right slide-over
+ * hosting the Maple AI conversation on a persistent org-scoped "quick" thread.
+ * Replaces the old sidebar nav entry — the full /chat page remains for deep
+ * links (alert triage, widget fix, shared views) and multi-tab work.
+ *
+ * The popup content (and with it the Flue connection) only mounts while open;
+ * history restores from the durable stream on reopen, same as AlertChatSheet.
+ */
+export function GlobalChatSheet() {
+	const [open, setOpen] = useState(false)
+	const orgId = useMapleOrganizationId()
+
+	useAppHotkey("chat.quickOpen", () => setOpen(true))
+
+	useEffect(() => {
+		const onOpen = () => setOpen(true)
+		document.addEventListener(OPEN_CHAT_EVENT, onOpen)
+		return () => document.removeEventListener(OPEN_CHAT_EVENT, onOpen)
+	}, [])
+
+	if (!orgId) return null
+
+	return (
+		<Sheet open={open} onOpenChange={setOpen}>
+			<SheetPopup
+				side="right"
+				className="w-[calc(100%-(--spacing(12)))] sm:max-w-2xl"
+				closeProps={{ className: "absolute end-3 top-5 z-10" }}
+			>
+				<SheetHeader className="flex flex-row items-start justify-between gap-3 border-b pe-14 pb-4">
+					<div className="min-w-0 space-y-1">
+						<SheetTitle className="truncate text-base">Maple AI</SheetTitle>
+						<SheetDescription>
+							Ask about your services, traces, errors, and alerts.
+						</SheetDescription>
+					</div>
+					<Button
+						size="sm"
+						variant="ghost"
+						onClick={() => {
+							ensureStoredTab(orgId, QUICK_CHAT_TAB_ID, QUICK_CHAT_TAB_TITLE)
+							setOpen(false)
+						}}
+						render={<Link to="/chat" search={{ tab: QUICK_CHAT_TAB_ID }} />}
+					>
+						Open full page
+						<ExternalLinkIcon className="size-3.5" />
+					</Button>
+				</SheetHeader>
+				<div className="flex min-h-0 flex-1 flex-col">
+					<FlueClientProvider>
+						<ChatConversation tabId={QUICK_CHAT_TAB_ID} isActive={open} />
+					</FlueClientProvider>
+				</div>
+			</SheetPopup>
+		</Sheet>
+	)
+}

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -16,7 +16,15 @@ import {
 	CommandShortcut,
 } from "@maple/ui/components/ui/command"
 import { Kbd } from "@maple/ui/components/ui/kbd"
-import { GearIcon, GridSquareCirclePlusIcon, KeyboardIcon, MoonIcon, SunIcon } from "@/components/icons"
+import {
+	ChatBubbleSparkleIcon,
+	GearIcon,
+	GridSquareCirclePlusIcon,
+	KeyboardIcon,
+	MoonIcon,
+	SunIcon,
+} from "@/components/icons"
+import { openGlobalChat } from "@/components/chat/global-chat-sheet"
 import {
 	investigateNavItems,
 	mainNavItems,
@@ -173,6 +181,15 @@ function PaletteContent({
 
 		const isDark = theme === "dark"
 		const actions: PaletteEntry[] = [
+			{
+				id: "action:ask-maple-ai",
+				title: "Ask Maple AI",
+				group: "Actions",
+				keywords: "chat ai assistant maple ask question",
+				icon: ChatBubbleSparkleIcon,
+				run: openGlobalChat,
+				shortcut: "C",
+			},
 			{
 				id: "action:toggle-theme",
 				title: isDark ? "Switch to light mode" : "Switch to dark mode",

--- a/apps/web/src/components/dashboard/nav-items.ts
+++ b/apps/web/src/components/dashboard/nav-items.ts
@@ -1,7 +1,6 @@
 import {
 	BellIcon,
 	ChartLineIcon,
-	ChatBubbleSparkleIcon,
 	CircleWarningIcon,
 	CloudflareIcon,
 	ComputerIcon,
@@ -37,11 +36,6 @@ export const mainNavItems: NavItem[] = [
 		title: "Overview",
 		href: "/",
 		icon: HouseIcon,
-	},
-	{
-		title: "Chat",
-		href: "/chat",
-		icon: ChatBubbleSparkleIcon,
 	},
 ]
 

--- a/apps/web/src/components/layout/dashboard-layout.tsx
+++ b/apps/web/src/components/layout/dashboard-layout.tsx
@@ -14,7 +14,10 @@ import {
 import { PageLayout } from "@maple/ui/components/ui/page-layout"
 import { Button } from "@maple/ui/components/ui/button"
 import { useIsMobile } from "@maple/ui/hooks/use-mobile"
-import { LayoutLeftIcon } from "@/components/icons"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@maple/ui/components/ui/tooltip"
+import { Kbd } from "@maple/ui/components/ui/kbd"
+import { ChatBubbleSparkleIcon, LayoutLeftIcon } from "@/components/icons"
+import { openGlobalChat } from "@/components/chat/global-chat-sheet"
 import { ConnectButton } from "@/components/header/connect-button"
 import { QuotaBanner } from "@/components/billing/quota-banner"
 import { PaymentFailedBanner } from "@/components/billing/payment-failed-banner"
@@ -120,6 +123,23 @@ export function DashboardLayout({
 							</BreadcrumbList>
 						</Breadcrumb>
 						<div className="ml-auto flex shrink-0 items-center gap-2">
+							<Tooltip>
+								<TooltipTrigger
+									render={
+										<Button
+											variant="outline"
+											size="icon-sm"
+											aria-label="Open AI chat"
+											onClick={openGlobalChat}
+										/>
+									}
+								>
+									<ChatBubbleSparkleIcon size={16} />
+								</TooltipTrigger>
+								<TooltipContent className="flex items-center gap-1.5">
+									Ask Maple AI <Kbd>C</Kbd>
+								</TooltipContent>
+							</Tooltip>
 							<ConnectButton />
 							{filterSidebar && isMobile && (
 								<PageLayout.FilterSidebarTrigger>

--- a/apps/web/src/hooks/use-chat-tabs.ts
+++ b/apps/web/src/hooks/use-chat-tabs.ts
@@ -57,6 +57,24 @@ function saveState(orgId: string, state: ChatTabsState) {
 	}
 }
 
+/**
+ * Register a tab in the org's persisted tab list (and activate it) without
+ * mounting the chat page — used by deep links like the global chat sheet's
+ * "Open full page", since useChatTabs only activates ids it already knows.
+ */
+export function ensureStoredTab(orgId: string, id: string, title: string) {
+	const state = loadState(orgId)
+	const now = Date.now()
+	const existing = state.tabs.find((t) => t.id === id)
+	const next: ChatTabsState = existing
+		? { ...state, activeTabId: id }
+		: {
+				tabs: [...state.tabs, { id, title, createdAt: now, updatedAt: now }],
+				activeTabId: id,
+			}
+	saveState(orgId, next)
+}
+
 export function useChatTabs(orgId: string, initialTabId?: string) {
 	const [state, setState] = useState<ChatTabsState>(() => {
 		const s = loadState(orgId)

--- a/apps/web/src/lib/shortcuts.ts
+++ b/apps/web/src/lib/shortcuts.ts
@@ -119,6 +119,11 @@ const SHORTCUTS = {
 		label: "Seek forward 5s",
 		group: "Session Replay",
 	},
+	"chat.quickOpen": {
+		combo: "C",
+		label: "Open AI chat",
+		group: "Chat",
+	},
 	"chat.newTab": {
 		combo: "Mod+Shift+O",
 		label: "New chat tab",

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -21,6 +21,7 @@ import { highlightCode } from "@/lib/sugar-high"
 import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 import type { RouterAuthContext } from "@/router"
 import { captureChatReferrer } from "@/components/chat/auto-contexts"
+import { GlobalChatSheet } from "@/components/chat/global-chat-sheet"
 import { GlobalShortcuts } from "@/components/command-palette/global-shortcuts"
 import { UnitflowDevtools } from "@/components/devtools/unitflow-devtools"
 
@@ -70,7 +71,12 @@ function AppFrame() {
 		>
 			<Outlet />
 			<Toaster />
-			{!PUBLIC_PATHS.has(pathname) && <GlobalShortcuts />}
+			{!PUBLIC_PATHS.has(pathname) && (
+				<>
+					<GlobalShortcuts />
+					<GlobalChatSheet />
+				</>
+			)}
 			{import.meta.env.DEV && <UnitflowDevtools />}
 		</AttributesProvider>
 	)


### PR DESCRIPTION
## What

Removes **Chat** from the sidebar nav and re-exposes it as a lightweight, on-demand surface:

- **`GlobalChatSheet`** (new): a right slide-over hosting the existing embeddable `ChatConversation` on a persistent org-scoped `"quick"` thread. Mounted once in `__root.tsx` next to `GlobalShortcuts`; content (and the Flue connection) only mounts while open.
- **Three triggers**: a small icon button in the header right cluster (tooltip "Ask Maple AI · C"), a new `C` hotkey (`chat.quickOpen`, shows up in the shortcuts help dialog automatically), and a ⌘K palette action "Ask Maple AI".
- **"Open full page"** hands off to `/chat?tab=quick`; a new exported `ensureStoredTab()` in `use-chat-tabs.ts` registers the tab first, since `useChatTabs` only activates ids already in localStorage.
- Cross-tree open uses a CustomEvent (`openGlobalChat()`), the same pattern as `showKeyboardShortcuts()`.

Also fixes a close-button overlap in sheet headers: `SheetHeader`'s 24px right padding let right-aligned header content slide under the absolutely-positioned close icon. The header now reserves the corner (`pe-14`) and the close aligns with the title row — fixed in both the new sheet and `alert-chat-sheet.tsx` (which had the same bug and was the template).

## Why

Usage telemetry shows chat adoption is too low to justify a permanent top-level sidebar slot — most visitors are one-time and few engage — but chat should stay discoverable and one keystroke away on every page.

## Not changed

The `/chat` page and every deep link into it (`mode=alert` triage handoffs, `mode=widget-fix`, shared views), `alert-chat-sheet` behavior, and the `chat.newTab` shortcut.

## Verified

- Sidebar entry gone (also auto-removed from the palette Navigation group, which spreads `mainNavItems`).
- Header button opens the sheet; Escape closes; conversation renders with suggestions + composer.
- "Open full page" lands on `/chat?tab=quick` with the Quick chat tab registered and active.
- Shortcuts help dialog lists "Open AI chat · C"; palette shows the new action.
- Mobile (375px): button visible, sheet spans viewport minus gutter.
- Header layout: "Open full page" and ✕ no longer overlap (12px gap, aligned).
- `vitest` shortcuts/hotkey suites pass. `bun typecheck` currently fails only on pre-existing `FilterSidebarError` errors from unrelated in-flight work, none in these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->