### PR TITLE
feat(traces): compact, de-emphasized duration filter with p50/p95 presets

### DIFF
--- a/apps/web/src/components/traces/duration-range-filter.tsx
+++ b/apps/web/src/components/traces/duration-range-filter.tsx
@@ -1,9 +1,8 @@
 import * as React from "react"
-import { ChevronDownIcon } from "@/components/icons"
+import { ChevronDownIcon, XmarkIcon } from "@/components/icons"
 
 import { cn } from "@maple/ui/utils"
 import { Input } from "@maple/ui/components/ui/input"
-import { Label } from "@maple/ui/components/ui/label"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@maple/ui/components/ui/collapsible"
 
 interface DurationRangeFilterProps {
@@ -26,9 +25,10 @@ export function DurationRangeFilter({
 	onMinChange,
 	onMaxChange,
 	durationStats,
-	defaultOpen = true,
+	defaultOpen = false,
 }: DurationRangeFilterProps) {
-	const [isOpen, setIsOpen] = React.useState(defaultOpen)
+	const hasActiveRange = minValue !== undefined || maxValue !== undefined
+	const [isOpen, setIsOpen] = React.useState(defaultOpen || hasActiveRange)
 
 	const handleMinChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const val = e.target.value
@@ -40,73 +40,127 @@ export function DurationRangeFilter({
 		onMaxChange(val === "" ? undefined : Number(val))
 	}
 
+	const applyPreset = (minMs: number) => {
+		if (minValue === Math.round(minMs) && maxValue === undefined) {
+			onMinChange(undefined)
+			return
+		}
+		onMinChange(Math.round(minMs))
+		onMaxChange(undefined)
+	}
+
+	const clearRange = () => {
+		onMinChange(undefined)
+		onMaxChange(undefined)
+	}
+
+	const presets: Array<{ key: string; label: string; minMs: number }> = []
+	if (durationStats && durationStats.p50DurationMs > 0) {
+		presets.push({
+			key: "p50",
+			label: `> p50 · ${formatDuration(durationStats.p50DurationMs)}`,
+			minMs: durationStats.p50DurationMs,
+		})
+	}
+	if (durationStats && durationStats.p95DurationMs > 0) {
+		presets.push({
+			key: "p95",
+			label: `> p95 · ${formatDuration(durationStats.p95DurationMs)}`,
+			minMs: durationStats.p95DurationMs,
+		})
+	}
+	presets.push({ key: "1s", label: "> 1s", minMs: 1000 })
+
 	return (
 		<Collapsible open={isOpen} onOpenChange={setIsOpen}>
 			<CollapsibleTrigger className="flex w-full items-center justify-between py-2 text-sm font-medium hover:text-foreground text-muted-foreground transition-colors">
-				<span>Duration (ms)</span>
-				<ChevronDownIcon className={cn("size-4 transition-transform", isOpen && "rotate-180")} />
+				<span>Duration</span>
+				<span className="flex items-center gap-1.5">
+					{!isOpen && hasActiveRange && (
+						<span className="inline-flex items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 text-xs tabular-nums text-foreground">
+							{formatRange(minValue, maxValue)}
+							<span
+								role="button"
+								tabIndex={0}
+								aria-label="Clear duration filter"
+								className="rounded-xs hover:text-muted-foreground"
+								onClick={(e) => {
+									e.stopPropagation()
+									clearRange()
+								}}
+								onKeyDown={(e) => {
+									if (e.key === "Enter" || e.key === " ") {
+										e.preventDefault()
+										e.stopPropagation()
+										clearRange()
+									}
+								}}
+							>
+								<XmarkIcon className="size-3" />
+							</span>
+						</span>
+					)}
+					<ChevronDownIcon className={cn("size-4 transition-transform", isOpen && "rotate-180")} />
+				</span>
 			</CollapsibleTrigger>
 			<CollapsibleContent className="pb-3">
-				<div className="space-y-3">
-					<div className="flex items-center gap-2">
-						<div className="flex-1">
-							<Label
-								htmlFor="min-duration"
-								className="text-xs text-muted-foreground mb-1 block"
-							>
-								Min
-							</Label>
-							<Input
-								id="min-duration"
-								type="number"
-								min={0}
-								placeholder={
-									durationStats ? String(Math.floor(durationStats.minDurationMs)) : "0"
-								}
-								value={minValue ?? ""}
-								onChange={handleMinChange}
-							/>
-						</div>
-						<span className="text-muted-foreground mt-5">-</span>
-						<div className="flex-1">
-							<Label
-								htmlFor="max-duration"
-								className="text-xs text-muted-foreground mb-1 block"
-							>
-								Max
-							</Label>
-							<Input
-								id="max-duration"
-								type="number"
-								min={0}
-								placeholder={
-									durationStats ? String(Math.ceil(durationStats.maxDurationMs)) : ""
-								}
-								value={maxValue ?? ""}
-								onChange={handleMaxChange}
-							/>
-						</div>
+				<div className="space-y-2">
+					<div className="flex flex-wrap gap-1">
+						{presets.map((preset) => {
+							const isActive = minValue === Math.round(preset.minMs) && maxValue === undefined
+							return (
+								<button
+									key={preset.key}
+									type="button"
+									onClick={() => applyPreset(preset.minMs)}
+									className={cn(
+										"h-6 rounded-sm border px-1.5 text-xs tabular-nums transition-colors",
+										isActive
+											? "border-primary/40 bg-primary/10 text-foreground"
+											: "border-border text-muted-foreground hover:bg-muted hover:text-foreground",
+									)}
+								>
+									{preset.label}
+								</button>
+							)
+						})}
 					</div>
-					{durationStats && (
-						<div className="text-xs text-muted-foreground space-y-1">
-							<div className="flex justify-between">
-								<span>p50:</span>
-								<span className="tabular-nums">
-									{formatDuration(durationStats.p50DurationMs)}
-								</span>
-							</div>
-							<div className="flex justify-between">
-								<span>p95:</span>
-								<span className="tabular-nums">
-									{formatDuration(durationStats.p95DurationMs)}
-								</span>
-							</div>
-						</div>
-					)}
+					<div className="flex items-center gap-1.5">
+						<Input
+							aria-label="Min duration (ms)"
+							type="number"
+							min={0}
+							className="h-7 text-xs"
+							placeholder={durationStats ? String(Math.floor(durationStats.minDurationMs)) : "0"}
+							value={minValue ?? ""}
+							onChange={handleMinChange}
+						/>
+						<span className="text-xs text-muted-foreground">–</span>
+						<Input
+							aria-label="Max duration (ms)"
+							type="number"
+							min={0}
+							className="h-7 text-xs"
+							placeholder={durationStats ? String(Math.ceil(durationStats.maxDurationMs)) : "max"}
+							value={maxValue ?? ""}
+							onChange={handleMaxChange}
+						/>
+						<span className="text-xs text-muted-foreground">ms</span>
+					</div>
 				</div>
 			</CollapsibleContent>
 		</Collapsible>
 	)
+}
+
+function formatRange(minValue: number | undefined, maxValue: number | undefined): string {
+	if (minValue !== undefined && maxValue !== undefined) {
+		return `${formatDuration(minValue)} – ${formatDuration(maxValue)}`
+	}
+	if (minValue !== undefined) {
+		return `≥ ${formatDuration(minValue)}`
+	}
+	return `≤ ${formatDuration(maxValue ?? 0)}`
 }
 
 function formatDuration(ms: number): string {

--- a/apps/web/src/components/traces/duration-range-filter.tsx
+++ b/apps/web/src/components/traces/duration-range-filter.tsx
@@ -5,11 +5,12 @@ import { cn } from "@maple/ui/utils"
 import { Input } from "@maple/ui/components/ui/input"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@maple/ui/components/ui/collapsible"
 
+const COMMIT_DEBOUNCE_MS = 400
+
 interface DurationRangeFilterProps {
 	minValue: number | undefined
 	maxValue: number | undefined
-	onMinChange: (value: number | undefined) => void
-	onMaxChange: (value: number | undefined) => void
+	onRangeChange: (min: number | undefined, max: number | undefined) => void
 	durationStats?: {
 		minDurationMs: number
 		maxDurationMs: number
@@ -22,54 +23,72 @@ interface DurationRangeFilterProps {
 export function DurationRangeFilter({
 	minValue,
 	maxValue,
-	onMinChange,
-	onMaxChange,
+	onRangeChange,
 	durationStats,
 	defaultOpen = false,
 }: DurationRangeFilterProps) {
 	const hasActiveRange = minValue !== undefined || maxValue !== undefined
 	const [isOpen, setIsOpen] = React.useState(defaultOpen || hasActiveRange)
 
-	const handleMinChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const val = e.target.value
-		onMinChange(val === "" ? undefined : Number(val))
+	// Inputs edit a local draft; the URL (and the queries behind it) only
+	// updates after a pause in typing, or immediately for preset clicks.
+	const [draft, setDraft] = React.useState({ min: toText(minValue), max: toText(maxValue) })
+	const [prevRange, setPrevRange] = React.useState({ minValue, maxValue })
+	if (prevRange.minValue !== minValue || prevRange.maxValue !== maxValue) {
+		setPrevRange({ minValue, maxValue })
+		setDraft({ min: toText(minValue), max: toText(maxValue) })
 	}
 
-	const handleMaxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const val = e.target.value
-		onMaxChange(val === "" ? undefined : Number(val))
+	const commitTimer = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+	const cancelPendingCommit = () => {
+		if (commitTimer.current !== undefined) {
+			clearTimeout(commitTimer.current)
+			commitTimer.current = undefined
+		}
+	}
+
+	const handleDraftChange = (next: { min: string; max: string }) => {
+		setDraft(next)
+		cancelPendingCommit()
+		commitTimer.current = setTimeout(() => {
+			commitTimer.current = undefined
+			onRangeChange(fromText(next.min), fromText(next.max))
+		}, COMMIT_DEBOUNCE_MS)
+	}
+
+	const applyRange = (min: number | undefined, max: number | undefined) => {
+		cancelPendingCommit()
+		setDraft({ min: toText(min), max: toText(max) })
+		onRangeChange(min, max)
 	}
 
 	const applyPreset = (minMs: number) => {
-		if (minValue === Math.round(minMs) && maxValue === undefined) {
-			onMinChange(undefined)
+		const rounded = Math.round(minMs)
+		if (minValue === rounded && maxValue === undefined) {
+			applyRange(undefined, undefined)
 			return
 		}
-		onMinChange(Math.round(minMs))
-		onMaxChange(undefined)
+		applyRange(rounded, undefined)
 	}
 
-	const clearRange = () => {
-		onMinChange(undefined)
-		onMaxChange(undefined)
-	}
-
-	const presets: Array<{ key: string; label: string; minMs: number }> = []
+	const presets: Array<{ key: string; label: string; minMs: number; value: string }> = []
 	if (durationStats && durationStats.p50DurationMs > 0) {
 		presets.push({
 			key: "p50",
-			label: `> p50 · ${formatDuration(durationStats.p50DurationMs)}`,
+			label: "> p50",
 			minMs: durationStats.p50DurationMs,
+			value: formatDuration(durationStats.p50DurationMs),
 		})
 	}
 	if (durationStats && durationStats.p95DurationMs > 0) {
 		presets.push({
 			key: "p95",
-			label: `> p95 · ${formatDuration(durationStats.p95DurationMs)}`,
+			label: "> p95",
 			minMs: durationStats.p95DurationMs,
+			value: formatDuration(durationStats.p95DurationMs),
 		})
 	}
-	presets.push({ key: "1s", label: "> 1s", minMs: 1000 })
+	presets.push({ key: "1s", label: "> 1s", minMs: 1000, value: "" })
 
 	return (
 		<Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -86,13 +105,13 @@ export function DurationRangeFilter({
 								className="rounded-xs hover:text-muted-foreground"
 								onClick={(e) => {
 									e.stopPropagation()
-									clearRange()
+									applyRange(undefined, undefined)
 								}}
 								onKeyDown={(e) => {
 									if (e.key === "Enter" || e.key === " ") {
 										e.preventDefault()
 										e.stopPropagation()
-										clearRange()
+										applyRange(undefined, undefined)
 									}
 								}}
 							>
@@ -105,7 +124,7 @@ export function DurationRangeFilter({
 			</CollapsibleTrigger>
 			<CollapsibleContent className="pb-3">
 				<div className="space-y-2">
-					<div className="flex flex-wrap gap-1">
+					<div>
 						{presets.map((preset) => {
 							const isActive = minValue === Math.round(preset.minMs) && maxValue === undefined
 							return (
@@ -114,13 +133,14 @@ export function DurationRangeFilter({
 									type="button"
 									onClick={() => applyPreset(preset.minMs)}
 									className={cn(
-										"h-6 rounded-sm border px-1.5 text-xs tabular-nums transition-colors",
+										"flex w-full items-center justify-between rounded-sm px-1.5 py-1 text-xs transition-colors",
 										isActive
-											? "border-primary/40 bg-primary/10 text-foreground"
-											: "border-border text-muted-foreground hover:bg-muted hover:text-foreground",
+											? "bg-primary/10 text-foreground"
+											: "text-muted-foreground hover:bg-muted hover:text-foreground",
 									)}
 								>
-									{preset.label}
+									<span>{preset.label}</span>
+									<span className="tabular-nums">{preset.value}</span>
 								</button>
 							)
 						})}
@@ -130,20 +150,22 @@ export function DurationRangeFilter({
 							aria-label="Min duration (ms)"
 							type="number"
 							min={0}
-							className="h-7 text-xs"
-							placeholder={durationStats ? String(Math.floor(durationStats.minDurationMs)) : "0"}
-							value={minValue ?? ""}
-							onChange={handleMinChange}
+							size="sm"
+							className="text-xs"
+							placeholder="0"
+							value={draft.min}
+							onChange={(e) => handleDraftChange({ ...draft, min: e.target.value })}
 						/>
 						<span className="text-xs text-muted-foreground">–</span>
 						<Input
 							aria-label="Max duration (ms)"
 							type="number"
 							min={0}
-							className="h-7 text-xs"
-							placeholder={durationStats ? String(Math.ceil(durationStats.maxDurationMs)) : "max"}
-							value={maxValue ?? ""}
-							onChange={handleMaxChange}
+							size="sm"
+							className="text-xs"
+							placeholder="max"
+							value={draft.max}
+							onChange={(e) => handleDraftChange({ ...draft, max: e.target.value })}
 						/>
 						<span className="text-xs text-muted-foreground">ms</span>
 					</div>
@@ -151,6 +173,16 @@ export function DurationRangeFilter({
 			</CollapsibleContent>
 		</Collapsible>
 	)
+}
+
+function toText(value: number | undefined): string {
+	return value === undefined ? "" : String(value)
+}
+
+function fromText(text: string): number | undefined {
+	if (text.trim() === "") return undefined
+	const value = Number(text)
+	return Number.isFinite(value) && value >= 0 ? value : undefined
 }
 
 function formatRange(minValue: number | undefined, maxValue: number | undefined): string {

--- a/apps/web/src/components/traces/traces-filter-sidebar.tsx
+++ b/apps/web/src/components/traces/traces-filter-sidebar.tsx
@@ -28,6 +28,7 @@ interface TracesFilterSidebarViewProps {
 	facetsResult: Result.Result<TracesFacetsResponse, unknown>
 	filters: TracesSearchParams
 	onFilterChange: <K extends keyof TracesSearchParams>(key: K, value: TracesSearchParams[K]) => void
+	onDurationRangeChange: (min: number | undefined, max: number | undefined) => void
 	onClearFilters: () => void
 }
 
@@ -35,6 +36,7 @@ function TracesFilterSidebarView({
 	facetsResult,
 	filters,
 	onFilterChange,
+	onDurationRangeChange,
 	onClearFilters,
 }: TracesFilterSidebarViewProps) {
 	const hasActiveFilters =
@@ -123,8 +125,7 @@ function TracesFilterSidebarView({
 						<DurationRangeFilter
 							minValue={filters.minDurationMs}
 							maxValue={filters.maxDurationMs}
-							onMinChange={(val) => onFilterChange("minDurationMs", val)}
-							onMaxChange={(val) => onFilterChange("maxDurationMs", val)}
+							onRangeChange={onDurationRangeChange}
 							durationStats={facets.durationStats}
 						/>
 
@@ -177,6 +178,17 @@ export function TracesFilterSidebar({ facetsResult }: TracesFilterSidebarProps) 
 		})
 	}
 
+	const onDurationRangeChange = (min: number | undefined, max: number | undefined) => {
+		navigate({
+			search: (prev) => ({
+				...prev,
+				minDurationMs: min,
+				maxDurationMs: max,
+			}),
+			replace: true,
+		})
+	}
+
 	const onClearFilters = () => {
 		navigate({
 			search: {
@@ -191,6 +203,7 @@ export function TracesFilterSidebar({ facetsResult }: TracesFilterSidebarProps) 
 			facetsResult={facetsResult}
 			filters={search}
 			onFilterChange={onFilterChange}
+			onDurationRangeChange={onDurationRangeChange}
 			onClearFilters={onClearFilters}
 		/>
 	)

--- a/apps/web/src/components/traces/traces-filter-sidebar.tsx
+++ b/apps/web/src/components/traces/traces-filter-sidebar.tsx
@@ -60,16 +60,6 @@ function TracesFilterSidebarView({
 				<FilterSidebarFrame waiting={result.waiting}>
 					<FilterSidebarHeader canClear={hasActiveFilters} onClear={onClearFilters} />
 					<FilterSidebarBody>
-						<DurationRangeFilter
-							minValue={filters.minDurationMs}
-							maxValue={filters.maxDurationMs}
-							onMinChange={(val) => onFilterChange("minDurationMs", val)}
-							onMaxChange={(val) => onFilterChange("maxDurationMs", val)}
-							durationStats={facets.durationStats}
-						/>
-
-						<Separator className="my-2" />
-
 						<SingleCheckboxFilter
 							title="Has Error"
 							checked={filters.hasError ?? false}
@@ -126,6 +116,16 @@ function TracesFilterSidebarView({
 							options={facets.spanNames ?? []}
 							selected={filters.spanNames ?? []}
 							onChange={(val) => onFilterChange("spanNames", val)}
+						/>
+
+						<Separator className="my-2" />
+
+						<DurationRangeFilter
+							minValue={filters.minDurationMs}
+							maxValue={filters.maxDurationMs}
+							onMinChange={(val) => onFilterChange("minDurationMs", val)}
+							onMaxChange={(val) => onFilterChange("maxDurationMs", val)}
+							durationStats={facets.durationStats}
 						/>
 
 						{(facets.httpMethods?.length ?? 0) > 0 && (


### PR DESCRIPTION
## What changed

Reworks the **Duration** filter in the traces filter sidebar (`apps/web`):

- **Moved down**: from the first slot to after Root Span, before HTTP Method / Status Code.
- **Collapsed by default**: takes a single row; auto-opens when a duration filter is already active (e.g. arriving via a shared URL).
- **Collapsed-state badge**: when a range is active, the header shows a compact tabular-nums badge (`≥ 1.35s`, `250ms – 1.2s`) with an inline × that clears both values without expanding.
- **Stats became actions**: the static `p50:` / `p95:` rows are replaced by one-click preset chips derived from live duration stats — `> p50 · <value>`, `> p95 · <value>`, and `> 1s`. A preset sets `minDurationMs` (clearing max); clicking the active chip toggles it off.
- **Compact custom row**: min/max collapsed from stacked labeled inputs into a single inline `[min] – [max] ms` row, placeholders still seeded from facet stats.

## Why

The filter sat first in the sidebar, open by default, spending ~180px of prime space on a rarely-first-reached filter while its p50/p95 stats were display-only. This keeps it available but quiet, and turns the stats into the fastest way to answer "show me the slow traces".

## Notes for review

- No search-schema, API, or query-engine changes — presets flow through the existing `minDurationMs`/`maxDurationMs` search params.
- The badge's clear control is a `span[role=button]` (with keyboard handling) because it nests inside the `CollapsibleTrigger` button.
- `apps/local-ui` has its own older copy of this component; porting it is tracked separately.

Verified in the browser against the dev server: preset click filters the list and highlights the chip, badge/× behavior, manual inputs, and "Clear all" all work; `bun --filter=@maple/web typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->