### PR TITLE
perf(traces): quick wins for trace view loading

### DIFF
--- a/apps/api/src/lib/trace-detail-cache.ts
+++ b/apps/api/src/lib/trace-detail-cache.ts
@@ -1,10 +1,4 @@
-// ClickHouse datetime string (`YYYY-MM-DD HH:mm:ss[.ffffff]`) ↔ epoch-ms.
-// Sub-second precision is irrelevant everywhere these are used, so the
-// seconds-level prefix is parsed as UTC.
-export const parseChDateTime = (timestamp: string): number =>
-	Date.parse(`${timestamp.slice(0, 19).replace(" ", "T")}Z`)
-export const formatChDateTime = (epochMs: number): string =>
-	new Date(epochMs).toISOString().replace("T", " ").slice(0, 19)
+import { parseWarehouseDateTime } from "@maple/query-engine"
 
 // Trace spans are immutable once a trace has finished — only recently-ended
 // traces can still receive late-arriving spans. Traces whose query window
@@ -18,7 +12,7 @@ const TRACE_SETTLED_AFTER_MS = 15 * 60_000
 
 export const traceCacheTtlSeconds = (endTime: string | undefined, nowMs: number): number => {
 	if (endTime == null) return TRACE_TTL_UNKNOWN_SECONDS
-	const endMs = parseChDateTime(endTime)
+	const endMs = parseWarehouseDateTime(endTime)
 	if (Number.isNaN(endMs)) return TRACE_TTL_LIVE_SECONDS
 	return nowMs - endMs > TRACE_SETTLED_AFTER_MS ? TRACE_TTL_SETTLED_SECONDS : TRACE_TTL_LIVE_SECONDS
 }

--- a/apps/api/src/lib/trace-detail-cache.ts
+++ b/apps/api/src/lib/trace-detail-cache.ts
@@ -1,0 +1,24 @@
+// ClickHouse datetime string (`YYYY-MM-DD HH:mm:ss[.ffffff]`) ↔ epoch-ms.
+// Sub-second precision is irrelevant everywhere these are used, so the
+// seconds-level prefix is parsed as UTC.
+export const parseChDateTime = (timestamp: string): number =>
+	Date.parse(`${timestamp.slice(0, 19).replace(" ", "T")}Z`)
+export const formatChDateTime = (epochMs: number): string =>
+	new Date(epochMs).toISOString().replace("T", " ").slice(0, 19)
+
+// Trace spans are immutable once a trace has finished — only recently-ended
+// traces can still receive late-arriving spans. Traces whose query window
+// ended a while ago can therefore be edge-cached far longer than the 15s
+// `cachedDirect` default. Without a window the age is unknown until the probe
+// runs inside the cache-miss effect, so use a conservative middle ground.
+const TRACE_TTL_SETTLED_SECONDS = 600
+const TRACE_TTL_LIVE_SECONDS = 15
+const TRACE_TTL_UNKNOWN_SECONDS = 60
+const TRACE_SETTLED_AFTER_MS = 15 * 60_000
+
+export const traceCacheTtlSeconds = (endTime: string | undefined, nowMs: number): number => {
+	if (endTime == null) return TRACE_TTL_UNKNOWN_SECONDS
+	const endMs = parseChDateTime(endTime)
+	if (Number.isNaN(endMs)) return TRACE_TTL_LIVE_SECONDS
+	return nowMs - endMs > TRACE_SETTLED_AFTER_MS ? TRACE_TTL_SETTLED_SECONDS : TRACE_TTL_LIVE_SECONDS
+}

--- a/apps/api/src/routes/query-engine.http.ts
+++ b/apps/api/src/routes/query-engine.http.ts
@@ -65,10 +65,11 @@ import {
 	TraceId,
 	SpanId,
 } from "@maple/domain/http"
-import { Effect, Match, Option, Schema } from "effect"
+import { Clock, Effect, Match, Option, Schema } from "effect"
 import { QueryEngineService } from "../services/QueryEngineService"
 import { RawSqlChartService } from "@maple/query-engine/runtime"
 import { WarehouseQueryService } from "../lib/WarehouseQueryService"
+import { formatChDateTime, parseChDateTime, traceCacheTtlSeconds } from "../lib/trace-detail-cache"
 import { CH, QueryEngineExecuteRequest } from "@maple/query-engine"
 import { LOGS_BODY_SEARCH_SETTINGS } from "@maple/query-engine/profiles"
 import { buildBreakdownQuerySpec, buildTimeseriesQuerySpec } from "@maple/query-engine/query-builder"
@@ -98,14 +99,18 @@ const decodeStatusCodeOption = Schema.decodeUnknownOption(StatusCode)
 const coerceStatusCode = (value: string): StatusCode =>
 	Option.getOrElse(decodeStatusCodeOption(value), () => "Unset" as const)
 
-// Build a ±1h partition-pruning window around a ClickHouse datetime string
-// (`YYYY-MM-DD HH:mm:ss[.ffffff]`). Sub-second precision is irrelevant for the
-// window bounds, so the seconds-level prefix is parsed as UTC.
+// Build a ±1h partition-pruning window around a ClickHouse datetime string.
 const partitionWindowAround = (timestamp: string): { startTime: string; endTime: string } => {
-	const ms = Date.parse(`${timestamp.slice(0, 19).replace(" ", "T")}Z`)
-	const fmt = (epoch: number) => new Date(epoch).toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(ms - 3_600_000), endTime: fmt(ms + 3_600_000) }
+	const ms = parseChDateTime(timestamp)
+	return { startTime: formatChDateTime(ms - 3_600_000), endTime: formatChDateTime(ms + 3_600_000) }
 }
+
+// Most traces opened without a timestamp are still recent (list rows carry
+// `?t=`; it's direct/shared/AI links that don't, and those overwhelmingly
+// point at fresh traces). Probing the last 48h first prunes to ~2 daily
+// partitions; only older traces fall back to the unbounded every-partition
+// probe.
+const PROBE_RECENT_WINDOW_MS = 48 * 3_600_000
 
 export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine", (handlers) =>
 	Effect.gen(function* () {
@@ -123,6 +128,7 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 			.handle("spanHierarchy", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					const nowMs = yield* Clock.currentTimeMillis
 					const rows = yield* queryEngine.cachedDirect(
 						tenant,
 						"spanHierarchy",
@@ -133,23 +139,35 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 						// seeks across every daily partition (~30) — p95 ~8.8s vs ~2.3s when
 						// pruned to one. When the caller has no timestamp (direct URL,
 						// shared link, AI link), resolve one via a cheap LIMIT-1 probe and
-						// derive a ±1h window so the main query can prune.
+						// derive a ±1h window so the main query can prune. The probe itself
+						// tries the recent window first (see PROBE_RECENT_WINDOW_MS).
 						Effect.gen(function* () {
 							let startTime = payload.startTime
 							let endTime = payload.endTime
 							if (startTime == null || endTime == null) {
-								const probe = yield* mapExecError(
-									warehouse
-										.compiledQueryFirst(
-											tenant,
-											CH.compile(CH.traceTimeProbeQuery({ traceId: payload.traceId }), {
-												orgId: tenant.orgId,
-											}),
-											{ profile: "discovery", context: "spanHierarchyProbe" },
-										)
-										.pipe(Effect.map(Option.getOrNull)),
-									"spanHierarchy probe failed",
-								)
+								const runProbe = (narrowByTime: boolean) =>
+									mapExecError(
+										warehouse
+											.compiledQueryFirst(
+												tenant,
+												CH.compile(
+													CH.traceTimeProbeQuery({ traceId: payload.traceId, narrowByTime }),
+													narrowByTime
+														? {
+																orgId: tenant.orgId,
+																startTime: formatChDateTime(nowMs - PROBE_RECENT_WINDOW_MS),
+															}
+														: { orgId: tenant.orgId },
+												),
+												{
+													profile: "discovery",
+													context: narrowByTime ? "spanHierarchyProbeRecent" : "spanHierarchyProbe",
+												},
+											)
+											.pipe(Effect.map(Option.getOrNull)),
+										"spanHierarchy probe failed",
+									)
+								const probe = (yield* runProbe(true)) ?? (yield* runProbe(false))
 								if (probe?.timestamp != null) {
 									const window = partitionWindowAround(probe.timestamp)
 									startTime = window.startTime
@@ -175,6 +193,7 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 								"spanHierarchy query failed",
 							)
 						}),
+						traceCacheTtlSeconds(payload.endTime, nowMs),
 					)
 					const typedRows = rows.map((row) => ({
 						...row,
@@ -190,6 +209,7 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 			.handle("spanDetail", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					const nowMs = yield* Clock.currentTimeMillis
 					const narrowByTime = payload.startTime != null && payload.endTime != null
 					const compiled = CH.compile(
 						CH.spanDetailQuery({
@@ -214,6 +234,7 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 								.pipe(Effect.map(Option.getOrNull)),
 							"spanDetail query failed",
 						),
+						traceCacheTtlSeconds(payload.endTime, nowMs),
 					)
 					return new SpanDetailResponse({
 						data: row

--- a/apps/api/src/routes/query-engine.http.ts
+++ b/apps/api/src/routes/query-engine.http.ts
@@ -69,8 +69,13 @@ import { Clock, Effect, Match, Option, Schema } from "effect"
 import { QueryEngineService } from "../services/QueryEngineService"
 import { RawSqlChartService } from "@maple/query-engine/runtime"
 import { WarehouseQueryService } from "../lib/WarehouseQueryService"
-import { formatChDateTime, parseChDateTime, traceCacheTtlSeconds } from "../lib/trace-detail-cache"
-import { CH, QueryEngineExecuteRequest } from "@maple/query-engine"
+import { traceCacheTtlSeconds } from "../lib/trace-detail-cache"
+import {
+	CH,
+	QueryEngineExecuteRequest,
+	formatWarehouseDateTime,
+	parseWarehouseDateTime,
+} from "@maple/query-engine"
 import { LOGS_BODY_SEARCH_SETTINGS } from "@maple/query-engine/profiles"
 import { buildBreakdownQuerySpec, buildTimeseriesQuerySpec } from "@maple/query-engine/query-builder"
 
@@ -101,8 +106,8 @@ const coerceStatusCode = (value: string): StatusCode =>
 
 // Build a ±1h partition-pruning window around a ClickHouse datetime string.
 const partitionWindowAround = (timestamp: string): { startTime: string; endTime: string } => {
-	const ms = parseChDateTime(timestamp)
-	return { startTime: formatChDateTime(ms - 3_600_000), endTime: formatChDateTime(ms + 3_600_000) }
+	const ms = parseWarehouseDateTime(timestamp)
+	return { startTime: formatWarehouseDateTime(ms - 3_600_000), endTime: formatWarehouseDateTime(ms + 3_600_000) }
 }
 
 // Most traces opened without a timestamp are still recent (list rows carry
@@ -155,7 +160,7 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 													narrowByTime
 														? {
 																orgId: tenant.orgId,
-																startTime: formatChDateTime(nowMs - PROBE_RECENT_WINDOW_MS),
+																startTime: formatWarehouseDateTime(nowMs - PROBE_RECENT_WINDOW_MS),
 															}
 														: { orgId: tenant.orgId },
 												),

--- a/apps/api/src/services/QueryEngineEvaluateCache.test.ts
+++ b/apps/api/src/services/QueryEngineEvaluateCache.test.ts
@@ -14,6 +14,7 @@ import {
 	type EdgeCacheServiceShape,
 } from "@maple/query-engine/caching"
 import { CacheBackendLive } from "../lib/CacheBackendLive"
+import { traceCacheTtlSeconds } from "../lib/trace-detail-cache"
 
 const edgeCacheLive = EdgeCacheService.layer.pipe(Layer.provide(CacheBackendLive))
 
@@ -296,5 +297,30 @@ describe("QueryEngineService.cachedDirect TTL", () => {
 				{ bucket: "qe-direct", ttlSeconds: 15 },
 			])
 		}).pipe(Effect.provide(layer))
+	})
+})
+
+// --- trace-detail cache TTL: age-conditional tiers. ---
+
+describe("traceCacheTtlSeconds", () => {
+	const nowMs = Date.parse("2026-07-17T12:00:00Z")
+
+	it("caches settled traces (window ended >15min ago) for 600s", () => {
+		assert.strictEqual(traceCacheTtlSeconds("2026-07-17 11:00:00", nowMs), 600)
+		assert.strictEqual(traceCacheTtlSeconds("2026-07-01 00:00:00", nowMs), 600)
+	})
+
+	it("keeps live traces (window still recent or in the future) on the 15s default", () => {
+		assert.strictEqual(traceCacheTtlSeconds("2026-07-17 11:50:00", nowMs), 15)
+		// ±1h windows around a fresh timestamp end in the future.
+		assert.strictEqual(traceCacheTtlSeconds("2026-07-17 12:45:00", nowMs), 15)
+	})
+
+	it("uses a conservative 60s when the payload has no window (probe path)", () => {
+		assert.strictEqual(traceCacheTtlSeconds(undefined, nowMs), 60)
+	})
+
+	it("falls back to 15s on an unparseable timestamp", () => {
+		assert.strictEqual(traceCacheTtlSeconds("not-a-date", nowMs), 15)
 	})
 })

--- a/apps/web/src/components/traces/advanced-filter-dialog.tsx
+++ b/apps/web/src/components/traces/advanced-filter-dialog.tsx
@@ -12,6 +12,7 @@ import { Button } from "@maple/ui/components/ui/button"
 import { Kbd } from "@maple/ui/components/ui/kbd"
 import { MagnifierIcon } from "@/components/icons"
 import { WhereClauseEditor } from "@/components/query-builder/where-clause-editor"
+import { useAutocompleteValuesContextOptional } from "@/hooks/use-autocomplete-values"
 import { useAppHotkey } from "@/hooks/use-app-hotkey"
 
 interface AdvancedFilterDialogProps {
@@ -20,8 +21,16 @@ interface AdvancedFilterDialogProps {
 }
 
 export function AdvancedFilterDialog({ initialValue, onApply }: AdvancedFilterDialogProps) {
-	const [open, setOpen] = React.useState(false)
+	const [open, setOpenState] = React.useState(false)
 	const [value, setValue] = React.useState(initialValue)
+	const autocompleteValues = useAutocompleteValuesContextOptional()
+
+	// Kick off the lazy autocomplete fetches while the dialog animates open so
+	// values are ready by the time the editor is focused.
+	const setOpen = (next: boolean) => {
+		if (next) autocompleteValues?.activate?.()
+		setOpenState(next)
+	}
 
 	React.useEffect(() => {
 		if (open) {

--- a/apps/web/src/hooks/use-autocomplete-values.tsx
+++ b/apps/web/src/hooks/use-autocomplete-values.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Result, useAtomValue } from "@/lib/effect-atom"
+import { Atom, Result, useAtomValue } from "@/lib/effect-atom"
 import { AutocompleteKeysProvider, useAutocompleteContext } from "@/hooks/use-autocomplete-context"
 import {
 	getLogsFacetsResultAtom,
@@ -48,42 +48,72 @@ export function useAutocompleteValuesContextOptional(): AutocompleteValuesContex
 // Inner component (must be inside AutocompleteKeysProvider)
 // ---------------------------------------------------------------------------
 
+/**
+ * Subscribe to `atom` only once `enabled` is true; until then read a static
+ * idle atom so no warehouse query fires. Keeps hook order stable, which lets
+ * the lazy provider keep one component tree across activation — swapping the
+ * tree shape instead would remount every descendant (and e.g. close the
+ * advanced-filter dialog the moment it activates the provider).
+ */
+function useGatedAtomValue<A, E>(
+	atom: Atom.Atom<Result.Result<A, E>>,
+	enabled: boolean,
+): Result.Result<A, E> {
+	const idle = React.useMemo(() => Atom.make<Result.Result<A, E>>(Result.initial()), [])
+	return useAtomValue(enabled ? atom : idle)
+}
+
 function AutocompleteValuesInner({
 	startTime,
 	endTime,
+	activated,
+	activate,
 	children,
 }: {
 	startTime?: string
 	endTime?: string
+	activated: boolean
+	activate: () => void
 	children: React.ReactNode
 }) {
 	const { activeAttributeKey, activeResourceAttributeKey } = useAutocompleteContext()
 
 	// --- Facets ---
-	const tracesFacetsResult = useAtomValue(getTracesFacetsResultAtom({ data: { startTime, endTime } }))
-	const logsFacetsResult = useAtomValue(getLogsFacetsResultAtom({ data: { startTime, endTime } }))
+	const tracesFacetsResult = useGatedAtomValue(
+		getTracesFacetsResultAtom({ data: { startTime, endTime } }),
+		activated,
+	)
+	const logsFacetsResult = useGatedAtomValue(
+		getLogsFacetsResultAtom({ data: { startTime, endTime } }),
+		activated,
+	)
 
 	// --- Attribute keys ---
-	const spanAttributeKeysResult = useAtomValue(
+	const spanAttributeKeysResult = useGatedAtomValue(
 		getSpanAttributeKeysResultAtom({ data: { startTime, endTime } }),
+		activated,
 	)
-	const resourceAttributeKeysResult = useAtomValue(
+	const resourceAttributeKeysResult = useGatedAtomValue(
 		getResourceAttributeKeysResultAtom({ data: { startTime, endTime } }),
+		activated,
 	)
-	const metricAttributeKeysResult = useAtomValue(
+	const metricAttributeKeysResult = useGatedAtomValue(
 		getMetricAttributeKeysResultAtom({ data: { startTime, endTime } }),
+		activated,
 	)
 
 	// --- Attribute values (lazy, driven by active key) ---
-	const spanAttributeValuesResult = useAtomValue(
+	const spanAttributeValuesResult = useGatedAtomValue(
 		getSpanAttributeValuesResultAtom({
 			data: { startTime, endTime, attributeKey: activeAttributeKey ?? "" },
 		}),
+		activated,
 	)
-	const resourceAttributeValuesResult = useAtomValue(
+	const resourceAttributeValuesResult = useGatedAtomValue(
 		getResourceAttributeValuesResultAtom({
 			data: { startTime, endTime, attributeKey: activeResourceAttributeKey ?? "" },
 		}),
+		activated,
 	)
 
 	// --- Derived arrays ---
@@ -177,6 +207,7 @@ function AutocompleteValuesInner({
 			attributeKeys,
 			resourceAttributeKeys,
 			metricAttributeKeys,
+			activate,
 		}
 	}, [
 		tracesFacetsResult,
@@ -186,6 +217,7 @@ function AutocompleteValuesInner({
 		resourceAttributeKeys,
 		resourceAttributeValues,
 		metricAttributeKeys,
+		activate,
 	])
 
 	return <AutocompleteValuesCtx value={value}>{children}</AutocompleteValuesCtx>
@@ -194,32 +226,6 @@ function AutocompleteValuesInner({
 // ---------------------------------------------------------------------------
 // Public provider
 // ---------------------------------------------------------------------------
-
-const emptyAutocompleteValues: AutocompleteValuesContextType = {
-	traces: {
-		services: [],
-		spanNames: [],
-		environments: [],
-		httpMethods: [],
-		httpStatusCodes: [],
-		attributeKeys: [],
-		attributeValues: [],
-		resourceAttributeKeys: [],
-		resourceAttributeValues: [],
-	},
-	logs: {
-		services: [],
-		severities: [],
-		attributeKeys: [],
-		attributeValues: [],
-		resourceAttributeKeys: [],
-		resourceAttributeValues: [],
-	},
-	metrics: { metricTypes: [...QUERY_BUILDER_METRIC_TYPES], attributeKeys: [] },
-	attributeKeys: [],
-	resourceAttributeKeys: [],
-	metricAttributeKeys: [],
-}
 
 export function AutocompleteValuesProvider({
 	startTime,
@@ -236,14 +242,17 @@ export function AutocompleteValuesProvider({
 	const [activated, setActivated] = React.useState(!lazy)
 	const activate = React.useCallback(() => setActivated(true), [])
 
-	if (!activated) {
-		const value = { ...emptyAutocompleteValues, activate }
-		return <AutocompleteValuesCtx value={value}>{children}</AutocompleteValuesCtx>
-	}
-
+	// One stable tree for both states — activation only flips which atoms the
+	// inner component subscribes to (see useGatedAtomValue). Swapping the
+	// wrapper structure here would remount all children on activate().
 	return (
 		<AutocompleteKeysProvider>
-			<AutocompleteValuesInner startTime={startTime} endTime={endTime}>
+			<AutocompleteValuesInner
+				startTime={startTime}
+				endTime={endTime}
+				activated={activated}
+				activate={activate}
+			>
 				{children}
 			</AutocompleteValuesInner>
 		</AutocompleteKeysProvider>

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
@@ -199,7 +199,11 @@ export const getTracesFacetValuesResultAtom = makeQueryAtomFamily(getTracesFacet
 	staleTime: 30_000,
 })
 
-export const getSpanHierarchyResultAtom = makeQueryAtomFamily(getSpanHierarchy)
+// Trace spans are near-immutable once ingested — keep the most expensive
+// detail query warm across back-navigation instead of refetching every mount.
+export const getSpanHierarchyResultAtom = makeQueryAtomFamily(getSpanHierarchy, {
+	staleTime: 60_000,
+})
 
 export const listReplaysResultAtom = makeQueryAtomFamily(listReplays, {
 	staleTime: 30_000,

--- a/apps/web/src/routes/-sign-in.clerk.test.tsx
+++ b/apps/web/src/routes/-sign-in.clerk.test.tsx
@@ -20,6 +20,10 @@ describe("SignInPage (clerk mode)", () => {
 
 		const module = await import("./sign-in")
 
+		// SignInPage reads redirect_url via Route.useSearch(), which needs a live
+		// router — stub it since this test renders the page standalone.
+		vi.spyOn(module.Route, "useSearch").mockReturnValue({ redirect_url: undefined })
+
 		render(<module.SignInPage />)
 
 		expect(screen.getByText("Clerk Sign In")).toBeTruthy()

--- a/apps/web/src/routes/traces/-index.test.tsx
+++ b/apps/web/src/routes/traces/-index.test.tsx
@@ -144,6 +144,12 @@ vi.mock("@/lib/effect-atom", async () => {
 				case atoms.resourceAttributeValues:
 					return actual.Result.success({ data: [] })
 				default:
+					// The lazy AutocompleteValuesProvider subscribes to a static idle
+					// atom (a real Atom, unlike the sentinel symbols above) until
+					// activate() is called — it holds Result.initial.
+					if (actual.Atom.isAtom(atom)) {
+						return actual.Result.initial()
+					}
 					throw new Error(`Unexpected atom: ${String(atom)}`)
 			}
 		},

--- a/apps/web/src/routes/traces/index.tsx
+++ b/apps/web/src/routes/traces/index.tsx
@@ -109,7 +109,10 @@ export function TracesPage() {
 	}
 
 	return (
-		<AutocompleteValuesProvider startTime={effectiveStartTime} endTime={effectiveEndTime}>
+		// lazy: the ~4 autocomplete warehouse queries (logs facets + attribute
+		// keys) are only needed by the advanced-filter editor, which calls
+		// activate() on focus/open — don't fire them on every page mount.
+		<AutocompleteValuesProvider lazy startTime={effectiveStartTime} endTime={effectiveEndTime}>
 			<PageRefreshProvider timePreset={search.timePreset ?? "12h"}>
 				<DashboardLayout
 					breadcrumbs={[{ label: "Traces" }]}

--- a/packages/query-engine/src/ch/ch.test.ts
+++ b/packages/query-engine/src/ch/ch.test.ts
@@ -1263,5 +1263,16 @@ describe("converted queries", () => {
 		// Must early-terminate per partition — no sort, no full projection.
 		expect(sql).not.toContain("ORDER BY")
 		expect(sql).not.toContain("toJSONString")
+		// Unbounded fallback shape — no time predicate.
+		expect(sql).not.toContain("Timestamp >=")
+	})
+
+	it("traceTimeProbeQuery with narrowByTime adds a Timestamp lower bound for partition pruning", () => {
+		const q = traceTimeProbeQuery({ traceId: "abc123", narrowByTime: true })
+		const { sql } = compileCH(q, { orgId: "org_1", startTime: "2026-04-15 13:00:00" })
+		expect(sql).toContain("Timestamp >= '2026-04-15 13:00:00'")
+		// Lower bound only — "recent" needs no upper bound.
+		expect(sql).not.toContain("Timestamp <=")
+		expect(sql).toContain("LIMIT 1")
 	})
 })

--- a/packages/query-engine/src/ch/queries/errors.ts
+++ b/packages/query-engine/src/ch/queries/errors.ts
@@ -326,11 +326,20 @@ export interface TraceTimeProbeOutput {
  * no `ORDER BY` and `LIMIT 1`, ClickHouse reads ~one granule per partition and
  * stops — far cheaper than the full `spanHierarchyQuery` projection. The caller
  * then derives a ±1h window so the real query can prune partitions.
+ *
+ * Even the probe pays the every-partition seek when unbounded, so callers
+ * should first try `narrowByTime: true` with a recent `startTime` lower bound
+ * (pruning to the last few partitions) and only fall back to the unbounded
+ * probe when the trace is older than that window.
  */
-export function traceTimeProbeQuery(opts: { traceId: string }) {
+export function traceTimeProbeQuery(opts: { traceId: string; narrowByTime?: boolean }) {
 	return from(TraceDetailSpans)
 		.select(($) => ({ timestamp: $.Timestamp }))
-		.where(($) => [$.TraceId.eq(opts.traceId), $.OrgId.eq(param.string("orgId"))])
+		.where(($) => [
+			$.TraceId.eq(opts.traceId),
+			$.OrgId.eq(param.string("orgId")),
+			CH.whenTrue(!!opts.narrowByTime, () => $.Timestamp.gte(param.dateTime("startTime"))),
+		])
 		.limit(1)
 		.format("JSON")
 }

--- a/packages/query-engine/src/datetime.test.ts
+++ b/packages/query-engine/src/datetime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
 	bucketTimeline,
 	computeBucketSeconds,
+	formatWarehouseDateTime,
 	parseWarehouseDateTime,
 	warehouseDateTimeToIso,
 } from "./datetime"
@@ -52,6 +53,21 @@ describe("parseWarehouseDateTime", () => {
 
 	it("returns NaN for unparseable input", () => {
 		expect(Number.isNaN(parseWarehouseDateTime("nonsense"))).toBe(true)
+	})
+})
+
+describe("formatWarehouseDateTime", () => {
+	it("formats epoch ms as tz-less space-separated UTC seconds", () => {
+		expect(formatWarehouseDateTime(Date.UTC(2026, 4, 24, 14, 30, 0))).toBe("2026-05-24 14:30:00")
+	})
+
+	it("drops fractional milliseconds", () => {
+		expect(formatWarehouseDateTime(Date.UTC(2026, 4, 24, 14, 30, 0, 999))).toBe("2026-05-24 14:30:00")
+	})
+
+	it("round-trips through parseWarehouseDateTime", () => {
+		const epoch = Date.UTC(2026, 0, 2, 3, 4, 5)
+		expect(parseWarehouseDateTime(formatWarehouseDateTime(epoch))).toBe(epoch)
 	})
 })
 

--- a/packages/query-engine/src/datetime.ts
+++ b/packages/query-engine/src/datetime.ts
@@ -43,6 +43,15 @@ export function parseWarehouseDateTime(value: string): number {
 	return Date.parse(warehouseDateTimeToIso(value))
 }
 
+/**
+ * Format epoch milliseconds as the tz-less second-precision
+ * `YYYY-MM-DD HH:MM:SS` shape ClickHouse/Tinybird DateTime params expect
+ * (UTC wall clock, space separator, no fractional part).
+ */
+export function formatWarehouseDateTime(epochMs: number): string {
+	return new Date(epochMs).toISOString().replace("T", " ").slice(0, 19)
+}
+
 // ---------------------------------------------------------------------------
 // Time-series bucketing — single source of truth
 //

--- a/packages/ui/src/lib/span-tree.ts
+++ b/packages/ui/src/lib/span-tree.ts
@@ -133,8 +133,20 @@ export function buildSpanTree(spans: Span[]): SpanNode[] {
 		setDepth(root, 0)
 	}
 
+	// Parse each node's startTime once — comparator-side `new Date(...)` costs
+	// O(n log n) parses on 5k-span traces.
+	const epochs = new Map<SpanNode, number>()
+	const epochOf = (node: SpanNode): number => {
+		let epoch = epochs.get(node)
+		if (epoch === undefined) {
+			epoch = new Date(node.startTime).getTime()
+			epochs.set(node, epoch)
+		}
+		return epoch
+	}
+
 	function sortChildren(node: SpanNode) {
-		node.children.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
+		node.children.sort((a, b) => epochOf(a) - epochOf(b))
 		for (const child of node.children) {
 			sortChildren(child)
 		}
@@ -144,7 +156,7 @@ export function buildSpanTree(spans: Span[]): SpanNode[] {
 		sortChildren(root)
 	}
 
-	rootSpans.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
+	rootSpans.sort((a, b) => epochOf(a) - epochOf(b))
 	return rootSpans
 }
 
@@ -166,16 +178,15 @@ export function buildTraceDetail(rows: ReadonlyArray<SpanHierarchyRow>): TraceDe
 	const rootSpans = buildSpanTree(spans)
 	const totalDurationMs = spans.length > 0 ? Math.max(...spans.map((span) => span.durationMs)) : 0
 	const services = Array.from(new Set(spans.map((span) => span.serviceName).filter(Boolean)))
-	const traceStartTime =
-		spans.length > 0
-			? spans.reduce(
-					(earliest, span) =>
-						new Date(span.startTime).getTime() < new Date(earliest).getTime()
-							? span.startTime
-							: earliest,
-					spans[0].startTime,
-				)
-			: new Date().toISOString()
+	let traceStartTime = spans.length > 0 ? spans[0].startTime : new Date().toISOString()
+	let earliestEpoch = new Date(traceStartTime).getTime()
+	for (const span of spans) {
+		const epoch = new Date(span.startTime).getTime()
+		if (epoch < earliestEpoch) {
+			earliestEpoch = epoch
+			traceStartTime = span.startTime
+		}
+	}
 
 	return { spans, rootSpans, totalDurationMs, services, traceStartTime }
 }


### PR DESCRIPTION
## Why

The trace views have been loading noticeably slower as data volume grew. Production telemetry (`query.context` on `executeSql` spans, last 3 weeks) shows the regression and the causes:

| query.context | p95 now | p95 3 wks ago |
|---|---|---|
| `spanHierarchyProbe` | 5.0s (= its own `max_execution_time`) | — |
| `pipe:span_hierarchy` | 2.9s | 2.6s |
| `tracesFacets` | 5.1s | 1.8s |

On top of the warehouse-side cost, the frontend refetched the most expensive query on every back-navigation and fired 4 unneeded autocomplete queries on every list-page mount.

## What changed

- **Bounded trace-time probe** — opening a trace without `?t=` (shared/direct/AI links) used to run a `LIMIT 1` probe with no time predicate; `trace_detail_spans` is partitioned by `toDate(Timestamp)`, so it seeked every daily partition (~30). It now probes the last 48h first (`spanHierarchyProbeRecent`) and falls back to the unbounded probe only for older traces. The old context name is unchanged, so its residual rate is directly observable.
- **Age-tiered edge-cache TTL** for `spanHierarchy`/`spanDetail` (`apps/api/src/lib/trace-detail-cache.ts`): 600s once the query window ended >15 min ago (trace spans are immutable after that), 15s while the trace may still receive late spans, 60s when no window is supplied.
- **`staleTime: 60s` on `getSpanHierarchyResultAtom`** — it was the only major read-atom without one; back-navigation now reuses the cached result instead of refetching.
- **Lazy `AutocompleteValuesProvider` on `/traces`** — mount drops from 7 warehouse queries to 3; the 4 autocomplete queries (incl. the raw-logs `logs_facets` scan) load when the advanced-filter dialog opens, during its open animation.
  - This surfaced a **latent bug in the provider's lazy mode**: activation swapped the element-tree shape (`Ctx > children` vs `KeysProvider > Inner > children`), remounting every descendant — the dialog that called `activate()` on open unmounted itself instantly. The provider now renders one stable tree; `useGatedAtomValue` subscribes to a static idle atom until activated.
- **`span-tree`**: cache `startTime` epochs instead of re-parsing `new Date()` per sort comparison (matters on 5k-span traces).

## Measured impact

- Probe at prod scale (server-side `db.duration_ms`, fresh trace per sample): unbounded 1770/1921/558ms vs 48h-bounded 605/239/122ms — **~4.5× mean**, and it removes the 5s p95 timeout cliff on the largest org.
- Edge-cache hit: **5ms** vs 150–640ms miss; settled traces cached 600s vs 15s.
- Re-opening a trace within 60s: **0 requests** (was a full hierarchy fetch each time).
- `/traces` mount: **3 warehouse queries instead of 7**.

## Reviewer notes

- `spanDetail` caches empty results for up to 600s on old traces — acceptable because spans are only requested after appearing in the hierarchy, and live traces stay on the 15s tier.
- Verified end-to-end on a local stack: with-`t` loads ~600ms, no-`t` direct link 751ms server-side, lazy activation fires exactly the 4 deferred queries and the dialog stays open. New tests: probe SQL shape (`ch.test.ts`), TTL tiers (`QueryEngineEvaluateCache.test.ts`).
- Follow-ups deliberately not in this PR: the raw-`traces` scans behind `tracesBreakdown`/`tracesFacets`/`span_search` (needs a live `EXPLAIN` gate on the migration-0005 bloom indexes first), propagating `?t=` from remaining nav sources, and snapping the trace window to 5-min boundaries for referrer-independent cache keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->