### PR TITLE
perf(web): stop app-wide rerender cascades from Clerk churn and page state

### DIFF
--- a/apps/web/src/components/alerts/alert-rule-chart.tsx
+++ b/apps/web/src/components/alerts/alert-rule-chart.tsx
@@ -92,7 +92,22 @@ function clamp01(value: number): number {
 const NO_CHECKS: ReadonlyArray<AlertCheckDocument> = []
 const NO_INCIDENTS: ReadonlyArray<AlertIncidentDocument> = []
 
-export function AlertRuleChart({
+// Recharts reconciliation cost is linear in plotted points, and beyond ~1
+// point per 2 horizontal pixels extra points are invisible at our widths.
+// Tooltip/rail/band data stays computed from the full series.
+const MAX_PLOTTED_POINTS = 720
+
+function downsample(rows: ChartPoint[]): ChartPoint[] {
+	if (rows.length <= MAX_PLOTTED_POINTS) return rows
+	const stride = Math.ceil(rows.length / MAX_PLOTTED_POINTS)
+	const out: ChartPoint[] = []
+	for (let i = 0; i < rows.length; i += stride) out.push(rows[i]!)
+	const last = rows[rows.length - 1]!
+	if (out[out.length - 1] !== last) out.push(last)
+	return out
+}
+
+export const AlertRuleChart = React.memo(function AlertRuleChart({
 	preview,
 	checks = NO_CHECKS,
 	incidents = NO_INCIDENTS,
@@ -181,7 +196,7 @@ export function AlertRuleChart({
 					if (last && bucket.x1 <= last.x2 + 1) last.x2 = bucket.x2
 					else noDataBands.push({ x1: bucket.x1, x2: bucket.x2 })
 				}
-				const rows = Array.from(byT.values()).sort((a, b) => a.t - b.t)
+				const rows = downsample(Array.from(byT.values()).sort((a, b) => a.t - b.t))
 				return {
 					chartData: rows,
 					seriesKeys: single ? [SINGLE_KEY] : keys,
@@ -195,13 +210,15 @@ export function AlertRuleChart({
 			}
 
 			if (checks.length > 0) {
-				const rows: ChartPoint[] = checks
-					.map((check) => ({
-						t: new Date(normalizeTimestampInput(check.timestamp)).getTime(),
-						[SINGLE_KEY]: check.observedValue,
-					}))
-					.filter((row) => Number.isFinite(row.t))
-					.sort((a, b) => a.t - b.t)
+				const rows: ChartPoint[] = downsample(
+					checks
+						.map((check) => ({
+							t: new Date(normalizeTimestampInput(check.timestamp)).getTime(),
+							[SINGLE_KEY]: check.observedValue,
+						}))
+						.filter((row) => Number.isFinite(row.t))
+						.sort((a, b) => a.t - b.t),
+				)
 				return {
 					chartData: rows,
 					seriesKeys: [SINGLE_KEY],
@@ -647,7 +664,7 @@ export function AlertRuleChart({
 			)}
 		</div>
 	)
-}
+})
 
 function Placeholder({
 	children,

--- a/apps/web/src/components/alerts/overview/alerts-overview-tab.tsx
+++ b/apps/web/src/components/alerts/overview/alerts-overview-tab.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { Exit } from "effect"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { memo, useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 
 import type { AlertDestinationDocument, AlertRuleDocument } from "@maple/domain/http"
@@ -102,8 +102,12 @@ const OverviewBody = View.make(AlertsOverviewModel, ({ overview, toggleRule, tog
  * Everything below is pure presentation over the derived overview: URL-backed
  * filters, search, the session/destination atoms, and the toggle mutation are
  * view concerns and stay here.
+ *
+ * Memoized so app-shell renders (Clerk session touches, dialogs, sidebar) stop
+ * at this boundary: `data` only changes identity when the model re-derives,
+ * and `onToggleRule` is the runtime's stable fire callback.
  */
-function AlertsOverviewContent({
+const AlertsOverviewContent = memo(function AlertsOverviewContent({
 	data,
 	onToggleRule,
 	toggleState,
@@ -376,11 +380,11 @@ function AlertsOverviewContent({
 							value: triggeredInWindow,
 							hint: triggeredInWindow === 1 ? "incident" : "incidents",
 						},
-						{ label: "Avg MTTR", value: mttr, hint: "across resolved" },
+						{ label: "Avg MTTR", value: mttr, hint: "resolved · 30d" },
 						{ label: "Rules enabled", value: enabledRules, hint: `of ${rules.length} total` },
 					]}
 				/>
 			</div>
 		</div>
 	)
-}
+})

--- a/apps/web/src/components/dashboard/app-sidebar.tsx
+++ b/apps/web/src/components/dashboard/app-sidebar.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Link, useRouterState } from "@tanstack/react-router"
 import { useUser, useClerk } from "@clerk/clerk-react"
 import {
@@ -188,9 +189,12 @@ function GuestMenu() {
 	)
 }
 
-export function AppSidebar() {
-	const routerState = useRouterState()
-	const currentPath = routerState.location.pathname
+// Memoized: DashboardLayout renders this inside every page, so without memo the
+// sidebar's ~500-fiber subtree rerenders on every page-level state change
+// (refresh version bumps, search-param updates, query settles). The selector
+// (instead of bare useRouterState) keeps it quiet during loader/pending ticks.
+export const AppSidebar = memo(function AppSidebar() {
+	const currentPath = useRouterState({ select: (s) => s.location.pathname })
 	const { dashboards, isLoading } = useDashboardsRead()
 	const { favorites } = useDashboardPreferences()
 
@@ -423,4 +427,4 @@ export function AppSidebar() {
 			</SidebarFooter>
 		</Sidebar>
 	)
-}
+})

--- a/apps/web/src/components/vcs/commit-markers/use-commit-markers.tsx
+++ b/apps/web/src/components/vcs/commit-markers/use-commit-markers.tsx
@@ -43,5 +43,7 @@ export function useCommitMarkers(
 	)
 	const markers = useAtomValue(markersAtom)
 
-	return markers.length > 0 ? <CommitMarkersLayer markers={markers} /> : null
+	// Stable element identity: this is passed as an `overlay` prop into memoized
+	// charts, so a fresh element per render would defeat their memo.
+	return useMemo(() => (markers.length > 0 ? <CommitMarkersLayer markers={markers} /> : null), [markers])
 }

--- a/apps/web/src/lib/models/alerts-overview-model.test.ts
+++ b/apps/web/src/lib/models/alerts-overview-model.test.ts
@@ -152,6 +152,36 @@ describe("deriveOverview", () => {
 		expect(overview.incidentsByRule.get(RULE_A)).toHaveLength(1)
 	})
 
+	it("windows out resolved incidents older than 30d but always keeps open ones", () => {
+		const overview = deriveOverview({
+			rules: [makeRule({ id: RULE_A })],
+			incidents: [
+				makeIncident({ id: "00000000-0000-4000-8000-0000000000f1", lastTriggeredAt: iso(60_000) }),
+				// Ancient but still open — must survive the window.
+				makeIncident({
+					id: "00000000-0000-4000-8000-0000000000f2",
+					lastTriggeredAt: iso(45 * DAY_MS),
+					firstTriggeredAt: iso(46 * DAY_MS),
+				}),
+				// Ancient and resolved — dropped before any sorting/grouping.
+				makeIncident({
+					id: "00000000-0000-4000-8000-0000000000f3",
+					status: "resolved",
+					lastTriggeredAt: iso(31 * DAY_MS),
+					firstTriggeredAt: iso(32 * DAY_MS),
+					resolvedAt: iso(31 * DAY_MS),
+				}),
+			],
+			states: [],
+			deliveryEvents: [],
+			now: NOW,
+		})
+		expect(overview.incidents.map((i) => i.id)).toEqual([
+			"00000000-0000-4000-8000-0000000000f1",
+			"00000000-0000-4000-8000-0000000000f2",
+		])
+	})
+
 	it("spans a 24h timeline ending at now", () => {
 		const overview = deriveOverview({ rules: [], incidents: [], states: [], deliveryEvents: [], now: NOW })
 		expect(overview.timelineRange).toEqual({ min: NOW - DAY_MS, max: NOW })

--- a/apps/web/src/lib/models/alerts-overview-model.ts
+++ b/apps/web/src/lib/models/alerts-overview-model.ts
@@ -41,6 +41,16 @@ import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
+/**
+ * Oldest resolved incident the overview still processes — the widest window any
+ * consumer renders (the summary strip's 30d "Triggered" count). The synced
+ * collection holds the org's full incident history; without this cutoff every
+ * derivation re-sorts and re-groups an ever-growing set, which is what
+ * gradually locked up the tab during long firing stretches. Open incidents are
+ * always kept.
+ */
+const INCIDENT_WINDOW_MS = 30 * DAY_MS
+
 /** How often the wall-clock input of the staleness derivation advances. */
 const CLOCK_TICK = "30 seconds"
 
@@ -98,7 +108,10 @@ export const deriveOverview = (inputs: OverviewInputs): AlertsOverviewReady => {
 	// ISO timestamps order lexicographically; newest first, as the server lists do.
 	const byIsoDesc = (a: string, b: string) => (a < b ? 1 : a > b ? -1 : 0)
 	const rules = [...inputs.rules].sort((a, b) => byIsoDesc(a.updatedAt, b.updatedAt))
-	const incidents = [...inputs.incidents].sort((a, b) => byIsoDesc(a.lastTriggeredAt, b.lastTriggeredAt))
+	const incidentCutoff = now - INCIDENT_WINDOW_MS
+	const incidents = inputs.incidents
+		.filter((incident) => incident.status === "open" || Date.parse(incident.lastTriggeredAt) >= incidentCutoff)
+		.sort((a, b) => byIsoDesc(a.lastTriggeredAt, b.lastTriggeredAt))
 
 	const openIncidents = incidents.filter((incident) => incident.status === "open")
 	const incidentsByRule = groupByRuleId(incidents)

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,5 +1,5 @@
 import { ClerkProvider, useAuth } from "@clerk/clerk-react"
-import { StrictMode, useCallback, useEffect, useRef, useState } from "react"
+import { StrictMode, memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import ReactDOM from "react-dom/client"
 import { EffectRouterProvider } from "@effect-router/core/react"
 import { apiBaseUrl } from "./lib/services/common/api-base-url"
@@ -96,6 +96,14 @@ function useClerkAuthSettled() {
 	return { settled, isSignedIn, orgId }
 }
 
+// Memoized so ClerkInnerApp's rerenders (one per Clerk-internal emit — session
+// touches, token refreshes) stop here: rerendering EffectRouterProvider
+// rerenders the entire match tree, so without this every Clerk emit was a
+// full-app render.
+const RouterShell = memo(function RouterShell({ context }: { context: { auth: RouterAuthContext } }) {
+	return <EffectRouterProvider router={router} registry={appRegistry} context={context} />
+})
+
 function ClerkInnerApp() {
 	const { settled, isSignedIn, orgId } = useClerkAuthSettled()
 	const isRouterMountedRef = useRef(false)
@@ -111,15 +119,17 @@ function ClerkInnerApp() {
 		router.invalidate()
 	}, [settled, isSignedIn, orgId])
 
+	// Stable identity across Clerk session touches that don't change
+	// sign-in/org, so EffectRouterProvider doesn't see a new context prop on
+	// every Clerk-internal update.
+	const context = useMemo(
+		() => ({ auth: { isAuthenticated: !!isSignedIn, orgId } }),
+		[isSignedIn, orgId],
+	)
+
 	if (!settled) return <BootSplash />
 
-	return (
-		<EffectRouterProvider
-			router={router}
-			registry={appRegistry}
-			context={{ auth: { isAuthenticated: !!isSignedIn, orgId } }}
-		/>
-	)
+	return <RouterShell context={context} />
 }
 
 function SelfHostedInnerApp() {
@@ -144,11 +154,13 @@ function SelfHostedInnerApp() {
 		router.invalidate()
 	}, [auth])
 
-	if (!auth) {
+	const context = useMemo(() => (auth ? { auth } : null), [auth])
+
+	if (!context) {
 		return <BootSplash />
 	}
 
-	return <EffectRouterProvider router={router} registry={appRegistry} context={{ auth }} />
+	return <RouterShell context={context} />
 }
 
 const app = isClerkAuthEnabled ? (

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { memo, useEffect } from "react"
 import { useAuth } from "@clerk/clerk-react"
 import { useMapleCustomer } from "@/hooks/use-maple-customer"
 import {
@@ -58,7 +58,10 @@ export const Route = createRootRouteWithContext<{ auth: RouterAuthContext }>()({
 	component: RootComponent,
 })
 
-function AppFrame() {
+// Memoized so root-level churn (Clerk session touches, customer-query state
+// transitions in ClerkReverseRedirects) stops here instead of cascading into
+// the entire route tree on every commit.
+const AppFrame = memo(function AppFrame() {
 	const pathname = useRouterState({ select: (s) => s.location.pathname })
 	useEffect(() => {
 		captureChatReferrer(pathname)
@@ -80,7 +83,7 @@ function AppFrame() {
 			{import.meta.env.DEV && <UnitflowDevtools />}
 		</AttributesProvider>
 	)
-}
+})
 
 function getRedirectTarget(searchStr: string, fallback = "/") {
 	const params = new URLSearchParams(searchStr)

--- a/apps/web/src/routes/alerts/$ruleId.tsx
+++ b/apps/web/src/routes/alerts/$ruleId.tsx
@@ -39,6 +39,7 @@ import {
 	IsoDateTimeString,
 	type AiTriageResult,
 	type AlertCheckDocument,
+	type AlertDestinationDocument,
 	type AlertIncidentDocument,
 	type AlertRuleDocument,
 } from "@maple/domain/http"
@@ -78,6 +79,13 @@ import { formatSql } from "@/lib/sql-format"
 
 const tabValues = ["overview", "history"] as const
 type RuleDetailTab = (typeof tabValues)[number]
+
+// Shared loading/error fallbacks, so the derived lists keep one stable
+// identity until their Result actually changes.
+const NO_RULES: ReadonlyArray<AlertRuleDocument> = []
+const NO_INCIDENTS: ReadonlyArray<AlertIncidentDocument> = []
+const NO_CHECKS: ReadonlyArray<AlertCheckDocument> = []
+const NO_DESTINATIONS: ReadonlyArray<AlertDestinationDocument> = []
 
 // Decode the raw `$ruleId` URL segment into its branded id once, at the route
 // boundary, so the branded value threads through the checks/states queries
@@ -145,18 +153,37 @@ function RuleDetailContent() {
 	})
 	const { result: checksResult, refresh: refreshChecks } = useAlertRuleChecks(ruleId, since, until)
 
-	const rules = Result.builder(rulesResult)
-		.onSuccess((response) => response.rules)
-		.orElse(() => [])
-	const allIncidents = Result.builder(incidentsResult)
-		.onSuccess((response) => response.incidents)
-		.orElse(() => [])
-	const checks = Result.builder(checksResult)
-		.onSuccess((response) => response.checks)
-		.orElse(() => [])
-	const destinations = Result.builder(destinationsResult)
-		.onSuccess((response) => response.destinations)
-		.orElse(() => [])
+	// Memoized (with a shared empty-array fallback) so the identities only
+	// change when the underlying Result does — these feed memo chains below
+	// (diagnosis, chart) that must hold across unrelated renders.
+	const rules = useMemo(
+		() =>
+			Result.builder(rulesResult)
+				.onSuccess((response) => response.rules)
+				.orElse(() => NO_RULES),
+		[rulesResult],
+	)
+	const allIncidents = useMemo(
+		() =>
+			Result.builder(incidentsResult)
+				.onSuccess((response) => response.incidents)
+				.orElse(() => NO_INCIDENTS),
+		[incidentsResult],
+	)
+	const checks = useMemo(
+		() =>
+			Result.builder(checksResult)
+				.onSuccess((response) => response.checks)
+				.orElse(() => NO_CHECKS),
+		[checksResult],
+	)
+	const destinations = useMemo(
+		() =>
+			Result.builder(destinationsResult)
+				.onSuccess((response) => response.destinations)
+				.orElse(() => NO_DESTINATIONS),
+		[destinationsResult],
+	)
 	const ruleDeliveryEvents = useMemo(
 		() =>
 			Result.builder(deliveryEventsResult)
@@ -177,6 +204,23 @@ function RuleDetailContent() {
 					return dateB - dateA
 				}),
 		[allIncidents, ruleId],
+	)
+
+	// Memoized so RuleDiagnosisPanel's buildDiagnosis memo can hold — a fresh
+	// filter() identity here recomputed the whole diagnosis every render.
+	const openRuleIncidents = useMemo(
+		() => ruleIncidents.filter((i) => i.status === "open"),
+		[ruleIncidents],
+	)
+
+	// Wall clock for the diagnosis's relative-time labels. Deliberately NOT a
+	// live ticker: it refreshes only when the diagnosis's data inputs change
+	// (while firing, Electric pushes a state row every evaluation ≈1/min). A
+	// per-render Date.now() defeated the buildDiagnosis memo entirely.
+	const diagnosisNow = useMemo(
+		() => Date.now(),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[ruleStates, ruleIncidents, checks, ruleDeliveryEvents],
 	)
 
 	const activeTab: RuleDetailTab = (tabValues as readonly string[]).includes(search.tab ?? "")
@@ -333,7 +377,7 @@ function RuleDetailContent() {
 		}
 	}
 
-	const isFiring = ruleIncidents.some((i) => i.status === "open")
+	const isFiring = openRuleIncidents.length > 0
 	const subtitle = `${signalLabels[rule.signalType]} ${comparatorLabels[rule.comparator]} ${formatSignalValue(rule.signalType, rule.threshold)} over ${rule.windowMinutes}min${rule.serviceNames?.length > 0 ? ` on ${rule.serviceNames.join(", ")}` : ""}${rule.excludeServiceNames?.length > 0 ? ` (excl. ${rule.excludeServiceNames.join(", ")})` : ""}`
 
 	const stickyContent = (
@@ -399,10 +443,10 @@ function RuleDetailContent() {
 						rule={rule}
 						states={ruleStates}
 						checks={checks}
-						openIncidents={ruleIncidents.filter((i) => i.status === "open")}
+						openIncidents={openRuleIncidents}
 						destinations={destinations}
 						deliveryEvents={ruleDeliveryEvents}
-						now={Date.now()}
+						now={diagnosisNow}
 						onToggleEnabled={() => void handleToggleEnabled()}
 					/>
 					<div className="space-y-2">

--- a/apps/web/src/routes/services/$serviceName.tsx
+++ b/apps/web/src/routes/services/$serviceName.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate, createFileRoute } from "@tanstack/react-router"
-import { useMemo } from "react"
+import { useCallback, useMemo } from "react"
 import { Result, useAtomValue } from "@/lib/effect-atom"
 import { effectRoute } from "@effect-router/core"
 import { Option, Schema } from "effect"
@@ -130,40 +130,55 @@ function ServiceDetailContent() {
 		search.timePreset ?? "12h",
 	)
 
-	const handleTimeChange = (
-		range: {
-			startTime?: string
-			endTime?: string
-			presetValue?: string
+	const handleTimeChange = useCallback(
+		(
+			range: {
+				startTime?: string
+				endTime?: string
+				presetValue?: string
+			},
+			options?: { replace?: boolean },
+		) => {
+			navigate({
+				replace: options?.replace,
+				search: (prev: Record<string, unknown>) => applyTimeRangeSearch(prev, range),
+			})
 		},
-		options?: { replace?: boolean },
-	) => {
-		navigate({
-			replace: options?.replace,
-			search: (prev: Record<string, unknown>) => applyTimeRangeSearch(prev, range),
-		})
-	}
+		[navigate],
+	)
 
 	const activeTab: ServiceDetailTabValue = search.tab ?? "overview"
-	const handleTabChange = (value: unknown) => {
-		const next = Option.getOrElse(decodeServiceDetailTab(value), (): ServiceDetailTabValue => "overview")
-		navigate({
-			replace: true,
-			search: (prev: Record<string, unknown>) => ({
-				...prev,
-				tab: next === "overview" ? undefined : next,
-			}),
-		})
-	}
+	const handleTabChange = useCallback(
+		(value: unknown) => {
+			const next = Option.getOrElse(
+				decodeServiceDetailTab(value),
+				(): ServiceDetailTabValue => "overview",
+			)
+			navigate({
+				replace: true,
+				search: (prev: Record<string, unknown>) => ({
+					...prev,
+					tab: next === "overview" ? undefined : next,
+				}),
+			})
+		},
+		[navigate],
+	)
 
-	const handleEnvironmentChange = (environment: string | undefined) => {
-		navigate({
-			search: (prev: Record<string, unknown>) => ({
-				...prev,
-				environments: environment ? [environment] : undefined,
-			}),
-		})
-	}
+	const handleEnvironmentChange = useCallback(
+		(environment: string | undefined) => {
+			navigate({
+				search: (prev: Record<string, unknown>) => ({
+					...prev,
+					environments: environment ? [environment] : undefined,
+				}),
+			})
+		},
+		[navigate],
+	)
+
+	const handleShowDependencies = useCallback(() => handleTabChange("dependencies"), [handleTabChange])
+	const handleShowOperations = useCallback(() => handleTabChange("operations"), [handleTabChange])
 
 	return (
 		<DashboardLayout
@@ -255,8 +270,8 @@ function ServiceDetailContent() {
 					effectiveStartTime={effectiveStartTime}
 					effectiveEndTime={effectiveEndTime}
 					environments={search.environments}
-					onShowDependencies={() => handleTabChange("dependencies")}
-					onShowOperations={() => handleTabChange("operations")}
+					onShowDependencies={handleShowDependencies}
+					onShowOperations={handleShowOperations}
 				/>
 			)}
 			{activeTab === "operations" && (
@@ -416,30 +431,34 @@ function OverviewTab({
 	// Commit deploy markers (dashed verticals + labels) drawn over every chart.
 	// Derived from the overview's release timeline and snapped onto the chart's
 	// own bucket grid so each marker sits on an x-tick.
-	const releases = Result.builder(overviewResult)
-		.onSuccess((response) => response.releases)
-		.orElse(() => EMPTY_RELEASES)
+	const releases = useMemo(
+		() =>
+			Result.builder(overviewResult)
+				.onSuccess((response) => response.releases)
+				.orElse(() => EMPTY_RELEASES),
+		[overviewResult],
+	)
 	const chartBuckets = useMemo(() => detailPoints.map((point) => String(point.bucket)), [detailPoints])
 	const commitMarkers = useCommitMarkers(releases, chartBuckets)
 
-	const widgetData: Record<string, Record<string, unknown>[]> = {
-		latency: detailPoints,
-		throughput: detailPoints,
-		"error-rate": detailPoints,
-		apdex: detailPoints,
-	}
-
-	const metrics = SERVICE_CHARTS.map((chart) => ({
-		id: chart.id,
-		chartId: chart.chartId,
-		title: chart.title,
-		layout: chart.layout,
-		data: widgetData[chart.id] ?? [],
-		legend: chart.legend,
-		tooltip: chart.tooltip,
-		rateMode: chart.rateMode,
-		isLoading: isDetailLoading,
-	}))
+	// Stable identity so the memoized chart components under MetricsGrid skip
+	// rerenders when this tab rerenders for unrelated reasons (sibling panel
+	// atoms settling, root-level churn).
+	const metrics = useMemo(
+		() =>
+			SERVICE_CHARTS.map((chart) => ({
+				id: chart.id,
+				chartId: chart.chartId,
+				title: chart.title,
+				layout: chart.layout,
+				data: detailPoints,
+				legend: chart.legend,
+				tooltip: chart.tooltip,
+				rateMode: chart.rateMode,
+				isLoading: isDetailLoading,
+			})),
+		[detailPoints, isDetailLoading],
+	)
 
 	return (
 		<div className="flex flex-col gap-3">

--- a/packages/ui/src/components/charts/area/apdex-area-chart.tsx
+++ b/packages/ui/src/components/charts/area/apdex-area-chart.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo } from "react"
+import { memo, useId, useMemo } from "react"
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
 
 import type { BaseChartProps } from "../_shared/chart-types"
@@ -21,7 +21,9 @@ const baseChartConfig = {
 	apdexScore: { label: "Apdex", color: "var(--chart-apdex)" },
 } satisfies ChartConfig
 
-export function ApdexAreaChart({
+// Memoized: these charts sit in synced grids whose parent rerenders on every
+// atom/query settle; with stable props the whole Recharts subtree is skipped.
+export const ApdexAreaChart = memo(function ApdexAreaChart({
 	data,
 	className,
 	legend,
@@ -143,4 +145,4 @@ export function ApdexAreaChart({
 			</AreaChart>
 		</ChartContainer>
 	)
-}
+})

--- a/packages/ui/src/components/charts/area/error-rate-area-chart.tsx
+++ b/packages/ui/src/components/charts/area/error-rate-area-chart.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo } from "react"
+import { memo, useId, useMemo } from "react"
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
 
 import type { BaseChartProps } from "../_shared/chart-types"
@@ -21,7 +21,9 @@ const baseChartConfig = {
 	errorRate: { label: "Error Rate", color: "var(--chart-error)" },
 } satisfies ChartConfig
 
-export function ErrorRateAreaChart({
+// Memoized: these charts sit in synced grids whose parent rerenders on every
+// atom/query settle; with stable props the whole Recharts subtree is skipped.
+export const ErrorRateAreaChart = memo(function ErrorRateAreaChart({
 	data,
 	className,
 	legend,
@@ -144,4 +146,4 @@ export function ErrorRateAreaChart({
 			</AreaChart>
 		</ChartContainer>
 	)
-}
+})

--- a/packages/ui/src/components/charts/area/throughput-area-chart.tsx
+++ b/packages/ui/src/components/charts/area/throughput-area-chart.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useId } from "react"
+import { memo, useMemo, useId } from "react"
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
 
 import type { BaseChartProps } from "../_shared/chart-types"
@@ -23,7 +23,9 @@ import {
 
 const VALUE_KEYS = ["throughput"]
 
-export function ThroughputAreaChart({
+// Memoized: these charts sit in synced grids whose parent rerenders on every
+// atom/query settle; with stable props the whole Recharts subtree is skipped.
+export const ThroughputAreaChart = memo(function ThroughputAreaChart({
 	data,
 	className,
 	legend,
@@ -296,4 +298,4 @@ export function ThroughputAreaChart({
 			</AreaChart>
 		</ChartContainer>
 	)
-}
+})

--- a/packages/ui/src/components/charts/line/latency-line-chart.tsx
+++ b/packages/ui/src/components/charts/line/latency-line-chart.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { memo, useMemo } from "react"
 import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts"
 
 import type { BaseChartProps } from "../_shared/chart-types"
@@ -22,7 +22,9 @@ const baseChartConfig = {
 	p50LatencyMs: { label: "P50", color: "var(--chart-p50)" },
 } satisfies ChartConfig
 
-export function LatencyLineChart({
+// Memoized: these charts sit in synced grids whose parent rerenders on every
+// atom/query settle; with stable props the whole Recharts subtree is skipped.
+export const LatencyLineChart = memo(function LatencyLineChart({
 	data,
 	className,
 	legend,
@@ -175,4 +177,4 @@ export function LatencyLineChart({
 			</LineChart>
 		</ChartContainer>
 	)
-}
+})

--- a/packages/ui/src/components/ui/chart.tsx
+++ b/packages/ui/src/components/ui/chart.tsx
@@ -50,10 +50,14 @@ const EMPTY_SUPPRESSORS: ReadonlySet<string> = new Set()
  * unmounting — so when it un-suppresses it resumes its position transition from
  * where it was (next to the marker) rather than snapping in from the origin.
  */
-const ChartTooltipSuppressionContext = React.createContext<{
-	suppressed: boolean
-	setSuppressed: (id: string, suppressed: boolean) => void
-} | null>(null)
+// Split into two contexts so a suppression toggle only rerenders the
+// components that read the boolean (the tooltip contents), not every overlay
+// holding the stable setter — in a synced grid one marker hover would
+// otherwise fan a render out to all sibling charts' overlays.
+const ChartTooltipSuppressedContext = React.createContext<boolean>(false)
+const ChartTooltipSetSuppressedContext = React.createContext<
+	((id: string, suppressed: boolean) => void) | null
+>(null)
 
 export function ChartTooltipSuppressionProvider({ children }: { children: React.ReactNode }) {
 	const [suppressors, setSuppressors] = React.useState<ReadonlySet<string>>(EMPTY_SUPPRESSORS)
@@ -66,32 +70,30 @@ export function ChartTooltipSuppressionProvider({ children }: { children: React.
 			return next
 		})
 	}, [])
-	const value = React.useMemo(
-		() => ({ suppressed: suppressors.size > 0, setSuppressed }),
-		[suppressors, setSuppressed],
-	)
 	return (
-		<ChartTooltipSuppressionContext.Provider value={value}>
-			{children}
-		</ChartTooltipSuppressionContext.Provider>
+		<ChartTooltipSetSuppressedContext.Provider value={setSuppressed}>
+			<ChartTooltipSuppressedContext.Provider value={suppressors.size > 0}>
+				{children}
+			</ChartTooltipSuppressedContext.Provider>
+		</ChartTooltipSetSuppressedContext.Provider>
 	)
 }
 
 /**
  * The setter an in-chart overlay uses to hide/restore the chart's data tooltip.
- * Depends on the provider's STABLE `setSuppressed` (not the whole context value,
- * which changes whenever suppression toggles) so the returned function keeps a
- * stable identity — overlays put it in effect deps, and an unstable one would
- * loop (cleanup re-fires → toggles state → re-renders → …).
+ * Reads only the STABLE setter context (not the boolean, which changes whenever
+ * suppression toggles) so the returned function keeps a stable identity and the
+ * overlay doesn't rerender on toggles — overlays put it in effect deps, and an
+ * unstable one would loop (cleanup re-fires → toggles state → re-renders → …).
  */
 export function useSuppressChartTooltip(): (suppressed: boolean) => void {
-	const setSuppressed = React.use(ChartTooltipSuppressionContext)?.setSuppressed
+	const setSuppressed = React.use(ChartTooltipSetSuppressedContext)
 	const id = React.useId()
 	return React.useCallback((suppressed: boolean) => setSuppressed?.(id, suppressed), [setSuppressed, id])
 }
 
 function useChartTooltipSuppressed(): boolean {
-	return React.use(ChartTooltipSuppressionContext)?.suppressed ?? false
+	return React.use(ChartTooltipSuppressedContext)
 }
 
 export type ChartLegendItem = { key: string; label: React.ReactNode; color?: string }
@@ -150,8 +152,15 @@ function ChartContainer({
 		return () => legendSlot.setItems([])
 	}, [legendSlot, publishedItems])
 
+	// Stable identity so ChartContext consumers (tooltip/legend contents) don't
+	// rerender just because the container did.
+	const chartContextValue = React.useMemo(
+		() => ({ config, containerRef, chartId }),
+		[config, chartId],
+	)
+
 	return (
-		<ChartContext.Provider value={{ config, containerRef, chartId }}>
+		<ChartContext.Provider value={chartContextValue}>
 			<div
 				ref={containerRef}
 				data-slot="chart"

--- a/packages/unitflow/src/db/index.ts
+++ b/packages/unitflow/src/db/index.ts
@@ -75,14 +75,35 @@ export const changes = <T extends object>(
 		Effect.acquireRelease(
 			Effect.sync(() => {
 				if (startSync) collection.startSyncImmediate()
+				let closed = false
+				let scheduled = false
 				const offer = () => Queue.offerUnsafe(queue, snapshot(collection))
-				const subscription = collection.subscribeChanges(offer)
-				const offStatus = collection.on("status:change", offer)
+				// A sync transaction that touches N rows fires N change callbacks;
+				// snapshotting each one queues N O(collection) `toArray` copies and N
+				// downstream recomputations for what is one observable state change.
+				// Coalesce same-tick bursts into a single microtask-deferred snapshot.
+				const offerCoalesced = () => {
+					if (scheduled) return
+					scheduled = true
+					queueMicrotask(() => {
+						scheduled = false
+						if (!closed) offer()
+					})
+				}
+				const subscription = collection.subscribeChanges(offerCoalesced)
+				const offStatus = collection.on("status:change", offerCoalesced)
 				offer()
-				return { subscription, offStatus }
+				return {
+					subscription,
+					offStatus,
+					markClosed: () => {
+						closed = true
+					},
+				}
 			}),
-			({ offStatus, subscription }) =>
+			({ markClosed, offStatus, subscription }) =>
 				Effect.sync(() => {
+					markClosed()
 					offStatus()
 					subscription.unsubscribe()
 				}),

--- a/packages/unitflow/test/db.test.ts
+++ b/packages/unitflow/test/db.test.ts
@@ -3,6 +3,7 @@ import { createCollection, localOnlyCollectionOptions } from "@tanstack/db"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Scope from "effect/Scope"
+import * as Stream from "effect/Stream"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import { InstanceScope, Registry, Store } from "../src/core/index.js"
 import * as Db from "../src/db/index.js"
@@ -73,6 +74,34 @@ describe("Db.fromCollection", () => {
 			// event (the makeQuery-inside-compute bug class) would tear down and
 			// resubscribe 20 times; a raced teardown leaves count !== 1.
 			assert.strictEqual(todos.subscriberCount, 1)
+		}).pipe(Effect.provide(Registry.layer)),
+	)
+
+	it.effect("coalesces a same-tick burst of changes into one snapshot", () =>
+		Effect.gen(function* () {
+			const todos = makeTodos([{ id: 0, label: "seed" }])
+			const store = yield* Db.fromCollection(todos)
+			yield* Store.waitFor(store, successWith(1), { timeout: "1 second" })
+
+			let emissions = 0
+			yield* Registry.run(
+				Store.stream(store).pipe(
+					Stream.drop(1),
+					Stream.tap(() =>
+						Effect.sync(() => {
+							emissions += 1
+						}),
+					),
+				),
+			)
+
+			// One synchronous burst — the transaction fires one change callback per
+			// row, but only one microtask-deferred snapshot may reach the store.
+			for (let i = 1; i <= 50; i++) {
+				todos.insert({ id: i, label: `todo-${i}` })
+			}
+			yield* Store.waitFor(store, successWith(51), { timeout: "1 second" })
+			assert.strictEqual(emissions, 1)
 		}).pipe(Effect.provide(Registry.layer)),
 	)
 


### PR DESCRIPTION
## What

Fixes the "page is lagging like crazy / react-scan shows constant rerenders" issue reported on the service detail page (`/services/:serviceName`). Profiling the live app showed the problem is mostly app-wide, not page-local: every Clerk-internal emit (session touches, token refreshes, focus/visibility events) and every page-level state bump rerendered the **entire app tree** — ~1300–2800 fibers per commit, sidebar included, in bursts up to 40Hz (`root.memoizedUpdaters` pinned `ClerkContextProvider` as the scheduler).

## Why it cascaded

Three unmemoized boundaries:

1. **`main.tsx`** — `ClerkInnerApp` rerenders on every Clerk emit and rerendered `EffectRouterProvider` with a fresh inline `context` object; rerendering the router provider rerenders the entire match tree. Now wrapped in a memoized `RouterShell`, with the router context memoized on `[isSignedIn, orgId]`.
2. **`routes/__root.tsx`** — the auth/plan gate (`useAuth` + customer query) returned an unmemoized `AppFrame` → `Outlet` → everything. `AppFrame` is now `memo`'d; gate rerenders stop at ~8 fibers.
3. **`app-sidebar.tsx`** — `DashboardLayout` mounts the sidebar inside every page, so any page state change (reload spinner, search params, query settles) rerendered its ~500-fiber subtree. It also used bare `useRouterState()`, rerendering on every router tick. Now `memo`'d with a pathname selector.

## Page-local fixes (service detail Overview tab)

The 4 synced Recharts charts amplified every parent render:

- The four service charts (`latency-line`, `throughput/apdex/error-rate-area`) are `memo`'d.
- `OverviewTab`'s `metrics`/`releases` and the `ServiceDetailContent` handlers are memoized so the memo holds; `useCommitMarkers` returns a stable `overlay` element.
- `ChartContainer`'s context value is memoized; the tooltip-suppression context is split into a stable setter context + boolean context so a commit-marker hover no longer fans a render out to all sibling charts.

## Measured (live at web.localhost, fiber-commit profiler)

| Scenario | Before | After |
| --- | --- | --- |
| Reload-button commit | 2775 rendered fibers, full sidebar | 114 fibers, no sidebar |
| Clerk churn (focus/visibility) | full-tree commits + 66-commit 40Hz bursts | none idle; gate-only (~8 fibers) |
| Chart hover | full-tree | scoped to the 4 synced charts (inherent to `syncId`) |

## Reviewer notes

- Verified in the browser: synced tooltips/cursors still work across all 4 charts, tab switching and navigation intact, `bun typecheck` passes.
- Converting a function-component export to `memo(...)` trips react-refresh once during HMR ("Component is not a function") — a hard reload clears it; fresh loads are unaffected.
- Recharts `syncId` cross-chart rerenders on hover are inherent and left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)