### PR TITLE
fix(web): adjust chart picker spacing

### DIFF
--- a/apps/web/src/components/dashboard-builder/config/chart-picker.tsx
+++ b/apps/web/src/components/dashboard-builder/config/chart-picker.tsx
@@ -352,7 +352,7 @@ export function WidgetPicker({ open, onOpenChange, onSelect }: WidgetPickerProps
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="flex gap-0 border-b border-border -mx-6 px-6">
+				<div className="flex gap-0 border-b border-border">
 					{tabs.map((tab) => (
 						<button
 							key={tab.id}
@@ -369,7 +369,7 @@ export function WidgetPicker({ open, onOpenChange, onSelect }: WidgetPickerProps
 					))}
 				</div>
 
-				<div className="flex flex-col gap-5 max-h-[60vh] overflow-y-auto py-1">
+				<div className="flex flex-col gap-5 max-h-[60vh] overflow-y-auto py-5 px-4">
 					{showCharts && (
 						<div className="flex flex-col gap-3">
 							{activeTab === "all" && (


### PR DESCRIPTION
Just came across this project. Thanks for making such awesome open source project!

Anyway I saw this UI issue and decided to push a fix

Before:
<img width="949" height="332" alt="Screenshot 2026-07-18 at 8 35 18 PM" src="https://github.com/user-attachments/assets/a28c0aa9-9f78-4ebe-8951-7800a46ebbc0" />

After:
<img width="890" height="293" alt="Screenshot 2026-07-18 at 8 30 16 PM" src="https://github.com/user-attachments/assets/40b9e782-69fc-4a7c-ae24-76ce21715965" />

