### PR TITLE
fix: resolve top production error sources from 24h error sweep

### DIFF
--- a/apps/alerting/alchemy.run.ts
+++ b/apps/alerting/alchemy.run.ts
@@ -69,6 +69,12 @@ export const createAlertingWorker = ({ stage, mapleDb }: CreateAlertingWorkerOpt
 				}),
 				TINYBIRD_HOST: requireEnv("TINYBIRD_HOST"),
 				TINYBIRD_TOKEN: Redacted.make(requireEnv("TINYBIRD_TOKEN")),
+				// Alert-rule evaluation runs Tinybird-scoped raw SQL through
+				// TinybirdOrgTokenService, which requires both of these — without them
+				// every tick fails with "TINYBIRD_SIGNING_KEY is required for
+				// Tinybird-scoped raw SQL" (same bindings as the api worker).
+				...optionalSecret("TINYBIRD_SIGNING_KEY"),
+				...optionalPlain("TINYBIRD_WORKSPACE_ID"),
 				MAPLE_AUTH_MODE: process.env.MAPLE_AUTH_MODE?.trim() || "self_hosted",
 				MAPLE_DEFAULT_ORG_ID: process.env.MAPLE_DEFAULT_ORG_ID?.trim() || "default",
 				MAPLE_INGEST_KEY_ENCRYPTION_KEY: Redacted.make(requireEnv("MAPLE_INGEST_KEY_ENCRYPTION_KEY")),

--- a/apps/api/src/lib/WarehouseQueryService.test.ts
+++ b/apps/api/src/lib/WarehouseQueryService.test.ts
@@ -726,6 +726,15 @@ describe("createTinybirdSdkSqlClient.sql FORMAT normalization", () => {
 		assert.match(sent, /FORMAT JSON$/)
 	})
 
+	it("does not double-append when profile SETTINGS precede FORMAT JSON", async () => {
+		// Canonical order emitted by appendSettings — Tinybird rejects the inverse.
+		const sent = await captureSql(
+			"SELECT 1 SETTINGS max_execution_time=15, max_memory_usage=1500000000\nFORMAT JSON",
+		)
+		assert.strictEqual(countFormats(sent), 1)
+		assert.match(sent, /SETTINGS max_execution_time=15, max_memory_usage=1500000000\nFORMAT JSON$/)
+	})
+
 	it("does not double-append when FORMAT JSON is followed by profile SETTINGS", async () => {
 		const sent = await captureSql(
 			"SELECT 1\nFORMAT JSON SETTINGS max_execution_time=15, max_memory_usage=1500000000",

--- a/apps/api/src/lib/WarehouseQueryService.ts
+++ b/apps/api/src/lib/WarehouseQueryService.ts
@@ -166,9 +166,11 @@ const createTinybirdSdkSqlClient = (
 				// Tinybird Cloud currently defaults /v0/sql to JSON, while Tinybird Local
 				// defaults to tab-separated output. The SDK always calls response.json(), so
 				// make the expected wire format explicit for both environments. DSL-compiled
-				// queries already end with `FORMAT JSON` (optionally followed by profile
-				// SETTINGS) — appending a second FORMAT clause is a ClickHouse syntax error,
-				// so only add one when the query doesn't carry its own.
+				// queries already end with `FORMAT JSON` (profile SETTINGS are inserted
+				// before it by appendSettings) — appending a second FORMAT clause is a
+				// ClickHouse syntax error, so only add one when the query doesn't carry
+				// its own. The trailing-SETTINGS alternative covers SQL from callers that
+				// still emit the legacy `FORMAT JSON SETTINGS …` order.
 				const trimmed = sql.trimEnd().replace(/;$/, "")
 				const hasFormat = /\bFORMAT\s+\w+(\s+SETTINGS\s[^\n]*)?$/i.test(trimmed)
 				const jsonSql = hasFormat ? trimmed : `${trimmed}\nFORMAT JSON`

--- a/apps/cli/src/server/inserts.ts
+++ b/apps/cli/src/server/inserts.ts
@@ -53,3 +53,48 @@ export function buildInsertSql(datasource: string, ndjson: string): string {
 	if (!template) throw new Error(`no insert mapping for datasource '${datasource}'`)
 	return template.prefix + escapeSqlLiteral(ndjson) + template.suffix
 }
+
+/**
+ * chDB parses the entire statement — inlined data literal included — against
+ * its default `max_query_size` (~256KB), so a large batch in one statement
+ * fails with "Code: 62 … Max query size exceeded". Budget for the escaped
+ * payload per statement, leaving headroom for the template prefix/suffix.
+ */
+const MAX_ESCAPED_PAYLOAD_BYTES = 200_000
+
+export interface InsertStatement {
+	readonly sql: string
+	readonly rowCount: number
+}
+
+/**
+ * Like {@link buildInsertSql}, but splits the NDJSON batch on line boundaries
+ * into as many statements as needed so each stays under chDB's query-size
+ * limit. A single line larger than the budget is emitted as its own statement
+ * (never split mid-line).
+ */
+export function buildInsertStatements(datasource: string, ndjson: string): InsertStatement[] {
+	const template = templates.get(datasource)
+	if (!template) throw new Error(`no insert mapping for datasource '${datasource}'`)
+	const out: InsertStatement[] = []
+	let chunk: string[] = []
+	let chunkBytes = 0
+	const flush = () => {
+		if (chunk.length === 0) return
+		out.push({ sql: template.prefix + chunk.join("\n") + template.suffix, rowCount: chunk.length })
+		chunk = []
+		chunkBytes = 0
+	}
+	for (const line of ndjson.split("\n")) {
+		if (line.length === 0) continue
+		// Escaping is per-character, so escaping line-by-line and joining with
+		// "\n" is identical to escaping the whole batch at once.
+		const escaped = escapeSqlLiteral(line)
+		const bytes = Buffer.byteLength(escaped, "utf8") + 1
+		if (chunkBytes > 0 && chunkBytes + bytes > MAX_ESCAPED_PAYLOAD_BYTES) flush()
+		chunk.push(escaped)
+		chunkBytes += bytes
+	}
+	flush()
+	return out
+}

--- a/apps/cli/src/server/serve.ts
+++ b/apps/cli/src/server/serve.ts
@@ -8,7 +8,7 @@ import { gunzipSync } from "node:zlib"
 import { TelemetryLayer } from "../core/telemetry"
 import { isLoopbackHostname } from "../lib/local-address"
 import { acquireChdb, type Chdb, type ChdbError } from "./chdb"
-import { buildInsertSql } from "./inserts"
+import { buildInsertStatements } from "./inserts"
 import { encodeLogs, encodeMetrics, encodeTraces, type EncodedBatch } from "./otlp/encode"
 import { decodeLogsRequest, decodeMetricsRequest, decodeTraceRequest } from "./otlp/proto"
 import schemaSql from "./schema/local-schema.sql" with { type: "text" }
@@ -177,16 +177,18 @@ async function ingest(db: Chdb, signal: Signal, req: Request): Promise<IngestRes
 	let accepted = 0
 	for (const batch of batches) {
 		if (batch.rowCount === 0) continue
-		try {
-			db.exec(buildInsertSql(batch.datasource, batch.ndjson))
-		} catch (error) {
-			return {
-				response: text(`chDB insert (${batch.datasource}): ${(error as Error).message}`, 500),
-				accepted,
-				requestBytes,
+		for (const statement of buildInsertStatements(batch.datasource, batch.ndjson)) {
+			try {
+				db.exec(statement.sql)
+			} catch (error) {
+				return {
+					response: text(`chDB insert (${batch.datasource}): ${(error as Error).message}`, 500),
+					accepted,
+					requestBytes,
+				}
 			}
+			accepted += statement.rowCount
 		}
-		accepted += batch.rowCount
 	}
 	return { response: json({ accepted }), accepted, requestBytes }
 }

--- a/apps/cli/test/inserts.test.ts
+++ b/apps/cli/test/inserts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+import { buildInsertSql, buildInsertStatements } from "../src/server/inserts"
+
+const line = (i: number, pad = 0) => JSON.stringify({ body: `row-${i}${"x".repeat(pad)}` })
+
+describe("buildInsertStatements", () => {
+	it("emits a single statement for a small batch, identical to buildInsertSql", () => {
+		const ndjson = [line(1), line(2), line(3)].join("\n")
+		const statements = buildInsertStatements("logs", ndjson)
+		expect(statements).toHaveLength(1)
+		expect(statements[0]?.rowCount).toBe(3)
+		expect(statements[0]?.sql).toBe(buildInsertSql("logs", ndjson))
+	})
+
+	it("ignores empty lines when counting rows", () => {
+		const statements = buildInsertStatements("logs", `${line(1)}\n\n${line(2)}\n`)
+		expect(statements).toHaveLength(1)
+		expect(statements[0]?.rowCount).toBe(2)
+	})
+
+	// Regression: a large OTLP logs batch inlined into one statement exceeded
+	// chDB's default max_query_size (~256KB) → "Code: 62 … Max query size
+	// exceeded". Batches must be split on line boundaries under the budget.
+	it("splits a large batch into multiple statements under the size budget", () => {
+		const rows = Array.from({ length: 50 }, (_, i) => line(i, 10_000))
+		const statements = buildInsertStatements("logs", rows.join("\n"))
+		expect(statements.length).toBeGreaterThan(1)
+		expect(statements.reduce((n, s) => n + s.rowCount, 0)).toBe(50)
+		for (const statement of statements) {
+			expect(Buffer.byteLength(statement.sql, "utf8")).toBeLessThan(256 * 1024)
+		}
+	})
+
+	it("splits only on line boundaries — concatenated payloads round-trip", () => {
+		const rows = Array.from({ length: 50 }, (_, i) => line(i, 10_000))
+		const statements = buildInsertStatements("logs", rows.join("\n"))
+		const payloads = statements.map((s) => {
+			const start = s.sql.lastIndexOf(", '") + 3
+			return s.sql.slice(start, -2)
+		})
+		expect(payloads.join("\n")).toBe(rows.join("\n"))
+	})
+
+	it("passes a single oversized line through as its own statement", () => {
+		const huge = line(0, 300_000)
+		const statements = buildInsertStatements("logs", [line(1), huge, line(2)].join("\n"))
+		expect(statements.map((s) => s.rowCount)).toEqual([1, 1, 1])
+		expect(statements[1]?.sql).toContain("x".repeat(300_000))
+	})
+
+	it("budgets on escaped bytes, not raw bytes", () => {
+		// Each backslash escapes to two characters; 60 rows of ~3.4KB raw escape
+		// to ~6.7KB each (~400KB total), forcing at least a three-way split.
+		const rows = Array.from({ length: 60 }, () => JSON.stringify({ body: "\\".repeat(3_333) }))
+		const statements = buildInsertStatements("logs", rows.join("\n"))
+		expect(statements.length).toBeGreaterThan(2)
+		for (const statement of statements) {
+			expect(Buffer.byteLength(statement.sql, "utf8")).toBeLessThan(256 * 1024)
+		}
+	})
+
+	it("throws on an unknown datasource", () => {
+		expect(() => buildInsertStatements("nope", line(1))).toThrow("no insert mapping")
+	})
+})

--- a/packages/query-engine/src/profiles/query-profile.test.ts
+++ b/packages/query-engine/src/profiles/query-profile.test.ts
@@ -52,6 +52,31 @@ describe("appendSettings", () => {
 	it("appends max_block_size", () => {
 		expect(appendSettings("SELECT 1", { maxBlockSize: 512 })).toBe("SELECT 1 SETTINGS max_block_size=512")
 	})
+
+	// Regression: Tinybird rejects `FORMAT JSON SETTINGS …` with
+	// "Syntax error: failed at position … (FORMAT)" — SETTINGS must precede
+	// a trailing FORMAT clause.
+	it("inserts SETTINGS before a trailing FORMAT clause", () => {
+		expect(appendSettings("SELECT 1 FORMAT JSON", { maxExecutionTime: 15 })).toBe(
+			"SELECT 1 SETTINGS max_execution_time=15 FORMAT JSON",
+		)
+	})
+
+	it("inserts SETTINGS before FORMAT with a trailing semicolon and newlines", () => {
+		expect(appendSettings("SELECT 1\nFORMAT JSONEachRow;", { maxThreads: 2 })).toBe(
+			"SELECT 1 SETTINGS max_threads=2\nFORMAT JSONEachRow",
+		)
+	})
+
+	it("leaves a trailing FORMAT untouched when settings are empty", () => {
+		expect(appendSettings("SELECT 1 FORMAT JSON", {})).toBe("SELECT 1 FORMAT JSON")
+	})
+
+	it("only treats a FORMAT at the end of the query as the format clause", () => {
+		expect(appendSettings("SELECT formatDateTime(now(), '%F') AS format_col", { maxThreads: 2 })).toBe(
+			"SELECT formatDateTime(now(), '%F') AS format_col SETTINGS max_threads=2",
+		)
+	})
 })
 
 describe("stripTinybirdRestrictedSettings", () => {

--- a/packages/query-engine/src/profiles/query-profile.ts
+++ b/packages/query-engine/src/profiles/query-profile.ts
@@ -126,8 +126,16 @@ export const stripTinybirdRestrictedSettings = (
 }
 
 /**
- * Append a ClickHouse `SETTINGS` clause to a SQL string. Returns the
- * input unchanged when no settings are provided.
+ * Matches a trailing `FORMAT <name>` clause (the DSL compiler terminates every
+ * query with `FORMAT JSON`). `SETTINGS` must precede `FORMAT` — Tinybird's
+ * ClickHouse rejects `FORMAT JSON SETTINGS …` with a syntax error.
+ */
+const trailingFormatRe = /\s+FORMAT\s+\w+\s*$/i
+
+/**
+ * Add a ClickHouse `SETTINGS` clause to a SQL string, inserting it before a
+ * trailing `FORMAT <name>` clause when present. Returns the input unchanged
+ * when no settings are provided.
  *
  * Caller must guarantee the SQL doesn't already contain a SETTINGS
  * clause — none of maple's DSL queries do today.
@@ -142,7 +150,14 @@ export const appendSettings = (sql: string, settings: WarehouseQuerySettings | u
 		}
 	}
 	if (parts.length === 0) return sql
-	return `${sql.replace(/;\s*$/, "")} SETTINGS ${parts.join(", ")}`
+	const clause = `SETTINGS ${parts.join(", ")}`
+	const trimmed = sql.replace(/;\s*$/, "")
+	const formatMatch = trimmed.match(trailingFormatRe)
+	if (formatMatch) {
+		const body = trimmed.slice(0, formatMatch.index)
+		return `${body} ${clause}${formatMatch[0]}`
+	}
+	return `${trimmed} ${clause}`
 }
 
 /**


### PR DESCRIPTION
## What

Three fixes from a sweep of the last 24h of production errors (~120k events, almost all from the `alerting` worker):

1. **Alerting worker: bind `TINYBIRD_SIGNING_KEY` + `TINYBIRD_WORKSPACE_ID`** (`apps/alerting/alchemy.run.ts`). `TinybirdOrgTokenService` requires both for Tinybird-scoped raw SQL; the api worker binds them but the alerting worker never did, so every scheduler tick failed alert-rule evaluation for Tinybird-scoped orgs with `WarehouseConfigError: TINYBIRD_SIGNING_KEY is required for Tinybird-scoped raw SQL` (~23k errors/day, ongoing until this deploys).

2. **query-engine: emit `SETTINGS` before a trailing `FORMAT` clause** (`packages/query-engine/src/profiles/query-profile.ts`). `appendSettings` appended the clause to the end of DSL SQL that already terminates in `FORMAT JSON`, producing `… FORMAT JSON SETTINGS …`, which Tinybird rejects with `DB::Exception: Syntax error … (FORMAT)`. This caused an ~85k-error burst on Jul 19. The `WarehouseQueryService` FORMAT-detection regex already accepts both orders; its comment is updated and both orders are now covered by tests.

3. **CLI local mode: chunk chDB inserts** (`apps/cli/src/server/inserts.ts`, `serve.ts`). The whole NDJSON batch was inlined into one `INSERT … FROM format(JSONEachRow, …)` statement; large log batches exceeded chDB's default ~256KB `max_query_size` (`Code: 62`, ~700 errors/day). New `buildInsertStatements` splits batches on line boundaries under a 200KB escaped-payload budget; a single oversized line still goes out intact as its own statement.

## Reviewer notes

- Fix 1 is deploy-config only and takes effect on the next alerting deploy; error fingerprints `17797887319973565170` / `14262904916114617522` should stop afterwards.
- Fix 2 keeps accepting the legacy `FORMAT JSON SETTINGS …` order in `WarehouseQueryService` so nothing regresses mid-rollout.
- Not addressed here (separate issues found in the same sweep): the Postgres `permission denied` on `alert_rules`/`issue_escalations`/`error_issue_states`/`oauth_connections` (ops-side grants, started Jul 19 16:20 UTC) and quarantining orgs with permanently broken configs (dead Tinybird workspace org, deleted Clerk org).

## Testing

- `packages/query-engine`: 808 tests pass (new `appendSettings` FORMAT-ordering cases included)
- `apps/api`: `WarehouseQueryService.test.ts` 34 tests pass (new canonical-order case)
- `apps/cli`: 108 tests pass (new `test/inserts.test.ts` covers splitting, round-trip, escaped-byte budgeting, oversized lines)
- `bun typecheck` green across all 29 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787134034&installation_id=147287781&pr_number=235&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F235&signature=4264026e8f0fffc70989acfb75b3d7dee66963477a9e7687007ff2e5318d5297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->