### PR TITLE
fix: stop duplicate notification emails

### DIFF
--- a/apps/alerting/alchemy.run.ts
+++ b/apps/alerting/alchemy.run.ts
@@ -64,9 +64,16 @@ export const createAlertingWorker = ({ stage, mapleDb }: CreateAlertingWorkerOpt
 				// Ref stages attach MAPLE_DB via worker.bind below.
 				...(mapleDb ? { MAPLE_DB: mapleDb } : {}),
 				AI_TRIAGE_WORKFLOW: aiTriageWorkflow,
-				EMAIL: Cloudflare.Email.SendEmail("email", {
-					allowedSenderAddresses: ["notifications@noreply.maple.dev"],
-				}),
+				// Production only: preview/stg workers run the same email crons against
+				// their own DB branches, so a binding here means every live stage sends
+				// its own copy of onboarding/digest/alert emails to real users.
+				...(stage.kind === "prd"
+					? {
+							EMAIL: Cloudflare.Email.SendEmail("email", {
+								allowedSenderAddresses: ["notifications@noreply.maple.dev"],
+							}),
+						}
+					: {}),
 				TINYBIRD_HOST: requireEnv("TINYBIRD_HOST"),
 				TINYBIRD_TOKEN: Redacted.make(requireEnv("TINYBIRD_TOKEN")),
 				// Alert-rule evaluation runs Tinybird-scoped raw SQL through

--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -143,9 +143,16 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 					simple: { limit: 600, period: 60 },
 				}),
 				API_V2_RATE_LIMIT_PARTITION: formatMapleStage(stage),
-				EMAIL: Cloudflare.Email.SendEmail("email", {
-					allowedSenderAddresses: ["notifications@noreply.maple.dev"],
-				}),
+				// Production only: preview/stg workers run the same email crons against
+				// their own DB branches, so a binding here means every live stage sends
+				// its own copy of onboarding/digest/alert emails to real users.
+				...(stage.kind === "prd"
+					? {
+							EMAIL: Cloudflare.Email.SendEmail("email", {
+								allowedSenderAddresses: ["notifications@noreply.maple.dev"],
+							}),
+						}
+					: {}),
 				TINYBIRD_HOST: requireEnv("TINYBIRD_HOST"),
 				TINYBIRD_TOKEN: Redacted.make(requireEnv("TINYBIRD_TOKEN")),
 				...optionalSecret("TINYBIRD_SIGNING_KEY"),

--- a/apps/api/src/lib/EmailService.ts
+++ b/apps/api/src/lib/EmailService.ts
@@ -47,7 +47,14 @@ export class EmailService extends Context.Service<EmailService, EmailServiceShap
 			const workerEnv = yield* WorkerEnvironment
 			const binding = (workerEnv as Record<string, SendEmailBinding | undefined>).EMAIL
 
-			const isConfigured = binding !== undefined
+			// Real sends are production-only: preview/stg stages share real user data
+			// (branched DBs, Clerk members), so a live binding there would deliver
+			// duplicate copies of every cron-driven email. The alchemy configs no
+			// longer attach EMAIL outside prd; this guard covers any binding that
+			// still reaches a non-prod worker (wrangler dev, manual deploys).
+			const emailAllowed =
+				env.MAPLE_ENVIRONMENT === "production" || env.MAPLE_EMAIL_ALLOW_NONPROD === "true"
+			const isConfigured = binding !== undefined && emailAllowed
 
 			const send = Effect.fn("EmailService.send")(function* (
 				to: string,
@@ -63,6 +70,14 @@ export class EmailService extends Context.Service<EmailService, EmailServiceShap
 					return yield* Effect.fail(
 						new EmailDeliveryError({
 							message: "Email not configured: EMAIL binding is missing",
+						}),
+					)
+				}
+
+				if (!emailAllowed) {
+					return yield* Effect.fail(
+						new EmailDeliveryError({
+							message: `Email suppressed: sends are disabled in ${env.MAPLE_ENVIRONMENT} (set MAPLE_EMAIL_ALLOW_NONPROD=true to override)`,
 						}),
 					)
 				}

--- a/apps/api/src/lib/Env.ts
+++ b/apps/api/src/lib/Env.ts
@@ -26,6 +26,10 @@ export interface EnvShape {
 	readonly MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: Redacted.Redacted<string>
 	readonly MAPLE_INGEST_PUBLIC_URL: string
 	readonly MAPLE_APP_BASE_URL: string
+	/** Deployment environment (`production`, `staging`, `pr-<n>`, `development`) — set by alchemy from the stage. */
+	readonly MAPLE_ENVIRONMENT: string
+	/** Escape hatch: allow real email sends outside production (e.g. a dedicated stg test run). */
+	readonly MAPLE_EMAIL_ALLOW_NONPROD: string
 	readonly CLERK_SECRET_KEY: Option.Option<Redacted.Redacted<string>>
 	readonly CLERK_PUBLISHABLE_KEY: Option.Option<string>
 	readonly CLERK_JWT_KEY: Option.Option<Redacted.Redacted<string>>
@@ -100,6 +104,8 @@ const envConfig = Config.all({
 	MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: Config.redacted("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
 	MAPLE_INGEST_PUBLIC_URL: stringWithDefault("MAPLE_INGEST_PUBLIC_URL", "http://127.0.0.1:3474"),
 	MAPLE_APP_BASE_URL: stringWithDefault("MAPLE_APP_BASE_URL", "http://127.0.0.1:3471"),
+	MAPLE_ENVIRONMENT: stringWithDefault("MAPLE_ENVIRONMENT", "development"),
+	MAPLE_EMAIL_ALLOW_NONPROD: stringWithDefault("MAPLE_EMAIL_ALLOW_NONPROD", "false"),
 	CLERK_SECRET_KEY: optionalRedacted("CLERK_SECRET_KEY"),
 	CLERK_PUBLISHABLE_KEY: optionalString("CLERK_PUBLISHABLE_KEY"),
 	CLERK_JWT_KEY: optionalRedacted("CLERK_JWT_KEY"),

--- a/apps/api/src/services/AlertDeliveryDispatch.test.ts
+++ b/apps/api/src/services/AlertDeliveryDispatch.test.ts
@@ -260,4 +260,54 @@ describe("dispatchDelivery", () => {
 			assert.include(error.message, "EMAIL binding is missing")
 		}),
 	)
+
+	it.effect("email: succeeds with annotation when only some members fail", () =>
+		Effect.gen(function* () {
+			const sent: string[] = []
+			const deps: DispatchDeps = {
+				sendEmail: (to) =>
+					to === "oncall@acme.test"
+						? Effect.fail(
+								new AlertDeliveryError({
+									message: "mailbox unavailable",
+									destinationType: "email",
+								}),
+							)
+						: Effect.sync(() => {
+								sent.push(to)
+							}),
+			}
+
+			const result = yield* dispatchDelivery(emailContext, "{}", failingFetch, 5_000, LINK, CHAT, deps)
+
+			assert.deepStrictEqual(sent, ["ops@acme.test"])
+			assert.include(result.providerMessage, "Emailed 1 of 2 members")
+			assert.include(result.providerMessage, "oncall@acme.test")
+			assert.include(result.providerMessage, "mailbox unavailable")
+		}),
+	)
+
+	it.effect("email: fails with the first member error when every member fails", () =>
+		Effect.gen(function* () {
+			const deps: DispatchDeps = {
+				sendEmail: () =>
+					Effect.fail(
+						new AlertDeliveryError({
+							message: "Cloudflare Email send timed out after 15s",
+							destinationType: "email",
+						}),
+					),
+			}
+
+			const error = yield* Effect.flip(
+				dispatchDelivery(emailContext, "{}", failingFetch, 5_000, LINK, CHAT, deps),
+			)
+
+			assert.instanceOf(error, AlertDeliveryError)
+			assert.include(error.message, "failed for all 2 members")
+			// The verbatim member error must survive aggregation so retryability
+			// classification (timeout detection) keeps working upstream.
+			assert.include(error.message, "timed out")
+		}),
+	)
 })

--- a/apps/api/src/services/AlertDeliveryDispatch.ts
+++ b/apps/api/src/services/AlertDeliveryDispatch.ts
@@ -881,12 +881,49 @@ export const dispatchDelivery = (
 				email: (config) =>
 					Effect.gen(function* () {
 						const { subject, html } = yield* buildAlertEmailContent(context, linkUrl, chatUrl)
-						yield* Effect.forEach(
-							config.members,
-							(member) => deps.sendEmail(member.email, subject, html),
-							{ discard: true },
+						const outcomes = yield* Effect.forEach(config.members, (member) =>
+							deps.sendEmail(member.email, subject, html).pipe(
+								Effect.match({
+									onSuccess: () => ({ member, error: null as string | null }),
+									onFailure: (error) => ({ member, error: error.message }),
+								}),
+							),
 						)
+						const failures = outcomes.filter((o) => o.error != null)
 						const count = config.members.length
+
+						if (failures.length === count && count > 0) {
+							// Nobody received the email — safe to fail retryable; the retry
+							// re-sends to members who all got nothing. Keep the first failure
+							// message verbatim so timeout classification survives aggregation.
+							return yield* Effect.fail(
+								makeDeliveryError(
+									`Email delivery failed for all ${count} member${count === 1 ? "" : "s"}: ${failures[0]!.error}`,
+									"email",
+								),
+							)
+						}
+
+						if (failures.length > 0) {
+							// Partial success is terminal: there is no per-member attempt
+							// state, so retrying the event would re-email the members who
+							// already received it. Report success and surface the failures.
+							yield* Effect.logWarning("Alert email delivered to a subset of members").pipe(
+								Effect.annotateLogs({
+									failedCount: failures.length,
+									memberCount: count,
+									firstError: failures[0]!.error,
+								}),
+							)
+							return {
+								providerMessage: `Emailed ${count - failures.length} of ${count} members; failed: ${failures
+									.map((f) => `${f.member.email} (${f.error})`)
+									.join(", ")}`,
+								providerReference: null,
+								responseCode: null,
+							} as DispatchResult
+						}
+
 						return {
 							providerMessage: `Emailed ${count} member${count === 1 ? "" : "s"}`,
 							providerReference: null,

--- a/apps/api/src/services/AlertsService.test.ts
+++ b/apps/api/src/services/AlertsService.test.ts
@@ -706,6 +706,161 @@ describe("AlertsService", () => {
 		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: okFetch })))
 	})
 
+	it.effect("suppresses trigger and resolve notifications while an incident flaps", () => {
+		const testDb = createTestDb(trackedDbs)
+		const breachedRows = [
+			{
+				count: 200,
+				avgDuration: 40,
+				p50Duration: 20,
+				p95Duration: 120,
+				p99Duration: 240,
+				errorRate: 10,
+				satisfiedCount: 180,
+				toleratingCount: 10,
+				apdexScore: 0.925,
+			},
+		] as ReadonlyArray<Record<string, unknown>>
+		const healthyRows = [
+			{
+				count: 200,
+				avgDuration: 20,
+				p50Duration: 10,
+				p95Duration: 80,
+				p99Duration: 160,
+				errorRate: 0.5,
+				satisfiedCount: 195,
+				toleratingCount: 3,
+				apdexScore: 0.9825,
+			},
+		] as ReadonlyArray<Record<string, unknown>>
+		const state = { tracesAggregateRows: breachedRows }
+
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
+			const alerts = yield* AlertsService
+			const orgId = asOrgId("org_flap")
+			const userId = asUserId("user_flap")
+			const destination = yield* createWebhookDestination(alerts, orgId, userId)
+			yield* createErrorRateRule(alerts, orgId, userId, destination.id)
+
+			const tick = Effect.gen(function* () {
+				yield* alerts.runSchedulerTick()
+				yield* TestClock.adjust(Duration.minutes(1))
+			})
+
+			// Flap 1: open (trigger delivered) then resolve (resolve delivered).
+			yield* tick
+			yield* tick
+			state.tracesAggregateRows = healthyRows
+			yield* tick
+			yield* tick
+
+			// Flap 2 within the renotify interval: incident opens again, but both
+			// its trigger and its resolve notifications are suppressed.
+			state.tracesAggregateRows = breachedRows
+			yield* tick
+			yield* tick
+			state.tracesAggregateRows = healthyRows
+			yield* tick
+			yield* tick
+
+			const incidents = yield* alerts.listIncidents(orgId)
+			const events = yield* alerts.listDeliveryEvents(orgId)
+
+			assert.lengthOf(incidents.incidents, 2)
+			assert.isTrue(incidents.incidents.every((incident) => incident.status === "resolved"))
+			// Only the first flap emailed: one trigger + one resolve, nothing for flap 2.
+			assert.deepStrictEqual(
+				events.events.map((event: { eventType: string }) => event.eventType).sort(),
+				["resolve", "trigger"],
+			)
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: okFetch })))
+	})
+
+	it.effect("queues at most one renotify per interval while deliveries keep failing", () => {
+		const testDb = createTestDb(trackedDbs)
+		const state = {
+			tracesAggregateRows: [
+				{
+					count: 200,
+					avgDuration: 40,
+					p50Duration: 20,
+					p95Duration: 120,
+					p99Duration: 240,
+					errorRate: 10,
+					satisfiedCount: 180,
+					toleratingCount: 10,
+					apdexScore: 0.925,
+				},
+			] as ReadonlyArray<Record<string, unknown>>,
+		}
+		const failingFetch: typeof fetch = (async () =>
+			new Response("boom", { status: 500 })) as unknown as typeof fetch
+
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
+			const alerts = yield* AlertsService
+			const orgId = asOrgId("org_renotify_gate")
+			const userId = asUserId("user_renotify_gate")
+			const destination = yield* createWebhookDestination(alerts, orgId, userId)
+			yield* alerts.createRule(
+				orgId,
+				userId,
+				adminRoles,
+				new AlertRuleUpsertRequest({
+					name: "Checkout error rate",
+					severity: "critical",
+					enabled: true,
+					serviceNames: ["checkout"],
+					signalType: "error_rate",
+					comparator: "gt",
+					threshold: 5,
+					windowMinutes: 5,
+					minimumSampleCount: 10,
+					consecutiveBreachesRequired: 2,
+					consecutiveHealthyRequired: 2,
+					renotifyIntervalMinutes: 5,
+					destinationIds: [destination.id],
+				}),
+			)
+
+			// Trigger opens on the second tick; every delivery attempt fails with a
+			// retryable 500 for the whole test, so lastNotifiedAt can only advance
+			// via the queue-time gate.
+			for (let minute = 0; minute < 9; minute += 1) {
+				yield* alerts.runSchedulerTick()
+				yield* TestClock.adjust(Duration.minutes(1))
+			}
+
+			const events = yield* alerts.listDeliveryEvents(orgId)
+			const renotifyFirstAttempts = events.events.filter(
+				(event: { eventType: string; attemptNumber: number }) =>
+					event.eventType === "renotify" && event.attemptNumber === 1,
+			)
+			// Trigger at t=1min → renotify due at t=6min. Ticks at 7/8 min must NOT
+			// re-queue a fresh renotify chain even though nothing was delivered.
+			assert.lengthOf(renotifyFirstAttempts, 1)
+
+			const incidents = yield* alerts.listIncidents(orgId)
+			assert.lengthOf(incidents.incidents, 1)
+			assert.isNotNull(incidents.incidents[0]?.lastNotifiedAt)
+
+			// One interval after the queue-time advance, a second renotify chain starts.
+			for (let minute = 0; minute < 3; minute += 1) {
+				yield* alerts.runSchedulerTick()
+				yield* TestClock.adjust(Duration.minutes(1))
+			}
+			const eventsAfter = yield* alerts.listDeliveryEvents(orgId)
+			const renotifyChains = new Set(
+				eventsAfter.events
+					.filter((event: { eventType: string }) => event.eventType === "renotify")
+					.map((event: { deliveryKey: string }) => event.deliveryKey.split(":").at(-1)),
+			)
+			assert.strictEqual(renotifyChains.size, 2)
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: failingFetch })))
+	})
+
 	it.effect("skips unchanged alert_rule_states writes and refreshes on the 5-minute heartbeat", () => {
 		const testDb = createTestDb(trackedDbs)
 		// Healthy from the start: errorRate 1 stays below the threshold of 5.

--- a/apps/api/src/services/AlertsService.ts
+++ b/apps/api/src/services/AlertsService.ts
@@ -85,7 +85,7 @@ import {
 	type AlertRuleRow,
 	alertRuleStates,
 } from "@maple/db"
-import { and, asc, desc, eq, inArray, isNotNull, isNull, lt, lte, ne, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, sql } from "drizzle-orm"
 import {
 	Array as Arr,
 	Cause,
@@ -3787,6 +3787,36 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 						openIncident == null &&
 						consecutiveBreaches >= normalized.consecutiveBreachesRequired
 					) {
+						// Flap suppression: a metric oscillating around the threshold opens
+						// a fresh incident per flap, which would email an identical trigger
+						// notification every few minutes. If the previous incident for this
+						// (rule, group) was notified within the renotify interval, open the
+						// incident but skip the trigger notification and carry the prior
+						// lastNotifiedAt forward — the renotify gate then enforces one
+						// email per interval while the flapping persists.
+						const priorNotified =
+							(yield* dbExecute((db) =>
+								db
+									.select({ lastNotifiedAt: alertIncidents.lastNotifiedAt })
+									.from(alertIncidents)
+									.where(
+										and(
+											eq(alertIncidents.orgId, row.orgId),
+											eq(alertIncidents.ruleId, row.id),
+											eq(alertIncidents.groupKey, groupKey),
+											eq(alertIncidents.status, "resolved"),
+											isNotNull(alertIncidents.lastNotifiedAt),
+											gte(
+												alertIncidents.lastNotifiedAt,
+												new Date(timestamp - normalized.renotifyIntervalMinutes * 60_000),
+											),
+										),
+									)
+									.orderBy(desc(alertIncidents.lastNotifiedAt))
+									.limit(1),
+							))[0] ?? null
+						const flapSuppressedAt = priorNotified?.lastNotifiedAt ?? null
+
 						const incidentId = decodeAlertIncidentIdSync(makeUuid())
 						const incident: AlertIncidentRow = {
 							id: incidentId,
@@ -3809,21 +3839,35 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 							lastEvaluatedAt: new Date(timestamp),
 							dedupeKey: `${row.orgId}:${row.id}:${groupKey}`,
 							lastDeliveredEventType: null,
-							lastNotifiedAt: null,
+							// Suppressed flaps inherit the prior incident's notify anchor so
+							// the renotify gate spaces the next email a full interval from
+							// the last one the user actually received.
+							lastNotifiedAt: flapSuppressedAt,
 							errorIssueId: null,
 							createdAt: new Date(timestamp),
 							updatedAt: new Date(timestamp),
 						}
 
 						yield* dbExecute((db) => db.insert(alertIncidents).values(incident))
-						yield* queueIncidentNotifications(
-							row.orgId,
-							normalized,
-							incident,
-							evaluation,
-							"trigger",
-							timestamp,
-						)
+						if (flapSuppressedAt != null) {
+							yield* Effect.logInfo("Skipping trigger notification for flapping incident").pipe(
+								Effect.annotateLogs({
+									ruleId: row.id,
+									incidentId,
+									groupKey,
+									priorNotifiedAt: flapSuppressedAt.toISOString(),
+								}),
+							)
+						} else {
+							yield* queueIncidentNotifications(
+								row.orgId,
+								normalized,
+								incident,
+								evaluation,
+								"trigger",
+								timestamp,
+							)
+						}
 						return {
 							transition: "opened" as const,
 							incidentId,
@@ -3843,6 +3887,18 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 							updatedAt: new Date(timestamp),
 						}
 
+						const renotifyDueAt =
+							(openIncident.lastNotifiedAt ?? openIncident.firstTriggeredAt).getTime() +
+							normalized.renotifyIntervalMinutes * 60_000
+						const renotifyDue = renotifyDueAt <= timestamp
+
+						// The gate closes at QUEUE time, not delivery time: advancing
+						// lastNotifiedAt only on delivery success re-queues a fresh event
+						// (new scheduledAt → new deliveryKey) every tick while a delivery
+						// is failing or slow, and the whole backlog fires once the
+						// destination recovers. Failed deliveries are covered by the
+						// per-event retry chain instead. Written before queueing so a
+						// crash in between skips one interval rather than duplicating.
 						yield* dbExecute((db) =>
 							db
 								.update(alertIncidents)
@@ -3852,14 +3908,12 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 									lastSampleCount: evaluation.sampleCount,
 									lastEvaluatedAt: new Date(timestamp),
 									updatedAt: new Date(timestamp),
+									...(renotifyDue ? { lastNotifiedAt: new Date(timestamp) } : {}),
 								})
 								.where(eq(alertIncidents.id, openIncident.id)),
 						)
 
-						const renotifyDueAt =
-							(openIncident.lastNotifiedAt ?? openIncident.firstTriggeredAt).getTime() +
-							normalized.renotifyIntervalMinutes * 60_000
-						if (renotifyDueAt <= timestamp) {
+						if (renotifyDue) {
 							yield* queueIncidentNotifications(
 								row.orgId,
 								normalized,
@@ -3907,14 +3961,30 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 								.where(eq(alertIncidents.id, openIncident.id)),
 						)
 
-						yield* queueIncidentNotifications(
-							row.orgId,
-							normalized,
-							resolvedIncident,
-							evaluation,
-							"resolve",
-							timestamp,
-						)
+						// A flap-suppressed incident (notify anchor inherited, nothing ever
+						// delivered for it) resolves silently too — pairing every silent
+						// open with a resolve email would spam just as hard as the
+						// triggers we suppressed.
+						const resolveSuppressed =
+							openIncident.lastDeliveredEventType == null && openIncident.lastNotifiedAt != null
+						if (resolveSuppressed) {
+							yield* Effect.logInfo("Skipping resolve notification for flapping incident").pipe(
+								Effect.annotateLogs({
+									ruleId: row.id,
+									incidentId: openIncident.id,
+									groupKey,
+								}),
+							)
+						} else {
+							yield* queueIncidentNotifications(
+								row.orgId,
+								normalized,
+								resolvedIncident,
+								evaluation,
+								"resolve",
+								timestamp,
+							)
+						}
 						return {
 							transition: "resolved" as const,
 							incidentId: openIncident.id,

--- a/apps/api/src/services/ErrorsService.test.ts
+++ b/apps/api/src/services/ErrorsService.test.ts
@@ -23,6 +23,7 @@ import {
 	errorIssues,
 	errorIssueEvents,
 	errorIssueStates,
+	errorNotificationPolicies,
 	issueEscalations,
 	orgIngestKeys,
 } from "@maple/db"
@@ -186,13 +187,17 @@ const makeErrorsLayer = (
 	onScan?: () => void,
 	edgeBackend?: ReturnType<typeof makeMemoryBackend>,
 	fingerprintRows?: () => ReadonlyArray<Record<string, unknown>>,
+	dispatcher?: (typeof NotificationDispatcher)["Service"],
 ) => {
 	const testDb = createTestDb(createdDbs)
 	const envLive = Env.layer.pipe(Layer.provide(testConfig()))
 	const databaseLive = testDb.layer
-	const dispatcherStub = Layer.succeed(NotificationDispatcher, {
-		dispatch: () => Effect.succeed({ delivered: 0, failed: 0 }),
-	})
+	const dispatcherStub = Layer.succeed(
+		NotificationDispatcher,
+		dispatcher ?? {
+			dispatch: () => Effect.succeed({ delivered: 0, failed: 0 }),
+		},
+	)
 	return ErrorsService.layer.pipe(
 		Layer.provide(
 			Layer.mergeAll(
@@ -936,6 +941,91 @@ describe("ErrorsService.runTick", () => {
 				1,
 			)
 		}).pipe(Effect.provide(makeErrorsLayer(() => rows)))
+	})
+
+	it.effect("overlapping ticks dispatch each incident notification exactly once", () => {
+		let rows: ReadonlyArray<Record<string, unknown>> = [scanRow()]
+		const dispatched: string[] = []
+		const countingDispatcher: (typeof NotificationDispatcher)["Service"] = {
+			dispatch: (_orgId, _destinationIds, context) =>
+				Effect.sync(() => {
+					dispatched.push(context.deliveryKey)
+					return { delivered: 1, failed: 0 }
+				}),
+		}
+		return Effect.gen(function* () {
+			const errors = yield* ErrorsService
+			const database = yield* Database
+			yield* TestClock.setTime(TICK_MS)
+			yield* seedIssue(asIssueId(randomUUID()))
+			// Enabled policy with a destination so incident open/resolve actually
+			// dispatches (the dispatcher itself is stubbed — no destination row needed).
+			yield* database.execute((db) =>
+				db.insert(errorNotificationPolicies).values({
+					orgId: ORG,
+					enabled: true,
+					destinationIdsJson: ["7d31c9e1-0000-4000-8000-000000000001"],
+					notifyOnResolve: true,
+					updatedAt: new Date(TICK_MS),
+					updatedBy: "test",
+				}),
+			)
+
+			yield* errors.runTick()
+			assert.lengthOf(
+				dispatched.filter((key) => key.endsWith(":open")),
+				1,
+			)
+
+			// Stale window elapsed, no fresh errors: two OVERLAPPING ticks race the
+			// open→resolved flip. The CAS lets exactly one dispatch the resolve.
+			rows = []
+			yield* TestClock.setTime(TICK_MS + 31 * 60_000)
+			const resolveResults = yield* Effect.all([errors.runTick(), errors.runTick()], {
+				concurrency: 2,
+			})
+			assert.strictEqual(
+				resolveResults.reduce((s, r) => s + r.incidentsResolved, 0),
+				1,
+			)
+			assert.lengthOf(
+				dispatched.filter((key) => key.endsWith(":resolve")),
+				1,
+			)
+
+			// Errors return: two OVERLAPPING ticks race the reopen. The state-row
+			// CAS lets exactly one insert the incident and dispatch its open.
+			const reopenMs = TICK_MS + 32 * 60_000
+			rows = [
+				scanRow({
+					firstSeen: toWarehouseDateTime(reopenMs - 60_000),
+					lastSeen: toWarehouseDateTime(reopenMs - 1_000),
+				}),
+			]
+			yield* TestClock.setTime(reopenMs)
+			const reopenResults = yield* Effect.all([errors.runTick(), errors.runTick()], {
+				concurrency: 2,
+			})
+			assert.strictEqual(
+				reopenResults.reduce((s, r) => s + r.incidentsOpened, 0),
+				1,
+			)
+			assert.lengthOf(
+				dispatched.filter((key) => key.endsWith(":open")),
+				2,
+			)
+
+			const issue = (yield* loadIssuesByFingerprint(SCAN_FINGERPRINT))[0]!
+			const incidents = yield* loadIncidentsForIssue(issue.id)
+			assert.lengthOf(incidents, 2)
+			const states = yield* database.execute((db) =>
+				db.select().from(errorIssueStates).where(eq(errorIssueStates.issueId, issue.id)),
+			)
+			assert.strictEqual(
+				states[0]?.openIncidentId,
+				incidents.find((incident) => incident.status === "open")?.id,
+			)
+		}).pipe(Effect.provide(makeErrorsLayer(() => rows, undefined, undefined, undefined, countingDispatcher)))
 	})
 
 	it.effect(

--- a/apps/api/src/services/ErrorsService.ts
+++ b/apps/api/src/services/ErrorsService.ts
@@ -2482,23 +2482,14 @@ const make: Effect.Effect<
 							? "regression"
 							: "first_seen"
 					const incidentId = newErrorIncidentId()
-					yield* dbExecute((db) =>
-						db.insert(errorIncidents).values({
-							id: incidentId,
-							orgId,
-							issueId,
-							status: "open",
-							reason,
-							firstTriggeredAt: new Date(firstSeenMs),
-							lastTriggeredAt: new Date(lastSeenMs),
-							resolvedAt: null,
-							occurrenceCount: row.count,
-							createdAt: new Date(windowEndMs),
-							updatedAt: new Date(windowEndMs),
-						}),
-					)
 
-					yield* dbExecute((db) =>
+					// CAS the open slot BEFORE creating the incident or dispatching:
+					// overlapping ticks can both read openIncidentId == null, and the
+					// notify path below dispatches immediately (no outbox), so only the
+					// upsert winner may proceed. setWhere keeps the conflict-update a
+					// no-op when another tick already claimed the slot; RETURNING then
+					// yields zero rows for the loser.
+					const claimed = yield* dbExecute((db) =>
 						db
 							.insert(errorIssueStates)
 							.values({
@@ -2517,7 +2508,37 @@ const make: Effect.Effect<
 									openIncidentId: incidentId,
 									updatedAt: new Date(windowEndMs),
 								},
-							}),
+								setWhere: isNull(errorIssueStates.openIncidentId),
+							})
+							.returning({ openIncidentId: errorIssueStates.openIncidentId }),
+					)
+					const wonOpenSlot = claimed[0]?.openIncidentId === incidentId
+
+					if (!wonOpenSlot) {
+						// Lost the race: a concurrent tick opened the incident for this
+						// same scan window and already dispatched its notification. Do
+						// not bump occurrence counts here — the winner counted this
+						// window's occurrences on insert.
+						yield* Effect.logInfo("Skipping duplicate error incident open (lost CAS)").pipe(
+							Effect.annotateLogs({ orgId, issueId }),
+						)
+						return { touched: 1, opened: 0 }
+					}
+
+					yield* dbExecute((db) =>
+						db.insert(errorIncidents).values({
+							id: incidentId,
+							orgId,
+							issueId,
+							status: "open",
+							reason,
+							firstTriggeredAt: new Date(firstSeenMs),
+							lastTriggeredAt: new Date(lastSeenMs),
+							resolvedAt: null,
+							occurrenceCount: row.count,
+							createdAt: new Date(windowEndMs),
+							updatedAt: new Date(windowEndMs),
+						}),
 					)
 
 					yield* notifyIncidentOpened(orgId, policy, {
@@ -2599,9 +2620,12 @@ const make: Effect.Effect<
 					),
 				),
 		)
-		yield* Effect.forEach(staleIncidents, (incident) =>
+		const resolveOutcomes = yield* Effect.forEach(staleIncidents, (incident) =>
 			Effect.gen(function* () {
-				yield* dbExecute((db) =>
+				// CAS the status flip: overlapping ticks both list the incident as
+				// stale, and the resolve notification dispatches immediately — only
+				// the tick that wins the open→resolved transition may notify.
+				const flipped = yield* dbExecute((db) =>
 					db
 						.update(errorIncidents)
 						.set({
@@ -2609,8 +2633,12 @@ const make: Effect.Effect<
 							resolvedAt: new Date(windowEndMs),
 							updatedAt: new Date(windowEndMs),
 						})
-						.where(eq(errorIncidents.id, incident.id)),
+						.where(and(eq(errorIncidents.id, incident.id), eq(errorIncidents.status, "open")))
+						.returning({ id: errorIncidents.id }),
 				)
+				if (flipped.length === 0) {
+					return { resolved: 0 }
+				}
 				yield* dbExecute((db) =>
 					db
 						.update(errorIssueStates)
@@ -2645,9 +2673,10 @@ const make: Effect.Effect<
 						})
 					}
 				}
+				return { resolved: 1 }
 			}),
 		)
-		const incidentsResolved = staleIncidents.length
+		const incidentsResolved = resolveOutcomes.reduce((s, r) => s + r.resolved, 0)
 
 		let issuesArchived = 0
 		let issuesDeleted = 0
@@ -2758,6 +2787,10 @@ const make: Effect.Effect<
 		}
 	})
 
+	// Overlapping ticks are tolerated (there is no per-org claim lock): scan
+	// bookkeeping may repeat under overlap, but incident open/resolve
+	// transitions — and the notifications they dispatch — are CAS-guarded in
+	// processOrg, so users never receive duplicate incident emails.
 	const runTick: ErrorsServiceShape["runTick"] = Effect.fn("ErrorsService.runTick")(function* () {
 		const endMs = yield* Clock.currentTimeMillis
 		const startMs = endMs - TICK_WINDOW_MS


### PR DESCRIPTION
## What

Users reported being spammed by the same email over and over. This traces and fixes four compounding causes, verified against production telemetry (internal-org alerting logs via the Maple MCP):

1. **EMAIL binding is now production-only** (`apps/api/alchemy.run.ts`, `apps/alerting/alchemy.run.ts`). PR-preview and stg workers run the same onboarding/digest/alert crons against branched real data and had a live binding — telemetry showed five PR previews each sending "Welcome to Maple" within 250 ms of each other, so a new user got one copy from prod plus one per live preview. `EmailService` also gains a runtime guard: sends require `MAPLE_ENVIRONMENT=production` (escape hatch: `MAPLE_EMAIL_ALLOW_NONPROD=true`), covering any binding that still reaches a non-prod worker (wrangler dev, manual deploys).
2. **Flap suppression** (`AlertsService`). Confirmed live on 07-16: a rule oscillating around its threshold opened/resolved short-lived incidents all day, emailing identical trigger/resolve pairs every few minutes. Incidents reopening within the renotify interval of the previously *notified* incident now open silently, inherit its notify anchor (so the renotify gate enforces one email per interval while flapping persists), and resolve silently.
3. **Renotify gate closes at queue time**, not delivery success. Previously a failing destination re-queued a fresh renotify chain every minute (the delivery key embeds `scheduledAt`, so the `(deliveryKey, attemptNumber)` unique index never collapsed cross-tick re-queues) and the entire backlog fired once the destination recovered. The per-event retry chain (5 attempts, backoff) already covers transient failures.
4. **Email fan-out partial failure** (`AlertDeliveryDispatch`). One member failing used to fail the whole event; the retry re-emailed members who already received it. Partial success now succeeds with the failures annotated in `providerMessage`; only all-members-failed is retried (first member error preserved verbatim so timeout classification survives). This also flows through `NotificationDispatcher`, fixing the EscalationService re-page on partially-delivered email destinations.
5. **Error-issue notification idempotency** (`ErrorsService`). Incident open/resolve dispatch immediately (no outbox) and were guarded only by a read-then-act check; overlapping ticks — including stg's crons, which currently share the prod DB — could double-dispatch. Both transitions are now CAS-guarded (`onConflictDoUpdate` + `setWhere` + `.returning()` for open; conditional `status='open'` update for resolve); only the winner notifies.

## Reviewer notes

- Semantics shift: `alert_incidents.lastNotifiedAt` now means "last notification queued" until a delivery success overwrites it with delivery time. All other readers are display-only (audited: web collections, incident-timeline MCP tool, v2 serializer).
- Suppressed flaps are identified at resolve time by `lastDeliveredEventType == null && lastNotifiedAt != null` — an incident that renotified successfully mid-flap still gets its resolve email.
- CAS-loss path in `ErrorsService` deliberately skips occurrence bumps (the winner already counted the same scan window).
- No schema changes. New tests: flap suppression, renotify-gate-under-failing-deliveries, partial-member email dispatch, overlapping-ticks-dispatch-once.
- Out of scope (running as a separate task): tearing down orphaned PR-preview workers and the pr-branch `issue_escalations` grant gap — those are preview-only hygiene; prod was healthy.

## Testing

- `bun typecheck` — 29/29 clean
- `bun run test` — full monorepo green (api 935, web 719, ingest 38)
- Post-deploy verification: preview envs should disappear from "Email sent successfully" logs; flapping episodes log "Skipping trigger notification for flapping incident" instead of repeated deliveries; at most one attempt-1 renotify event per interval per incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787139680&installation_id=147287781&pr_number=237&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F237&signature=40ef36eea1e26c4548ef64777555844c8345f4e209ab42c42e63547ffd2dc978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->