### PR TITLE
feat: @maple-dev/alchemy — Alchemy provider for Maple resources

### DIFF
--- a/apps/api/src/routes/v2/alchemy-provider.integration.test.ts
+++ b/apps/api/src/routes/v2/alchemy-provider.integration.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Integration test for the `@maple-dev/alchemy` provider package
+ * (`lib/alchemy-maple`): drives the real provider lifecycle functions
+ * (reconcile / read / delete) through the real v2 handlers over PGlite,
+ * with the package's own HTTP client routed at the in-process web handler
+ * via a custom `fetch`.
+ */
+import { afterEach, describe, expect, it } from "@effect/vitest"
+import { ConfigProvider, Context, Effect, Layer, ManagedRuntime, Redacted, Schema } from "effect"
+import { FetchHttpClient, HttpRouter } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { OrgId, UserId } from "@maple/domain/http"
+import { MapleApiV2 } from "@maple/domain/http/v2"
+import { BucketCacheService, EdgeCacheService } from "@maple/query-engine/caching"
+import type { ScopedPlanStatusSession } from "alchemy/Cli/Cli"
+import { AlertDestination, AlertDestinationProvider } from "../../../../../lib/alchemy-maple/src/AlertDestination.ts"
+import { AlertRule, AlertRuleProvider } from "../../../../../lib/alchemy-maple/src/AlertRule.ts"
+import { ApiKey, ApiKeyProvider } from "../../../../../lib/alchemy-maple/src/ApiKey.ts"
+import { Dashboard, DashboardProvider } from "../../../../../lib/alchemy-maple/src/Dashboard.ts"
+import { make as makeMapleApi, MapleApi } from "../../../../../lib/alchemy-maple/src/MapleApi.ts"
+import { MapleEnvironment } from "../../../../../lib/alchemy-maple/src/MapleEnvironment.ts"
+import { CacheBackendLive } from "../../lib/CacheBackendLive"
+import { EmailService } from "../../lib/EmailService"
+import { Env } from "../../lib/Env"
+import { cleanupTestDbs, createTestDb, type TestDb } from "../../lib/test-pglite"
+import type { WarehouseQueryServiceShape } from "../../lib/WarehouseQueryService"
+import { WarehouseQueryService } from "../../lib/WarehouseQueryService"
+import { ApiAuthorizationV2Layer } from "../../services/ApiAuthorizationV2Layer"
+import { ApiKeysService } from "../../services/ApiKeysService"
+import { AuthService } from "../../services/AuthService"
+import { DashboardPersistenceService } from "../../services/DashboardPersistenceService"
+import { AlertRuntime, AlertsService } from "../../services/AlertsService"
+import { HazelOAuthService } from "../../services/HazelOAuthService"
+import { OrgMembersService } from "../../services/OrgMembersService"
+import { QueryEngineService } from "../../services/QueryEngineService"
+import { V2SchemaErrorsLive } from "./error-envelope"
+import {
+	AllV2GroupLayersLive,
+	ApiV2RateLimiterAllowAllLayer,
+	ConfigResourceServiceStubsLayer,
+	TelemetryServiceStubsLayer,
+} from "./v2-test-support"
+
+const createdDbs: TestDb[] = []
+afterEach(() => cleanupTestDbs(createdDbs))
+
+const testConfig = () =>
+	ConfigProvider.layer(
+		ConfigProvider.fromUnknown({
+			PORT: "3486",
+			MCP_PORT: "3487",
+			TINYBIRD_HOST: "https://api.tinybird.co",
+			TINYBIRD_TOKEN: "test-token",
+			MAPLE_AUTH_MODE: "self_hosted",
+			MAPLE_ROOT_PASSWORD: "test-root-password",
+			MAPLE_DEFAULT_ORG_ID: "default",
+			MAPLE_INGEST_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 1).toString("base64"),
+			MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: "maple-test-lookup-secret",
+			MAPLE_APP_BASE_URL: "http://127.0.0.1:3471",
+			INTERNAL_SERVICE_TOKEN: "test-internal-token",
+			QE_EVAL_BUCKET_CACHE_ENABLED: "false",
+		}),
+	)
+
+/** The v2 CRUD endpoints exercised here never reach the warehouse. */
+const warehouseStub: WarehouseQueryServiceShape = {
+	query: () => Effect.die(new Error("unexpected warehouse pipe query")),
+	sqlQuery: () => Effect.succeed([]),
+	rawSqlQuery: () => Effect.succeed([]),
+	compiledQuery: (_tenant, compiled) => compiled.decodeRows([]).pipe(Effect.orDie),
+	compiledQueryFirst: () => Effect.die(new Error("unexpected compiled query")),
+	ingest: () => Effect.void,
+	asExecutor: () => {
+		throw new Error("asExecutor is not supported by this test stub")
+	},
+}
+
+const session: ScopedPlanStatusSession = {
+	emit: () => Effect.void,
+	done: () => Effect.void,
+	note: () => Effect.void,
+}
+
+const makeHarness = () => {
+	const testDb = createTestDb(createdDbs)
+	const configLive = testConfig()
+	const envLive = Env.layer.pipe(Layer.provide(configLive))
+	const warehouseLive = Layer.succeed(WarehouseQueryService, warehouseStub)
+	const edgeCacheLive = EdgeCacheService.layer.pipe(Layer.provide(CacheBackendLive))
+	const bucketCacheLive = BucketCacheService.layer.pipe(Layer.provide(edgeCacheLive))
+	const queryEngineLive = QueryEngineService.layer.pipe(
+		Layer.provide(warehouseLive),
+		Layer.provide(edgeCacheLive),
+		Layer.provide(bucketCacheLive),
+		Layer.provide(configLive),
+	)
+	const runtimeLive = Layer.succeed(AlertRuntime, {
+		now: Effect.sync(() => Date.now()),
+		makeUuid: () => crypto.randomUUID(),
+		fetch: globalThis.fetch,
+		deliveryTimeoutMs: () => 15_000,
+	})
+	const hazelOAuthLive = HazelOAuthService.layer.pipe(Layer.provide(Layer.mergeAll(envLive, testDb.layer)))
+	const emailLive = Layer.succeed(EmailService, {
+		isConfigured: false,
+		send: () => Effect.void,
+	})
+	const orgMembersLive = Layer.succeed(OrgMembersService, {
+		resolveMembers: () => Effect.succeed([]),
+	})
+	const alertsLive = AlertsService.layer.pipe(
+		Layer.provide(
+			Layer.mergeAll(
+				envLive,
+				testDb.layer,
+				queryEngineLive,
+				warehouseLive,
+				runtimeLive,
+				hazelOAuthLive,
+				emailLive,
+				orgMembersLive,
+			),
+		),
+	)
+	const servicesLive = Layer.mergeAll(
+		ApiKeysService.layer,
+		AuthService.layer,
+		DashboardPersistenceService.layer,
+		alertsLive,
+	).pipe(Layer.provideMerge(Layer.mergeAll(envLive, testDb.layer)))
+
+	const routes = HttpApiBuilder.layer(MapleApiV2).pipe(
+		Layer.provide(AllV2GroupLayersLive),
+		Layer.provide(ConfigResourceServiceStubsLayer),
+		Layer.provide(TelemetryServiceStubsLayer),
+		Layer.provide(V2SchemaErrorsLive),
+		Layer.provideMerge(ApiAuthorizationV2Layer),
+		Layer.provideMerge(ApiV2RateLimiterAllowAllLayer),
+		Layer.provideMerge(servicesLive),
+	)
+	const { handler, dispose: disposeHandler } = HttpRouter.toWebHandler(routes, {
+		disableLogger: true,
+	})
+	const runtime = ManagedRuntime.make(servicesLive)
+	const ORG = Schema.decodeUnknownSync(OrgId)("org_alchemy_e2e")
+	const USER = Schema.decodeUnknownSync(UserId)("user_alchemy_e2e")
+
+	const bootstrapKey = () =>
+		runtime.runPromise(
+			Effect.gen(function* () {
+				const service = yield* ApiKeysService
+				// No scopes = legacy full access; API-key tenants carry the root role.
+				return yield* service.create(ORG, USER, { name: "alchemy-provider-test" })
+			}),
+		)
+
+	/** Route the provider package's HTTP client at the in-process handler. */
+	const providerLayers = (secret: string) => {
+		const fetchToHandler = ((input: RequestInfo | URL, init?: RequestInit) =>
+			handler(new Request(input, init), Context.empty() as never)) as typeof globalThis.fetch
+		const clientLive = Layer.effect(MapleApi, makeMapleApi).pipe(
+			Layer.provide(FetchHttpClient.layer),
+			Layer.provide(Layer.succeed(FetchHttpClient.Fetch, fetchToHandler)),
+			Layer.provide(
+				Layer.succeed(MapleEnvironment, {
+					baseUrl: "http://maple.test",
+					apiKey: Redacted.make(secret),
+				}),
+			),
+		)
+		return Layer.mergeAll(
+			DashboardProvider(),
+			AlertDestinationProvider(),
+			AlertRuleProvider(),
+			ApiKeyProvider(),
+		).pipe(Layer.provideMerge(clientLive))
+	}
+
+	return {
+		bootstrapKey,
+		providerLayers,
+		dispose: async () => {
+			await disposeHandler()
+			await runtime.dispose()
+		},
+	}
+}
+
+describe("@maple-dev/alchemy providers against the real v2 handlers", () => {
+	it("runs the full dashboard lifecycle: create → noop → drift patch → delete", async () => {
+		const harness = makeHarness()
+		const key = await harness.bootstrapKey()
+		const layers = harness.providerLayers(key.secret)
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const provider = yield* Dashboard.Provider
+
+				// Create.
+				const created = yield* provider.reconcile({
+					id: "ops",
+					instanceId: "i-1",
+					news: { name: "Operations", tags: ["production"] },
+					olds: undefined,
+					output: undefined,
+					session,
+					bindings: [],
+				})
+				expect(created.dashboardId).toMatch(/^dash_/)
+
+				// Steady state: no drift, no mutation (updated name unchanged).
+				const steady = yield* provider.reconcile({
+					id: "ops",
+					instanceId: "i-1",
+					news: { name: "Operations", tags: ["production"] },
+					olds: { name: "Operations", tags: ["production"] },
+					output: created,
+					session,
+					bindings: [],
+				})
+				expect(steady.dashboardId).toBe(created.dashboardId)
+
+				// Drift: rename via PATCH, id stable.
+				const renamed = yield* provider.reconcile({
+					id: "ops",
+					instanceId: "i-1",
+					news: { name: "Operations v2", tags: ["production"] },
+					olds: { name: "Operations", tags: ["production"] },
+					output: created,
+					session,
+					bindings: [],
+				})
+				expect(renamed.dashboardId).toBe(created.dashboardId)
+				expect(renamed.name).toBe("Operations v2")
+
+				// Read observes the renamed dashboard.
+				const observed = yield* provider.read!({
+					id: "ops",
+					instanceId: "i-1",
+					olds: { name: "Operations v2" },
+					output: renamed,
+				})
+				expect(observed?.name).toBe("Operations v2")
+
+				// Delete, then read sees nothing; second delete tolerates the 404.
+				yield* provider.delete({
+					id: "ops",
+					instanceId: "i-1",
+					olds: { name: "Operations v2" },
+					output: renamed,
+					session,
+					bindings: [],
+				})
+				const gone = yield* provider.read!({
+					id: "ops",
+					instanceId: "i-1",
+					olds: { name: "Operations v2" },
+					output: renamed,
+				})
+				expect(gone).toBeUndefined()
+				yield* provider.delete({
+					id: "ops",
+					instanceId: "i-1",
+					olds: { name: "Operations v2" },
+					output: renamed,
+					session,
+					bindings: [],
+				})
+			}).pipe(Effect.provide(layers)) as Effect.Effect<void>,
+		)
+		await harness.dispose()
+	})
+
+	it("wires destination → rule, adopts rules by unique name, and deletes cleanly", async () => {
+		const harness = makeHarness()
+		const key = await harness.bootstrapKey()
+		const layers = harness.providerLayers(key.secret)
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const destinations = yield* AlertDestination.Provider
+				const rules = yield* AlertRule.Provider
+
+				const dest = yield* destinations.reconcile({
+					id: "hook",
+					instanceId: "i-1",
+					news: { type: "webhook", name: "Ops hook", url: "https://example.com/hooks/maple" },
+					olds: undefined,
+					output: undefined,
+					session,
+					bindings: [],
+				})
+				expect(dest.destinationId).toMatch(/^dest_/)
+
+				const ruleProps = {
+					name: "Checkout error rate",
+					severity: "critical" as const,
+					signal_type: "error_rate" as const,
+					comparator: "gt" as const,
+					threshold: 0.05,
+					window_minutes: 5,
+					destination_ids: [dest.destinationId],
+				}
+				const rule = yield* rules.reconcile({
+					id: "checkout-errors",
+					instanceId: "i-1",
+					news: ruleProps,
+					olds: undefined,
+					output: undefined,
+					session,
+					bindings: [],
+				})
+				expect(rule.ruleId).toMatch(/^alrt_/)
+
+				// Lost state (output undefined) → adopted by org-unique name, not duplicated.
+				const adopted = yield* rules.reconcile({
+					id: "checkout-errors",
+					instanceId: "i-1",
+					news: ruleProps,
+					olds: undefined,
+					output: undefined,
+					session,
+					bindings: [],
+				})
+				expect(adopted.ruleId).toBe(rule.ruleId)
+
+				// Update threshold via PATCH.
+				const updated = yield* rules.reconcile({
+					id: "checkout-errors",
+					instanceId: "i-1",
+					news: { ...ruleProps, threshold: 0.1 },
+					olds: ruleProps,
+					output: rule,
+					session,
+					bindings: [],
+				})
+				expect(updated.ruleId).toBe(rule.ruleId)
+
+				// Delete rule first (destination delete conflicts while referenced).
+				yield* rules.delete({
+					id: "checkout-errors",
+					instanceId: "i-1",
+					olds: ruleProps,
+					output: updated,
+					session,
+					bindings: [],
+				})
+				yield* destinations.delete({
+					id: "hook",
+					instanceId: "i-1",
+					news: undefined,
+					olds: { type: "webhook", name: "Ops hook", url: "https://example.com/hooks/maple" },
+					output: dest,
+					session,
+					bindings: [],
+				})
+				const goneRules = yield* rules.list()
+				expect(goneRules).toHaveLength(0)
+			}).pipe(Effect.provide(layers)) as Effect.Effect<void>,
+		)
+		await harness.dispose()
+	})
+
+	it("creates an API key with a one-time secret, preserves it, rolls, and revokes", async () => {
+		const harness = makeHarness()
+		const key = await harness.bootstrapKey()
+		const layers = harness.providerLayers(key.secret)
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const provider = yield* ApiKey.Provider
+
+				const created = yield* provider.reconcile({
+					id: "ci",
+					instanceId: "i-1",
+					news: { name: "ci-pipeline", scopes: ["dashboards:write"] },
+					olds: undefined,
+					output: undefined,
+					session,
+					bindings: [],
+				})
+				expect(created.keyId).toMatch(/^key_/)
+				expect(Redacted.value(created.secret)).toMatch(/^maple_ak_/)
+
+				// Steady state preserves the secret (the API never returns it again).
+				const steady = yield* provider.reconcile({
+					id: "ci",
+					instanceId: "i-1",
+					news: { name: "ci-pipeline", scopes: ["dashboards:write"] },
+					olds: { name: "ci-pipeline", scopes: ["dashboards:write"] },
+					output: created,
+					session,
+					bindings: [],
+				})
+				expect(steady.keyId).toBe(created.keyId)
+				expect(Redacted.value(steady.secret)).toBe(Redacted.value(created.secret))
+
+				// Rotate bump → roll: new id + secret, same name.
+				const rolled = yield* provider.reconcile({
+					id: "ci",
+					instanceId: "i-1",
+					news: { name: "ci-pipeline", scopes: ["dashboards:write"], rotate: 1 },
+					olds: { name: "ci-pipeline", scopes: ["dashboards:write"] },
+					output: steady,
+					session,
+					bindings: [],
+				})
+				expect(rolled.keyId).not.toBe(created.keyId)
+				expect(Redacted.value(rolled.secret)).not.toBe(Redacted.value(created.secret))
+				expect(rolled.name).toBe("ci-pipeline")
+
+				// Revoke; read reports it gone.
+				yield* provider.delete({
+					id: "ci",
+					instanceId: "i-1",
+					olds: { name: "ci-pipeline", scopes: ["dashboards:write"], rotate: 1 },
+					output: rolled,
+					session,
+					bindings: [],
+				})
+				const gone = yield* provider.read!({
+					id: "ci",
+					instanceId: "i-1",
+					olds: { name: "ci-pipeline", scopes: ["dashboards:write"], rotate: 1 },
+					output: rolled,
+				})
+				expect(gone).toBeUndefined()
+			}).pipe(Effect.provide(layers)) as Effect.Effect<void>,
+		)
+		await harness.dispose()
+	})
+})

--- a/bun.lock
+++ b/bun.lock
@@ -339,6 +339,15 @@
         "vitest": "catalog:",
       },
     },
+    "examples/alchemy-maple": {
+      "name": "@maple-examples/alchemy",
+      "devDependencies": {
+        "@maple-dev/alchemy": "workspace:*",
+        "alchemy": "2.0.0-beta.61",
+        "effect": "catalog:effect",
+        "typescript": "catalog:tooling",
+      },
+    },
     "examples/effect-todo": {
       "name": "@maple-examples/effect-todo",
       "version": "0.0.0",
@@ -360,6 +369,25 @@
         "tailwindcss": "catalog:tailwind",
         "typescript": "catalog:tooling",
         "vite": "catalog:",
+      },
+    },
+    "lib/alchemy-maple": {
+      "name": "@maple-dev/alchemy",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@effect/language-service": "catalog:effect",
+        "@effect/vitest": "4.0.0-beta.93",
+        "@maple/domain": "workspace:*",
+        "@types/node": "catalog:tooling",
+        "alchemy": "2.0.0-beta.61",
+        "effect": "catalog:effect",
+        "tsdown": "^0.21.7",
+        "typescript": "catalog:tooling",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "alchemy": ">=2.0.0-beta.61 <3",
+        "effect": ">=4.0.0-beta.93 || >=4.0.0",
       },
     },
     "lib/clickhouse-builder": {
@@ -1483,11 +1511,15 @@
 
     "@lix-js/server-protocol-schema": ["@lix-js/server-protocol-schema@0.1.1", "", {}, "sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ=="],
 
+    "@maple-dev/alchemy": ["@maple-dev/alchemy@workspace:lib/alchemy-maple"],
+
     "@maple-dev/browser": ["@maple-dev/browser@workspace:packages/browser"],
 
     "@maple-dev/clickhouse-builder": ["@maple-dev/clickhouse-builder@workspace:lib/clickhouse-builder"],
 
     "@maple-dev/effect-sdk": ["@maple-dev/effect-sdk@workspace:lib/effect-sdk"],
+
+    "@maple-examples/alchemy": ["@maple-examples/alchemy@workspace:examples/alchemy-maple"],
 
     "@maple-examples/effect-todo": ["@maple-examples/effect-todo@workspace:examples/effect-todo"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -376,7 +376,6 @@
       "version": "0.1.0",
       "devDependencies": {
         "@effect/language-service": "catalog:effect",
-        "@effect/vitest": "4.0.0-beta.93",
         "@maple/domain": "workspace:*",
         "@types/node": "catalog:tooling",
         "alchemy": "2.0.0-beta.61",

--- a/examples/alchemy-maple/README.md
+++ b/examples/alchemy-maple/README.md
@@ -1,0 +1,14 @@
+# alchemy-maple example
+
+Declares Maple resources (a Slack alert destination, two alert rules, a dashboard, a scoped API key, and the org ingest keys) as infrastructure-as-code via [`@maple-dev/alchemy`](../../lib/alchemy-maple).
+
+```bash
+# one-time: build the provider package
+bun run --cwd ../../lib/alchemy-maple build
+
+# deploy (needs an org-admin maple_ak_… key; MAPLE_API_URL to target non-prod)
+MAPLE_API_KEY=maple_ak_… SLACK_WEBHOOK_URL=https://hooks.slack.com/… bun alchemy deploy
+
+# tear down
+MAPLE_API_KEY=maple_ak_… bun alchemy destroy
+```

--- a/examples/alchemy-maple/alchemy.run.ts
+++ b/examples/alchemy-maple/alchemy.run.ts
@@ -1,0 +1,69 @@
+/**
+ * Example stack: Maple observability resources as infrastructure-as-code.
+ *
+ * Run with a Maple API key (org-admin, or scope it to what you declare):
+ *
+ *   MAPLE_API_KEY=maple_ak_… bun alchemy deploy
+ *
+ * Requires `@maple-dev/alchemy` to be built first (`bun run --cwd ../../lib/alchemy-maple build`).
+ */
+import * as Alchemy from "alchemy"
+import * as Maple from "@maple-dev/alchemy"
+import { Effect } from "effect"
+
+export default Alchemy.Stack(
+	"maple-example",
+	{ providers: Maple.providers() },
+	Effect.gen(function* () {
+		// A Slack notification channel. The webhook URL is write-only server-side.
+		const slack = yield* Maple.AlertDestination("oncall-slack", {
+			type: "slack",
+			name: "On-call Slack",
+			webhook_url: process.env.SLACK_WEBHOOK_URL ?? "https://hooks.slack.com/services/CHANGE/ME/PLEASE",
+			channel_label: "#incidents",
+		})
+
+		// An error-rate alert delivering to it — Alchemy orders the dependency.
+		yield* Maple.AlertRule("checkout-error-rate", {
+			name: "Checkout error rate",
+			severity: "critical",
+			signal_type: "error_rate",
+			comparator: "gt",
+			threshold: 0.05,
+			window_minutes: 5,
+			service_names: ["checkout"],
+			destination_ids: [slack.destinationId],
+		})
+
+		// A latency alert on the same channel.
+		yield* Maple.AlertRule("checkout-p95", {
+			name: "Checkout p95 latency",
+			severity: "warning",
+			signal_type: "p95_latency",
+			comparator: "gt",
+			threshold: 750,
+			window_minutes: 10,
+			service_names: ["checkout"],
+			destination_ids: [slack.destinationId],
+		})
+
+		// A dashboard shell (widgets are the v2 wire shape — see /v2/docs).
+		yield* Maple.Dashboard("service-health", {
+			name: "Service health",
+			description: "Golden signals for the checkout service",
+			tags: ["golden-signals"],
+			time_range: { type: "relative", value: "12h" },
+		})
+
+		// A scoped CI key; the secret is minted once and kept in Alchemy state.
+		const ciKey = yield* Maple.ApiKey("ci-key", {
+			name: "ci-pipeline",
+			scopes: ["dashboards:write"],
+		})
+
+		// The org's ingest keys, as Redacted outputs for other resources.
+		const ingest = yield* Maple.IngestKeys("ingest")
+
+		return { ciKeyId: ciKey.keyId, ingestRotatedAt: ingest.publicRotatedAt }
+	}),
+)

--- a/examples/alchemy-maple/package.json
+++ b/examples/alchemy-maple/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@maple-examples/alchemy",
+	"private": true,
+	"type": "module",
+	"description": "Example: declaring Maple resources (dashboards, alerts, keys) in alchemy.run.ts via @maple-dev/alchemy",
+	"devDependencies": {
+		"@maple-dev/alchemy": "workspace:*",
+		"alchemy": "2.0.0-beta.61",
+		"effect": "catalog:effect",
+		"typescript": "catalog:tooling"
+	}
+}

--- a/lib/alchemy-maple/README.md
+++ b/lib/alchemy-maple/README.md
@@ -1,0 +1,88 @@
+# @maple-dev/alchemy
+
+[Alchemy](https://alchemy.run) provider for [Maple](https://maple.dev) resources. Declare Maple API keys, ingest keys, dashboards, alert destinations, and alert rules in your `alchemy.run.ts` — right next to the infrastructure they observe.
+
+```bash
+npm install @maple-dev/alchemy alchemy effect
+```
+
+## Usage
+
+```typescript
+import * as Alchemy from "alchemy"
+import * as Cloudflare from "alchemy/Cloudflare"
+import * as Maple from "@maple-dev/alchemy"
+import { Effect, Layer } from "effect"
+
+export default Alchemy.Stack(
+	"my-app",
+	{ providers: Layer.mergeAll(Cloudflare.providers(), Maple.providers()) },
+	Effect.gen(function* () {
+		// A notification channel…
+		const slack = yield* Maple.AlertDestination("oncall", {
+			type: "slack",
+			name: "On-call Slack",
+			webhook_url: process.env.SLACK_WEBHOOK_URL!,
+			channel_label: "#incidents",
+		})
+
+		// …an alert rule that delivers to it (dependency resolved automatically)…
+		yield* Maple.AlertRule("checkout-errors", {
+			name: "Checkout error rate",
+			severity: "critical",
+			signal_type: "error_rate",
+			comparator: "gt",
+			threshold: 0.05, // error rates are 0–1 ratios
+			window_minutes: 5,
+			destination_ids: [slack.destinationId],
+		})
+
+		// …a dashboard…
+		yield* Maple.Dashboard("service-health", {
+			name: "Service health",
+			tags: ["golden-signals"],
+			time_range: { type: "relative", value: "12h" },
+		})
+
+		// …a scoped API key (secret captured once, kept in Alchemy state)…
+		const key = yield* Maple.ApiKey("ci", {
+			name: "ci-pipeline",
+			scopes: ["dashboards:write"],
+		})
+
+		// …and your org's ingest keys as outputs for other resources.
+		const ingest = yield* Maple.IngestKeys("ingest")
+		// e.g. env: { MAPLE_INGEST_KEY: ingest.privateKey }
+	}),
+)
+```
+
+```bash
+MAPLE_API_KEY=maple_ak_… alchemy deploy
+```
+
+## Authentication
+
+Set `MAPLE_API_KEY` to a Maple API key (create one in the Maple dashboard, or with this provider). Requirements:
+
+- **Dashboards** need the `dashboards:write` scope.
+- **Alert rules & destinations** need `alerts:write` **and** an org-admin key.
+- **API keys & ingest keys** need `api_keys:write` / `ingest_keys:read` **and** an org-admin key.
+
+`MAPLE_API_URL` overrides the API base URL (defaults to `https://api.maple.dev`). To source configuration differently, provide your own `Maple.MapleEnvironment` layer.
+
+## Resources
+
+| Resource | Semantics |
+| --- | --- |
+| `Maple.Dashboard` | Full CRUD. Props are the v2 wire shape (`snake_case`, see `/v2/docs`); widget/variable documents pass through verbatim. Updates PATCH in place. |
+| `Maple.AlertDestination` | Full CRUD. Discriminated on `type` (slack, pagerduty, webhook, hazel, discord, email). Channel secrets are write-only — accept `Redacted` values. Changing `type` replaces the destination. |
+| `Maple.AlertRule` | Full CRUD. `destination_ids` accepts outputs from `Maple.AlertDestination`. Rule names are org-unique, so lost state is re-adopted by name instead of duplicating. |
+| `Maple.ApiKey` | Create / roll / revoke (the API has no key update). Changing props replaces the key; bumping the `rotate` prop rolls it in place (same name/scopes, new secret). `secret` is captured once and preserved in Alchemy state — it can never be re-read from the API. |
+| `Maple.IngestKeys` | Read-only per-org singleton. Surfaces `publicKey` / `privateKey` as `Redacted` outputs; delete only stops tracking it. |
+
+## Notes
+
+- Store your Alchemy state somewhere durable: the `ApiKey.secret` output lives only there.
+- The client retries 429/5xx with bounded exponential backoff (the v2 API allows 600 requests per 60s per key).
+- Deleting an `AlertDestination` fails with a conflict while alert rules still reference it — Alchemy's dependency ordering handles this automatically when the rule is declared in the same stack.

--- a/lib/alchemy-maple/package.json
+++ b/lib/alchemy-maple/package.json
@@ -21,7 +21,6 @@
 	},
 	"devDependencies": {
 		"@effect/language-service": "catalog:effect",
-		"@effect/vitest": "4.0.0-beta.93",
 		"@maple/domain": "workspace:*",
 		"@types/node": "catalog:tooling",
 		"alchemy": "2.0.0-beta.61",

--- a/lib/alchemy-maple/package.json
+++ b/lib/alchemy-maple/package.json
@@ -1,0 +1,37 @@
+{
+	"name": "@maple-dev/alchemy",
+	"version": "0.1.0",
+	"description": "Alchemy provider for Maple resources — declare API keys, ingest keys, dashboards, alert destinations, and alert rules in your alchemy.run.ts",
+	"license": "MIT",
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.mts",
+			"import": "./dist/index.mjs"
+		}
+	},
+	"scripts": {
+		"build": "tsdown",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run"
+	},
+	"devDependencies": {
+		"@effect/language-service": "catalog:effect",
+		"@effect/vitest": "4.0.0-beta.93",
+		"@maple/domain": "workspace:*",
+		"@types/node": "catalog:tooling",
+		"alchemy": "2.0.0-beta.61",
+		"effect": "catalog:effect",
+		"tsdown": "^0.21.7",
+		"typescript": "catalog:tooling",
+		"vitest": "catalog:"
+	},
+	"peerDependencies": {
+		"alchemy": ">=2.0.0-beta.61 <3",
+		"effect": ">=4.0.0-beta.93 || >=4.0.0"
+	}
+}

--- a/lib/alchemy-maple/src/AlertDestination.ts
+++ b/lib/alchemy-maple/src/AlertDestination.ts
@@ -1,0 +1,195 @@
+import { Schema } from "effect"
+import * as Effect from "effect/Effect"
+import * as Redacted from "effect/Redacted"
+import { deepEqual, isResolved } from "alchemy/Diff"
+import * as Provider from "alchemy/Provider"
+import { Resource } from "alchemy/Resource"
+import { listAll, MapleApi } from "./MapleApi"
+import type { Providers } from "./Providers"
+
+/** A write-only channel secret: plain string or `Redacted` (recommended). */
+type SecretInput = string | Redacted.Redacted<string>
+
+interface DestinationBaseProps {
+	/** Human-readable label for the destination. */
+	name: string
+	/** Whether the destination starts enabled. Defaults to `true`. */
+	enabled?: boolean
+}
+
+/**
+ * Alert destination props, discriminated on `type` — mirrors the v2
+ * `POST /v2/alerts/destinations` body. Channel secrets are write-only:
+ * the API never returns them, so drift on secret fields is detected from
+ * prop changes only.
+ */
+export type AlertDestinationProps =
+	| (DestinationBaseProps & { type: "slack"; webhook_url: SecretInput; channel_label?: string })
+	| (DestinationBaseProps & { type: "pagerduty"; integration_key: SecretInput })
+	| (DestinationBaseProps & { type: "webhook"; url: string; signing_secret?: SecretInput })
+	| (DestinationBaseProps & { type: "hazel"; webhook_url: SecretInput; signing_secret?: SecretInput })
+	| (DestinationBaseProps & { type: "discord"; webhook_url: SecretInput })
+	| (DestinationBaseProps & { type: "email"; member_user_ids: string[] })
+
+export type AlertDestination = Resource<
+	"Maple.AlertDestination",
+	AlertDestinationProps,
+	{
+		/** The `dest_…` public ID — reference it from `Maple.AlertRule` `destination_ids`. */
+		destinationId: string
+		name: string
+		type: string
+		enabled: boolean
+	},
+	never,
+	Providers
+>
+
+/**
+ * A notification channel (Slack, PagerDuty, webhook, Hazel, Discord, or
+ * workspace-member email) that `Maple.AlertRule`s deliver to.
+ *
+ * @example
+ * ```typescript
+ * const slack = yield* Maple.AlertDestination("oncall", {
+ *   type: "slack",
+ *   name: "On-call Slack",
+ *   webhook_url: Redacted.make(process.env.SLACK_WEBHOOK_URL!),
+ *   channel_label: "#incidents",
+ * })
+ * ```
+ */
+export const AlertDestination = Resource<AlertDestination>("Maple.AlertDestination")
+
+const WireDestination = Schema.Struct({
+	id: Schema.String,
+	name: Schema.String,
+	type: Schema.String,
+	enabled: Schema.Boolean,
+	channel_label: Schema.NullOr(Schema.String),
+})
+const decodeWireDestination = Schema.decodeUnknownEffect(WireDestination)
+
+const unwrap = (value: SecretInput): string => (Redacted.isRedacted(value) ? Redacted.value(value) : value)
+
+/** The create/update body: all declared props, secrets unwrapped. */
+const desiredBody = (props: AlertDestinationProps): Record<string, unknown> => {
+	const body: Record<string, unknown> = { type: props.type, name: props.name }
+	if (props.enabled !== undefined) body.enabled = props.enabled
+	switch (props.type) {
+		case "slack":
+			body.webhook_url = unwrap(props.webhook_url)
+			if (props.channel_label !== undefined) body.channel_label = props.channel_label
+			break
+		case "pagerduty":
+			body.integration_key = unwrap(props.integration_key)
+			break
+		case "webhook":
+			body.url = props.url
+			if (props.signing_secret !== undefined) body.signing_secret = unwrap(props.signing_secret)
+			break
+		case "hazel":
+			body.webhook_url = unwrap(props.webhook_url)
+			if (props.signing_secret !== undefined) body.signing_secret = unwrap(props.signing_secret)
+			break
+		case "discord":
+			body.webhook_url = unwrap(props.webhook_url)
+			break
+		case "email":
+			body.member_user_ids = props.member_user_ids
+			break
+	}
+	return body
+}
+
+/**
+ * Observable drift only — secrets are write-only, so the server can never
+ * disagree with them; they change via prop changes (caught in `diff`).
+ */
+const drifted = (props: AlertDestinationProps, observed: Schema.Schema.Type<typeof WireDestination>): boolean =>
+	props.name !== observed.name ||
+	(props.enabled ?? true) !== observed.enabled ||
+	(props.type === "slack" &&
+		props.channel_label !== undefined &&
+		props.channel_label !== (observed.channel_label ?? undefined))
+
+const toAttributes = (observed: Schema.Schema.Type<typeof WireDestination>) => ({
+	destinationId: observed.id,
+	name: observed.name,
+	type: observed.type,
+	enabled: observed.enabled,
+})
+
+export const AlertDestinationProvider = () =>
+	Provider.effect(
+		AlertDestination,
+		Effect.gen(function* () {
+			const api = yield* MapleApi
+			return {
+				stables: ["destinationId" as const],
+				diff: Effect.fn(function* ({ news, olds, output }) {
+					if (!isResolved(news)) return undefined
+					// `type` is immutable server-side — changing it replaces the destination.
+					if ((output?.type ?? olds?.type) !== undefined && news.type !== (output?.type ?? olds?.type)) {
+						return { action: "replace" } as const
+					}
+					if (olds !== undefined && !deepEqual(olds, news, { stripNullish: true })) {
+						return { action: "update", stables: ["destinationId"] } as const
+					}
+					return undefined
+				}),
+				reconcile: Effect.fn(function* ({ news, olds, output }) {
+					// Observe — re-fetch by id; recover from out-of-band deletes.
+					let observed: Schema.Schema.Type<typeof WireDestination> | undefined
+					if (output?.destinationId) {
+						const fetched = yield* api
+							.get(`/v2/alerts/destinations/${output.destinationId}`)
+							.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.succeed(undefined)))
+						if (fetched !== undefined) observed = yield* decodeWireDestination(fetched)
+					}
+
+					// Ensure — create if missing.
+					if (observed === undefined) {
+						const created = yield* api.post("/v2/alerts/destinations", desiredBody(news))
+						observed = yield* decodeWireDestination(created)
+					} else if (
+						drifted(news, observed) ||
+						olds === undefined ||
+						!deepEqual(olds, news, { stripNullish: true })
+					) {
+						// Sync — PATCH when observable fields drift OR declared props changed
+						// (write-only secrets can only be pushed, never compared).
+						const updated = yield* api.patch(
+							`/v2/alerts/destinations/${observed.id}`,
+							desiredBody(news),
+						)
+						observed = yield* decodeWireDestination(updated)
+					}
+
+					return toAttributes(observed)
+				}),
+				delete: Effect.fn(function* ({ output }) {
+					yield* api
+						.delete(`/v2/alerts/destinations/${output.destinationId}`)
+						.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.void))
+				}),
+				read: Effect.fn(function* ({ output }) {
+					if (!output?.destinationId) return undefined
+					const fetched = yield* api
+						.get(`/v2/alerts/destinations/${output.destinationId}`)
+						.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.succeed(undefined)))
+					if (fetched === undefined) return undefined
+					return toAttributes(yield* decodeWireDestination(fetched))
+				}),
+				list: Effect.fn(function* () {
+					const items = yield* listAll(api, "/v2/alerts/destinations")
+					return yield* Effect.forEach(items, (item) =>
+						Effect.map(decodeWireDestination(item), toAttributes),
+					)
+				}),
+			}
+		}),
+	)
+
+/** @internal Exposed for the in-repo contract test against `@maple/domain`. */
+export const _alertDestinationCreateBody = desiredBody

--- a/lib/alchemy-maple/src/AlertRule.ts
+++ b/lib/alchemy-maple/src/AlertRule.ts
@@ -1,0 +1,202 @@
+import { Schema } from "effect"
+import * as Effect from "effect/Effect"
+import { deepEqual, isResolved } from "alchemy/Diff"
+import * as Provider from "alchemy/Provider"
+import { Resource } from "alchemy/Resource"
+import { listAll, MapleApi } from "./MapleApi"
+import type { Providers } from "./Providers"
+
+export type AlertSignalType =
+	| "error_rate"
+	| "p95_latency"
+	| "p99_latency"
+	| "apdex"
+	| "throughput"
+	| "metric"
+	| "builder_query"
+	| "raw_query"
+
+export type AlertComparator = "gt" | "gte" | "lt" | "lte" | "eq" | "neq" | "between" | "not_between"
+
+/**
+ * Alert rule props, authored in the v2 wire shape — mirrors
+ * `POST /v2/alerts/rules`. Signal-specific fields (`metric_*`,
+ * `apdex_threshold_ms`, `query_builder_draft`, `raw_query_*`) are validated
+ * server-side against `signal_type`.
+ */
+export interface AlertRuleProps {
+	/** Rule name — unique per organization. */
+	name: string
+	severity: "warning" | "critical"
+	signal_type: AlertSignalType
+	comparator: AlertComparator
+	/** Error rates are 0–1 ratios. */
+	threshold: number
+	window_minutes: number
+	/** `dest_…` IDs — pass `destination.destinationId` outputs from `Maple.AlertDestination`. */
+	destination_ids: string[]
+	notes?: string | null
+	enabled?: boolean
+	service_names?: string[]
+	exclude_service_names?: string[]
+	tags?: string[]
+	group_by?: string[] | null
+	threshold_upper?: number | null
+	minimum_sample_count?: number
+	consecutive_breaches_required?: number
+	consecutive_healthy_required?: number
+	renotify_interval_minutes?: number
+	metric_name?: string | null
+	metric_type?: "sum" | "gauge" | "histogram" | "exponential_histogram" | null
+	metric_aggregation?: "avg" | "min" | "max" | "sum" | "count" | null
+	apdex_threshold_ms?: number | null
+	/** Opaque query-builder draft for `builder_query` rules (verbatim passthrough). */
+	query_builder_draft?: Record<string, unknown> | null
+	raw_query_sql?: string | null
+	raw_query_reducer?: "identity" | "sum" | "avg" | "min" | "max" | null
+	notification_template?: Record<string, unknown> | null
+}
+
+export type AlertRule = Resource<
+	"Maple.AlertRule",
+	AlertRuleProps,
+	{
+		/** The `alrt_…` public ID. */
+		ruleId: string
+		name: string
+		enabled: boolean
+	},
+	never,
+	Providers
+>
+
+/**
+ * A Maple alert rule managed through the public v2 API. Reference the
+ * destinations it notifies by their `dest_…` IDs — typically outputs of
+ * `Maple.AlertDestination` resources, which Alchemy resolves and orders
+ * automatically.
+ *
+ * @example
+ * ```typescript
+ * const slack = yield* Maple.AlertDestination("oncall", { ... })
+ * yield* Maple.AlertRule("checkout-errors", {
+ *   name: "Checkout error rate",
+ *   severity: "critical",
+ *   signal_type: "error_rate",
+ *   comparator: "gt",
+ *   threshold: 0.05,
+ *   window_minutes: 5,
+ *   destination_ids: [slack.destinationId],
+ * })
+ * ```
+ */
+export const AlertRule = Resource<AlertRule>("Maple.AlertRule")
+
+const WireRule = Schema.Struct({
+	id: Schema.String,
+	name: Schema.String,
+	enabled: Schema.Boolean,
+})
+const decodeWireRule = Schema.decodeUnknownEffect(WireRule)
+
+/** The create/update body: exactly the props the user declared. */
+const desiredBody = (props: AlertRuleProps): Record<string, unknown> => {
+	const body: Record<string, unknown> = {}
+	for (const [key, value] of Object.entries(props)) {
+		if (value !== undefined) body[key] = value
+	}
+	return body
+}
+
+/** Wire drift compare: declared fields vs the observed wire rule. */
+const drifted = (props: AlertRuleProps, observed: Record<string, unknown>): boolean => {
+	const body = desiredBody(props)
+	return Object.keys(body).some((key) => !deepEqual(body[key], observed[key], { stripNullish: true }))
+}
+
+const toAttributes = (observed: Schema.Schema.Type<typeof WireRule>) => ({
+	ruleId: observed.id,
+	name: observed.name,
+	enabled: observed.enabled,
+})
+
+export const AlertRuleProvider = () =>
+	Provider.effect(
+		AlertRule,
+		Effect.gen(function* () {
+			const api = yield* MapleApi
+
+			/** Rule names are org-unique — adopt an existing rule with the same name. */
+			const findByName = (name: string) =>
+				Effect.gen(function* () {
+					const items = yield* listAll(api, "/v2/alerts/rules")
+					const match = items.find(
+						(item) => typeof item === "object" && item !== null && (item as { name?: unknown }).name === name,
+					)
+					return match === undefined ? undefined : yield* decodeWireRule(match)
+				})
+
+			return {
+				stables: ["ruleId" as const],
+				diff: Effect.fn(function* ({ news, olds }) {
+					if (!isResolved(news)) return undefined
+					if (olds !== undefined && !deepEqual(olds, news, { stripNullish: true })) {
+						return { action: "update", stables: ["ruleId"] } as const
+					}
+					return undefined
+				}),
+				reconcile: Effect.fn(function* ({ news, output }) {
+					// Observe — re-fetch by id, falling back to the org-unique name so we
+					// recover from partial state-persistence failures without duplicating.
+					let observedRaw: unknown
+					if (output?.ruleId) {
+						observedRaw = yield* api
+							.get(`/v2/alerts/rules/${output.ruleId}`)
+							.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.succeed(undefined)))
+					}
+					if (observedRaw === undefined) {
+						const adopted = yield* findByName(news.name)
+						if (adopted !== undefined) {
+							observedRaw = yield* api.get(`/v2/alerts/rules/${adopted.id}`)
+						}
+					}
+
+					// Ensure — create if missing.
+					if (observedRaw === undefined) {
+						observedRaw = yield* api.post("/v2/alerts/rules", desiredBody(news))
+					} else if (drifted(news, observedRaw as Record<string, unknown>)) {
+						// Sync — PATCH only on drift of declared fields.
+						const current = yield* decodeWireRule(observedRaw)
+						observedRaw = yield* api.patch(`/v2/alerts/rules/${current.id}`, desiredBody(news))
+					}
+
+					return toAttributes(yield* decodeWireRule(observedRaw))
+				}),
+				delete: Effect.fn(function* ({ output }) {
+					yield* api
+						.delete(`/v2/alerts/rules/${output.ruleId}`)
+						.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.void))
+				}),
+				read: Effect.fn(function* ({ olds, output }) {
+					if (output?.ruleId) {
+						const fetched = yield* api
+							.get(`/v2/alerts/rules/${output.ruleId}`)
+							.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.succeed(undefined)))
+						if (fetched !== undefined) return toAttributes(yield* decodeWireRule(fetched))
+					}
+					if (olds?.name !== undefined) {
+						const adopted = yield* findByName(olds.name)
+						if (adopted !== undefined) return toAttributes(adopted)
+					}
+					return undefined
+				}),
+				list: Effect.fn(function* () {
+					const items = yield* listAll(api, "/v2/alerts/rules")
+					return yield* Effect.forEach(items, (item) => Effect.map(decodeWireRule(item), toAttributes))
+				}),
+			}
+		}),
+	)
+
+/** @internal Exposed for the in-repo contract test against `@maple/domain`. */
+export const _alertRuleCreateBody = desiredBody

--- a/lib/alchemy-maple/src/ApiKey.ts
+++ b/lib/alchemy-maple/src/ApiKey.ts
@@ -1,0 +1,186 @@
+import { Schema } from "effect"
+import * as Effect from "effect/Effect"
+import * as Redacted from "effect/Redacted"
+import { deepEqual, isResolved } from "alchemy/Diff"
+import * as Provider from "alchemy/Provider"
+import { Resource } from "alchemy/Resource"
+import { listAll, MapleApi } from "./MapleApi"
+import type { Providers } from "./Providers"
+
+/**
+ * API key props — mirrors `POST /v2/api_keys`. The v2 API has no update
+ * endpoint for keys, so changing `name`/`description`/`scopes`/`kind`/
+ * `expires_in_seconds` **replaces** the key (new ID + secret); bumping
+ * `rotate` rolls it in place via `POST /v2/api_keys/:id/roll` (preserves
+ * name/scopes, mints a new secret).
+ */
+export interface ApiKeyProps {
+	name: string
+	description?: string
+	/** e.g. `["dashboards:write", "alerts:read"]`; omit for full access. */
+	scopes?: string[]
+	/** Defaults to `standard`. `mcp` keys are only valid for the MCP server. */
+	kind?: "standard" | "mcp"
+	expires_in_seconds?: number
+	/** Bump (e.g. `1` → `2`) to roll the key: same name/scopes, new secret. */
+	rotate?: number | string
+}
+
+export type ApiKey = Resource<
+	"Maple.ApiKey",
+	ApiKeyProps,
+	{
+		/** The `key_…` public ID. */
+		keyId: string
+		name: string
+		keyPrefix: string
+		/**
+		 * The full `maple_ak_…` secret, captured at create/roll — the API never
+		 * returns it again, so it is preserved in Alchemy state across deploys.
+		 */
+		secret: Redacted.Redacted<string>
+	},
+	never,
+	Providers
+>
+
+/**
+ * A Maple API key managed through the public v2 API. Requires the deploy
+ * credential to be backed by an org admin.
+ *
+ * @example
+ * ```typescript
+ * const key = yield* Maple.ApiKey("ci", {
+ *   name: "ci-pipeline",
+ *   scopes: ["dashboards:write"],
+ * })
+ * // key.secret is a Redacted<string> — pass it into another resource's env.
+ * ```
+ */
+export const ApiKey = Resource<ApiKey>("Maple.ApiKey")
+
+const WireApiKey = Schema.Struct({
+	id: Schema.String,
+	name: Schema.String,
+	key_prefix: Schema.String,
+	revoked: Schema.Boolean,
+})
+const decodeWireApiKey = Schema.decodeUnknownEffect(WireApiKey)
+
+const WireApiKeyWithSecret = Schema.Struct({
+	...WireApiKey.fields,
+	secret: Schema.String,
+})
+const decodeWireApiKeyWithSecret = Schema.decodeUnknownEffect(WireApiKeyWithSecret)
+
+const createBody = (props: ApiKeyProps): Record<string, unknown> => {
+	const body: Record<string, unknown> = { name: props.name }
+	if (props.description !== undefined) body.description = props.description
+	if (props.scopes !== undefined) body.scopes = props.scopes
+	if (props.kind !== undefined) body.kind = props.kind
+	if (props.expires_in_seconds !== undefined) body.expires_in_seconds = props.expires_in_seconds
+	return body
+}
+
+const fromSecretResponse = (wire: Schema.Schema.Type<typeof WireApiKeyWithSecret>) => ({
+	keyId: wire.id,
+	name: wire.name,
+	keyPrefix: wire.key_prefix,
+	secret: Redacted.make(wire.secret),
+})
+
+export const ApiKeyProvider = () =>
+	Provider.effect(
+		ApiKey,
+		Effect.gen(function* () {
+			const api = yield* MapleApi
+			return {
+				diff: Effect.fn(function* ({ news, olds }) {
+					if (!isResolved(news)) return undefined
+					if (olds === undefined) return undefined
+					const { rotate: oldRotate, ...oldRest } = olds
+					const { rotate: newRotate, ...newRest } = news
+					// No PATCH endpoint: any non-rotate change replaces the key.
+					if (!deepEqual(oldRest, newRest, { stripNullish: true })) {
+						return { action: "replace" } as const
+					}
+					if (oldRotate !== newRotate) {
+						return { action: "update", stables: [] } as const
+					}
+					return undefined
+				}),
+				reconcile: Effect.fn(function* ({ news, olds, output }) {
+					// Observe — confirm the key still exists and is not revoked.
+					let observed: Schema.Schema.Type<typeof WireApiKey> | undefined
+					if (output?.keyId) {
+						const fetched = yield* api
+							.get(`/v2/api_keys/${output.keyId}`)
+							.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.succeed(undefined)))
+						if (fetched !== undefined) {
+							const wire = yield* decodeWireApiKey(fetched)
+							if (!wire.revoked) observed = wire
+						}
+					}
+
+					// Ensure — create if missing/revoked. The secret is returned exactly
+					// once; it lives in Alchemy state from here on.
+					if (observed === undefined || output === undefined) {
+						const created = yield* api.post("/v2/api_keys", createBody(news))
+						return fromSecretResponse(yield* decodeWireApiKeyWithSecret(created))
+					}
+
+					// Roll — `rotate` bumped: replace the secret in place.
+					if (olds !== undefined && olds.rotate !== news.rotate) {
+						const rolled = yield* api.post(`/v2/api_keys/${observed.id}/roll`)
+						return fromSecretResponse(yield* decodeWireApiKeyWithSecret(rolled))
+					}
+
+					// Steady state — preserve the stored secret (GET never returns it).
+					return {
+						keyId: observed.id,
+						name: observed.name,
+						keyPrefix: observed.key_prefix,
+						secret: output.secret,
+					}
+				}),
+				delete: Effect.fn(function* ({ output }) {
+					yield* api
+						.delete(`/v2/api_keys/${output.keyId}`)
+						.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.void))
+				}),
+				read: Effect.fn(function* ({ output }) {
+					if (!output?.keyId) return undefined
+					const fetched = yield* api
+						.get(`/v2/api_keys/${output.keyId}`)
+						.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.succeed(undefined)))
+					if (fetched === undefined) return undefined
+					const wire = yield* decodeWireApiKey(fetched)
+					if (wire.revoked) return undefined
+					return {
+						keyId: wire.id,
+						name: wire.name,
+						keyPrefix: wire.key_prefix,
+						// The API never returns the secret; keep the state's copy.
+						secret: output.secret,
+					}
+				}),
+				list: Effect.fn(function* () {
+					const items = yield* listAll(api, "/v2/api_keys")
+					const wires = yield* Effect.forEach(items, (item) => decodeWireApiKey(item))
+					// Secrets are unrecoverable via list — empty placeholder (list only
+					// powers enumeration/nuke, which needs IDs, not secrets).
+					return wires
+						.filter((wire) => !wire.revoked)
+						.map((wire) => ({
+							keyId: wire.id,
+							name: wire.name,
+							keyPrefix: wire.key_prefix,
+							secret: Redacted.make(""),
+						}))
+				}),
+			}
+		}),
+	)
+
+/** @internal Exposed for the in-repo contract test against `@maple/domain`. */
+export const _apiKeyCreateBody = createBody

--- a/lib/alchemy-maple/src/Dashboard.ts
+++ b/lib/alchemy-maple/src/Dashboard.ts
@@ -1,0 +1,145 @@
+import { Schema } from "effect"
+import * as Effect from "effect/Effect"
+import { deepEqual, isResolved } from "alchemy/Diff"
+import * as Provider from "alchemy/Provider"
+import { Resource } from "alchemy/Resource"
+import { listAll, MapleApi } from "./MapleApi"
+import type { Providers } from "./Providers"
+
+/**
+ * Dashboard props, authored in the v2 wire shape (snake_case, exactly as
+ * documented at `/v2/docs`). `widgets`, `variables`, and `time_range` are
+ * passed through verbatim.
+ */
+export interface DashboardProps {
+	/** Dashboard name (unique-ish label shown in the UI). */
+	name: string
+	description?: string | null
+	tags?: string[]
+	/** e.g. `{ type: "relative", value: "12h" }`. */
+	time_range?: Record<string, unknown>
+	widgets?: Array<Record<string, unknown>>
+	variables?: Array<Record<string, unknown>>
+}
+
+export type Dashboard = Resource<
+	"Maple.Dashboard",
+	DashboardProps,
+	{
+		/** The `dash_…` public ID. */
+		dashboardId: string
+		name: string
+	},
+	never,
+	Providers
+>
+
+/**
+ * A Maple dashboard managed through the public v2 API.
+ *
+ * @example
+ * ```typescript
+ * const dash = yield* Maple.Dashboard("service-health", {
+ *   name: "Service health",
+ *   widgets: [...],
+ * })
+ * ```
+ */
+export const Dashboard = Resource<Dashboard>("Maple.Dashboard")
+
+/** Decode just the wire fields the provider stores/compares. */
+const WireDashboard = Schema.Struct({
+	id: Schema.String,
+	name: Schema.String,
+	description: Schema.NullOr(Schema.String),
+	tags: Schema.Array(Schema.String),
+	time_range: Schema.Record(Schema.String, Schema.Unknown),
+	widgets: Schema.Array(Schema.Record(Schema.String, Schema.Unknown)),
+	variables: Schema.Array(Schema.Record(Schema.String, Schema.Unknown)),
+})
+const decodeWireDashboard = Schema.decodeUnknownEffect(WireDashboard)
+
+/** The request body for create/update: exactly the props the user set. */
+const desiredBody = (props: DashboardProps) => ({
+	name: props.name,
+	...(props.description !== undefined ? { description: props.description } : {}),
+	...(props.tags !== undefined ? { tags: props.tags } : {}),
+	...(props.time_range !== undefined ? { time_range: props.time_range } : {}),
+	...(props.widgets !== undefined ? { widgets: props.widgets } : {}),
+	...(props.variables !== undefined ? { variables: props.variables } : {}),
+})
+
+/** Compare only the fields the user declared against the observed wire object. */
+const drifted = (props: DashboardProps, observed: Schema.Schema.Type<typeof WireDashboard>): boolean => {
+	const body = desiredBody(props) as Record<string, unknown>
+	return Object.keys(body).some(
+		(key) => !deepEqual(body[key], (observed as unknown as Record<string, unknown>)[key], { stripNullish: true }),
+	)
+}
+
+const toAttributes = (observed: Schema.Schema.Type<typeof WireDashboard>) => ({
+	dashboardId: observed.id,
+	name: observed.name,
+})
+
+export const DashboardProvider = () =>
+	Provider.effect(
+		Dashboard,
+		Effect.gen(function* () {
+			const api = yield* MapleApi
+			return {
+				stables: ["dashboardId" as const],
+				diff: Effect.fn(function* ({ news, olds }) {
+					if (!isResolved(news)) return undefined
+					if (olds !== undefined && !deepEqual(olds, news, { stripNullish: true })) {
+						return { action: "update", stables: ["dashboardId"] } as const
+					}
+					return undefined
+				}),
+				reconcile: Effect.fn(function* ({ news, output }) {
+					// Observe — re-fetch by id; recover from out-of-band deletes.
+					let observed: Schema.Schema.Type<typeof WireDashboard> | undefined
+					if (output?.dashboardId) {
+						const fetched = yield* api
+							.get(`/v2/dashboards/${output.dashboardId}`)
+							.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.succeed(undefined)))
+						if (fetched !== undefined) observed = yield* decodeWireDashboard(fetched)
+					}
+
+					// Ensure — create if missing.
+					if (observed === undefined) {
+						const created = yield* api.post("/v2/dashboards", desiredBody(news))
+						observed = yield* decodeWireDashboard(created)
+					} else if (drifted(news, observed)) {
+						// Sync — PATCH only when the declared fields drift.
+						const updated = yield* api.patch(`/v2/dashboards/${observed.id}`, desiredBody(news))
+						observed = yield* decodeWireDashboard(updated)
+					}
+
+					return toAttributes(observed)
+				}),
+				delete: Effect.fn(function* ({ output }) {
+					yield* api
+						.delete(`/v2/dashboards/${output.dashboardId}`)
+						.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.void))
+				}),
+				read: Effect.fn(function* ({ output }) {
+					if (!output?.dashboardId) return undefined
+					const fetched = yield* api
+						.get(`/v2/dashboards/${output.dashboardId}`)
+						.pipe(Effect.catchTag("Maple::NotFoundError", () => Effect.succeed(undefined)))
+					if (fetched === undefined) return undefined
+					return toAttributes(yield* decodeWireDashboard(fetched))
+				}),
+				list: Effect.fn(function* () {
+					const items = yield* listAll(api, "/v2/dashboards")
+					return yield* Effect.forEach(items, (item) =>
+						Effect.map(decodeWireDashboard(item), toAttributes),
+					)
+				}),
+			}
+		}),
+	)
+
+/** @internal Exposed for the in-repo contract test against `@maple/domain`. */
+export const _dashboardCreateBody = desiredBody

--- a/lib/alchemy-maple/src/IngestKeys.ts
+++ b/lib/alchemy-maple/src/IngestKeys.ts
@@ -1,0 +1,78 @@
+import { Schema } from "effect"
+import * as Effect from "effect/Effect"
+import * as Redacted from "effect/Redacted"
+import * as Provider from "alchemy/Provider"
+import { Resource } from "alchemy/Resource"
+import { MapleApi } from "./MapleApi"
+import type { Providers } from "./Providers"
+
+/**
+ * The org's telemetry ingest keys — a per-organization **singleton** the API
+ * creates lazily on first access. This resource only observes it (making the
+ * keys available as outputs); rolling is deliberately not modeled yet since
+ * a roll immediately invalidates the previous key for all senders.
+ */
+export interface IngestKeysProps {}
+
+export type IngestKeys = Resource<
+	"Maple.IngestKeys",
+	IngestKeysProps,
+	{
+		/** The `maple_pk_…` public ingest key (safe for client-side senders). */
+		publicKey: Redacted.Redacted<string>
+		/** The `maple_sk_…` private ingest key (server-side senders only). */
+		privateKey: Redacted.Redacted<string>
+		publicRotatedAt: string
+		privateRotatedAt: string
+	},
+	never,
+	Providers
+>
+
+/**
+ * Your organization's ingest credentials, surfaced as resource outputs so
+ * they can flow into other resources (e.g. a Worker's env).
+ *
+ * @example
+ * ```typescript
+ * const ingest = yield* Maple.IngestKeys("ingest")
+ * // ingest.publicKey / ingest.privateKey are Redacted<string> outputs.
+ * ```
+ */
+export const IngestKeys = Resource<IngestKeys>("Maple.IngestKeys")
+
+const WireIngestKeys = Schema.Struct({
+	public_key: Schema.String,
+	private_key: Schema.String,
+	public_rotated_at: Schema.String,
+	private_rotated_at: Schema.String,
+})
+const decodeWireIngestKeys = Schema.decodeUnknownEffect(WireIngestKeys)
+
+const toAttributes = (wire: Schema.Schema.Type<typeof WireIngestKeys>) => ({
+	publicKey: Redacted.make(wire.public_key),
+	privateKey: Redacted.make(wire.private_key),
+	publicRotatedAt: wire.public_rotated_at,
+	privateRotatedAt: wire.private_rotated_at,
+})
+
+export const IngestKeysProvider = () =>
+	Provider.effect(
+		IngestKeys,
+		Effect.gen(function* () {
+			const api = yield* MapleApi
+			const fetchKeys = Effect.gen(function* () {
+				const fetched = yield* api.get("/v2/ingest_keys")
+				return toAttributes(yield* decodeWireIngestKeys(fetched))
+			})
+			return {
+				// Always-present org configuration: deleting the resource only stops
+				// tracking it, and nuke skips it entirely.
+				nuke: { singleton: true },
+				reconcile: () => fetchKeys,
+				delete: () => Effect.void,
+				read: () => fetchKeys,
+				list: () => Effect.map(fetchKeys, (attributes) => [attributes]),
+			}
+		}),
+	)

--- a/lib/alchemy-maple/src/MapleApi.ts
+++ b/lib/alchemy-maple/src/MapleApi.ts
@@ -1,0 +1,155 @@
+import * as Context from "effect/Context"
+import * as Duration from "effect/Duration"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Redacted from "effect/Redacted"
+import * as Schedule from "effect/Schedule"
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
+import {
+	MapleApiError,
+	MapleConflictError,
+	MapleNotFoundError,
+	MapleUnauthorizedError,
+	type MapleError,
+} from "./errors"
+import { MapleEnvironment } from "./MapleEnvironment"
+
+/**
+ * Thin JSON client for the Maple public v2 API.
+ *
+ * Providers call these instead of a generated client so the package ships
+ * with zero runtime dependencies beyond `effect`. Responses are returned as
+ * parsed JSON (`unknown`); each provider decodes just the fields it needs.
+ *
+ * Known statuses map to typed errors (404 / 409 / 401·403); everything else
+ * non-2xx is a {@link MapleApiError}. 429s and 5xx are retried with bounded
+ * exponential backoff (the v2 API allows 600 requests per 60s per key).
+ */
+export interface MapleApiShape {
+	readonly get: (path: string) => Effect.Effect<unknown, MapleError>
+	readonly post: (path: string, body?: unknown) => Effect.Effect<unknown, MapleError>
+	readonly patch: (path: string, body: unknown) => Effect.Effect<unknown, MapleError>
+	readonly delete: (path: string) => Effect.Effect<unknown, MapleError>
+}
+
+export class MapleApi extends Context.Service<MapleApi, MapleApiShape>()("Maple::Api") {}
+
+const errorFromResponse = (status: number, bodyText: string): MapleError => {
+	let message = `Maple API request failed with status ${status}`
+	let errorType: string | undefined
+	let code: string | undefined
+	try {
+		const parsed = JSON.parse(bodyText) as { error?: { type?: string; code?: string; message?: string } }
+		if (parsed?.error?.message) message = parsed.error.message
+		errorType = parsed?.error?.type
+		code = parsed?.error?.code
+	} catch {
+		if (bodyText.length > 0) message = `${message}: ${bodyText.slice(0, 200)}`
+	}
+	const fields = {
+		status,
+		message,
+		...(errorType !== undefined ? { errorType } : {}),
+		...(code !== undefined ? { code } : {}),
+	}
+	if (status === 404) return new MapleNotFoundError(fields)
+	if (status === 409) return new MapleConflictError(fields)
+	if (status === 401 || status === 403) return new MapleUnauthorizedError(fields)
+	return new MapleApiError(fields)
+}
+
+const isRetryable = (error: MapleError): boolean =>
+	error._tag === "Maple::ApiError" && (error.status === 429 || error.status >= 500)
+
+const retryPolicy = Schedule.exponential(Duration.millis(500), 2).pipe(
+	Schedule.either(Schedule.spaced(Duration.seconds(10))),
+	Schedule.both(Schedule.recurs(6)),
+)
+
+export const make = Effect.gen(function* () {
+	const { baseUrl, apiKey } = yield* MapleEnvironment
+	const httpClient = yield* HttpClient.HttpClient
+
+	const request = (method: "GET" | "POST" | "PATCH" | "DELETE", path: string, body?: unknown) =>
+		Effect.gen(function* () {
+			let req = HttpClientRequest.make(method)(`${baseUrl}${path}`).pipe(
+				HttpClientRequest.setHeaders({
+					Authorization: `Bearer ${Redacted.value(apiKey)}`,
+					Accept: "application/json",
+				}),
+			)
+			if (body !== undefined) {
+				req = yield* HttpClientRequest.bodyJson(req, body).pipe(
+					Effect.mapError(
+						(error) =>
+							new MapleApiError({
+								status: 0,
+								message: `Failed to encode request body: ${String(error)}`,
+							}),
+					),
+				)
+			}
+			const response = yield* httpClient.execute(req).pipe(
+				Effect.mapError(
+					(error) => new MapleApiError({ status: 0, message: `Maple API request failed: ${error.message}` }),
+				),
+			)
+			// Drain the body either way so the connection is released.
+			const text = yield* response.text.pipe(
+				Effect.mapError(
+					(error) =>
+						new MapleApiError({ status: response.status, message: `Failed to read response: ${error.message}` }),
+				),
+			)
+			if (response.status >= 200 && response.status < 300) {
+				if (text.length === 0) return undefined as unknown
+				return yield* Effect.try({
+					try: () => JSON.parse(text) as unknown,
+					catch: () =>
+						new MapleApiError({
+							status: response.status,
+							message: `Maple API returned invalid JSON (status ${response.status})`,
+						}),
+				})
+			}
+			return yield* Effect.fail(errorFromResponse(response.status, text))
+		}).pipe(
+			Effect.retry({
+				schedule: retryPolicy,
+				while: isRetryable,
+			}),
+		)
+
+	return {
+		get: (path: string) => request("GET", path),
+		post: (path: string, body?: unknown) => request("POST", path, body),
+		patch: (path: string, body: unknown) => request("PATCH", path, body),
+		delete: (path: string) => request("DELETE", path),
+	}
+})
+
+/** Live client: {@link MapleEnvironment} + the runtime's global `fetch`. */
+export const MapleApiLive = () =>
+	Layer.effect(MapleApi, make).pipe(Layer.provide(FetchHttpClient.layer))
+
+/**
+ * Fetch every page of a v2 list endpoint (`{ object: "list", data, has_more,
+ * next_cursor }`), following cursors until exhausted.
+ */
+export const listAll = (
+	api: MapleApiShape,
+	path: string,
+): Effect.Effect<ReadonlyArray<unknown>, MapleError> =>
+	Effect.gen(function* () {
+		const items: Array<unknown> = []
+		let cursor: string | null = null
+		do {
+			const sep = path.includes("?") ? "&" : "?"
+			const page = (yield* api.get(
+				cursor === null ? `${path}${sep}limit=100` : `${path}${sep}limit=100&cursor=${encodeURIComponent(cursor)}`,
+			)) as { data?: ReadonlyArray<unknown>; has_more?: boolean; next_cursor?: string | null }
+			items.push(...(page.data ?? []))
+			cursor = page.has_more === true && typeof page.next_cursor === "string" ? page.next_cursor : null
+		} while (cursor !== null)
+		return items
+	})

--- a/lib/alchemy-maple/src/MapleEnvironment.ts
+++ b/lib/alchemy-maple/src/MapleEnvironment.ts
@@ -1,0 +1,45 @@
+import * as Config from "effect/Config"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import type * as Redacted from "effect/Redacted"
+
+/**
+ * Connection settings for the Maple public v2 API.
+ *
+ * Every Maple provider resolves its base URL and credential from this
+ * service. `Maple.providers()` wires it from the environment by default
+ * ({@link fromEnv}); provide your own layer to point at a different
+ * deployment or to source the key from elsewhere.
+ */
+export class MapleEnvironment extends Context.Service<
+	MapleEnvironment,
+	{
+		/** Base URL of the Maple API, without a trailing slash. */
+		readonly baseUrl: string
+		/** A Maple API key (`maple_ak_…`) with the scopes the declared resources need. */
+		readonly apiKey: Redacted.Redacted<string>
+	}
+>()("Maple::Environment") {}
+
+export const DEFAULT_BASE_URL = "https://api.maple.dev"
+
+/**
+ * Resolve the Maple environment from process env:
+ *
+ * - `MAPLE_API_KEY` (required) — a `maple_ak_…` API key. Mutating API keys,
+ *   ingest keys, and alert rules/destinations requires a key backed by an
+ *   org-admin; dashboards need the `dashboards:write` scope.
+ * - `MAPLE_API_URL` (optional) — defaults to `https://api.maple.dev`.
+ */
+export const fromEnv = () =>
+	Layer.effect(
+		MapleEnvironment,
+		Effect.gen(function* () {
+			const apiKey = yield* Config.redacted("MAPLE_API_KEY")
+			const baseUrl = yield* Config.string("MAPLE_API_URL").pipe(
+				Config.withDefault(DEFAULT_BASE_URL),
+			)
+			return { baseUrl: baseUrl.replace(/\/+$/, ""), apiKey }
+		}).pipe(Effect.orDie),
+	)

--- a/lib/alchemy-maple/src/Providers.ts
+++ b/lib/alchemy-maple/src/Providers.ts
@@ -1,0 +1,43 @@
+import * as Layer from "effect/Layer"
+import * as Provider from "alchemy/Provider"
+import { AlertDestination, AlertDestinationProvider } from "./AlertDestination"
+import { AlertRule, AlertRuleProvider } from "./AlertRule"
+import { ApiKey, ApiKeyProvider } from "./ApiKey"
+import { Dashboard, DashboardProvider } from "./Dashboard"
+import { IngestKeys, IngestKeysProvider } from "./IngestKeys"
+import { MapleApiLive } from "./MapleApi"
+import * as MapleEnvironment from "./MapleEnvironment"
+
+export class Providers extends Provider.ProviderCollection<Providers>()("Maple") {}
+
+/**
+ * The Maple provider collection. Merge it into your stack's `providers`
+ * layer alongside any others:
+ *
+ * ```typescript
+ * export default Alchemy.Stack("my-app", {
+ *   providers: Layer.mergeAll(Cloudflare.providers(), Maple.providers()),
+ * }, Effect.gen(function* () { ... }))
+ * ```
+ *
+ * Credentials come from `MAPLE_API_KEY` / `MAPLE_API_URL` by default; provide
+ * your own {@link MapleEnvironment.MapleEnvironment} layer to override.
+ */
+export const providers = () =>
+	Layer.effect(
+		Providers,
+		Provider.collection([ApiKey, Dashboard, AlertDestination, AlertRule, IngestKeys]),
+	).pipe(
+		Layer.provide(
+			Layer.mergeAll(
+				ApiKeyProvider(),
+				DashboardProvider(),
+				AlertDestinationProvider(),
+				AlertRuleProvider(),
+				IngestKeysProvider(),
+			),
+		),
+		Layer.provide(MapleApiLive()),
+		Layer.provide(MapleEnvironment.fromEnv()),
+		Layer.orDie,
+	)

--- a/lib/alchemy-maple/src/errors.ts
+++ b/lib/alchemy-maple/src/errors.ts
@@ -1,0 +1,36 @@
+import { Schema } from "effect"
+
+/**
+ * Typed failures surfaced by the Maple API client. The v2 error envelope is
+ * `{ error: { type, code, message, param? } }`; the client maps well-known
+ * statuses to dedicated tags so providers can `catchTag` (404 → adopt/recreate,
+ * 409 → adopt-by-name) and leaves everything else on `MapleApiError`.
+ */
+
+const errorFields = {
+	status: Schema.Number,
+	message: Schema.String,
+	/** The v2 envelope `error.type`, when the body carried one. */
+	errorType: Schema.optionalKey(Schema.String),
+	/** The v2 envelope `error.code`, when the body carried one. */
+	code: Schema.optionalKey(Schema.String),
+}
+
+export class MapleApiError extends Schema.TaggedErrorClass<MapleApiError>()("Maple::ApiError", errorFields) {}
+
+export class MapleNotFoundError extends Schema.TaggedErrorClass<MapleNotFoundError>()(
+	"Maple::NotFoundError",
+	errorFields,
+) {}
+
+export class MapleConflictError extends Schema.TaggedErrorClass<MapleConflictError>()(
+	"Maple::ConflictError",
+	errorFields,
+) {}
+
+export class MapleUnauthorizedError extends Schema.TaggedErrorClass<MapleUnauthorizedError>()(
+	"Maple::UnauthorizedError",
+	errorFields,
+) {}
+
+export type MapleError = MapleApiError | MapleNotFoundError | MapleConflictError | MapleUnauthorizedError

--- a/lib/alchemy-maple/src/index.ts
+++ b/lib/alchemy-maple/src/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Alchemy provider for Maple resources.
+ *
+ * Declare Maple API keys, ingest keys, dashboards, alert destinations, and
+ * alert rules in your `alchemy.run.ts`, authenticated with a `maple_ak_…`
+ * API key against the Maple public v2 API.
+ *
+ * @example
+ * ```typescript
+ * import * as Alchemy from "alchemy"
+ * import * as Maple from "@maple-dev/alchemy"
+ * import { Effect, Layer } from "effect"
+ *
+ * export default Alchemy.Stack("my-app", {
+ *   providers: Maple.providers(),
+ * }, Effect.gen(function* () {
+ *   const slack = yield* Maple.AlertDestination("oncall", {
+ *     type: "slack",
+ *     name: "On-call Slack",
+ *     webhook_url: process.env.SLACK_WEBHOOK_URL!,
+ *   })
+ *   yield* Maple.AlertRule("checkout-errors", {
+ *     name: "Checkout error rate",
+ *     severity: "critical",
+ *     signal_type: "error_rate",
+ *     comparator: "gt",
+ *     threshold: 0.05,
+ *     window_minutes: 5,
+ *     destination_ids: [slack.destinationId],
+ *   })
+ * }))
+ * ```
+ */
+
+export { AlertDestination, AlertDestinationProvider, type AlertDestinationProps } from "./AlertDestination"
+export {
+	AlertRule,
+	AlertRuleProvider,
+	type AlertComparator,
+	type AlertRuleProps,
+	type AlertSignalType,
+} from "./AlertRule"
+export { ApiKey, ApiKeyProvider, type ApiKeyProps } from "./ApiKey"
+export { Dashboard, DashboardProvider, type DashboardProps } from "./Dashboard"
+export {
+	MapleApiError,
+	MapleConflictError,
+	MapleNotFoundError,
+	MapleUnauthorizedError,
+	type MapleError,
+} from "./errors"
+export { IngestKeys, IngestKeysProvider, type IngestKeysProps } from "./IngestKeys"
+export { listAll, MapleApi, MapleApiLive, type MapleApiShape } from "./MapleApi"
+export { DEFAULT_BASE_URL, fromEnv, MapleEnvironment } from "./MapleEnvironment"
+export { Providers, providers } from "./Providers"

--- a/lib/alchemy-maple/test/contract.test.ts
+++ b/lib/alchemy-maple/test/contract.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Contract tests: the provider's hand-written wire bodies/decoders must stay
+ * compatible with the real `@maple/domain` v2 schemas (dev-only dependency —
+ * never shipped). If a v2 schema changes shape, these fail in CI.
+ */
+import { describe, expect, it } from "vitest"
+import { Effect, Schema } from "effect"
+import {
+	V2AlertDestinationCreateParams,
+	V2AlertRuleCreateParams,
+	V2ApiKeyCreateParams,
+	V2DashboardCreateParams,
+} from "@maple/domain/http/v2"
+import { _alertDestinationCreateBody } from "../src/AlertDestination"
+import { _alertRuleCreateBody } from "../src/AlertRule"
+import { _apiKeyCreateBody } from "../src/ApiKey"
+import { _dashboardCreateBody } from "../src/Dashboard"
+
+const decodes = <S extends Schema.Codec<unknown, unknown, never, never>>(schema: S, wire: unknown) =>
+	Effect.runSync(Schema.decodeUnknownEffect(schema)(wire).pipe(Effect.asVoid))
+
+describe("provider request bodies decode against the real v2 create-param schemas", () => {
+	it("dashboard create body", () => {
+		const body = _dashboardCreateBody({
+			name: "Service health",
+			description: "Golden signals",
+			tags: ["golden"],
+			time_range: { type: "relative", value: "12h" },
+			widgets: [
+				{
+					id: "w1",
+					visualization: "timeseries",
+					data_source: { endpoint: "query_builder", params: { granularity_seconds: 60 } },
+					display: { title: "Throughput" },
+					layout: { x: 0, y: 0, w: 6, h: 4 },
+				},
+			],
+			variables: [{ name: "service", type: "textbox" }],
+		})
+		expect(() => decodes(V2DashboardCreateParams, body)).not.toThrow()
+	})
+
+	it("alert destination create bodies (each channel type)", () => {
+		const bodies = [
+			_alertDestinationCreateBody({
+				type: "slack",
+				name: "On-call Slack",
+				webhook_url: "https://hooks.slack.com/services/T000/B000/XXXX",
+				channel_label: "#incidents",
+				enabled: true,
+			}),
+			_alertDestinationCreateBody({ type: "pagerduty", name: "PD", integration_key: "key" }),
+			_alertDestinationCreateBody({
+				type: "webhook",
+				name: "Hook",
+				url: "https://example.com/hooks/maple",
+				signing_secret: "shh",
+			}),
+			_alertDestinationCreateBody({
+				type: "hazel",
+				name: "Hazel",
+				webhook_url: "https://hazel.example.com/hook",
+			}),
+			_alertDestinationCreateBody({
+				type: "discord",
+				name: "Discord",
+				webhook_url: "https://discord.com/api/webhooks/x",
+			}),
+			_alertDestinationCreateBody({
+				type: "email",
+				name: "Email",
+				member_user_ids: ["user_2Nk8mXqPfR3yZ1aB4cD5eF6g"],
+			}),
+		]
+		for (const body of bodies) {
+			expect(() => decodes(V2AlertDestinationCreateParams, body)).not.toThrow()
+		}
+	})
+
+	it("alert rule create body", () => {
+		const body = _alertRuleCreateBody({
+			name: "Checkout error rate",
+			severity: "critical",
+			signal_type: "error_rate",
+			comparator: "gt",
+			threshold: 0.05,
+			window_minutes: 5,
+			destination_ids: ["dest_oybbpTBhtSFGShMjjLiCrh"],
+			service_names: ["checkout"],
+			tags: ["payments"],
+			minimum_sample_count: 50,
+		})
+		expect(() => decodes(V2AlertRuleCreateParams, body)).not.toThrow()
+	})
+
+	it("api key create body", () => {
+		const body = _apiKeyCreateBody({
+			name: "ci-pipeline",
+			description: "Publishes deploys",
+			scopes: ["dashboards:write", "alerts:read"],
+			kind: "standard",
+			expires_in_seconds: 7_776_000,
+		})
+		expect(() => decodes(V2ApiKeyCreateParams, body)).not.toThrow()
+	})
+})

--- a/lib/alchemy-maple/test/providers.test.ts
+++ b/lib/alchemy-maple/test/providers.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "vitest"
+import { Effect, Layer, Redacted } from "effect"
+import type { ScopedPlanStatusSession } from "alchemy/Cli/Cli"
+import { ApiKey, ApiKeyProvider } from "../src/ApiKey"
+import { Dashboard, DashboardProvider } from "../src/Dashboard"
+import { MapleApi, type MapleApiShape } from "../src/MapleApi"
+import { MapleNotFoundError, type MapleError } from "../src/errors"
+
+/** In-memory stub of the v2 API: canned responses + a call log. */
+const makeStub = (
+	routes: Record<string, (body?: unknown) => Effect.Effect<unknown, MapleError>>,
+): { api: MapleApiShape; calls: Array<string> } => {
+	const calls: Array<string> = []
+	const dispatch = (method: string, path: string, body?: unknown) => {
+		calls.push(`${method} ${path}`)
+		const handler = routes[`${method} ${path}`]
+		if (handler === undefined) {
+			return Effect.fail<MapleError>(new MapleNotFoundError({ status: 404, message: `no route: ${method} ${path}` }))
+		}
+		return handler(body)
+	}
+	return {
+		calls,
+		api: {
+			get: (path) => dispatch("GET", path),
+			post: (path, body) => dispatch("POST", path, body),
+			patch: (path, body) => dispatch("PATCH", path, body),
+			delete: (path) => dispatch("DELETE", path),
+		},
+	}
+}
+
+const session: ScopedPlanStatusSession = {
+	emit: () => Effect.void,
+	done: () => Effect.void,
+	note: () => Effect.void,
+}
+
+const wireDashboard = {
+	id: "dash_abc",
+	object: "dashboard",
+	name: "Service health",
+	description: null,
+	tags: [],
+	time_range: { type: "relative", value: "12h" },
+	widgets: [],
+	variables: [],
+	created_at: "2026-07-01T12:00:00.000Z",
+	updated_at: "2026-07-01T12:00:00.000Z",
+}
+
+const runWithProvider = <A>(
+	api: MapleApiShape,
+	program: Effect.Effect<A, unknown, any>,
+): Promise<A> =>
+	Effect.runPromise(
+		program.pipe(
+			Effect.provide(DashboardProvider().pipe(Layer.provide(Layer.succeed(MapleApi, api)))),
+			Effect.provide(ApiKeyProvider().pipe(Layer.provide(Layer.succeed(MapleApi, api)))),
+		) as Effect.Effect<A>,
+	)
+
+describe("DashboardProvider", () => {
+	it("creates when there is no prior state", async () => {
+		const stub = makeStub({
+			"POST /v2/dashboards": () => Effect.succeed(wireDashboard),
+		})
+		const attributes = await runWithProvider(
+			stub.api,
+			Effect.gen(function* () {
+				const provider = yield* Dashboard.Provider
+				return yield* provider.reconcile({
+					id: "service-health",
+					instanceId: "i-1",
+					news: { name: "Service health" },
+					olds: undefined,
+					output: undefined,
+					session,
+					bindings: [],
+				})
+			}),
+		)
+		expect(attributes).toEqual({ dashboardId: "dash_abc", name: "Service health" })
+		expect(stub.calls).toEqual(["POST /v2/dashboards"])
+	})
+
+	it("observes without mutating when nothing drifted", async () => {
+		const stub = makeStub({
+			"GET /v2/dashboards/dash_abc": () => Effect.succeed(wireDashboard),
+		})
+		await runWithProvider(
+			stub.api,
+			Effect.gen(function* () {
+				const provider = yield* Dashboard.Provider
+				return yield* provider.reconcile({
+					id: "service-health",
+					instanceId: "i-1",
+					news: { name: "Service health" },
+					olds: { name: "Service health" },
+					output: { dashboardId: "dash_abc", name: "Service health" },
+					session,
+					bindings: [],
+				})
+			}),
+		)
+		expect(stub.calls).toEqual(["GET /v2/dashboards/dash_abc"])
+	})
+
+	it("patches when a declared field drifted", async () => {
+		const stub = makeStub({
+			"GET /v2/dashboards/dash_abc": () => Effect.succeed(wireDashboard),
+			"PATCH /v2/dashboards/dash_abc": (body) =>
+				Effect.succeed({ ...wireDashboard, ...(body as object) }),
+		})
+		const attributes = await runWithProvider(
+			stub.api,
+			Effect.gen(function* () {
+				const provider = yield* Dashboard.Provider
+				return yield* provider.reconcile({
+					id: "service-health",
+					instanceId: "i-1",
+					news: { name: "Renamed", tags: ["golden"] },
+					olds: { name: "Service health" },
+					output: { dashboardId: "dash_abc", name: "Service health" },
+					session,
+					bindings: [],
+				})
+			}),
+		)
+		expect(attributes.name).toBe("Renamed")
+		expect(stub.calls).toEqual(["GET /v2/dashboards/dash_abc", "PATCH /v2/dashboards/dash_abc"])
+	})
+
+	it("recreates after an out-of-band delete", async () => {
+		const stub = makeStub({
+			"POST /v2/dashboards": () => Effect.succeed(wireDashboard),
+		})
+		await runWithProvider(
+			stub.api,
+			Effect.gen(function* () {
+				const provider = yield* Dashboard.Provider
+				return yield* provider.reconcile({
+					id: "service-health",
+					instanceId: "i-1",
+					news: { name: "Service health" },
+					olds: { name: "Service health" },
+					output: { dashboardId: "dash_gone", name: "Service health" },
+					session,
+					bindings: [],
+				})
+			}),
+		)
+		expect(stub.calls).toEqual(["GET /v2/dashboards/dash_gone", "POST /v2/dashboards"])
+	})
+
+	it("delete tolerates 404", async () => {
+		const stub = makeStub({})
+		await runWithProvider(
+			stub.api,
+			Effect.gen(function* () {
+				const provider = yield* Dashboard.Provider
+				yield* provider.delete({
+					id: "service-health",
+					instanceId: "i-1",
+					olds: { name: "Service health" },
+					output: { dashboardId: "dash_gone", name: "Service health" },
+					session,
+					bindings: [],
+				})
+			}),
+		)
+		expect(stub.calls).toEqual(["DELETE /v2/dashboards/dash_gone"])
+	})
+})
+
+const wireApiKey = {
+	id: "key_abc",
+	object: "api_key",
+	name: "ci",
+	key_prefix: "maple_ak_9f2c",
+	revoked: false,
+}
+
+describe("ApiKeyProvider", () => {
+	it("captures the one-time secret on create", async () => {
+		const stub = makeStub({
+			"POST /v2/api_keys": () => Effect.succeed({ ...wireApiKey, secret: "maple_ak_secret1" }),
+		})
+		const attributes = await runWithProvider(
+			stub.api,
+			Effect.gen(function* () {
+				const provider = yield* ApiKey.Provider
+				return yield* provider.reconcile({
+					id: "ci",
+					instanceId: "i-1",
+					news: { name: "ci" },
+					olds: undefined,
+					output: undefined,
+					session,
+					bindings: [],
+				})
+			}),
+		)
+		expect(Redacted.value(attributes.secret)).toBe("maple_ak_secret1")
+	})
+
+	it("preserves the stored secret on steady-state reconcile", async () => {
+		const stub = makeStub({
+			"GET /v2/api_keys/key_abc": () => Effect.succeed(wireApiKey),
+		})
+		const secret = Redacted.make("maple_ak_secret1")
+		const attributes = await runWithProvider(
+			stub.api,
+			Effect.gen(function* () {
+				const provider = yield* ApiKey.Provider
+				return yield* provider.reconcile({
+					id: "ci",
+					instanceId: "i-1",
+					news: { name: "ci" },
+					olds: { name: "ci" },
+					output: { keyId: "key_abc", name: "ci", keyPrefix: "maple_ak_9f2c", secret },
+					session,
+					bindings: [],
+				})
+			}),
+		)
+		expect(Redacted.value(attributes.secret)).toBe("maple_ak_secret1")
+		expect(stub.calls).toEqual(["GET /v2/api_keys/key_abc"])
+	})
+
+	it("rolls in place when `rotate` is bumped", async () => {
+		const stub = makeStub({
+			"GET /v2/api_keys/key_abc": () => Effect.succeed(wireApiKey),
+			"POST /v2/api_keys/key_abc/roll": () =>
+				Effect.succeed({ ...wireApiKey, id: "key_new", secret: "maple_ak_secret2" }),
+		})
+		const attributes = await runWithProvider(
+			stub.api,
+			Effect.gen(function* () {
+				const provider = yield* ApiKey.Provider
+				return yield* provider.reconcile({
+					id: "ci",
+					instanceId: "i-1",
+					news: { name: "ci", rotate: 2 },
+					olds: { name: "ci", rotate: 1 },
+					output: {
+						keyId: "key_abc",
+						name: "ci",
+						keyPrefix: "maple_ak_9f2c",
+						secret: Redacted.make("maple_ak_secret1"),
+					},
+					session,
+					bindings: [],
+				})
+			}),
+		)
+		expect(attributes.keyId).toBe("key_new")
+		expect(Redacted.value(attributes.secret)).toBe("maple_ak_secret2")
+	})
+
+	it("recreates when the key was revoked out-of-band", async () => {
+		const stub = makeStub({
+			"GET /v2/api_keys/key_abc": () => Effect.succeed({ ...wireApiKey, revoked: true }),
+			"POST /v2/api_keys": () => Effect.succeed({ ...wireApiKey, id: "key_new", secret: "maple_ak_secret2" }),
+		})
+		const attributes = await runWithProvider(
+			stub.api,
+			Effect.gen(function* () {
+				const provider = yield* ApiKey.Provider
+				return yield* provider.reconcile({
+					id: "ci",
+					instanceId: "i-1",
+					news: { name: "ci" },
+					olds: { name: "ci" },
+					output: {
+						keyId: "key_abc",
+						name: "ci",
+						keyPrefix: "maple_ak_9f2c",
+						secret: Redacted.make("maple_ak_secret1"),
+					},
+					session,
+					bindings: [],
+				})
+			}),
+		)
+		expect(attributes.keyId).toBe("key_new")
+	})
+})

--- a/lib/alchemy-maple/tsconfig.json
+++ b/lib/alchemy-maple/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"include": ["src/**/*.ts", "test/**/*.ts"],
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"lib": ["ES2022", "DOM"],
+		"moduleResolution": "bundler",
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true,
+		"plugins": [
+			{
+				"name": "@effect/language-service",
+				"reportSuggestionsAsWarningsInTsc": true
+			}
+		]
+	}
+}

--- a/lib/alchemy-maple/tsdown.config.ts
+++ b/lib/alchemy-maple/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsdown"
+
+export default defineConfig({
+	entry: {
+		index: "./src/index.ts",
+	},
+	format: "esm",
+	dts: true,
+	outDir: "dist",
+	deps: {
+		neverBundle: ["effect", "alchemy"],
+	},
+})


### PR DESCRIPTION
## What

A new publishable package, **`@maple-dev/alchemy`** (`lib/alchemy-maple`), an [Alchemy](https://alchemy.run) provider that lets Maple customers declare Maple resources in their own `alchemy.run.ts`, authenticated with a `maple_ak_…` key against the public v2 API:

| Resource | Semantics |
| --- | --- |
| `Maple.Dashboard` | Full CRUD; wire-shape props pass through verbatim; drift-checked PATCH |
| `Maple.AlertDestination` | Full CRUD; discriminated on `type`; write-only secrets accept `Redacted`; `type` change ⇒ replace |
| `Maple.AlertRule` | Full CRUD; `destination_ids` takes Output refs from destinations; lost state re-adopts by org-unique name |
| `Maple.ApiKey` | Create/roll/revoke; one-time `secret` captured as `Redacted` into Alchemy state; `rotate` prop bump rolls in place; other prop changes replace |
| `Maple.IngestKeys` | Read-only per-org singleton (`nuke: { singleton: true }`) surfacing keys as `Redacted` outputs |

Usage: `providers: Layer.mergeAll(Cloudflare.providers(), Maple.providers())`, credentials from `MAPLE_API_KEY` / `MAPLE_API_URL`.

## Why

Maple-side resources previously had to be clicked together in the UI or scripted by hand. This makes them declarable IaC next to the infrastructure they observe, dogfooding the v2 public API.

## Design notes for review

- **Zero runtime deps**: `alchemy` (`>=2.0.0-beta.61 <3`) and `effect` are peers so customers get a single Effect/alchemy instance. `@maple/domain` is a **dev-only** dependency — the package ships small hand-written wire schemas instead, kept honest by contract tests that decode the provider's request bodies against the real `V2*CreateParams` schemas.
- **Client**: thin JSON client on `effect/unstable/http` with typed errors (404/409/401·403 tags for adopt/recreate flows) and bounded 429/5xx retry (v2 allows 600 req/60s).
- No Idempotency-Key on the v2 API yet, so reconcile is observe-then-create; alert rules are safe against double-create via org-unique-name adoption (dashboards/destinations are documented as best-effort).
- `ApiKey.secret` can never be re-read from the API — it lives only in Alchemy state; `list()` returns secretless placeholders (enumeration/nuke only).

## Testing

- 13 unit + contract tests in the package (provider lifecycles vs a stub API; wire-schema contract vs `@maple/domain`).
- `apps/api/src/routes/v2/alchemy-provider.integration.test.ts`: drives the real provider code through the **real v2 handlers over PGlite** (custom `fetch` into the in-process web handler) — create → noop → drift-patch → adopt-by-name → roll → revoke/delete cycles for dashboards, destinations+rules, and API keys.
- `tsdown` build emits a clean 24 kB ESM dist with only `effect`/`alchemy` externals; `npm pack --dry-run` = 4 files, no workspace specifiers; root `bun typecheck` green.

Not included (follow-ups): npm publish, manual smoke deploy of `examples/alchemy-maple` against a dev deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787222717&installation_model_id=427786&pr_number=240&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F240&signature=418631cee2a1f9187d1ba6c6ab18a0712181c83c34121c953a3602cc4e946b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->