### PR TITLE
fix(auth): resolve API-key tenants with the key's pinned roles

### DIFF
--- a/apps/api/src/mcp/lib/resolve-tenant.ts
+++ b/apps/api/src/mcp/lib/resolve-tenant.ts
@@ -167,7 +167,7 @@ export const resolveMcpTenantContext = Effect.fn("resolveMcpTenantContext")(func
 		return {
 			orgId: validOrgId,
 			userId: validUserId,
-			roles: apiKeyDefaultRoles,
+			roles: apiKeyResolved.value.roles ?? apiKeyDefaultRoles,
 			authMode: "self_hosted",
 			...(actorId ? { actorId } : {}),
 		} as McpTenantContext

--- a/apps/api/src/services/ApiAuthorizationLayer.ts
+++ b/apps/api/src/services/ApiAuthorizationLayer.ts
@@ -59,7 +59,7 @@ export const ApiAuthorizationLayer = Layer.effect(
 						const tenant = new CurrentTenant.TenantSchema({
 							orgId: resolved.orgId,
 							userId: resolved.userId,
-							roles: apiKeyDefaultRoles,
+							roles: resolved.roles ?? apiKeyDefaultRoles,
 							authMode: "self_hosted",
 						})
 						return yield* Effect.provideService(httpEffect, CurrentTenant.Context, tenant)

--- a/apps/api/src/services/ApiAuthorizationV2Layer.ts
+++ b/apps/api/src/services/ApiAuthorizationV2Layer.ts
@@ -117,7 +117,7 @@ export const ApiAuthorizationV2Layer = Layer.effect(
 						const tenant = new CurrentTenant.TenantSchema({
 							orgId: resolved.orgId,
 							userId: resolved.userId,
-							roles: apiKeyDefaultRoles,
+							roles: resolved.roles ?? apiKeyDefaultRoles,
 							authMode: "self_hosted",
 							...(resolved.scopes !== null ? { scopes: resolved.scopes } : {}),
 						})


### PR DESCRIPTION
## What

Main CI is red: 3 tests in `apps/api/src/routes/v2/api-keys.http.test.ts` fail with `expected 200 to be 403`.

#242 pinned creator roles onto MCP keys and added tests asserting a member key cannot create standard API keys or revoke other users' keys — but the authorization layers still stamp every resolved API key with the default (root) roles, so the restrictions never apply.

This plumbs `resolved.roles` through:
- `ApiAuthorizationLayer` (v1)
- `ApiAuthorizationV2Layer` (v2)
- `resolveMcpTenantContext` (MCP)

falling back to `apiKeyDefaultRoles` for keys without pinned roles (unchanged behavior for existing standard keys).

## Verification

On a clean checkout of main: `api-keys.http.test.ts` fails 3/16 → with this change 16/16 pass, and the full `apps/api` suite passes (948 tests; the one failing file locally, `AiTriageWorkflow.run.test.ts`, is only a missing local `effect-sdk` dist build — CI builds it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787232617&installation_model_id=427786&pr_number=244&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F244&signature=75ed495f473d62faca1d8ca57615d6d53d4c80269b01cdb3f3871d54a6239b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->