### PR TITLE
feat(services): dense services list — health, Δ7d baseline, issues, last-deploy

### DIFF
--- a/apps/api/src/routes/query-engine.http.ts
+++ b/apps/api/src/routes/query-engine.http.ts
@@ -70,7 +70,7 @@ import {
 } from "@maple/domain/http"
 import { Clock, Config, Effect, Match, Option, Schema } from "effect"
 import { QueryEngineService } from "../services/QueryEngineService"
-import { makeExecuteRawSql } from "@maple/query-engine/runtime"
+import { makeDirectRouteCachePolicy, makeExecuteRawSql } from "@maple/query-engine/runtime"
 import { WarehouseQueryService } from "../lib/WarehouseQueryService"
 import { traceCacheTtlSeconds } from "../lib/trace-detail-cache"
 import {
@@ -463,6 +463,9 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 							}),
 							"serviceOverview query failed",
 						),
+						// v2: rows gained per-commit `firstSeen`; the version bump keeps
+						// pre-upgrade cached rows (missing the field) from being served.
+						makeDirectRouteCachePolicy({ ttlSeconds: 15, version: 2 }),
 					)
 					return new ServiceOverviewResponse({ data: rows })
 				}),

--- a/apps/api/src/routes/v2/error-issues.http.ts
+++ b/apps/api/src/routes/v2/error-issues.http.ts
@@ -173,6 +173,23 @@ export const HttpV2ErrorIssuesLive = HttpApiBuilder.group(MapleApiV2, "errorIssu
 					}
 				}),
 			)
+			.handle("serviceCounts", () =>
+				Effect.gen(function* () {
+					const tenant = yield* CurrentTenant.Context
+					const counts = yield* errors
+						.countOpenIssuesByService(tenant.orgId)
+						.pipe(mapPersistenceError)
+					return {
+						object: "list" as const,
+						data: counts.map((row) => ({
+							service_name: row.serviceName,
+							open_count: row.openCount,
+						})),
+						has_more: false,
+						next_cursor: null,
+					}
+				}),
+			)
 			.handle("retrieve", ({ params, query }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context

--- a/apps/api/src/routes/v2/v2-test-support.ts
+++ b/apps/api/src/routes/v2/v2-test-support.ts
@@ -99,6 +99,7 @@ export const Phase1ResourceStubsLayer = Layer.mergeAll(
 	}),
 	Layer.succeed(ErrorsService, {
 		listIssues: die,
+		countOpenIssuesByService: die,
 		getIssue: die,
 		transitionIssue: die,
 		claimIssue: die,

--- a/apps/api/src/services/ErrorsService.test.ts
+++ b/apps/api/src/services/ErrorsService.test.ts
@@ -352,6 +352,37 @@ const seedIngestKey = (orgId: string) =>
 	})
 
 // ---------------------------------------------------------------------------
+// countOpenIssuesByService
+// ---------------------------------------------------------------------------
+
+describe("ErrorsService.countOpenIssuesByService", () => {
+	it.effect("groups actionable error issues by service, excluding done/alert/archived", () =>
+		Effect.gen(function* () {
+			const errors = yield* ErrorsService
+			const now = new Date()
+			yield* seedIssue(asIssueId(randomUUID()), { serviceName: "checkout-api" })
+			yield* seedIssue(asIssueId(randomUUID()), {
+				serviceName: "checkout-api",
+				workflowState: "in_progress",
+			})
+			yield* seedIssue(asIssueId(randomUUID()), { serviceName: "ingest", workflowState: "todo" })
+			// Non-actionable, alert-kind, archived, and empty-service rows are all excluded.
+			yield* seedIssue(asIssueId(randomUUID()), { serviceName: "checkout-api", workflowState: "done" })
+			yield* seedIssue(asIssueId(randomUUID()), { serviceName: "alerting", kind: "alert" })
+			yield* seedIssue(asIssueId(randomUUID()), { serviceName: "ingest", archivedAt: now })
+			yield* seedIssue(asIssueId(randomUUID()), { serviceName: "" })
+
+			const counts = yield* errors.countOpenIssuesByService(ORG)
+			const byService = new Map(counts.map((row) => [row.serviceName, row.openCount]))
+			assert.strictEqual(byService.get("checkout-api"), 2)
+			assert.strictEqual(byService.get("ingest"), 1)
+			assert.isFalse(byService.has("alerting"))
+			assert.isFalse(byService.has(""))
+		}).pipe(Effect.provide(makeErrorsLayer())),
+	)
+})
+
+// ---------------------------------------------------------------------------
 // setSeverity
 // ---------------------------------------------------------------------------
 

--- a/apps/api/src/services/ErrorsService.ts
+++ b/apps/api/src/services/ErrorsService.ts
@@ -262,6 +262,17 @@ export interface ErrorsServiceShape {
 			readonly sort?: "last_seen" | "severity"
 		},
 	) => Effect.Effect<ErrorIssuesListResponse, ErrorPersistenceError>
+	/**
+	 * Fleet-level open (actionable-state) error-issue counts grouped by service
+	 * name. One Postgres GROUP BY over the org's actionable subset; alert-kind
+	 * issues are excluded because their serviceName can be empty or synthetic.
+	 */
+	readonly countOpenIssuesByService: (
+		orgId: OrgId,
+	) => Effect.Effect<
+		ReadonlyArray<{ readonly serviceName: string; readonly openCount: number }>,
+		ErrorPersistenceError
+	>
 	readonly getIssue: (
 		orgId: OrgId,
 		issueId: ErrorIssueId,
@@ -1197,6 +1208,32 @@ const make: Effect.Effect<
 			)
 		},
 	)
+
+	const countOpenIssuesByService: ErrorsServiceShape["countOpenIssuesByService"] = Effect.fn(
+		"ErrorsService.countOpenIssuesByService",
+	)(function* (orgId) {
+		yield* Effect.annotateCurrentSpan({ orgId })
+		const rows = yield* dbExecute((db) =>
+			db
+				.select({
+					serviceName: errorIssues.serviceName,
+					openCount: sql<number>`count(*)::int`,
+				})
+				.from(errorIssues)
+				.where(
+					and(
+						eq(errorIssues.orgId, orgId),
+						inArray(errorIssues.workflowState, ACTIONABLE_WORKFLOW_STATES),
+						eq(errorIssues.kind, "error"),
+						isNull(errorIssues.archivedAt),
+					),
+				)
+				.groupBy(errorIssues.serviceName),
+		)
+		const counts = rows.filter((row) => row.serviceName !== "")
+		yield* Effect.annotateCurrentSpan({ serviceCount: counts.length })
+		return counts
+	})
 
 	const getIssue: ErrorsServiceShape["getIssue"] = Effect.fn("ErrorsService.getIssue")(
 		function* (orgId, issueId, opts) {
@@ -2914,6 +2951,7 @@ const make: Effect.Effect<
 
 	return ErrorsService.of({
 		listIssues,
+		countOpenIssuesByService,
 		getIssue,
 		transitionIssue,
 		claimIssue,

--- a/apps/web/src/api/warehouse/services.ts
+++ b/apps/web/src/api/warehouse/services.ts
@@ -35,6 +35,9 @@ export interface CommitBreakdown {
 	commitSha: string
 	spanCount: number
 	percentage: number
+	errorCount: number
+	/** Earliest span for this commit inside the queried window ("" when unknown). */
+	firstSeen: string
 }
 
 export interface ServiceOverview {
@@ -76,6 +79,7 @@ interface CoercedRow {
 	p95LatencyMs: number
 	p99LatencyMs: number
 	estimatedSpanCount: number
+	firstSeen: string
 }
 
 function coerceRow(raw: Record<string, unknown>): CoercedRow {
@@ -92,6 +96,7 @@ function coerceRow(raw: Record<string, unknown>): CoercedRow {
 		p95LatencyMs: Number(raw.p95LatencyMs ?? 0),
 		p99LatencyMs: Number(raw.p99LatencyMs ?? 0),
 		estimatedSpanCount: Number(raw.estimatedSpanCount ?? 0),
+		firstSeen: String(raw.firstSeen ?? ""),
 	}
 }
 
@@ -151,13 +156,32 @@ function aggregateByServiceEnvironment(rows: CoercedRow[], durationSeconds: numb
 			}
 		}
 
-		const commits: CommitBreakdown[] = group
-			.map((r) => ({
-				commitSha: r.commitSha,
-				spanCount: r.spanCount,
-				percentage: totalSpans > 0 ? Math.round((r.spanCount / totalSpans) * 100) : 0,
-			}))
-			.sort((a, b) => b.percentage - a.percentage)
+		// Merge namespace variants of the same commit so a sha never appears twice
+		// and its firstSeen/error totals cover every variant.
+		const commitTotals = new Map<string, { spanCount: number; errorCount: number; firstSeen: string }>()
+		for (const r of group) {
+			const existing = commitTotals.get(r.commitSha)
+			if (existing) {
+				existing.spanCount += r.spanCount
+				existing.errorCount += r.errorCount
+				if (r.firstSeen !== "" && (existing.firstSeen === "" || r.firstSeen < existing.firstSeen)) {
+					existing.firstSeen = r.firstSeen
+				}
+			} else {
+				commitTotals.set(r.commitSha, {
+					spanCount: r.spanCount,
+					errorCount: r.errorCount,
+					firstSeen: r.firstSeen,
+				})
+			}
+		}
+		const commits: CommitBreakdown[] = Array.from(commitTotals, ([commitSha, totals]) => ({
+			commitSha,
+			spanCount: totals.spanCount,
+			percentage: totalSpans > 0 ? Math.round((totals.spanCount / totalSpans) * 100) : 0,
+			errorCount: totals.errorCount,
+			firstSeen: totals.firstSeen,
+		})).sort((a, b) => b.percentage - a.percentage)
 
 		results.push({
 			serviceName: representative.serviceName,

--- a/apps/web/src/components/services/services-filter-sidebar.tsx
+++ b/apps/web/src/components/services/services-filter-sidebar.tsx
@@ -8,6 +8,10 @@ import { Route } from "@/routes/services/index"
 import { Separator } from "@maple/ui/components/ui/separator"
 import { getServicesFacetsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import {
+	isServiceHealth,
+	useServiceHealthSummary,
+} from "@/components/services/use-service-health-summary"
+import {
 	FilterSidebarBody,
 	FilterSidebarError,
 	FilterSidebarFrame,
@@ -37,6 +41,16 @@ export function ServicesFilterSidebar() {
 	const facetsResult = useRefreshableAtomValue(facetsAtom)
 	const refreshFacets = useAtomRefresh(facetsAtom)
 
+	// Client-side facet: derived from the same cached overview/incident/anomaly
+	// atoms the table subscribes to — no extra requests, counts always agree
+	// with the table's health badges.
+	const healthSummary = useServiceHealthSummary({
+		startTime: effectiveStartTime,
+		endTime: effectiveEndTime,
+		environments: search.environments,
+		commitShas: search.commitShas,
+	})
+
 	const updateFilter = <K extends keyof typeof search>(key: K, value: (typeof search)[K]) => {
 		navigate({
 			search: (prev: Record<string, unknown>) => ({
@@ -57,7 +71,10 @@ export function ServicesFilterSidebar() {
 		})
 	}
 
-	const hasActiveFilters = (search.environments?.length ?? 0) > 0 || (search.commitShas?.length ?? 0) > 0
+	const hasActiveFilters =
+		(search.environments?.length ?? 0) > 0 ||
+		(search.commitShas?.length ?? 0) > 0 ||
+		search.health !== undefined
 
 	return Result.builder(facetsResult)
 		.onInitial(() => <LoadingState />)
@@ -69,6 +86,33 @@ export function ServicesFilterSidebar() {
 				<FilterSidebarFrame waiting={result.waiting}>
 					<FilterSidebarHeader canClear={hasActiveFilters} onClear={clearAllFilters} />
 					<FilterSidebarBody>
+						{healthSummary !== undefined && (
+							<>
+								<FilterSection
+									title="Health"
+									options={(["unhealthy", "degraded", "healthy"] as const).map(
+										(level) => ({
+											name: level,
+											count: healthSummary.counts[level],
+										}),
+									)}
+									selected={search.health === undefined ? [] : [search.health]}
+									onChange={(selected) => {
+										// Single-select semantics on a multi-select control: the
+										// newly toggled value wins; re-unchecking clears the filter.
+										const next = selected.find((value) => value !== search.health)
+										updateFilter(
+											"health",
+											next !== undefined && isServiceHealth(next)
+												? next
+												: undefined,
+										)
+									}}
+								/>
+								<Separator className="my-2" />
+							</>
+						)}
+
 						{(facets.environments.length ?? 0) > 0 && (
 							<>
 								<FilterSection

--- a/apps/web/src/components/services/services-table.tsx
+++ b/apps/web/src/components/services/services-table.tsx
@@ -5,7 +5,17 @@ import { Link, useNavigate } from "@tanstack/react-router"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { useAlertIncidentsList } from "@/hooks/use-alerts-list"
-import { deriveServiceHealthFromCauses, type ServiceHealthCause } from "@/components/dashboard/service-health"
+import {
+	buildBaselineMap,
+	baselineKey,
+	type LatencyBaselineSignal,
+	type ServiceHealth,
+} from "@/components/dashboard/service-health"
+import {
+	serviceHealthRowKey,
+	useServiceHealthSummary,
+} from "@/components/services/use-service-health-summary"
+import { formatTimeAgo } from "@/components/services/section-card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@maple/ui/components/ui/table"
 import { Badge } from "@maple/ui/components/ui/badge"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
@@ -13,16 +23,34 @@ import { Sparkline } from "@maple/ui/components/ui/gradient-chart"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@maple/ui/components/ui/tooltip"
 import { cn } from "@maple/ui/utils"
 import { formatErrorRate } from "@maple/ui/lib/format"
-import { CommitShaHoverCard } from "@/components/vcs/commit-sha-hover-card"
+import {
+	CommitShaHoverCard,
+	commitQueryAtom,
+	firstLine,
+	isResolvableSha,
+} from "@/components/vcs/commit-sha-hover-card"
 import { QueryErrorState } from "@/components/common/query-error-state"
-import { type ServiceOverview, type CommitBreakdown } from "@/api/warehouse/services"
+import {
+	type CommitBreakdown,
+	type ServiceOverview,
+	type ServiceTimeSeriesPoint,
+} from "@/api/warehouse/services"
 import {
 	getCustomChartServiceSparklinesResultAtom,
+	getServiceHealthBaselineResultAtom,
 	getServiceOverviewResultAtom,
 } from "@/lib/services/atoms/warehouse-query-atoms"
 import { openAnomalyIncidentsAtom } from "@/lib/services/atoms/anomaly-atoms"
+import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 import type { ServicesSearchParams } from "@/routes/services/index"
 import { ServiceDot } from "@maple/ui/components/service-dot"
+
+// One fleet-level call: open (actionable) error-issue counts grouped by
+// service name. Progressive enrichment — the table renders without it.
+const openIssueCountsAtom = MapleApiV2AtomClient.query("errorIssues", "serviceCounts", {
+	reactivityKeys: ["errorIssues"],
+	timeToLive: 60_000,
+})
 
 function formatLatency(ms: number): string {
 	if (ms == null || Number.isNaN(ms)) {
@@ -102,58 +130,201 @@ function truncateCommitSha(sha: string, length = 7): string {
 	return sha.slice(0, length)
 }
 
-function CommitsList({ commits }: { commits: CommitBreakdown[] }) {
-	if (commits.length === 0) {
-		return <span className="text-muted-foreground">N/A</span>
-	}
+// ---------------------------------------------------------------------------
+// Health lane
+// ---------------------------------------------------------------------------
 
-	if (commits.length === 1) {
-		const sha = commits[0].commitSha
-		return (
-			<CommitShaHoverCard sha={sha} className="font-mono">
-				{truncateCommitSha(sha)}
-			</CommitShaHoverCard>
-		)
-	}
+const HEALTH_DOT_CLASS: Record<ServiceHealth, string> = {
+	healthy: "bg-success",
+	degraded: "bg-severity-warn",
+	unhealthy: "bg-destructive",
+}
 
-	// Several versions served traffic: keep the row ONE line — the dominant
-	// commit (hover-resolvable) plus a "+N" chip whose tooltip holds the full
-	// breakdown. Rendering every sha inline stacked the cell several rows tall
-	// and made the table unreadable for services mid-rollout.
-	const ordered = commits.toSorted((a, b) => b.percentage - a.percentage)
-	const [dominant, ...rest] = ordered
+/** Quiet health marker next to the service name — rendered only when there is
+ *  something to say (degraded/unhealthy); healthy rows stay unadorned. */
+function HealthDot({ health }: { health: ServiceHealth | undefined }) {
+	if (health === undefined || health === "healthy") return null
 	return (
-		<div className="flex items-center gap-1">
-			<CommitShaHoverCard sha={dominant.commitSha} className="font-mono">
-				{truncateCommitSha(dominant.commitSha)}
-			</CommitShaHoverCard>
-			<Badge variant="secondary" className="px-1 py-0 text-[10px] leading-tight">
-				{dominant.percentage}%
-			</Badge>
-			<Tooltip>
-				<TooltipTrigger
-					className="cursor-default rounded bg-muted px-1 py-0 font-mono text-[10px] leading-tight text-muted-foreground"
-					aria-label={`${rest.length} more versions`}
-				>
-					+{rest.length}
-				</TooltipTrigger>
-				<TooltipContent side="left" className="p-2">
-					<div className="flex flex-col gap-1">
-						{rest.map((c) => (
-							<div
-								key={c.commitSha}
-								className="flex items-center justify-between gap-3 font-mono text-xs"
-							>
-								<span>{truncateCommitSha(c.commitSha)}</span>
-								<span className="tabular-nums text-muted-foreground">{c.percentage}%</span>
-							</div>
-						))}
-					</div>
-				</TooltipContent>
-			</Tooltip>
-		</div>
+		<span
+			aria-label={health}
+			title={health}
+			className={cn("size-1.5 shrink-0 rounded-full", HEALTH_DOT_CLASS[health])}
+		/>
 	)
 }
+
+// ---------------------------------------------------------------------------
+// P95 baseline delta
+// ---------------------------------------------------------------------------
+
+// Mirrors MIN_BASELINE_SPANS in service-health.ts: a baseline computed from
+// fewer spans is noise, so the delta line is withheld entirely.
+const MIN_BASELINE_SPANS = 100
+
+interface BaselineDelta {
+	label: string
+	className: string
+}
+
+function baselineDelta(p95LatencyMs: number, baseline: LatencyBaselineSignal | undefined): BaselineDelta | undefined {
+	if (baseline === undefined || baseline.spanCount < MIN_BASELINE_SPANS || baseline.p95LatencyMs <= 0) {
+		return undefined
+	}
+	const delta = (p95LatencyMs - baseline.p95LatencyMs) / baseline.p95LatencyMs
+	const pct = Math.round(delta * 100)
+	return {
+		label: `${pct > 0 ? "+" : ""}${pct}% vs 7d`,
+		className:
+			delta >= 1 ? "text-severity-error" : delta >= 0.25 ? "text-severity-warn" : "text-muted-foreground",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Last deploy cell
+// ---------------------------------------------------------------------------
+
+// Below this many spans on either side of the split, the errors-since-deploy
+// comparison is too noisy to flag.
+const MIN_DEPLOY_COMPARE_SPANS = 50
+// A commit needs at least this share of traffic to count toward "mid-rollout".
+const ROLLOUT_MIN_SHARE_PCT = 5
+
+interface DeployCellInfo {
+	sha: string
+	firstSeen: string
+	rollout?: { percentage: number; others: CommitBreakdown[] }
+	errorsSince: boolean
+}
+
+function deriveDeployInfo(commits: CommitBreakdown[]): DeployCellInfo | undefined {
+	const real = commits.filter((c) => c.commitSha && c.commitSha !== "N/A" && c.commitSha !== "unknown")
+	if (real.length === 0) return undefined
+	const dated = real.filter((c) => c.firstSeen !== "")
+	const pool = dated.length > 0 ? dated : real
+	const latest = pool.reduce((best, c) => (c.firstSeen > best.firstSeen ? c : best))
+	const dominant = real.reduce((best, c) => (c.spanCount > best.spanCount ? c : best))
+
+	const older = real.filter((c) => c !== latest)
+	const olderSpans = older.reduce((sum, c) => sum + c.spanCount, 0)
+	const olderErrors = older.reduce((sum, c) => sum + c.errorCount, 0)
+	const latestRate = latest.spanCount > 0 ? latest.errorCount / latest.spanCount : 0
+	const olderRate = olderSpans > 0 ? olderErrors / olderSpans : 0
+	// "Errors ↑ since deploy": the newest commit errors at least twice as often
+	// as everything it is replacing, by a margin that can't be rounding noise.
+	const errorsSince =
+		latest.spanCount >= MIN_DEPLOY_COMPARE_SPANS &&
+		olderSpans >= MIN_DEPLOY_COMPARE_SPANS &&
+		latestRate >= olderRate * 2 &&
+		latestRate - olderRate >= 0.005
+
+	const meaningful = real.filter((c) => c.percentage >= ROLLOUT_MIN_SHARE_PCT)
+	const rollout =
+		meaningful.length > 1
+			? {
+					percentage: dominant.percentage,
+					others: real.filter((c) => c !== dominant).toSorted((a, b) => b.percentage - a.percentage),
+				}
+			: undefined
+
+	return { sha: latest.commitSha, firstSeen: latest.firstSeen, rollout, errorsSince }
+}
+
+interface DeployLinesProps {
+	sha: string
+	firstSeen: string
+	/** Replaces the default `sha · age` meta line (rollout / errors-since state). */
+	stateLine: React.ReactNode | undefined
+}
+
+function deployMetaLine(text: string) {
+	return text === "" ? null : (
+		<span className="truncate font-mono text-[10px] text-muted-foreground">{text}</span>
+	)
+}
+
+/**
+ * Message-first deploy lines: subject line on top (once the deduped, cached
+ * per-sha lookup resolves), `sha · age` demoted underneath. While unresolved —
+ * or when the reference isn't a resolvable sha — the sha IS the headline, so
+ * the meta line carries only the age instead of repeating it.
+ */
+function ResolvedDeployLines({ sha, firstSeen, stateLine }: DeployLinesProps) {
+	const result = useAtomValue(commitQueryAtom(sha))
+	const shortSha = truncateCommitSha(sha)
+	const age = firstSeen !== "" ? formatTimeAgo(firstSeen) : ""
+	const message = Result.isSuccess(result) ? firstLine(result.value.message) : ""
+	return (
+		<>
+			<CommitShaHoverCard sha={sha} className="min-w-0 max-w-full truncate text-xs text-foreground">
+				{message !== "" ? message : shortSha}
+			</CommitShaHoverCard>
+			{stateLine ?? deployMetaLine(message !== "" ? [shortSha, age].filter(Boolean).join(" · ") : age)}
+		</>
+	)
+}
+
+function DeployLines({ sha, firstSeen, stateLine }: DeployLinesProps) {
+	if (isResolvableSha(sha)) {
+		return <ResolvedDeployLines sha={sha} firstSeen={firstSeen} stateLine={stateLine} />
+	}
+	const age = firstSeen !== "" ? formatTimeAgo(firstSeen) : ""
+	return (
+		<>
+			<CommitShaHoverCard sha={sha} className="min-w-0 max-w-full truncate text-xs text-foreground">
+				{truncateCommitSha(sha)}
+			</CommitShaHoverCard>
+			{stateLine ?? deployMetaLine(age)}
+		</>
+	)
+}
+
+const DeployCell = React.memo(function DeployCell({ commits }: { commits: CommitBreakdown[] }) {
+	const info = deriveDeployInfo(commits)
+	if (info === undefined) {
+		return <span className="text-xs text-muted-foreground">N/A</span>
+	}
+	const stateLine = info.errorsSince ? (
+		<span className="truncate text-[10px] text-severity-error">
+			{info.firstSeen !== "" ? `${formatTimeAgo(info.firstSeen)} · ` : ""}errors ↑ since
+		</span>
+	) : info.rollout !== undefined ? (
+		<Tooltip>
+			<TooltipTrigger className="flex cursor-default items-center gap-1.5">
+				<span className="relative h-[3px] w-10 shrink-0 overflow-hidden rounded-full bg-muted">
+					<span
+						className="absolute inset-y-0 left-0 rounded-full bg-primary"
+						style={{ width: `${info.rollout.percentage}%` }}
+					/>
+				</span>
+				<span className="font-mono text-[10px] text-primary">
+					{info.rollout.percentage}% · +{info.rollout.others.length}
+				</span>
+			</TooltipTrigger>
+			<TooltipContent side="left" className="p-2">
+				<div className="flex flex-col gap-1">
+					{info.rollout.others.map((c) => (
+						<div
+							key={c.commitSha}
+							className="flex items-center justify-between gap-3 font-mono text-xs"
+						>
+							<span>{truncateCommitSha(c.commitSha)}</span>
+							<span className="tabular-nums text-muted-foreground">{c.percentage}%</span>
+						</div>
+					))}
+				</div>
+			</TooltipContent>
+		</Tooltip>
+	) : undefined
+	return (
+		<div className="flex min-w-0 flex-col gap-0.5">
+			<DeployLines sha={info.sha} firstSeen={info.firstSeen} stateLine={stateLine} />
+		</div>
+	)
+})
+
+// ---------------------------------------------------------------------------
+// Environment group header
+// ---------------------------------------------------------------------------
 
 function EnvironmentBadge({ environment }: { environment: string }) {
 	const getVariant = () => {
@@ -176,6 +347,162 @@ function EnvironmentBadge({ environment }: { environment: string }) {
 	)
 }
 
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
+
+interface ServiceRowProps {
+	service: ServiceOverview
+	series: ServiceTimeSeriesPoint[] | undefined
+	filters: ServicesSearchParams | undefined
+	health: ServiceHealth | undefined
+	baseline: LatencyBaselineSignal | undefined
+	issueCount: number | undefined
+	navigate: ReturnType<typeof useNavigate>
+}
+
+const ServiceRow = React.memo(function ServiceRow({
+	service,
+	series,
+	filters,
+	health,
+	baseline,
+	issueCount,
+	navigate,
+}: ServiceRowProps) {
+	const throughputData = React.useMemo(
+		() => (series === undefined ? [] : series.map((p) => ({ value: p.throughput }))),
+		[series],
+	)
+	const errorRateData = React.useMemo(
+		() => (series === undefined ? [] : series.map((p) => ({ value: p.errorRate }))),
+		[series],
+	)
+	const delta = baselineDelta(service.p95LatencyMs, baseline)
+	const goToDetail = () =>
+		navigate({
+			to: "/services/$serviceName",
+			params: { serviceName: service.serviceName },
+			search: serviceDetailSearch(filters, service.environment),
+		})
+
+	return (
+		<TableRow
+			className={cn(
+				"cursor-pointer border-l-2 border-l-transparent hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset",
+				health === "unhealthy" && "border-l-destructive",
+			)}
+			tabIndex={0}
+			onClick={goToDetail}
+			onKeyDown={(e) => {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault()
+					goToDetail()
+				}
+			}}
+		>
+			<TableCell>
+				<Link
+					to="/services/$serviceName"
+					params={{ serviceName: service.serviceName }}
+					search={serviceDetailSearch(filters, service.environment)}
+					className="flex max-w-full items-center gap-1.5 font-medium text-primary hover:underline"
+					onClick={(e) => e.stopPropagation()}
+					title={service.serviceName}
+				>
+					<ServiceDot serviceName={service.serviceName} />
+					<span className="min-w-0 truncate">{service.serviceName}</span>
+					<HealthDot health={health} />
+				</Link>
+				{service.serviceNamespace ? (
+					<div className="truncate text-xs text-muted-foreground">{service.serviceNamespace}</div>
+				) : null}
+			</TableCell>
+			<TableCell className="hidden lg:table-cell font-mono text-xs">
+				{formatLatency(service.p50LatencyMs)}
+			</TableCell>
+			<TableCell className="font-mono text-xs">
+				<div>{formatLatency(service.p95LatencyMs)}</div>
+				{delta !== undefined && (
+					<div className={cn("text-[10px] tabular-nums", delta.className)}>{delta.label}</div>
+				)}
+			</TableCell>
+			<TableCell className="hidden lg:table-cell font-mono text-xs">
+				{formatLatency(service.p99LatencyMs)}
+			</TableCell>
+			<TableCell>
+				<div
+					className="relative h-8 w-full max-w-[120px]"
+					role="img"
+					aria-label={`Error rate: ${formatErrorRate(service.errorRate)}`}
+				>
+					<Sparkline
+						data={errorRateData}
+						color="var(--color-destructive, #ef4444)"
+						className="absolute inset-0 h-full w-full"
+					/>
+					<div className="absolute inset-0 flex items-center justify-center">
+						<span className="font-mono text-xs font-semibold [text-shadow:0_0_6px_var(--background),0_0_12px_var(--background),0_0_18px_var(--background)]">
+							{formatErrorRate(service.errorRate)}
+						</span>
+					</div>
+				</div>
+			</TableCell>
+			<TableCell className="hidden md:table-cell">
+				<Tooltip>
+					<TooltipTrigger
+						className="relative block h-8 w-full max-w-[120px]"
+						aria-label={`Throughput: ${formatThroughput(service.throughput)}`}
+					>
+						<Sparkline
+							data={throughputData}
+							color="var(--color-primary, #3b82f6)"
+							className="absolute inset-0 h-full w-full"
+						/>
+						<div className="absolute inset-0 flex flex-col items-center justify-center">
+							<span className="font-mono text-xs font-semibold [text-shadow:0_0_6px_var(--background),0_0_12px_var(--background),0_0_18px_var(--background)]">
+								{service.hasSampling ? "~" : ""}
+								{formatThroughput(service.throughput)}
+							</span>
+							{service.hasSampling && (
+								<span className="font-mono text-[9px] text-muted-foreground [text-shadow:0_0_6px_var(--background),0_0_12px_var(--background),0_0_18px_var(--background)]">
+									~{formatThroughput(service.tracedThroughput)} traced
+								</span>
+							)}
+						</div>
+					</TooltipTrigger>
+					{service.hasSampling && (
+						<TooltipContent side="bottom">
+							<p>
+								Estimated from {((1 / service.samplingWeight) * 100).toFixed(0)}% sampled traces
+								(x{service.samplingWeight.toFixed(0)} extrapolation)
+							</p>
+						</TooltipContent>
+					)}
+				</Tooltip>
+			</TableCell>
+			<TableCell className="hidden lg:table-cell text-center">
+				{issueCount !== undefined && issueCount > 0 ? (
+					<Badge
+						variant="secondary"
+						className={cn(
+							"px-1.5 py-0 font-mono text-[10px] tabular-nums",
+							health === "unhealthy" && "bg-destructive/15 text-severity-error",
+						)}
+					>
+						{issueCount}
+					</Badge>
+				) : (
+					<span className="text-xs text-muted-foreground">—</span>
+				)}
+			</TableCell>
+			<TableCell className="hidden lg:table-cell">
+				<DeployCell commits={service.commits} />
+			</TableCell>
+		</TableRow>
+	)
+})
+
 interface ServicesTableProps {
 	filters?: ServicesSearchParams
 }
@@ -188,12 +515,13 @@ function LoadingState() {
 					<TableHeader>
 						<TableRow>
 							<TableHead>Service</TableHead>
-							<TableHead className="w-[8%]">P50</TableHead>
-							<TableHead className="w-[8%]">P95</TableHead>
-							<TableHead className="w-[8%]">P99</TableHead>
-							<TableHead className="w-[14%]">Error Rate</TableHead>
-							<TableHead className="w-[14%]">Throughput</TableHead>
-							<TableHead className="w-[16%]">Commit</TableHead>
+							<TableHead className="w-[6%]">P50</TableHead>
+							<TableHead className="w-[9%]">P95</TableHead>
+							<TableHead className="w-[7%]">P99</TableHead>
+							<TableHead className="w-[12%]">Error Rate</TableHead>
+							<TableHead className="w-[12%]">Throughput</TableHead>
+							<TableHead className="w-[7%]">Issues</TableHead>
+							<TableHead className="w-[15%]">Last deploy</TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
@@ -203,13 +531,13 @@ function LoadingState() {
 									<Skeleton className="h-4 w-32" />
 								</TableCell>
 								<TableCell>
-									<Skeleton className="h-4 w-14" />
+									<Skeleton className="h-4 w-12" />
 								</TableCell>
 								<TableCell>
 									<Skeleton className="h-4 w-14" />
 								</TableCell>
 								<TableCell>
-									<Skeleton className="h-4 w-14" />
+									<Skeleton className="h-4 w-12" />
 								</TableCell>
 								<TableCell>
 									<Skeleton className="h-8 w-full" />
@@ -218,7 +546,10 @@ function LoadingState() {
 									<Skeleton className="h-8 w-full" />
 								</TableCell>
 								<TableCell>
-									<Skeleton className="h-4 w-16" />
+									<Skeleton className="h-4 w-8" />
+								</TableCell>
+								<TableCell>
+									<Skeleton className="h-4 w-24" />
 								</TableCell>
 							</TableRow>
 						))}
@@ -274,277 +605,169 @@ export function ServicesTable({ filters }: ServicesTableProps) {
 	)
 
 	const healthFilter = filters?.health
+	// Kept in the blocking Result.all below so the health lane never flashes
+	// from "healthy" to "unhealthy" after first paint; the derivation itself
+	// lives in useServiceHealthSummary (shared with the filter sidebar).
 	const { result: incidentsResult } = useAlertIncidentsList()
 	const anomaliesResult = useAtomValue(openAnomalyIncidentsAtom)
+	const healthSummary = useServiceHealthSummary({
+		startTime: effectiveStartTime,
+		endTime: effectiveEndTime,
+		environments: filters?.environments,
+		commitShas: filters?.commitShas,
+	})
+
+	// Progressive enrichment — neither blocks first paint. The baseline payload
+	// is hour-snapped upstream, so this atom refetches at most hourly; issue
+	// counts are one cheap Postgres GROUP BY.
+	const baselineResult = useAtomValue(
+		getServiceHealthBaselineResultAtom({
+			data: {
+				rangeStartTime: effectiveStartTime,
+				environments: filters?.environments,
+			},
+		}),
+	)
+	const issueCountsResult = useAtomValue(openIssueCountsAtom)
+
+	const baselineData = Result.isSuccess(baselineResult) ? baselineResult.value : undefined
+	const baselineMap = React.useMemo(
+		() => (baselineData === undefined ? undefined : buildBaselineMap(baselineData.data)),
+		[baselineData],
+	)
+	const issueCountsData = Result.isSuccess(issueCountsResult) ? issueCountsResult.value : undefined
+	const issueCountByService = React.useMemo(() => {
+		if (issueCountsData === undefined) return undefined
+		return new Map(issueCountsData.data.map((row) => [row.service_name, row.open_count]))
+	}, [issueCountsData])
 
 	return Result.builder(Result.all([overviewResult, timeSeriesResult, anomaliesResult, incidentsResult]))
 		.onInitial(() => <LoadingState />)
 		.onError((error) => <QueryErrorState error={error} />)
-		.onSuccess(
-			(
-				[overviewResponse, timeSeriesResponse, anomaliesResponse, incidentsResponse],
-				combinedResult,
-			) => {
-				const timeSeriesMap = timeSeriesResponse.data
-				const openIncidents = incidentsResponse.incidents.filter(
-					(incident) => incident.status === "open",
-				)
-				const services = healthFilter
-					? overviewResponse.data.filter((service) => {
-							const alertCauses: ServiceHealthCause[] = openIncidents
-								.filter((incident) => incident.groupKey === service.serviceName)
-								.map((incident) => ({ severity: incident.severity, label: "Alert firing" }))
-							const anomalyCauses: ServiceHealthCause[] = anomaliesResponse.incidents
-								.filter(
-									(incident) =>
-										incident.serviceName === service.serviceName &&
-										incident.deploymentEnv === service.environment,
-								)
-								.map((incident) => ({ severity: incident.severity, label: "Anomaly" }))
-							return (
-								deriveServiceHealthFromCauses([...alertCauses, ...anomalyCauses]) ===
-								healthFilter
-							)
-						})
-					: overviewResponse.data
+		.onSuccess(([overviewResponse, timeSeriesResponse], combinedResult) => {
+			const timeSeriesMap = timeSeriesResponse.data
+			const healthFor = (service: ServiceOverview) =>
+				healthSummary?.byRow.get(serviceHealthRowKey(service.serviceName, service.environment))
+			const services = healthFilter
+				? overviewResponse.data.filter((service) => healthFor(service) === healthFilter)
+				: overviewResponse.data
 
-				const groups = groupByEnvironment(services)
+			const groups = groupByEnvironment(services)
 
+			// Tally over the DISPLAYED rows so the footer agrees with the table
+			// under active filters.
+			let unhealthyCount = 0
+			let degradedCount = 0
+			for (const service of services) {
+				const health = healthFor(service)
+				if (health === "unhealthy") unhealthyCount += 1
+				else if (health === "degraded") degradedCount += 1
+			}
+
+			const rowFor = (service: ServiceOverview) => {
+				const serviceSeries = Object.hasOwn(timeSeriesMap, service.serviceName)
+					? timeSeriesMap[service.serviceName]
+					: undefined
 				return (
-					<div
-						className={`space-y-4 transition-opacity ${combinedResult.waiting ? "opacity-60" : ""}`}
-					>
-						{/* Desktop: full metrics table. Below md the fixed-width columns and
-					    in-cell sparklines force horizontal scroll, so we swap to a list. */}
-						<div className="hidden md:block rounded-md border overflow-auto">
-							{/* Fixed layout: the metric columns keep their set widths and the
-							    Service column absorbs whatever remains, truncating long names —
-							    so the table always fits the viewport instead of scrolling
-							    horizontally. */}
-							<Table aria-label="Services" className="w-full table-fixed">
-								<TableHeader>
+					<ServiceRow
+						key={`${service.serviceName}-${service.serviceNamespace}-${service.environment}`}
+						service={service}
+						series={Array.isArray(serviceSeries) ? serviceSeries : undefined}
+						filters={filters}
+						health={healthFor(service)}
+						baseline={baselineMap?.get(
+							baselineKey(service.serviceName, service.serviceNamespace, service.environment),
+						)}
+						issueCount={issueCountByService?.get(service.serviceName)}
+						navigate={navigate}
+					/>
+				)
+			}
+
+			return (
+				<div
+					className={`space-y-4 transition-opacity ${combinedResult.waiting ? "opacity-60" : ""}`}
+				>
+					{/* Desktop: full metrics table. Below md the fixed-width columns and
+				    in-cell sparklines force horizontal scroll, so we swap to a list. */}
+					<div className="hidden md:block rounded-md border overflow-auto">
+						{/* Fixed layout: the metric columns keep their set widths and the
+						    Service column absorbs whatever remains, truncating long names —
+						    so the table always fits the viewport instead of scrolling
+						    horizontally. */}
+						<Table aria-label="Services" className="w-full table-fixed">
+							<TableHeader>
+								<TableRow>
+									{/* Explicit width so the fixed layout scales every column
+									    proportionally — leaving Service auto would let the fixed
+									    metric columns squeeze it to nothing on narrow viewports. */}
+									<TableHead>Service</TableHead>
+									<TableHead className="hidden lg:table-cell w-[6%]">P50</TableHead>
+									<TableHead className="w-[9%]">P95</TableHead>
+									<TableHead className="hidden lg:table-cell w-[7%]">P99</TableHead>
+									<TableHead className="w-[12%]">Error Rate</TableHead>
+									<TableHead className="hidden md:table-cell w-[12%]">
+										Throughput
+									</TableHead>
+									<TableHead className="hidden lg:table-cell w-[7%] text-center">
+										Issues
+									</TableHead>
+									<TableHead className="hidden lg:table-cell w-[15%]">
+										Last deploy
+									</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{services.length === 0 ? (
 									<TableRow>
-										{/* Explicit width so the fixed layout scales every column
-										    proportionally — leaving Service auto would let the fixed
-										    metric columns squeeze it to nothing on narrow viewports. */}
-										<TableHead>Service</TableHead>
-										<TableHead className="hidden lg:table-cell w-[8%]">P50</TableHead>
-										<TableHead className="hidden lg:table-cell w-[8%]">P95</TableHead>
-										<TableHead className="w-[8%]">P99</TableHead>
-										<TableHead className="w-[14%]">Error Rate</TableHead>
-										<TableHead className="hidden md:table-cell w-[14%]">
-											Throughput
-										</TableHead>
-										<TableHead className="hidden lg:table-cell w-[16%]">Commit</TableHead>
+										<TableCell colSpan={8} className="h-24 text-center">
+											No services found
+										</TableCell>
 									</TableRow>
-								</TableHeader>
-								<TableBody>
-									{services.length === 0 ? (
-										<TableRow>
-											<TableCell colSpan={7} className="h-24 text-center">
-												No services found
-											</TableCell>
-										</TableRow>
-									) : (
-										groups.map(([environment, envServices]) => (
-											<React.Fragment key={environment}>
-												<TableRow className="bg-muted/30 hover:bg-muted/30">
-													<TableCell colSpan={7} className="py-2">
-														<div className="flex items-center gap-2">
-															<EnvironmentBadge environment={environment} />
-															<span className="text-xs text-muted-foreground">
-																{envServices.length}{" "}
-																{envServices.length === 1
-																	? "service"
-																	: "services"}
-															</span>
-														</div>
-													</TableCell>
-												</TableRow>
-												{envServices.map((service: ServiceOverview) => {
-													const serviceSeries = Object.hasOwn(
-														timeSeriesMap,
-														service.serviceName,
-													)
-														? timeSeriesMap[service.serviceName]
-														: undefined
-													const throughputData = Array.isArray(serviceSeries)
-														? serviceSeries.map((p) => ({ value: p.throughput }))
-														: []
-													const errorRateData = Array.isArray(serviceSeries)
-														? serviceSeries.map((p) => ({ value: p.errorRate }))
-														: []
+								) : (
+									groups.map(([environment, envServices]) => (
+										<React.Fragment key={environment}>
+											<TableRow className="bg-muted/30 hover:bg-muted/30">
+												<TableCell colSpan={8} className="py-2">
+													<div className="flex items-center gap-2">
+														<EnvironmentBadge environment={environment} />
+														<span className="text-xs text-muted-foreground">
+															{envServices.length}{" "}
+															{envServices.length === 1
+																? "service"
+																: "services"}
+														</span>
+													</div>
+												</TableCell>
+											</TableRow>
+											{envServices.map(rowFor)}
+										</React.Fragment>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</div>
 
-													return (
-														<TableRow
-															key={`${service.serviceName}-${service.serviceNamespace}-${service.environment}`}
-															className="cursor-pointer hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset"
-															tabIndex={0}
-															onClick={() =>
-																navigate({
-																	to: "/services/$serviceName",
-																	params: {
-																		serviceName: service.serviceName,
-																	},
-																	search: serviceDetailSearch(
-																		filters,
-																		service.environment,
-																	),
-																})
-															}
-															onKeyDown={(e) => {
-																if (e.key === "Enter" || e.key === " ") {
-																	e.preventDefault()
-																	navigate({
-																		to: "/services/$serviceName",
-																		params: {
-																			serviceName: service.serviceName,
-																		},
-																		search: serviceDetailSearch(
-																			filters,
-																			service.environment,
-																		),
-																	})
-																}
-															}}
-														>
-															<TableCell>
-																<Link
-																	to="/services/$serviceName"
-																	params={{
-																		serviceName: service.serviceName,
-																	}}
-																	search={serviceDetailSearch(
-																		filters,
-																		service.environment,
-																	)}
-																	className="flex max-w-full items-center gap-1.5 font-medium text-primary hover:underline"
-																	onClick={(e) => e.stopPropagation()}
-																	title={service.serviceName}
-																>
-																	<ServiceDot
-																		serviceName={service.serviceName}
-																	/>
-																	<span className="min-w-0 truncate">
-																		{service.serviceName}
-																	</span>
-																</Link>
-																{service.serviceNamespace ? (
-																	<div className="truncate text-xs text-muted-foreground">
-																		{service.serviceNamespace}
-																	</div>
-																) : null}
-															</TableCell>
-															<TableCell className="hidden lg:table-cell font-mono text-xs">
-																{formatLatency(service.p50LatencyMs)}
-															</TableCell>
-															<TableCell className="hidden lg:table-cell font-mono text-xs">
-																{formatLatency(service.p95LatencyMs)}
-															</TableCell>
-															<TableCell className="font-mono text-xs">
-																{formatLatency(service.p99LatencyMs)}
-															</TableCell>
-															<TableCell>
-																<div
-																	className="relative h-8 w-full max-w-[120px]"
-																	role="img"
-																	aria-label={`Error rate: ${formatErrorRate(service.errorRate)}`}
-																>
-																	<Sparkline
-																		data={errorRateData}
-																		color="var(--color-destructive, #ef4444)"
-																		className="absolute inset-0 h-full w-full"
-																	/>
-																	<div className="absolute inset-0 flex items-center justify-center">
-																		<span className="font-mono text-xs font-semibold [text-shadow:0_0_6px_var(--background),0_0_12px_var(--background),0_0_18px_var(--background)]">
-																			{formatErrorRate(
-																				service.errorRate,
-																			)}
-																		</span>
-																	</div>
-																</div>
-															</TableCell>
-															<TableCell className="hidden md:table-cell">
-																<Tooltip>
-																	<TooltipTrigger
-																		className="relative block h-8 w-full max-w-[120px]"
-																		aria-label={`Throughput: ${formatThroughput(service.throughput)}`}
-																	>
-																		<Sparkline
-																			data={throughputData}
-																			color="var(--color-primary, #3b82f6)"
-																			className="absolute inset-0 h-full w-full"
-																		/>
-																		<div className="absolute inset-0 flex flex-col items-center justify-center">
-																			<span className="font-mono text-xs font-semibold [text-shadow:0_0_6px_var(--background),0_0_12px_var(--background),0_0_18px_var(--background)]">
-																				{service.hasSampling
-																					? "~"
-																					: ""}
-																				{formatThroughput(
-																					service.throughput,
-																				)}
-																			</span>
-																			{service.hasSampling && (
-																				<span className="font-mono text-[9px] text-muted-foreground [text-shadow:0_0_6px_var(--background),0_0_12px_var(--background),0_0_18px_var(--background)]">
-																					~
-																					{formatThroughput(
-																						service.tracedThroughput,
-																					)}{" "}
-																					traced
-																				</span>
-																			)}
-																		</div>
-																	</TooltipTrigger>
-																	{service.hasSampling && (
-																		<TooltipContent side="bottom">
-																			<p>
-																				Estimated from{" "}
-																				{(
-																					(1 /
-																						service.samplingWeight) *
-																					100
-																				).toFixed(0)}
-																				% sampled traces (x
-																				{service.samplingWeight.toFixed(
-																					0,
-																				)}{" "}
-																				extrapolation)
-																			</p>
-																		</TooltipContent>
-																	)}
-																</Tooltip>
-															</TableCell>
-															<TableCell className="hidden lg:table-cell font-mono text-xs text-muted-foreground">
-																<CommitsList commits={service.commits} />
-															</TableCell>
-														</TableRow>
-													)
-												})}
-											</React.Fragment>
-										))
-									)}
-								</TableBody>
-							</Table>
-						</div>
-
-						{/* Mobile: stacked, tap-to-drill list. Grouped by environment to
-					    match the desktop table; metrics collapse to a tight mono line. */}
-						<div className="overflow-hidden rounded-md border md:hidden">
-							{services.length === 0 ? (
-								<div className="p-6 text-center text-sm text-muted-foreground">
-									No services found
-								</div>
-							) : (
-								groups.map(([environment, envServices]) => (
-									<div key={environment}>
-										<div className="flex items-center gap-2 border-b bg-muted/30 px-3 py-2">
-											<EnvironmentBadge environment={environment} />
-											<span className="text-xs text-muted-foreground">
-												{envServices.length}{" "}
-												{envServices.length === 1 ? "service" : "services"}
-											</span>
-										</div>
-										{envServices.map((service: ServiceOverview) => (
+					{/* Mobile: stacked, tap-to-drill list. Grouped by environment to
+				    match the desktop table; metrics collapse to a tight mono line. */}
+					<div className="overflow-hidden rounded-md border md:hidden">
+						{services.length === 0 ? (
+							<div className="p-6 text-center text-sm text-muted-foreground">
+								No services found
+							</div>
+						) : (
+							groups.map(([environment, envServices]) => (
+								<div key={environment}>
+									<div className="flex items-center gap-2 border-b bg-muted/30 px-3 py-2">
+										<EnvironmentBadge environment={environment} />
+										<span className="text-xs text-muted-foreground">
+											{envServices.length}{" "}
+											{envServices.length === 1 ? "service" : "services"}
+										</span>
+									</div>
+									{envServices.map((service: ServiceOverview) => {
+										const health = healthFor(service)
+										return (
 											<Link
 												key={`${service.serviceName}-${service.serviceNamespace}-${service.environment}`}
 												to="/services/$serviceName"
@@ -558,6 +781,7 @@ export function ServicesTable({ filters }: ServicesTableProps) {
 														<span className="truncate">
 															{service.serviceName}
 														</span>
+														<HealthDot health={health} />
 													</div>
 													{service.serviceNamespace ? (
 														<div className="truncate text-xs text-muted-foreground">
@@ -598,19 +822,28 @@ export function ServicesTable({ filters }: ServicesTableProps) {
 													</div>
 												</div>
 											</Link>
-										))}
-									</div>
-								))
-							)}
-						</div>
+										)
+									})}
+								</div>
+							))
+						)}
+					</div>
 
-						<div className="text-sm text-muted-foreground">
+					<div className="flex items-center justify-between text-sm text-muted-foreground">
+						<span>
 							Showing {services.length} {healthFilter ?? ""}{" "}
 							{services.length === 1 ? "service" : "services"}
-						</div>
+						</span>
+						{(unhealthyCount > 0 || degradedCount > 0) && (
+							<span className="text-xs">
+								{unhealthyCount > 0 ? `${unhealthyCount} unhealthy` : null}
+								{unhealthyCount > 0 && degradedCount > 0 ? " · " : null}
+								{degradedCount > 0 ? `${degradedCount} degraded` : null}
+							</span>
+						)}
 					</div>
-				)
-			},
-		)
+				</div>
+			)
+		})
 		.render()
 }

--- a/apps/web/src/components/services/use-service-health-summary.ts
+++ b/apps/web/src/components/services/use-service-health-summary.ts
@@ -1,0 +1,81 @@
+import React from "react"
+import { Result, useAtomValue } from "@/lib/effect-atom"
+import { useAlertIncidentsList } from "@/hooks/use-alerts-list"
+import { openAnomalyIncidentsAtom } from "@/lib/services/atoms/anomaly-atoms"
+import { getServiceOverviewResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
+import {
+	deriveServiceHealthFromCauses,
+	type ServiceHealth,
+	type ServiceHealthCause,
+} from "@/components/dashboard/service-health"
+import type { GetServiceOverviewInput } from "@/api/warehouse/services"
+
+export interface ServiceHealthSummary {
+	/** Keyed by {@link serviceHealthRowKey} — one entry per (service, environment) row. */
+	byRow: Map<string, ServiceHealth>
+	counts: Record<ServiceHealth, number>
+}
+
+export const serviceHealthRowKey = (serviceName: string, environment: string) =>
+	`${serviceName}::${environment}`
+
+const HEALTH_LEVELS: readonly ServiceHealth[] = ["healthy", "degraded", "unhealthy"]
+
+export const isServiceHealth = (value: string): value is ServiceHealth =>
+	(HEALTH_LEVELS as readonly string[]).includes(value)
+
+/**
+ * Fleet-level health for every (service, environment) row of the services list.
+ *
+ * Derived purely from data the page already loads — the one-shot service
+ * overview, the locally-synced alert-incident collection, and the single
+ * open-anomalies call — so subscribing here from several components shares the
+ * same cached atoms and costs no extra requests. Alert incidents match by
+ * service name only (an incident's groupKey carries no environment), so an
+ * alert-caused badge repeats across a service's environment rows; anomalies
+ * match per (service, environment).
+ */
+export function useServiceHealthSummary(input: GetServiceOverviewInput): ServiceHealthSummary | undefined {
+	const overviewResult = useAtomValue(getServiceOverviewResultAtom({ data: input }))
+	const { result: incidentsResult } = useAlertIncidentsList()
+	const anomaliesResult = useAtomValue(openAnomalyIncidentsAtom)
+
+	const overview = Result.isSuccess(overviewResult) ? overviewResult.value : undefined
+	const incidents = Result.isSuccess(incidentsResult) ? incidentsResult.value : undefined
+	const anomalies = Result.isSuccess(anomaliesResult) ? anomaliesResult.value : undefined
+
+	return React.useMemo(() => {
+		if (overview === undefined || incidents === undefined || anomalies === undefined) return undefined
+
+		const alertCausesByService = new Map<string, ServiceHealthCause[]>()
+		for (const incident of incidents.incidents) {
+			if (incident.status !== "open" || !incident.groupKey) continue
+			const causes = alertCausesByService.get(incident.groupKey)
+			const cause: ServiceHealthCause = { severity: incident.severity, label: "Alert firing" }
+			if (causes) causes.push(cause)
+			else alertCausesByService.set(incident.groupKey, [cause])
+		}
+
+		const anomalyCausesByRow = new Map<string, ServiceHealthCause[]>()
+		for (const incident of anomalies.incidents) {
+			const key = serviceHealthRowKey(incident.serviceName, incident.deploymentEnv)
+			const causes = anomalyCausesByRow.get(key)
+			const cause: ServiceHealthCause = { severity: incident.severity, label: "Anomaly" }
+			if (causes) causes.push(cause)
+			else anomalyCausesByRow.set(key, [cause])
+		}
+
+		const byRow = new Map<string, ServiceHealth>()
+		const counts: Record<ServiceHealth, number> = { healthy: 0, degraded: 0, unhealthy: 0 }
+		for (const service of overview.data) {
+			const key = serviceHealthRowKey(service.serviceName, service.environment)
+			const health = deriveServiceHealthFromCauses([
+				...(alertCausesByService.get(service.serviceName) ?? []),
+				...(anomalyCausesByRow.get(key) ?? []),
+			])
+			byRow.set(key, health)
+			counts[health] += 1
+		}
+		return { byRow, counts }
+	}, [overview, incidents, anomalies])
+}

--- a/packages/domain/src/http/v2/error-issues.ts
+++ b/packages/domain/src/http/v2/error-issues.ts
@@ -133,6 +133,21 @@ const ErrorIssueList = ListOf(V2ErrorIssue).annotate({
 	identifier: "ErrorIssueList",
 	title: "Error issue list",
 })
+
+export const V2ErrorIssueServiceCount = Schema.Struct({
+	service_name: Schema.String,
+	open_count: Schema.Number,
+}).annotate({
+	identifier: "ErrorIssueServiceCount",
+	title: "Error issue service count",
+	description: "Number of open (actionable-state) error issues for one service.",
+})
+export type V2ErrorIssueServiceCount = Schema.Schema.Type<typeof V2ErrorIssueServiceCount>
+
+const ErrorIssueServiceCountList = ListOf(V2ErrorIssueServiceCount).annotate({
+	identifier: "ErrorIssueServiceCountList",
+	title: "Error issue service count list",
+})
 const commonErrors = [V2InvalidRequestError, V2ServiceUnavailableError] as const
 
 export class V2ErrorIssuesApiGroup extends HttpApiGroup.make("errorIssues")
@@ -147,6 +162,20 @@ export class V2ErrorIssuesApiGroup extends HttpApiGroup.make("errorIssues")
 				summary: "List error issues",
 				description:
 					"Returns a bounded, cursor-paginated page of your organization's issues. Requires `error_issues:read`.",
+			}),
+		),
+	)
+	.add(
+		// Static path — must be registered before the `/:id` param route.
+		HttpApiEndpoint.get("serviceCounts", "/service_counts", {
+			success: ErrorIssueServiceCountList,
+			error: [...commonErrors],
+		}).annotateMerge(
+			OpenApi.annotations({
+				identifier: "listErrorIssueServiceCounts",
+				summary: "List open issue counts by service",
+				description:
+					"Returns the number of open (actionable-state) error issues per service, in one call. Alert-kind issues are excluded. Requires `error_issues:read`.",
 			}),
 		),
 	)

--- a/packages/domain/src/http/v2/openapi.test.ts
+++ b/packages/domain/src/http/v2/openapi.test.ts
@@ -84,6 +84,7 @@ describe("MapleApiV2 OpenAPI", () => {
 			"GET /v2/dashboards/{id}/versions",
 			"GET /v2/dashboards/{id}/versions/{version_id}",
 			"GET /v2/error_issues",
+			"GET /v2/error_issues/service_counts",
 			"GET /v2/error_issues/{id}",
 			"GET /v2/ingest_keys",
 			"GET /v2/instrumentation/recommendations",

--- a/packages/query-engine/src/ch/queries/services.test.ts
+++ b/packages/query-engine/src/ch/queries/services.test.ts
@@ -110,6 +110,7 @@ describe("serviceOverviewQuery", () => {
 		expect(sql).toContain("quantile(0.5)(Duration) / 1000000 AS p50LatencyMs")
 		expect(sql).toContain("quantile(0.95)(Duration) / 1000000 AS p95LatencyMs")
 		expect(sql).toContain("quantile(0.99)(Duration) / 1000000 AS p99LatencyMs")
+		expect(sql).toContain("min(Timestamp) AS firstSeen")
 		expect(sql).toContain("GROUP BY serviceName, serviceNamespace, environment, commitSha")
 		expect(sql).toContain("ORDER BY throughput DESC")
 		expect(sql).toContain("LIMIT 100")

--- a/packages/query-engine/src/ch/queries/services.ts
+++ b/packages/query-engine/src/ch/queries/services.ts
@@ -38,6 +38,7 @@ export interface ServiceOverviewOutput {
 	readonly p95LatencyMs: number
 	readonly p99LatencyMs: number
 	readonly estimatedSpanCount: number
+	readonly firstSeen: string
 }
 
 export interface ServiceCatalogOpts {
@@ -113,6 +114,10 @@ export function serviceOverviewQuery(opts: ServiceOverviewOpts) {
 			// rows or `1 / acceptanceProbability` for spans carrying a `th:` value.
 			// Replaces the broken `sampledSpanCount * dominantWeight` approximation.
 			estimatedSpanCount: CH.sum($.SampleRate),
+			// Earliest span per (service, env, commit) inside the window — the
+			// list page derives deploy age / errors-since-deploy from this, so it
+			// is window-clamped by construction.
+			firstSeen: CH.min_($.Timestamp),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),


### PR DESCRIPTION
## What

Redesigns the `/services` list to the approved "dense table+" direction (designed in Paper first): each row now carries a health signal, a P95 delta vs the trailing-7d baseline, an open-issues count, and a message-first **Last deploy** cell — replacing the raw commit-sha column.

## How (data stays fleet-level — no N+1)

The page still issues a fixed number of fleet-level requests (verified in the network pane: overview, sparklines, facets, anomalies, baseline, issue counts):

- **Health** — new `useServiceHealthSummary` hook derives per-(service, env) health from the already-fetched alert incidents + anomalies; shared by the table and the sidebar's new client-side Health facet, so counts and badges can't disagree. Shown as a quiet dot next to the name (degraded/unhealthy only) + a destructive left rail, not a dedicated column.
- **P95 · Δ7d** — wires the existing fleet-level, hour-cached `serviceHealthBaseline` query (previously zero consumers); joined via the canonical `baselineKey`.
- **Issues** — new `GET /v2/error_issues/service_counts` → `ErrorsService.countOpenIssuesByService`, one Postgres `GROUP BY service_name` over actionable, error-kind, non-archived issues. Name-scoped only (env scoping would require the warehouse fingerprint intersection; deliberately out of scope).
- **Last deploy** — `serviceOverviewQuery` gains per-commit `firstSeen: min(Timestamp)` on the same scan; the cell derives rollout state (progress bar + breakdown tooltip) and an `errors ↑ since` flag (newest commit ≥2× older-commit error rate, ≥0.5pp, ≥50 spans both sides) client-side. Commit messages resolve lazily via the existing deduped per-sha `commitQueryAtom` — the one accepted soft fan-out, bounded by distinct live shas.

## Reviewer notes

- `serviceOverview`'s `cachedDirect` policy is bumped to **version 2** because rows gained `firstSeen` (stale cached rows would otherwise miss the field for one TTL window).
- `ServiceOverviewResponse` is schema-open (`Record<string, Unknown>`), so no domain change was needed for the overview; the v2 OpenAPI surface test pins the new `service_counts` path.
- Rows are extracted into a memoized `ServiceRow`; baseline/issues/messages are progressive enrichment (`Result.isSuccess` fallback) and never block first paint.
- `service.version` was considered and skipped — it isn't materialized in ClickHouse (only `CommitSha` is); would need an MV column first.

## Testing

- `bun run test` green across all 24 packages (new: query-engine compile assertions incl. `min(Timestamp) AS firstSeen`, PGlite test for `countOpenIssuesByService`, updated v2 surface test); `bun typecheck` green.
- Verified live against the dev stack: fleet-level request set confirmed, health filter + facet + footer tally work, columns render progressively, layout checked at 1280/1600px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787266525&installation_model_id=427786&pr_number=247&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F247&signature=65877d32640520887930dbb3b7f18986aa2dff599cd680b5bf71975639e27ab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->