### PR TITLE
feat(settings): redesign Ingestion page to Paper spec

### DIFF
--- a/apps/web/src/components/ingest/guided-setup.tsx
+++ b/apps/web/src/components/ingest/guided-setup.tsx
@@ -42,20 +42,29 @@ interface GuidedSetupProps {
 }
 
 /**
+ * Per-org framework selection for the guided ingestion flow, defaulting from the
+ * quick-start qualify answers. Shared by `GuidedSetup` and the ingestion
+ * settings page (which composes the picker into its own section header).
+ */
+export function useGuidedFramework() {
+	const { orgId } = useAuth()
+	const { selectedFramework, setSelectedFramework, qualifyAnswers } = useQuickStart(orgId)
+
+	const roleDefault = qualifyAnswers.role ? ROLE_DEFAULT_FRAMEWORK[qualifyAnswers.role] : "nodejs"
+	return { framework: selectedFramework ?? roleDefault, setFramework: setSelectedFramework }
+}
+
+/**
  * Framework picker + Install / Instrument / Claude Code tabs. The shared body of
  * the guided ingestion flow, used by the dashboard setup checklist and the
  * ingestion settings page. Selection persists via the per-org quick-start atom.
  */
 export function GuidedSetup({ apiKey, showCredentials = false }: GuidedSetupProps) {
-	const { orgId } = useAuth()
-	const { selectedFramework, setSelectedFramework, qualifyAnswers } = useQuickStart(orgId)
-
-	const roleDefault = qualifyAnswers.role ? ROLE_DEFAULT_FRAMEWORK[qualifyAnswers.role] : "nodejs"
-	const framework = selectedFramework ?? roleDefault
+	const { framework, setFramework } = useGuidedFramework()
 
 	return (
 		<div className="space-y-4">
-			<FrameworkPicker selected={framework} onSelect={setSelectedFramework} />
+			<FrameworkPicker selected={framework} onSelect={setFramework} />
 			<ConnectInstructions
 				framework={framework}
 				apiKey={apiKey}
@@ -65,56 +74,77 @@ export function GuidedSetup({ apiKey, showCredentials = false }: GuidedSetupProp
 	)
 }
 
-function FrameworkPicker({
+export function FrameworkPicker({
 	selected,
 	onSelect,
+	compact = false,
 }: {
 	selected: FrameworkId
 	onSelect: (id: FrameworkId) => void
+	/** Pill chips without the "Pick your stack" label — for section headers. */
+	compact?: boolean
 }) {
+	const chips = (
+		<div className="flex flex-wrap gap-1.5">
+			{sdkSnippets.map((snippet) => {
+				const Icon = frameworkIconMap[snippet.language]
+				const active = selected === snippet.language
+				return (
+					<button
+						key={snippet.language}
+						type="button"
+						onClick={() => onSelect(snippet.language)}
+						className={cn(
+							"flex items-center gap-1.5 border font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring",
+							compact
+								? "rounded-full px-2.5 py-1 font-mono text-[11px] leading-3.5"
+								: "rounded-lg px-3 py-2 text-xs gap-2",
+							active
+								? compact
+									? "border-primary text-primary"
+									: "border-primary bg-primary/10 text-primary"
+								: compact
+									? "border-border text-muted-foreground hover:text-foreground hover:border-foreground/30"
+									: "border-border hover:border-foreground/30",
+						)}
+					>
+						<Icon size={compact ? 12 : 14} />
+						{snippet.label}
+					</button>
+				)
+			})}
+		</div>
+	)
+
+	if (compact) return chips
+
 	return (
 		<div className="space-y-2">
 			<span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
 				Pick your stack
 			</span>
-			<div className="flex flex-wrap gap-2">
-				{sdkSnippets.map((snippet) => {
-					const Icon = frameworkIconMap[snippet.language]
-					const active = selected === snippet.language
-					return (
-						<button
-							key={snippet.language}
-							type="button"
-							onClick={() => onSelect(snippet.language)}
-							className={cn(
-								"flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring",
-								active
-									? "border-primary bg-primary/10 text-primary"
-									: "border-border hover:border-foreground/30",
-							)}
-						>
-							<Icon size={14} />
-							{snippet.label}
-						</button>
-					)
-				})}
-			</div>
+			{chips}
 		</div>
 	)
 }
 
-function ConnectInstructions({
+export function ConnectInstructions({
 	framework,
 	apiKey,
-	showCredentials,
+	showCredentials = false,
+	variant = "boxed",
 }: {
 	framework: FrameworkId
 	apiKey: string
-	showCredentials: boolean
+	showCredentials?: boolean
+	/** `flush` drops the outer border/background so the tabs sit directly in a parent card. */
+	variant?: "boxed" | "flush"
 }) {
 	const snippet = sdkSnippets.find((s) => s.language === framework)
 
 	if (!snippet) return null
+
+	const contentPadding = variant === "boxed" ? "p-3" : "px-4 pt-3 pb-4"
 
 	function interpolate(template: string) {
 		return template
@@ -123,9 +153,9 @@ function ConnectInstructions({
 	}
 
 	const tabs = (
-		<div className="rounded-lg border bg-card overflow-hidden">
+		<div className={variant === "boxed" ? "rounded-lg border bg-card overflow-hidden" : undefined}>
 			<Tabs defaultValue="install" className="flex flex-col">
-				<div className="border-b px-3">
+				<div className={cn("border-b", variant === "boxed" ? "px-3" : "px-4")}>
 					<TabsList variant="underline" className="h-9">
 						<TabsTrigger value="install">Install</TabsTrigger>
 						<TabsTrigger value="instrument">Instrument</TabsTrigger>
@@ -133,7 +163,7 @@ function ConnectInstructions({
 					</TabsList>
 				</div>
 
-				<TabsContent value="install" className="overflow-auto p-3 mt-0">
+				<TabsContent value="install" className={cn("overflow-auto mt-0", contentPadding)}>
 					{typeof snippet.install === "string" ? (
 						<CodeBlock code={snippet.install} language="shell" />
 					) : (
@@ -141,11 +171,11 @@ function ConnectInstructions({
 					)}
 				</TabsContent>
 
-				<TabsContent value="instrument" className="overflow-auto p-3 mt-0">
+				<TabsContent value="instrument" className={cn("overflow-auto mt-0", contentPadding)}>
 					<CodeBlock code={interpolate(snippet.instrument)} language={snippet.label.toLowerCase()} />
 				</TabsContent>
 
-				<TabsContent value="claude-code" className="overflow-auto p-3 mt-0 space-y-2">
+				<TabsContent value="claude-code" className={cn("overflow-auto mt-0 space-y-2", contentPadding)}>
 					<p className="text-xs text-muted-foreground">
 						Run this prompt in Claude Code (or Codex / Cursor with the skill installed). The{" "}
 						<code className="rounded bg-muted px-1">maple-onboard</code> skill walks every service

--- a/apps/web/src/components/ingest/use-ingest-connection.ts
+++ b/apps/web/src/components/ingest/use-ingest-connection.ts
@@ -14,6 +14,8 @@ export interface IngestConnection {
 	serviceCount: number
 	/** First real service name, if any — handy for "we're seeing X" copy. */
 	firstRealService?: string
+	/** Spans per minute across real services, averaged over the 1h window. */
+	spansPerMinute: number
 	/** The org's public ingest key (empty string until loaded / when denied). */
 	apiKey: string
 	/** Force an immediate re-poll of the service overview. */
@@ -50,11 +52,13 @@ export function useIngestConnection({ poll = true }: UseIngestConnectionOptions 
 	)
 	const firstRealService =
 		typeof realServices[0]?.serviceName === "string" ? (realServices[0].serviceName as string) : undefined
+	const spansPerMinute = realServices.reduce((sum, s) => sum + (s.spanCount ?? 0), 0) / 60
 
 	return {
 		status: realServices.length > 0 ? "connected" : "waiting",
 		serviceCount: realServices.length,
 		firstRealService,
+		spansPerMinute,
 		apiKey,
 		refresh,
 	}

--- a/apps/web/src/components/settings/attribute-mappings-section.tsx
+++ b/apps/web/src/components/settings/attribute-mappings-section.tsx
@@ -22,14 +22,6 @@ import {
 import { Badge } from "@maple/ui/components/ui/badge"
 import { Button } from "@maple/ui/components/ui/button"
 import {
-	Card,
-	CardAction,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@maple/ui/components/ui/card"
-import {
 	Dialog,
 	DialogContent,
 	DialogDescription,
@@ -68,6 +60,7 @@ import {
 import { AttributeKeyAutocomplete } from "./attribute-key-autocomplete"
 
 const MONO = "font-mono text-[0.92em] text-muted-foreground"
+const COL_HEADER = "text-muted-foreground/70 font-mono text-[10px] uppercase tracking-[0.12em]"
 
 const SOURCE_CONTEXT_LABELS: Record<IngestMappingSourceContext, string> = {
 	span: "Span attribute",
@@ -228,30 +221,32 @@ export function AttributeMappingsSection() {
 
 	return (
 		<>
-			<Card>
-				<CardHeader>
-					<CardTitle className="flex items-center gap-2">
-						Attribute Mappings
-						{mappingCount !== null && mappingCount > 0 && (
-							<Badge variant="secondary" className="font-normal tabular-nums">
-								{mappingCount}
-							</Badge>
-						)}
-					</CardTitle>
-					<CardDescription>
-						Rename or promote span attribute keys at ingest so telemetry from different SDKs stays
-						consistent. Applied only to spans received after a rule is saved.
-					</CardDescription>
-					<CardAction>
-						<Button size="sm" onClick={openAddDialog}>
-							<PlusIcon size={14} />
-							Add Mapping
-						</Button>
-					</CardAction>
-				</CardHeader>
-				<CardContent>
+			<div className="bg-card flex flex-col rounded-lg border">
+				<div className="flex items-start gap-3 px-4 pt-4 pb-3">
+					<div className="flex flex-col gap-1">
+						<h3 className="text-sm font-medium">
+							Attribute mappings
+							{mappingCount !== null && mappingCount > 0 && (
+								<span className="text-muted-foreground font-normal tabular-nums">
+									{" "}
+									· {mappingCount}
+								</span>
+							)}
+						</h3>
+						<p className="text-muted-foreground text-xs">
+							Rename or promote span attribute keys at ingest. Applied only to spans received
+							after a rule is saved.
+						</p>
+					</div>
+					<div className="grow" />
+					<Button variant="outline" size="sm" className="shrink-0" onClick={openAddDialog}>
+						<PlusIcon size={14} />
+						Add mapping
+					</Button>
+				</div>
+				<div className="border-t">
 					{Result.isInitial(listResult) ? (
-						<div className="space-y-px">
+						<div className="space-y-px px-4">
 							{[0, 1].map((i) => (
 								<div key={i} className="flex items-center gap-4 py-3">
 									<div className="flex-1 space-y-2">
@@ -292,32 +287,32 @@ export function AttributeMappingsSection() {
 							</EmptyHeader>
 							<Button size="sm" onClick={openAddDialog}>
 								<PlusIcon size={14} />
-								Add Mapping
+								Add mapping
 							</Button>
 						</Empty>
 					) : (
 						<div>
 							{/* column header */}
-							<div className="text-muted-foreground border-border/60 -mx-6 flex items-center gap-4 border-b px-6 pt-1 pb-2 text-xs">
-								<div className="w-44 shrink-0">Name</div>
-								<div className="flex-1">Mapping</div>
-								<div className="w-24 shrink-0">Operation</div>
-								<div className="w-40 shrink-0 text-right">Added</div>
+							<div className="flex items-center gap-3 px-4 py-1.5">
+								<div className={cn(COL_HEADER, "w-44 shrink-0")}>Name</div>
+								<div className={cn(COL_HEADER, "flex-1")}>Rule</div>
+								<div className={cn(COL_HEADER, "hidden w-24 shrink-0 md:block")}>Operation</div>
+								<div className={cn(COL_HEADER, "hidden w-20 shrink-0 md:block")}>Context</div>
+								<div className="w-28 shrink-0" />
 							</div>
 
 							{mappings.map((mapping) => {
 								const operation = OPERATION_BADGE[mapping.operation]
-								const OperationIcon = operation.icon
 								return (
 									<div
 										key={mapping.id}
 										className={cn(
-											"group border-border/60 hover:bg-muted/40 -mx-6 flex items-center gap-4 border-b px-6 py-2.5 transition-colors last:border-b-0",
+											"group hover:bg-muted/20 flex items-center gap-3 border-t px-4 py-2.5 transition-colors",
 											!mapping.enabled && "opacity-55",
 										)}
 									>
 										<span
-											className="w-44 shrink-0 truncate text-sm font-medium"
+											className="w-44 shrink-0 truncate text-sm"
 											title={mapping.name}
 										>
 											{mapping.name}
@@ -332,33 +327,23 @@ export function AttributeMappingsSection() {
 											<code className="font-mono text-[0.92em] text-foreground">
 												{mapping.target_key}
 											</code>
-											{mapping.source_context === "resource" && (
-												<span className="text-muted-foreground text-xs">
-													· from {SOURCE_CONTEXT_LABELS.resource.toLowerCase()}
-												</span>
+										</div>
+
+										<span
+											className={cn(
+												"hidden w-24 shrink-0 font-mono text-[10px] font-medium uppercase tracking-[0.12em] md:block",
+												operation.tone,
 											)}
-										</div>
+										>
+											{OPERATION_LABELS[mapping.operation]}
+										</span>
 
-										<div className="w-24 shrink-0">
-											<Badge variant={operation.variant} className="gap-1">
-												<OperationIcon size={11} />
-												{OPERATION_LABELS[mapping.operation]}
-											</Badge>
-										</div>
+										<span className="text-muted-foreground hidden w-20 shrink-0 text-xs md:block">
+											{mapping.source_context === "resource" ? "Resource" : "Spans"}
+										</span>
 
-										<div className="relative flex w-40 shrink-0 items-center justify-end gap-3">
-											<Switch
-												checked={mapping.enabled}
-												onCheckedChange={() => handleToggleEnabled(mapping)}
-												disabled={togglingId === mapping.id}
-											/>
-											<span
-												className="text-muted-foreground w-20 text-right text-xs whitespace-nowrap tabular-nums transition-opacity group-hover:opacity-0"
-												title={new Date(mapping.created_at).toLocaleString()}
-											>
-												{formatRelativeTime(mapping.created_at)}
-											</span>
-											<div className="absolute right-0 flex items-center gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+										<div className="flex w-28 shrink-0 items-center justify-end gap-1.5">
+											<div className="flex items-center gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
 												<Button
 													variant="ghost"
 													size="icon-sm"
@@ -380,14 +365,20 @@ export function AttributeMappingsSection() {
 													<TrashIcon size={14} />
 												</Button>
 											</div>
+											<Switch
+												checked={mapping.enabled}
+												onCheckedChange={() => handleToggleEnabled(mapping)}
+												disabled={togglingId === mapping.id}
+												title={`Added ${formatRelativeTime(mapping.created_at)}`}
+											/>
 										</div>
 									</div>
 								)
 							})}
 						</div>
 					)}
-				</CardContent>
-			</Card>
+				</div>
+			</div>
 
 			{/* Add / Edit Dialog */}
 			<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>

--- a/apps/web/src/components/settings/ingestion-section.tsx
+++ b/apps/web/src/components/settings/ingestion-section.tsx
@@ -1,15 +1,9 @@
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
 import { useMemo, useState } from "react"
+import { Link } from "@tanstack/react-router"
 import { Exit } from "effect"
 import { toast } from "sonner"
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@maple/ui/components/ui/card"
-import {
-	InputGroup,
-	InputGroupAddon,
-	InputGroupButton,
-	InputGroupInput,
-} from "@maple/ui/components/ui/input-group"
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -21,94 +15,197 @@ import {
 	AlertDialogMedia,
 	AlertDialogTitle,
 } from "@maple/ui/components/ui/alert-dialog"
-import { Badge } from "@maple/ui/components/ui/badge"
-import { Separator } from "@maple/ui/components/ui/separator"
-import { AlertWarningIcon, ArrowPathIcon, CheckIcon, CopyIcon, EyeIcon, ShieldIcon } from "@/components/icons"
+import { Button } from "@maple/ui/components/ui/button"
+import { cn } from "@maple/ui/lib/utils"
+import {
+	AlertWarningIcon,
+	ArrowPathIcon,
+	ArrowRightIcon,
+	CheckIcon,
+	CopyIcon,
+	EyeIcon,
+	PaperPlaneIcon,
+	PulseIcon,
+} from "@/components/icons"
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard"
+import { formatNumber } from "@/lib/format"
 import { ingestUrl } from "@/lib/services/common/ingest-url"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 import { maskKey } from "@/components/ingest/copyable-field"
-import { GuidedSetup } from "@/components/ingest/guided-setup"
-import { IngestStatusPanel } from "@/components/ingest/connection-status"
-import { useIngestConnection } from "@/components/ingest/use-ingest-connection"
+import { ConnectInstructions, FrameworkPicker, useGuidedFramework } from "@/components/ingest/guided-setup"
+import {
+	sendTestEvent,
+	useIngestConnection,
+	type IngestConnection,
+} from "@/components/ingest/use-ingest-connection"
 import { AttributeMappingsSection } from "./attribute-mappings-section"
 import { RecommendedMappingsSection } from "./recommended-mappings-section"
 
-interface ApiKeyRowProps {
-	type: "public" | "private"
-	label: string
-	description: string
-	keyValue: string
-	isVisible: boolean
-	onToggleVisibility: () => void
-	isCopied: boolean
-	onCopy: () => void
-	onRegenerate: () => void
-	disabled: boolean
+const LANE_BADGE = "w-14 shrink-0 font-mono text-[10px] font-medium uppercase tracking-[0.12em]"
+
+/** Live ingest-health strip: green once telemetry lands, amber pulse while waiting. */
+function StatusBanner({ connection }: { connection: IngestConnection }) {
+	const [sending, setSending] = useState(false)
+	const connected = connection.status === "connected"
+
+	async function handleSendTest() {
+		if (!connection.apiKey || sending) return
+		setSending(true)
+		try {
+			await sendTestEvent(connection.apiKey)
+			toast.success("Test event sent — watch for it to land in traces")
+			connection.refresh()
+		} catch {
+			toast.error("Couldn't reach the ingest endpoint — double-check your API key")
+		} finally {
+			setSending(false)
+		}
+	}
+
+	const spansPerMinute = Math.round(connection.spansPerMinute)
+
+	return (
+		<div className="bg-card flex items-center gap-3 rounded-lg border px-4 py-2.5">
+			{connected ? (
+				<span className="bg-severity-info size-2 shrink-0 rounded-full" />
+			) : (
+				<PulseIcon size={12} className="text-primary shrink-0 animate-pulse motion-reduce:animate-none" />
+			)}
+			<span className="text-sm font-medium whitespace-nowrap">
+				{connected ? "Receiving telemetry" : "Waiting for telemetry"}
+			</span>
+			<span className="text-muted-foreground truncate font-mono text-xs">
+				{connected
+					? [
+							`${connection.serviceCount} ${connection.serviceCount === 1 ? "service" : "services"}`,
+							spansPerMinute > 0 ? `${formatNumber(spansPerMinute)} spans/min` : null,
+						]
+							.filter(Boolean)
+							.join(" · ")
+					: "watching for your first trace"}
+			</span>
+			<div className="grow" />
+			{connected ? (
+				<Button
+					variant="ghost"
+					size="sm"
+					className="text-muted-foreground hover:text-foreground gap-1.5"
+					render={<Link to="/traces" />}
+				>
+					Explore traces
+					<ArrowRightIcon size={13} />
+				</Button>
+			) : (
+				<Button
+					variant="outline"
+					size="sm"
+					className="shrink-0 gap-2"
+					onClick={handleSendTest}
+					disabled={sending || !connection.apiKey}
+				>
+					<PaperPlaneIcon size={13} />
+					{sending ? "Sending…" : "Send test event"}
+				</Button>
+			)}
+		</div>
+	)
 }
 
-function ApiKeyRow({
-	type,
+interface CredentialRowProps {
+	label: string
+	badge: string
+	badgeClass: string
+	value: string
+	masked?: boolean
+	description?: string
+	isVisible?: boolean
+	onToggleVisibility?: () => void
+	isCopied: boolean
+	onCopy: () => void
+	onRegenerate?: () => void
+	disabled?: boolean
+}
+
+function CredentialRow({
 	label,
+	badge,
+	badgeClass,
+	value,
+	masked = false,
 	description,
-	keyValue,
-	isVisible,
+	isVisible = false,
 	onToggleVisibility,
 	isCopied,
 	onCopy,
 	onRegenerate,
-	disabled,
-}: ApiKeyRowProps) {
+	disabled = false,
+}: CredentialRowProps) {
 	return (
-		<div className="space-y-2">
-			<div className="flex items-center gap-2">
-				<Badge variant={type === "private" ? "outline" : "secondary"}>
-					{type === "private" && <ShieldIcon size={12} />}
-					{label}
-				</Badge>
-				<span className="text-muted-foreground text-xs">{description}</span>
+		<div className="flex items-center gap-3 border-t px-4 py-3">
+			<span className="w-[120px] shrink-0 text-sm">{label}</span>
+			<span className={cn(LANE_BADGE, badgeClass)}>{badge}</span>
+			<div className="flex min-w-0 grow flex-col items-start gap-0.5">
+				<button
+					type="button"
+					onClick={onCopy}
+					disabled={disabled}
+					title={isCopied ? "Copied!" : "Click to copy"}
+					className="group/value text-muted-foreground hover:text-foreground flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 font-mono text-xs tracking-wide transition-colors"
+				>
+					<span className="truncate">{masked && !isVisible ? maskKey(value) : value}</span>
+					{isCopied ? (
+						<CheckIcon size={12} className="text-severity-info shrink-0" />
+					) : (
+						<CopyIcon
+							size={12}
+							className="shrink-0 opacity-0 transition-opacity group-hover/value:opacity-60"
+						/>
+					)}
+				</button>
+				{description && (
+					<span className="text-muted-foreground/75 text-[11px] leading-3.5">{description}</span>
+				)}
 			</div>
-
-			<InputGroup>
-				<InputGroupInput
-					readOnly
-					value={isVisible ? keyValue : maskKey(keyValue)}
-					className="font-mono text-xs tracking-wide select-all"
-				/>
-				<InputGroupAddon align="inline-end">
-					<InputGroupButton
+			<div className="flex shrink-0 items-center gap-1.5">
+				{onToggleVisibility && (
+					<Button
+						variant="outline"
+						size="icon-sm"
 						onClick={onToggleVisibility}
 						aria-label={isVisible ? "Hide key" : "Reveal key"}
 						title={isVisible ? "Hide" : "Reveal"}
 						disabled={disabled}
 					>
-						<EyeIcon size={14} className={isVisible ? "text-foreground" : undefined} />
-					</InputGroupButton>
-
-					<InputGroupButton
-						onClick={onCopy}
-						aria-label="Copy key to clipboard"
-						title={isCopied ? "Copied!" : "Copy"}
-						disabled={disabled}
-					>
-						{isCopied ? (
-							<CheckIcon size={14} className="text-severity-info" />
-						) : (
-							<CopyIcon size={14} />
-						)}
-					</InputGroupButton>
-
-					<InputGroupButton
+						<EyeIcon size={13} className={isVisible ? "text-foreground" : "text-muted-foreground"} />
+					</Button>
+				)}
+				<Button
+					variant="outline"
+					size="icon-sm"
+					onClick={onCopy}
+					aria-label={`Copy ${label.toLowerCase()} to clipboard`}
+					title={isCopied ? "Copied!" : "Copy"}
+					disabled={disabled}
+				>
+					{isCopied ? (
+						<CheckIcon size={13} className="text-severity-info" />
+					) : (
+						<CopyIcon size={13} className="text-muted-foreground" />
+					)}
+				</Button>
+				{onRegenerate && (
+					<Button
+						variant="outline"
+						size="icon-sm"
 						onClick={onRegenerate}
-						aria-label="Regenerate key"
+						aria-label={`Regenerate ${label.toLowerCase()}`}
 						title="Regenerate"
-						className="text-destructive hover:text-destructive"
 						disabled={disabled}
 					>
-						<ArrowPathIcon size={14} />
-					</InputGroupButton>
-				</InputGroupAddon>
-			</InputGroup>
+						<ArrowPathIcon size={13} className="text-destructive" />
+					</Button>
+				)}
+			</div>
 		</div>
 	)
 }
@@ -128,6 +225,7 @@ export function IngestionSection() {
 	const refreshKeys = useAtomRefresh(keysQueryAtom)
 
 	const connection = useIngestConnection()
+	const { framework, setFramework } = useGuidedFramework()
 
 	const rerollPublicMutation = useAtomSet(MapleApiV2AtomClient.mutation("ingestKeys", "rollPublic"), {
 		mode: "promiseExit",
@@ -185,99 +283,78 @@ export function IngestionSection() {
 
 	return (
 		<>
-			<div className="space-y-4">
-				<Card>
-					<CardHeader>
-						<CardTitle>Send your first telemetry</CardTitle>
-						<CardDescription>
-							Point your OpenTelemetry SDK at Maple, or let Claude Code wire it up for you.
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="space-y-4">
-						<GuidedSetup apiKey={connection.apiKey} />
-						<IngestStatusPanel connection={connection} onTestSent={connection.refresh} />
-					</CardContent>
-				</Card>
+			<div className="space-y-5">
+				<StatusBanner connection={connection} />
 
-				<div className="grid grid-cols-2 gap-4">
-					<Card>
-						<CardHeader>
-							<CardTitle>Ingest Endpoint</CardTitle>
-							<CardDescription>
-								Send telemetry data to this endpoint using OTLP.
-							</CardDescription>
-						</CardHeader>
-						<CardContent className="space-y-3">
-							<InputGroup>
-								<InputGroupInput
-									readOnly
-									value={ingestUrl}
-									className="font-mono text-xs tracking-wide select-all"
-								/>
-								<InputGroupAddon align="inline-end">
-									<InputGroupButton
-										onClick={() => endpointCopy.copy(ingestUrl)}
-										aria-label="Copy endpoint to clipboard"
-										title={endpointCopy.copied ? "Copied!" : "Copy"}
-									>
-										{endpointCopy.copied ? (
-											<CheckIcon size={14} className="text-severity-info" />
-										) : (
-											<CopyIcon size={14} />
-										)}
-									</InputGroupButton>
-								</InputGroupAddon>
-							</InputGroup>
+				<div className="bg-card flex flex-col rounded-lg border">
+					<div className="flex items-start gap-3 px-4 pt-4 pb-3">
+						<div className="flex flex-col gap-1">
+							<h3 className="text-sm font-medium">Endpoint &amp; keys</h3>
 							<p className="text-muted-foreground text-xs">
-								Learn how to send telemetry data in the{" "}
-								<a
-									href="https://maple.dev/docs"
-									target="_blank"
-									rel="noopener noreferrer"
-									className="text-foreground underline underline-offset-2 hover:no-underline"
-								>
-									documentation
-								</a>
-								.
+								Point your OTLP exporter at the endpoint and authenticate with an ingest key.
 							</p>
-						</CardContent>
-					</Card>
+						</div>
+						<div className="grow" />
+						<a
+							href="https://maple.dev/docs"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-muted-foreground hover:text-foreground font-mono text-[11px] whitespace-nowrap transition-colors"
+						>
+							Docs ↗
+						</a>
+					</div>
+					<CredentialRow
+						label="OTLP endpoint"
+						badge="HTTP"
+						badgeClass="text-muted-foreground"
+						value={ingestUrl}
+						isCopied={endpointCopy.copied}
+						onCopy={() => endpointCopy.copy(ingestUrl)}
+					/>
+					<CredentialRow
+						label="Public key"
+						badge="Client"
+						badgeClass="text-info"
+						value={publicKey}
+						masked
+						description="For browser and client-side telemetry SDKs"
+						isVisible={publicKeyVisible}
+						onToggleVisibility={() => setPublicKeyVisible((v) => !v)}
+						isCopied={publicKeyCopy.copied}
+						onCopy={() => handleCopy("public")}
+						onRegenerate={() => openRegenerateDialog("public")}
+						disabled={isBusy}
+					/>
+					<CredentialRow
+						label="Private key"
+						badge="Server"
+						badgeClass="text-warning"
+						value={privateKey}
+						masked
+						description="For server-side ingestion and backend services"
+						isVisible={privateKeyVisible}
+						onToggleVisibility={() => setPrivateKeyVisible((v) => !v)}
+						isCopied={privateKeyCopy.copied}
+						onCopy={() => handleCopy("private")}
+						onRegenerate={() => openRegenerateDialog("private")}
+						disabled={isBusy}
+					/>
+				</div>
 
-					<Card>
-						<CardHeader>
-							<CardTitle>Ingest Keys</CardTitle>
-							<CardDescription>
-								Use these keys to authenticate ingestion requests.
-							</CardDescription>
-						</CardHeader>
-						<CardContent className="space-y-4">
-							<ApiKeyRow
-								type="public"
-								label="Public"
-								description="For browser and client-side telemetry SDKs"
-								keyValue={publicKey}
-								isVisible={publicKeyVisible}
-								onToggleVisibility={() => setPublicKeyVisible((v) => !v)}
-								isCopied={publicKeyCopy.copied}
-								onCopy={() => handleCopy("public")}
-								onRegenerate={() => openRegenerateDialog("public")}
-								disabled={isBusy}
-							/>
-							<Separator />
-							<ApiKeyRow
-								type="private"
-								label="Private"
-								description="For server-side ingestion and backend services"
-								keyValue={privateKey}
-								isVisible={privateKeyVisible}
-								onToggleVisibility={() => setPrivateKeyVisible((v) => !v)}
-								isCopied={privateKeyCopy.copied}
-								onCopy={() => handleCopy("private")}
-								onRegenerate={() => openRegenerateDialog("private")}
-								disabled={isBusy}
-							/>
-						</CardContent>
-					</Card>
+				<div className="bg-card flex flex-col rounded-lg border">
+					<div className="flex flex-wrap items-start gap-x-6 gap-y-3 px-4 pt-4 pb-3">
+						<div className="flex min-w-[260px] flex-col gap-1">
+							<h3 className="text-sm font-medium whitespace-nowrap">Send your first telemetry</h3>
+							<p className="text-muted-foreground text-xs">
+								Point your OpenTelemetry SDK at Maple, or let Claude Code wire it up for you.
+							</p>
+						</div>
+						<div className="ml-auto">
+							<FrameworkPicker compact selected={framework} onSelect={setFramework} />
+						</div>
+					</div>
+					<ConnectInstructions framework={framework} apiKey={connection.apiKey} variant="flush" />
 				</div>
 
 				<RecommendedMappingsSection />

--- a/apps/web/src/components/settings/recommended-mappings-section.tsx
+++ b/apps/web/src/components/settings/recommended-mappings-section.tsx
@@ -7,7 +7,6 @@ import { toast } from "sonner"
 
 import { Badge } from "@maple/ui/components/ui/badge"
 import { Button } from "@maple/ui/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@maple/ui/components/ui/card"
 import { cn } from "@maple/ui/lib/utils"
 import {
 	ArrowRotateAnticlockwiseIcon,
@@ -22,15 +21,16 @@ import {
 	ingestAttributeMappingsListAtom,
 	recommendationIssuesListAtom,
 } from "@/lib/services/atoms/ingestion-atoms"
-import { formatRelativeTime } from "@/lib/format"
+import { formatNumber, formatRelativeTime } from "@/lib/format"
 
 type IssueKind = V2Recommendation["kind"]
 type IssueStatus = V2Recommendation["status"]
 
-const KIND_BADGE: Record<IssueKind, { label: string; variant: "success" | "warning" | "info" }> = {
-	rename: { label: "Safe rename", variant: "success" },
-	"double-emission": { label: "Both emitted", variant: "warning" },
-	naming: { label: "Naming", variant: "info" },
+// Mono uppercase kind tags in the row's leading lane (Paper ingestion redesign).
+const KIND_TAG: Record<IssueKind, { label: string; className: string }> = {
+	rename: { label: "Rename", className: "text-info" },
+	"double-emission": { label: "Duplicate", className: "text-warning" },
+	naming: { label: "Naming", className: "text-warning" },
 }
 
 const STATUS_BADGE: Record<IssueStatus, { label: string; variant: "success" | "secondary" }> = {
@@ -178,180 +178,148 @@ export function RecommendedMappingsSection() {
 
 	const rows = tab === "open" ? openIssues : closedIssues
 
-	function TabButton({ id, label, count }: { id: "open" | "closed"; label: string; count: number }) {
+	function FilterTab({ id, label, count }: { id: "open" | "closed"; label: string; count: number }) {
 		const active = tab === id
 		return (
 			<button
 				type="button"
 				onClick={() => setTab(id)}
 				className={cn(
-					"-mb-px flex items-center gap-2 border-b-2 pt-1 pb-2.5 text-sm font-medium transition-colors",
+					"rounded-md px-2.5 py-1 font-mono text-[11px] leading-3.5 transition-colors",
 					active
-						? "border-primary text-foreground"
-						: "text-muted-foreground hover:text-foreground border-transparent",
+						? "bg-accent text-foreground font-medium"
+						: "text-muted-foreground hover:text-foreground border border-transparent",
 				)}
 			>
-				{label}
-				<span
-					className={cn(
-						"rounded-full px-1.5 text-xs tabular-nums",
-						active ? "bg-foreground/10 text-foreground" : "bg-muted text-muted-foreground",
-					)}
-				>
-					{count}
-				</span>
+				{label} · {count}
 			</button>
 		)
 	}
 
 	return (
-		<Card>
-			<CardHeader>
-				<CardTitle>Recommendations</CardTitle>
-				<CardDescription>
-					Deprecated or non-conforming OpenTelemetry attribute keys detected on your spans. Apply a
-					fix to create the matching mapping, or dismiss it.
-				</CardDescription>
-			</CardHeader>
-			<CardContent>
-				{/* tabs */}
-				<div className="border-border/60 -mx-6 flex items-center gap-5 border-b px-6">
-					<TabButton id="open" label="Open" count={openIssues.length} />
-					<TabButton id="closed" label="Closed" count={closedIssues.length} />
-				</div>
-
-				{/* column header */}
-				<div className="text-muted-foreground border-border/60 -mx-6 flex items-center gap-4 border-b px-6 pt-3 pb-2 text-xs">
-					<div className="w-12 shrink-0">#</div>
-					<div className="w-28 shrink-0">Type</div>
-					<div className="flex-1">Recommendation</div>
-					<div className="w-28 shrink-0">{tab === "open" ? "Action" : "Status"}</div>
-					<div className="w-32 shrink-0 text-right">Opened</div>
-				</div>
-
-				{rows.length === 0 ? (
-					<p className="text-muted-foreground py-10 text-center text-sm">
-						{tab === "open"
-							? "No open recommendations — your span attributes look healthy."
-							: "Nothing here yet."}
+		<div className="bg-card flex flex-col rounded-lg border">
+			<div className="flex items-start gap-3 px-4 pt-4 pb-3">
+				<div className="flex flex-col gap-1">
+					<h3 className="text-sm font-medium">Recommendations</h3>
+					<p className="text-muted-foreground text-xs">
+						Deprecated or non-conforming OpenTelemetry attribute keys detected on your spans.
 					</p>
-				) : (
-					<div>
-						{rows.map((issue) => {
-							const badge = KIND_BADGE[issue.kind]
-							const mode = issue.kind === "rename" ? MODE.auto : MODE.manual
-							const ModeIcon = mode.icon
-							const status = STATUS_BADGE[issue.status]
-							const isApplying = applyingId === issue.id
-							const isBusy = busyId === issue.id
+				</div>
+				<div className="grow" />
+				<div className="flex shrink-0 items-center gap-1.5">
+					<FilterTab id="open" label="Open" count={openIssues.length} />
+					<FilterTab id="closed" label="Closed" count={closedIssues.length} />
+				</div>
+			</div>
 
-							return (
-								<div
-									key={issue.id}
-									className="group border-border/60 hover:bg-muted/40 -mx-6 flex items-center gap-4 border-b px-6 py-2.5 transition-colors last:border-b-0"
-								>
-									<Link
-										to="/recommendations/$recommendationKey"
-										params={{ recommendationKey: issue.id }}
-										className="text-muted-foreground hover:text-foreground w-12 shrink-0 font-mono text-[13px] tabular-nums"
-									>
-										#{issue.number}
-									</Link>
-									<div className="w-28 shrink-0">
-										<Badge variant={badge.variant}>{badge.label}</Badge>
-									</div>
-									<Link
-										to="/recommendations/$recommendationKey"
-										params={{ recommendationKey: issue.id }}
-										className="group/link min-w-0 flex-1 truncate text-sm"
-										title={recPlainText(issue)}
-									>
-										<span className="underline-offset-4 decoration-muted-foreground/40 group-hover/link:underline">
-											{recSentence(issue)}
-										</span>
-									</Link>
+			{rows.length === 0 ? (
+				<p className="text-muted-foreground border-t px-4 py-8 text-center text-sm">
+					{tab === "open"
+						? "No open recommendations — your span attributes look healthy."
+						: "Nothing here yet."}
+				</p>
+			) : (
+				rows.map((issue) => {
+					const kindTag = KIND_TAG[issue.kind]
+					const mode = issue.kind === "rename" ? MODE.auto : MODE.manual
+					const status = STATUS_BADGE[issue.status]
+					const isApplying = applyingId === issue.id
+					const isBusy = busyId === issue.id
 
-									<div className="w-28 shrink-0">
-										{tab === "open" ? (
+					return (
+						<div
+							key={issue.id}
+							className="group hover:bg-muted/20 flex items-center gap-3 border-t px-4 py-2.5 transition-colors"
+						>
+							<span
+								className={cn(
+									"w-20 shrink-0 font-mono text-[10px] font-medium uppercase tracking-[0.12em]",
+									kindTag.className,
+								)}
+							>
+								{kindTag.label}
+							</span>
+							<Link
+								to="/recommendations/$recommendationKey"
+								params={{ recommendationKey: issue.id }}
+								className="group/link min-w-0 flex-1 truncate text-sm"
+								title={`${recPlainText(issue)} · ${issue.usage_count.toLocaleString()} spans in 24h · opened ${formatRelativeTime(issue.opened_at)}`}
+							>
+								<span className="underline-offset-4 decoration-muted-foreground/40 group-hover/link:underline">
+									{recSentence(issue)}
+								</span>
+								<span className="text-muted-foreground">
+									{" "}
+									· {formatNumber(issue.usage_count)} spans/24h
+								</span>
+							</Link>
+
+							<div className="flex shrink-0 items-center gap-1.5">
+								{issue.status === "open" ? (
+									<>
+										{issue.kind === "rename" ? (
+											<Button
+												size="sm"
+												onClick={() => handleApply(issue)}
+												disabled={isApplying}
+											>
+												{isApplying ? (
+													<LoaderIcon size={14} className="animate-spin" />
+												) : (
+													<CheckIcon size={14} />
+												)}
+												Apply fix
+											</Button>
+										) : (
 											<Badge
 												variant="outline"
 												className={cn("gap-1", mode.className)}
 												title={mode.title}
 											>
-												<ModeIcon size={11} />
+												<mode.icon size={11} />
 												{mode.label}
 											</Badge>
-										) : (
-											<Badge variant={status.variant}>{status.label}</Badge>
 										)}
-									</div>
-
-									<div className="relative flex w-32 shrink-0 items-center justify-end">
-										<span
-											className="text-muted-foreground text-xs whitespace-nowrap tabular-nums transition-opacity group-hover:opacity-0"
-											title={`${issue.usage_count.toLocaleString()} spans · 24h`}
+										<Button
+											variant="outline"
+											size="sm"
+											className="text-muted-foreground hover:text-foreground"
+											onClick={() => handleDismiss(issue)}
+											disabled={isBusy}
 										>
-											{formatRelativeTime(issue.opened_at)}
-										</span>
-										<div className="absolute right-0 flex items-center gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
-											{issue.status === "open" ? (
-												<>
-													{issue.kind === "rename" ? (
-														<Button
-															size="sm"
-															onClick={() => handleApply(issue)}
-															disabled={isApplying}
-														>
-															{isApplying ? (
-																<LoaderIcon
-																	size={14}
-																	className="animate-spin"
-																/>
-															) : (
-																<CheckIcon size={14} />
-															)}
-															Apply
-														</Button>
-													) : null}
-													<Button
-														variant="ghost"
-														size="icon-sm"
-														className="text-muted-foreground hover:text-foreground"
-														onClick={() => handleDismiss(issue)}
-														disabled={isBusy}
-														aria-label="Dismiss recommendation"
-														title="Dismiss"
-													>
-														{isBusy ? (
-															<LoaderIcon size={14} className="animate-spin" />
-														) : (
-															<XmarkIcon size={14} />
-														)}
-													</Button>
-												</>
-											) : issue.status === "dismissed" ? (
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() => handleReopen(issue)}
-													disabled={isBusy}
-												>
-													{isBusy ? (
-														<LoaderIcon size={14} className="animate-spin" />
-													) : (
-														<ArrowRotateAnticlockwiseIcon size={14} />
-													)}
-													Reopen
-												</Button>
-											) : null}
-										</div>
-									</div>
-								</div>
-							)
-						})}
-					</div>
-				)}
-			</CardContent>
-		</Card>
+											{isBusy ? (
+												<LoaderIcon size={14} className="animate-spin" />
+											) : (
+												<XmarkIcon size={14} />
+											)}
+											Dismiss
+										</Button>
+									</>
+								) : issue.status === "dismissed" ? (
+									<>
+										<Badge variant={status.variant}>{status.label}</Badge>
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => handleReopen(issue)}
+											disabled={isBusy}
+										>
+											{isBusy ? (
+												<LoaderIcon size={14} className="animate-spin" />
+											) : (
+												<ArrowRotateAnticlockwiseIcon size={14} />
+											)}
+											Reopen
+										</Button>
+									</>
+								) : (
+									<Badge variant={status.variant}>{status.label}</Badge>
+								)}
+							</div>
+						</div>
+					)
+				})
+			)}
+		</div>
 	)
 }

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,7 @@
 			"outputs": ["dist/**", ".output/**"]
 		},
 		"typecheck": {
-			"dependsOn": ["^typecheck"]
+			"dependsOn": ["^typecheck", "^build"]
 		},
 		"test": {
 			"dependsOn": ["^build"],


### PR DESCRIPTION
## What

Rebuilds **Settings → Ingestion** to match the Paper design ("Settings — Ingestion (redesign)" artboard in the "Maple MCP" file), aligning it with the recently redesigned API Keys page (bordered lists, mono micro-labels, hover-reveal actions).

- **Status banner** — live ingest health at the top: green dot + `N services · X spans/min` when receiving (with an Explore traces link), amber pulse while waiting. **Send test event** shows only when telemetry isn't set up yet. `useIngestConnection` now exposes `spansPerMinute` (1h service-overview span counts ÷ 60). The design's "last event Xs ago" was dropped — no data source for it.
- **Endpoint & keys** — the two side-by-side cards merged into one card with lane-aligned rows: label | mono `HTTP`/`CLIENT`/`SERVER` badge | value + description | reveal/copy/regenerate actions, plus a `Docs ↗` header link. Values are click-to-copy with inline check feedback (masked keys copy the full value without revealing).
- **Send your first telemetry** — framework picker rendered as compact pills in the section header; Install / Instrument / Claude Code tabs sit flush in the card. `guided-setup.tsx` now exports `useGuidedFramework()`, `FrameworkPicker` (`compact`), and `ConnectInstructions` (`variant="flush"`); the dashboard checklist's `GuidedSetup` is unchanged.
- **Recommendations** — bordered-list rows with mono uppercase kind tags (RENAME/DUPLICATE/NAMING), always-visible Apply fix / Dismiss / Reopen, and `Open · N` / `Closed · N` segmented pills. Detail-page links kept.
- **Attribute mappings** — 4-lane table (`NAME | RULE | OPERATION | CONTEXT`) with mono column headers; keeps the enable Switch, hover edit/delete, and the add/edit + delete dialogs.

## Why

The old page was a stack of mismatched Cards; this brings it in line with the design system used by the API Keys redesign and the rest of the settings surface.

## Notes for review

- Presentation-only: no API/domain/backend changes, all existing atoms/mutations reused.
- Verified live at `/settings?tab=ingestion` (dev login): key reveal/click-to-copy, chip + tab switching with URL/key interpolation, Open/Closed recommendation tabs, add-mapping dialog, both banner states. `bun typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787354303&installation_model_id=427786&pr_number=251&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F251&signature=1ac7da9134ee7cdc5b193321e2884d68eaec6bc38f17400f5ec25c7227a9cd48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->