### PR TITLE
fix(infra): client-side search on k8s + hosts pages (stop full-page reload)

### DIFF
--- a/apps/web/src/routes/infra/index.tsx
+++ b/apps/web/src/routes/infra/index.tsx
@@ -59,7 +59,6 @@ function InfraPageContent() {
 			data: {
 				startTime,
 				endTime,
-				search: search.trim() || undefined,
 			},
 		}),
 	)
@@ -166,10 +165,14 @@ function FleetView({
 		return c
 	}, [annotated])
 
+	const q = search.trim().toLowerCase()
 	const filtered = useMemo(() => {
-		if (statusFilter === "all") return hosts
-		return annotated.filter((a) => a.status === statusFilter).map((a) => a.host)
-	}, [hosts, annotated, statusFilter])
+		const byStatus =
+			statusFilter === "all"
+				? hosts
+				: annotated.filter((a) => a.status === statusFilter).map((a) => a.host)
+		return q ? byStatus.filter((h) => h.hostName.toLowerCase().includes(q)) : byStatus
+	}, [hosts, annotated, statusFilter, q])
 
 	const showFleetGrid = hosts.length >= FLEET_GRID_THRESHOLD
 
@@ -240,7 +243,21 @@ function FleetView({
 					</div>
 				</div>
 
-				<HostTable hosts={filtered} waiting={waiting} />
+				{q && filtered.length === 0 ? (
+					<Empty className="py-12">
+						<EmptyHeader>
+							<EmptyMedia variant="icon">
+								<MagnifierIcon size={16} />
+							</EmptyMedia>
+							<EmptyTitle>No hosts match “{search}”</EmptyTitle>
+							<EmptyDescription>
+								Try a different name, or clear the search to see all hosts.
+							</EmptyDescription>
+						</EmptyHeader>
+					</Empty>
+				) : (
+					<HostTable hosts={filtered} waiting={waiting} />
+				)}
 			</div>
 		</div>
 	)

--- a/apps/web/src/routes/infra/kubernetes/nodes/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/nodes/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { Navigate, createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Schema } from "effect"
 import { Result, useAtomValue } from "@/lib/effect-atom"
@@ -26,7 +27,6 @@ import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 
 const nodesSearchSchema = Schema.Struct({
-	search: Schema.optional(Schema.String),
 	nodeNames: OptionalStringArrayParam,
 	clusters: OptionalStringArrayParam,
 	environments: OptionalStringArrayParam,
@@ -51,6 +51,7 @@ function NodesPage() {
 function NodesPageContent() {
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
+	const [searchText, setSearchText] = useState("")
 
 	const { startTime, endTime } = useEffectiveTimeRange(
 		search.startTime,
@@ -69,7 +70,6 @@ function NodesPageContent() {
 			data: {
 				startTime,
 				endTime,
-				search: search.search?.trim() || undefined,
 				...filters,
 			},
 		}),
@@ -80,7 +80,6 @@ function NodesPageContent() {
 			data: {
 				startTime,
 				endTime,
-				search: search.search?.trim() || undefined,
 			},
 		}),
 	)
@@ -96,6 +95,7 @@ function NodesPageContent() {
 	}
 
 	const onClearFilters = () => {
+		setSearchText("")
 		navigate({
 			search: {
 				startTime: search.startTime,
@@ -150,13 +150,12 @@ function NodesPageContent() {
 						.onError((err) => <QueryErrorState error={err} />)
 						.onSuccess((response, result) => {
 							const nodes = response.data
-							const hasAnyFilter =
-								!!search.search?.trim() ||
+							const hasStructuredFilter =
 								(filters.nodeNames?.length ?? 0) > 0 ||
 								(filters.clusters?.length ?? 0) > 0 ||
 								(filters.environments?.length ?? 0) > 0
 
-							if (nodes.length === 0 && !hasAnyFilter) {
+							if (nodes.length === 0 && !hasStructuredFilter) {
 								return (
 									<Empty className="py-16">
 										<EmptyHeader>
@@ -173,14 +172,19 @@ function NodesPageContent() {
 								)
 							}
 
+							const q = searchText.trim().toLowerCase()
+							const filtered = q
+								? nodes.filter((n) => n.nodeName.toLowerCase().includes(q))
+								: nodes
+
 							return (
 								<div
 									className={`space-y-4 transition-opacity ${
 										result.waiting ? "opacity-60" : ""
 									}`}
 								>
-									{nodes.length >= 4 && (
-										<NodeHoneycomb nodes={nodes} referenceTime={endTime} />
+									{filtered.length >= 4 && (
+										<NodeHoneycomb nodes={filtered} referenceTime={endTime} />
 									)}
 									<div className="flex items-center justify-between gap-3">
 										<InputGroup className="w-64">
@@ -190,28 +194,14 @@ function NodesPageContent() {
 											<InputGroupInput
 												size="sm"
 												placeholder="Search nodes…"
-												value={search.search ?? ""}
-												onChange={(e) =>
-													navigate({
-														search: (prev) => ({
-															...prev,
-															search: e.target.value || undefined,
-														}),
-													})
-												}
+												value={searchText}
+												onChange={(e) => setSearchText(e.target.value)}
 											/>
-											{search.search && (
+											{searchText && (
 												<InputGroupAddon align="inline-end">
 													<InputGroupButton
 														aria-label="Clear search"
-														onClick={() =>
-															navigate({
-																search: (prev) => ({
-																	...prev,
-																	search: undefined,
-																}),
-															})
-														}
+														onClick={() => setSearchText("")}
 													>
 														<XmarkIcon />
 													</InputGroupButton>
@@ -219,14 +209,29 @@ function NodesPageContent() {
 											)}
 										</InputGroup>
 										<span className="text-xs text-muted-foreground">
-											{nodes.length} {nodes.length === 1 ? "node" : "nodes"}
+											{filtered.length} {filtered.length === 1 ? "node" : "nodes"}
 										</span>
 									</div>
-									<NodeTable
-										nodes={nodes}
-										waiting={result.waiting}
-										referenceTime={endTime}
-									/>
+									{q && filtered.length === 0 ? (
+										<Empty className="py-12">
+											<EmptyHeader>
+												<EmptyMedia variant="icon">
+													<MagnifierIcon size={16} />
+												</EmptyMedia>
+												<EmptyTitle>No nodes match “{searchText}”</EmptyTitle>
+												<EmptyDescription>
+													Try a different name, or clear the search to see all
+													nodes.
+												</EmptyDescription>
+											</EmptyHeader>
+										</Empty>
+									) : (
+										<NodeTable
+											nodes={filtered}
+											waiting={result.waiting}
+											referenceTime={endTime}
+										/>
+									)}
 								</div>
 							)
 						})

--- a/apps/web/src/routes/infra/kubernetes/pods/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/pods/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { Navigate, createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Schema } from "effect"
 import { Result, useAtomValue } from "@/lib/effect-atom"
@@ -26,7 +27,6 @@ import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 
 const podsSearchSchema = Schema.Struct({
-	search: Schema.optional(Schema.String),
 	podNames: OptionalStringArrayParam,
 	namespaces: OptionalStringArrayParam,
 	nodeNames: OptionalStringArrayParam,
@@ -58,6 +58,7 @@ function PodsPage() {
 function PodsPageContent() {
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
+	const [searchText, setSearchText] = useState("")
 
 	const { startTime, endTime } = useEffectiveTimeRange(
 		search.startTime,
@@ -83,7 +84,6 @@ function PodsPageContent() {
 			data: {
 				startTime,
 				endTime,
-				search: search.search?.trim() || undefined,
 				...filters,
 			},
 		}),
@@ -94,7 +94,6 @@ function PodsPageContent() {
 			data: {
 				startTime,
 				endTime,
-				search: search.search?.trim() || undefined,
 			},
 		}),
 	)
@@ -110,6 +109,7 @@ function PodsPageContent() {
 	}
 
 	const onClearFilters = () => {
+		setSearchText("")
 		navigate({
 			search: {
 				startTime: search.startTime,
@@ -164,8 +164,7 @@ function PodsPageContent() {
 						.onError((err) => <QueryErrorState error={err} />)
 						.onSuccess((response, result) => {
 							const pods = response.data
-							const hasAnyFilter =
-								!!search.search?.trim() ||
+							const hasStructuredFilter =
 								(filters.podNames?.length ?? 0) > 0 ||
 								(filters.namespaces?.length ?? 0) > 0 ||
 								(filters.nodeNames?.length ?? 0) > 0 ||
@@ -177,7 +176,7 @@ function PodsPageContent() {
 								(filters.environments?.length ?? 0) > 0 ||
 								(filters.computeTypes?.length ?? 0) > 0
 
-							if (pods.length === 0 && !hasAnyFilter) {
+							if (pods.length === 0 && !hasStructuredFilter) {
 								return (
 									<Empty className="py-16">
 										<EmptyHeader>
@@ -194,14 +193,19 @@ function PodsPageContent() {
 								)
 							}
 
+							const q = searchText.trim().toLowerCase()
+							const filtered = q
+								? pods.filter((p) => p.podName.toLowerCase().includes(q))
+								: pods
+
 							return (
 								<div
 									className={`space-y-4 transition-opacity ${
 										result.waiting ? "opacity-60" : ""
 									}`}
 								>
-									{pods.length >= 4 && (
-										<PodHoneycomb pods={pods} referenceTime={endTime} />
+									{filtered.length >= 4 && (
+										<PodHoneycomb pods={filtered} referenceTime={endTime} />
 									)}
 									<div className="flex flex-wrap items-center justify-between gap-3">
 										<InputGroup className="w-64">
@@ -211,28 +215,14 @@ function PodsPageContent() {
 											<InputGroupInput
 												size="sm"
 												placeholder="Search pods…"
-												value={search.search ?? ""}
-												onChange={(e) =>
-													navigate({
-														search: (prev) => ({
-															...prev,
-															search: e.target.value || undefined,
-														}),
-													})
-												}
+												value={searchText}
+												onChange={(e) => setSearchText(e.target.value)}
 											/>
-											{search.search && (
+											{searchText && (
 												<InputGroupAddon align="inline-end">
 													<InputGroupButton
 														aria-label="Clear search"
-														onClick={() =>
-															navigate({
-																search: (prev) => ({
-																	...prev,
-																	search: undefined,
-																}),
-															})
-														}
+														onClick={() => setSearchText("")}
 													>
 														<XmarkIcon />
 													</InputGroupButton>
@@ -240,10 +230,28 @@ function PodsPageContent() {
 											)}
 										</InputGroup>
 										<span className="text-xs text-muted-foreground">
-											{pods.length} {pods.length === 1 ? "pod" : "pods"}
+											{filtered.length} {filtered.length === 1 ? "pod" : "pods"}
 										</span>
 									</div>
-									<PodTable pods={pods} waiting={result.waiting} referenceTime={endTime} />
+									{q && filtered.length === 0 ? (
+										<Empty className="py-12">
+											<EmptyHeader>
+												<EmptyMedia variant="icon">
+													<MagnifierIcon size={16} />
+												</EmptyMedia>
+												<EmptyTitle>No pods match “{searchText}”</EmptyTitle>
+												<EmptyDescription>
+													Try a different name, or clear the search to see all pods.
+												</EmptyDescription>
+											</EmptyHeader>
+										</Empty>
+									) : (
+										<PodTable
+											pods={filtered}
+											waiting={result.waiting}
+											referenceTime={endTime}
+										/>
+									)}
 								</div>
 							)
 						})

--- a/apps/web/src/routes/infra/kubernetes/workloads/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/workloads/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { Navigate, createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Schema } from "effect"
 import { Result, useAtomValue } from "@/lib/effect-atom"
@@ -29,7 +30,6 @@ const WorkloadKindLiteral = Schema.Literals(["deployment", "statefulset", "daemo
 
 const workloadsSearchSchema = Schema.Struct({
 	kind: Schema.optional(WorkloadKindLiteral),
-	search: Schema.optional(Schema.String),
 	workloadNames: OptionalStringArrayParam,
 	namespaces: OptionalStringArrayParam,
 	clusters: OptionalStringArrayParam,
@@ -62,6 +62,7 @@ const KIND_LABEL: Record<WorkloadKind, string> = {
 function WorkloadsPageContent() {
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
+	const [searchText, setSearchText] = useState("")
 	const kind: WorkloadKind = search.kind ?? "deployment"
 
 	const { startTime, endTime } = useEffectiveTimeRange(
@@ -84,7 +85,6 @@ function WorkloadsPageContent() {
 				kind,
 				startTime,
 				endTime,
-				search: search.search?.trim() || undefined,
 				...filters,
 			},
 		}),
@@ -96,7 +96,6 @@ function WorkloadsPageContent() {
 				kind,
 				startTime,
 				endTime,
-				search: search.search?.trim() || undefined,
 			},
 		}),
 	)
@@ -112,6 +111,7 @@ function WorkloadsPageContent() {
 	}
 
 	const onClearFilters = () => {
+		setSearchText("")
 		navigate({
 			search: {
 				kind: search.kind,
@@ -198,15 +198,14 @@ function WorkloadsPageContent() {
 						.onError((err) => <QueryErrorState error={err} />)
 						.onSuccess((response, result) => {
 							const wls = response.data
-							const hasAnyFilter =
-								!!search.search?.trim() ||
+							const hasStructuredFilter =
 								(filters.workloadNames?.length ?? 0) > 0 ||
 								(filters.namespaces?.length ?? 0) > 0 ||
 								(filters.clusters?.length ?? 0) > 0 ||
 								(filters.environments?.length ?? 0) > 0 ||
 								(filters.computeTypes?.length ?? 0) > 0
 
-							if (wls.length === 0 && !hasAnyFilter) {
+							if (wls.length === 0 && !hasStructuredFilter) {
 								return (
 									<Empty className="py-16">
 										<EmptyHeader>
@@ -225,6 +224,11 @@ function WorkloadsPageContent() {
 								)
 							}
 
+							const q = searchText.trim().toLowerCase()
+							const filtered = q
+								? wls.filter((w) => w.workloadName.toLowerCase().includes(q))
+								: wls
+
 							return (
 								<div
 									className={`space-y-4 transition-opacity ${
@@ -239,28 +243,14 @@ function WorkloadsPageContent() {
 											<InputGroupInput
 												size="sm"
 												placeholder="Search…"
-												value={search.search ?? ""}
-												onChange={(e) =>
-													navigate({
-														search: (prev) => ({
-															...prev,
-															search: e.target.value || undefined,
-														}),
-													})
-												}
+												value={searchText}
+												onChange={(e) => setSearchText(e.target.value)}
 											/>
-											{search.search && (
+											{searchText && (
 												<InputGroupAddon align="inline-end">
 													<InputGroupButton
 														aria-label="Clear search"
-														onClick={() =>
-															navigate({
-																search: (prev) => ({
-																	...prev,
-																	search: undefined,
-																}),
-															})
-														}
+														onClick={() => setSearchText("")}
 													>
 														<XmarkIcon />
 													</InputGroupButton>
@@ -268,15 +258,31 @@ function WorkloadsPageContent() {
 											)}
 										</InputGroup>
 										<span className="text-xs text-muted-foreground">
-											{wls.length} {wls.length === 1 ? "workload" : "workloads"}
+											{filtered.length}{" "}
+											{filtered.length === 1 ? "workload" : "workloads"}
 										</span>
 									</div>
-									<WorkloadTable
-										workloads={wls}
-										kind={kind}
-										waiting={result.waiting}
-										referenceTime={endTime}
-									/>
+									{q && filtered.length === 0 ? (
+										<Empty className="py-12">
+											<EmptyHeader>
+												<EmptyMedia variant="icon">
+													<MagnifierIcon size={16} />
+												</EmptyMedia>
+												<EmptyTitle>No workloads match “{searchText}”</EmptyTitle>
+												<EmptyDescription>
+													Try a different name, or clear the search to see all
+													workloads.
+												</EmptyDescription>
+											</EmptyHeader>
+										</Empty>
+									) : (
+										<WorkloadTable
+											workloads={filtered}
+											kind={kind}
+											waiting={result.waiting}
+											referenceTime={endTime}
+										/>
+									)}
 								</div>
 							)
 						})


### PR DESCRIPTION
## Problem

Typing in the free-text search box on the Infrastructure list pages — **Pods**, **Nodes**, **Workloads**, and the **Hosts** fleet — made the whole page flash back to loading skeletons on *every keystroke*. The main table/honeycomb **and** the filter sidebar both dropped to skeletons, reading as "the entire page reloads."

### Root cause

The search value was part of the warehouse-query **atom key**. `makeQueryAtomFamily` keys each atom on `encodeKey(input)` (the full input, including `search`), so every distinct search string was a brand-new atom that had never fetched → its `Result` started in the `Initial` state → the `.onInitial(() => <…Loading/>)` branch fired and swapped in the full skeleton for both the list and the sidebar. There was no debounce and no keep-previous-data. (The Hosts page fed local `search` state straight into the atom key with the same effect.)

## Fix

Make search a **client-side filter** over the already-loaded rows. The server `search` param is only a case-insensitive substring match on a single name column (`k8s.pod.name` / `k8s.node.name` / `k8s.<workload>.name` / host name), and the lists are already fetched (server caps at 200), so filtering in the browser by name is faithful for the common case and removes `search` from the atom key entirely — which is what eliminates the reload.

- **Dropped `search` from the list *and* facets/sidebar atom keys** — neither query refetches while typing, so nothing re-enters the loading state. The sidebar stays stable.
- **Search now lives in local `useState`** and filters rows by name (`podName`/`nodeName`/`workloadName`/`hostName`) instantly.
- **Added a "No … match …" empty state** (search input stays usable) and gated the onboarding empty on the truly-empty fetched set.
- "Clear filters" (sidebar) also clears the search box.

## Files

- `apps/web/src/routes/infra/kubernetes/pods/index.tsx`
- `apps/web/src/routes/infra/kubernetes/nodes/index.tsx`
- `apps/web/src/routes/infra/kubernetes/workloads/index.tsx`
- `apps/web/src/routes/infra/index.tsx` (Hosts)

## Trade-off (intentional)

The free-text box now filters within the fetched rows (server cap = 200). On clusters with >200 of a resource, a name match beyond the first 200 won't appear in the free-text box — those users narrow with the **namespace/cluster/node facet filters**, which remain server-side. The `search` param on the server functions is unchanged (just unused by these pages now).

## Verification

- `bun --filter=@maple/web typecheck` → clean.
- Signed in against the running dev server (demo-seed org) and exercised all four pages:
  - **Pods** (200): `nats` → instant narrow to the 3 `prd-nats-*` pods; network shows **still exactly one `list-pods` + one `pod-facets`** — zero requests fired while typing. Non-matching text → "No pods match …" empty with the sidebar fully intact (no skeleton flash). Clearing → 200 + honeycomb restored instantly.
  - **Nodes** (30 → 1), **Workloads** (28 → 2 on `enrichment`), **Hosts** (30 → 1) — each: filtering instant, count updates, **no new warehouse request per keystroke**, "No … match" empty renders. On Hosts the summary cards + fleet grid + status tabs stay on the full fleet while the table narrows.
  - Zero console errors throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787409481&installation_model_id=427786&pr_number=253&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F253&signature=c8e307d9f31ad2072579412767fea061263b4d5b60b6d3c2e0d59ddd3df9991e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->