### PR TITLE
Harden the customer-facing PlanetScale integration

### DIFF
--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -115,8 +115,13 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 		// `api` worker is both producer (binding) and consumer (Queues.Consumer
 		// below). Local dev is wired separately in wrangler.jsonc so miniflare runs
 		// it in-process.
+		const vcsSyncQueueName = resolveWorkerName("vcs-sync", stage)
 		const vcsSyncQueue = yield* Cloudflare.Queues.Queue("vcs-sync", {
-			name: resolveWorkerName("vcs-sync", stage),
+			name: vcsSyncQueueName,
+		})
+		const planetScaleWebhookQueueName = resolveWorkerName("planetscale-webhooks", stage)
+		const planetScaleWebhookQueue = yield* Cloudflare.Queues.Queue("planetscale-webhooks", {
+			name: planetScaleWebhookQueueName,
 		})
 
 		const worker = (yield* Cloudflare.Worker("api", {
@@ -136,6 +141,9 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 				...(mapleDb ? { MAPLE_DB: mapleDb } : {}),
 				MCP_SESSIONS: mcpSessions,
 				VCS_SYNC_QUEUE: vcsSyncQueue,
+				VCS_SYNC_QUEUE_NAME: vcsSyncQueueName,
+				PLANETSCALE_WEBHOOK_QUEUE: planetScaleWebhookQueue,
+				PLANETSCALE_WEBHOOK_QUEUE_NAME: planetScaleWebhookQueueName,
 				CLICKHOUSE_SCHEMA_APPLY_WORKFLOW: schemaApplyWorkflow,
 				AI_TRIAGE_WORKFLOW: aiTriageWorkflow,
 				API_V2_RATE_LIMITER: Cloudflare.RateLimit("API_V2_RATE_LIMITER", {
@@ -244,6 +252,16 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 		// Attach the api worker as the vcs-sync queue consumer (v1 `eventSources`).
 		yield* Cloudflare.Queues.Consumer("vcs-sync-consumer", {
 			queueId: vcsSyncQueue.queueId,
+			scriptName: worker.workerName,
+			settings: {
+				batchSize: 10,
+				maxConcurrency: 2,
+				maxRetries: 3,
+				maxWaitTimeMs: 5000,
+			},
+		})
+		yield* Cloudflare.Queues.Consumer("planetscale-webhooks-consumer", {
+			queueId: planetScaleWebhookQueue.queueId,
 			scriptName: worker.workerName,
 			settings: {
 				batchSize: 10,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -89,6 +89,7 @@ import { QueryEngineService } from "./services/QueryEngineService"
 import { RecommendationIssueService } from "./services/RecommendationIssueService"
 import { PlanetScaleConnectionService } from "./services/PlanetScaleConnectionService"
 import { PlanetScaleDiscoveryService } from "./services/PlanetScaleDiscoveryService"
+import { PlanetScaleWebhookQueue } from "./services/planetscale/PlanetScaleWebhookQueue"
 import { PlanetScaleOAuthService } from "./services/PlanetScaleOAuthService"
 import { PlanetScaleService } from "./services/PlanetScaleService"
 import { ScrapeTargetsService } from "./services/ScrapeTargetsService"
@@ -152,9 +153,10 @@ const CoreServicesLive = Layer.mergeAll(
 	OrganizationService.layer,
 	PlanetScaleOAuthLive,
 	PlanetScaleDiscoveryLive,
+	PlanetScaleWebhookQueue.layer,
 	ScrapeTargetsLive,
 	PlanetScaleConnectionService.layer.pipe(
-		Layer.provide(Layer.mergeAll(ScrapeTargetsLive, PlanetScaleOAuthLive)),
+		Layer.provide(Layer.mergeAll(ScrapeTargetsLive, PlanetScaleDiscoveryLive, PlanetScaleOAuthLive)),
 	),
 	PlanetScaleService.layer.pipe(Layer.provide(PlanetScaleOAuthLive)),
 	IngestAttributeMappingService.layer,

--- a/apps/api/src/dashboard-templates/infrastructure/planetscale.ts
+++ b/apps/api/src/dashboard-templates/infrastructure/planetscale.ts
@@ -14,9 +14,9 @@ import type { TemplateDefinition, WidgetDef } from "../types"
 // PlanetScale branch metrics arrive via the scraper (the integration's managed
 // scrape target) with PlanetScale's own Prometheus metric names, all gauges.
 // The http_sd discovery labels ride along as point attributes, so widgets group
-// and filter on `attr.planetscale_database` / `attr.planetscale_branch`.
+// and filter on PlanetScale's canonical `_name` discovery labels.
 function databaseWhere(database?: string): string {
-	return database ? `attr.planetscale_database = "${escapeMetricStringLiteral(database)}"` : ""
+	return database ? `attr.planetscale_database_name = "${escapeMetricStringLiteral(database)}"` : ""
 }
 
 function gaugeChart(opts: {
@@ -40,7 +40,7 @@ function gaugeChart(opts: {
 			metricType: "gauge",
 			aggregation: opts.aggregation ?? "max",
 			whereClause: opts.where,
-			groupBy: ["attr.planetscale_database"],
+			groupBy: ["attr.planetscale_database_name"],
 		}),
 		display: { title: opts.title, ...(opts.display ?? CHART_DISPLAY_LINE), unit: opts.unit },
 		layout: opts.layout,
@@ -60,7 +60,7 @@ function widgets(database?: string): WidgetDef[] {
 				metricType: "gauge",
 				aggregation: "sum",
 				whereClause: where,
-				groupBy: ["attr.planetscale_database"],
+				groupBy: ["attr.planetscale_database_name"],
 			}),
 			display: { title: "Active Connections (MySQL)", ...CHART_DISPLAY_AREA, unit: "number" },
 			layout: { x: 0, y: 0, w: 6, h: 4 },
@@ -75,7 +75,7 @@ function widgets(database?: string): WidgetDef[] {
 				metricType: "gauge",
 				aggregation: "sum",
 				whereClause: where,
-				groupBy: ["attr.planetscale_database"],
+				groupBy: ["attr.planetscale_database_name"],
 			}),
 			display: { title: "Active Connections (Postgres)", ...CHART_DISPLAY_AREA, unit: "number" },
 			layout: { x: 6, y: 0, w: 6, h: 4 },
@@ -126,7 +126,7 @@ function widgets(database?: string): WidgetDef[] {
 				metricType: "gauge",
 				aggregation: "sum",
 				whereClause: combineWhere(where),
-				groupBy: ["attr.planetscale_branch"],
+				groupBy: ["attr.planetscale_branch_name"],
 			}),
 			display: { title: "Connections by Branch", ...CHART_DISPLAY_AREA, unit: "number" },
 			layout: { x: 0, y: 12, w: 6, h: 4 },

--- a/apps/api/src/dashboard-templates/query-specs.test.ts
+++ b/apps/api/src/dashboard-templates/query-specs.test.ts
@@ -96,4 +96,14 @@ describe("dashboard template query specs", () => {
 		}
 		expect(queryBuilderQueries).toBeGreaterThan(0)
 	})
+
+	it("uses PlanetScale's canonical discovery label keys", () => {
+		const template = DASHBOARD_TEMPLATES.find((candidate) => candidate.id === "planetscale")
+		expect(template).toBeDefined()
+		const encoded = JSON.stringify(template?.build({ database: "shop" }))
+		expect(encoded).toContain("attr.planetscale_database_name")
+		expect(encoded).toContain("attr.planetscale_branch_name")
+		expect(encoded).not.toContain('"attr.planetscale_database"')
+		expect(encoded).not.toContain('"attr.planetscale_branch"')
+	})
 })

--- a/apps/api/src/planetscale-webhook-runtime.test.ts
+++ b/apps/api/src/planetscale-webhook-runtime.test.ts
@@ -1,0 +1,147 @@
+import type { MessageBatch } from "@cloudflare/workers-types"
+import { afterEach, assert, describe, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+import { Database, DatabaseError } from "./lib/DatabaseLive"
+import { cleanupTestDbs, createTestDb, queryFirstRow, type TestDb } from "./lib/test-pglite"
+import { processPlanetScaleWebhookBatch } from "./planetscale-webhook-runtime"
+import type { PlanetScaleWebhookJob } from "./services/planetscale/PlanetScaleWebhookQueue"
+
+const trackedDbs: TestDb[] = []
+
+afterEach(() => cleanupTestDbs(trackedDbs))
+
+const job: PlanetScaleWebhookJob = {
+	kind: "planetscale-webhook",
+	orgId: "org_1",
+	connectionId: "connection_1",
+	payload: {
+		event: "branch.out_of_memory",
+		organization: "acme",
+		database: "shop",
+		resource: { name: "main" },
+	},
+	receivedAt: 1_000,
+}
+
+const makeBatch = (body: unknown) => {
+	let acknowledged = false
+	let retried = false
+	const message = {
+		id: "message_1",
+		timestamp: new Date(1_000),
+		body,
+		attempts: 1,
+		ack: () => {
+			acknowledged = true
+		},
+		retry: () => {
+			retried = true
+		},
+	}
+	return {
+		batch: {
+			queue: "maple-planetscale-webhooks-local",
+			messages: [message],
+			ackAll: () => undefined,
+			retryAll: () => undefined,
+		} as unknown as MessageBatch<unknown>,
+		acknowledged: () => acknowledged,
+		retried: () => retried,
+	}
+}
+
+describe("PlanetScale webhook queue consumer", () => {
+	it.effect("persists an issue and acknowledges the delivery", () => {
+		const testDb = createTestDb(trackedDbs)
+		const delivery = makeBatch(job)
+		return Effect.gen(function* () {
+			yield* processPlanetScaleWebhookBatch(delivery.batch)
+			assert.isTrue(delivery.acknowledged())
+			assert.isFalse(delivery.retried())
+			const row = yield* Effect.promise(() =>
+				queryFirstRow<{ workflow_state: string; occurrence_count: number }>(
+					testDb,
+					"SELECT workflow_state, occurrence_count FROM error_issues WHERE org_id = $1",
+					["org_1"],
+				),
+			)
+			assert.strictEqual(row?.workflow_state, "triage")
+			assert.strictEqual(row?.occurrence_count, 1)
+		}).pipe(Effect.provide(testDb.layer))
+	})
+
+	it.effect("acknowledges terminal malformed jobs", () => {
+		const testDb = createTestDb(trackedDbs)
+		const delivery = makeBatch({ kind: "not-a-planetscale-job" })
+		return processPlanetScaleWebhookBatch(delivery.batch).pipe(
+			Effect.tap(() =>
+				Effect.sync(() => {
+					assert.isTrue(delivery.acknowledged())
+					assert.isFalse(delivery.retried())
+				}),
+			),
+			Effect.provide(testDb.layer),
+		)
+	})
+
+	it.effect("reclassifies lifecycle events and acknowledges them without persistence", () => {
+		const testDb = createTestDb(trackedDbs)
+		const delivery = makeBatch({
+			...job,
+			payload: { ...job.payload, event: "branch.ready" },
+		})
+		return Effect.gen(function* () {
+			yield* processPlanetScaleWebhookBatch(delivery.batch)
+			assert.isTrue(delivery.acknowledged())
+			assert.isFalse(delivery.retried())
+			const row = yield* Effect.promise(() =>
+				queryFirstRow<{ count: number }>(
+					testDb,
+					"SELECT count(*)::int AS count FROM error_issues WHERE org_id = $1",
+					["org_1"],
+				),
+			)
+			assert.strictEqual(row?.count, 0)
+		}).pipe(Effect.provide(testDb.layer))
+	})
+
+	it.effect("retries typed database failures without acknowledging", () => {
+		const delivery = makeBatch(job)
+		const failedDatabase = Layer.succeed(Database, {
+			execute: () =>
+				Effect.fail(
+					new DatabaseError({
+						message: "database unavailable",
+						cause: new Error("database unavailable"),
+					}),
+				),
+		})
+		return processPlanetScaleWebhookBatch(delivery.batch).pipe(
+			Effect.tap(() =>
+				Effect.sync(() => {
+					assert.isFalse(delivery.acknowledged())
+					assert.isTrue(delivery.retried())
+				}),
+			),
+			Effect.provide(failedDatabase),
+		)
+	})
+
+	it.effect("does not turn persistence defects into acknowledgement or retry", () => {
+		const delivery = makeBatch(job)
+		const defectiveDatabase = Layer.succeed(Database, {
+			execute: () => Effect.die(new Error("unexpected persistence defect")),
+		})
+		return processPlanetScaleWebhookBatch(delivery.batch).pipe(
+			Effect.exit,
+			Effect.tap((exit) =>
+				Effect.sync(() => {
+					assert.strictEqual(exit._tag, "Failure")
+					assert.isFalse(delivery.acknowledged())
+					assert.isFalse(delivery.retried())
+				}),
+			),
+			Effect.provide(defectiveDatabase),
+		)
+	})
+})

--- a/apps/api/src/planetscale-webhook-runtime.ts
+++ b/apps/api/src/planetscale-webhook-runtime.ts
@@ -1,0 +1,141 @@
+import type { MessageBatch } from "@cloudflare/workers-types"
+import * as MapleCloudflareSDK from "@maple-dev/effect-sdk/cloudflare"
+import { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
+import { WorkerConfigProviderLayer, WorkerEnvironment } from "@maple/effect-cloudflare"
+import { Effect, Layer, Schema } from "effect"
+import { layerPg } from "./lib/DatabasePgLive"
+import { classifyPlanetScaleEvent, upsertPlanetScaleIssue } from "./services/planetscale/webhook-events"
+import { PlanetScaleWebhookJob } from "./services/planetscale/PlanetScaleWebhookQueue"
+
+const telemetry = MapleCloudflareSDK.make({
+	serviceName: "maple-api",
+	serviceNamespace: "backend",
+	repositoryUrl: "https://github.com/Makisuo/maple",
+	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
+})
+
+export const buildPlanetScaleWebhookLayer = (_env: Record<string, unknown>) => {
+	const DatabaseLive = layerPg.pipe(Layer.provide(WorkerEnvironment.layer))
+	return DatabaseLive.pipe(
+		Layer.provideMerge(telemetry.layer),
+		Layer.provideMerge(WorkerEnvironment.layer),
+		Layer.provideMerge(WorkerConfigProviderLayer),
+	)
+}
+
+export const flushPlanetScaleWebhookTelemetry = (env: Record<string, unknown>) => telemetry.flush(env)
+
+const decodeJob = Schema.decodeUnknownEffect(PlanetScaleWebhookJob)
+
+export const processPlanetScaleWebhookBatch = (batch: MessageBatch<unknown>) =>
+	Effect.forEach(
+		batch.messages,
+		(message) =>
+			decodeJob(message.body).pipe(
+				Effect.matchEffect({
+					onFailure: (error) =>
+						Effect.logWarning("Discarding malformed PlanetScale webhook queue message").pipe(
+							Effect.annotateLogs({
+								attempt: message.attempts,
+								error: String(error),
+							}),
+							Effect.flatMap(() => Effect.sync(() => message.ack())),
+							Effect.tap(() =>
+								Effect.annotateCurrentSpan({
+									"maple.planetscale.webhook.queue.outcome": "malformed_ack",
+								}),
+							),
+						),
+					onSuccess: (job) => {
+						const classified = classifyPlanetScaleEvent(job.payload.event)
+						const annotateJob = Effect.annotateCurrentSpan({
+							orgId: job.orgId,
+							"maple.planetscale.connection_id": job.connectionId,
+							"maple.planetscale.webhook.event": job.payload.event,
+						})
+						if (classified.action !== "issue") {
+							return annotateJob.pipe(
+								Effect.flatMap(() =>
+									Effect.logInfo(
+										"PlanetScale webhook queue message no longer requires an issue",
+									),
+								),
+								Effect.annotateLogs({
+									orgId: job.orgId,
+									connectionId: job.connectionId,
+									event: job.payload.event,
+								}),
+								Effect.flatMap(() => Effect.sync(() => message.ack())),
+							)
+						}
+
+						const timestamp =
+							job.payload.timestamp != null && job.payload.timestamp > 0
+								? job.payload.timestamp * 1000
+								: job.receivedAt
+						const persist = upsertPlanetScaleIssue({
+							orgId: job.orgId,
+							payload: job.payload,
+							severity: classified.severity,
+							title: classified.title,
+							description: classified.describe(job.payload),
+							timestamp,
+						}).pipe(
+							Effect.withSpan("PlanetScaleWebhookQueue.persistIssue", {
+								attributes: {
+									orgId: job.orgId,
+									"maple.planetscale.connection_id": job.connectionId,
+									"maple.planetscale.webhook.event": job.payload.event,
+								},
+							}),
+						)
+						return annotateJob.pipe(
+							Effect.flatMap(() => persist),
+							Effect.matchEffect({
+								onFailure: (error) =>
+									Effect.logError("PlanetScale webhook issue persistence failed").pipe(
+										Effect.annotateLogs({
+											orgId: job.orgId,
+											connectionId: job.connectionId,
+											event: job.payload.event,
+											attempt: message.attempts,
+											error: error.message,
+										}),
+										Effect.flatMap(() => Effect.sync(() => message.retry())),
+										Effect.tap(() =>
+											Effect.annotateCurrentSpan({
+												"maple.planetscale.webhook.queue.outcome": "database_retry",
+											}),
+										),
+									),
+								onSuccess: (result) =>
+									Effect.logInfo("PlanetScale webhook issue persisted").pipe(
+										Effect.annotateLogs({
+											orgId: job.orgId,
+											connectionId: job.connectionId,
+											event: job.payload.event,
+											issueId: result.issueId,
+											issueAction: result.action,
+										}),
+										Effect.flatMap(() => Effect.sync(() => message.ack())),
+										Effect.tap(() =>
+											Effect.annotateCurrentSpan({
+												"maple.planetscale.webhook.queue.outcome": "persisted_ack",
+												"maple.planetscale.webhook.issue_action": result.action,
+											}),
+										),
+									),
+							}),
+						)
+					},
+				}),
+				Effect.withSpan("PlanetScaleWebhookQueue.processMessage", {
+					attributes: { "messaging.message.delivery_attempt": message.attempts },
+				}),
+			),
+		{ concurrency: 5, discard: true },
+	).pipe(
+		Effect.withSpan("PlanetScaleWebhookQueue.processBatch", {
+			attributes: { "messaging.batch.message_count": batch.messages.length },
+		}),
+	)

--- a/apps/api/src/queue-dispatch.test.ts
+++ b/apps/api/src/queue-dispatch.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+import { classifyWorkerQueue } from "./queue-dispatch"
+
+const env = {
+	PLANETSCALE_WEBHOOK_QUEUE_NAME: "maple-planetscale-webhooks-local",
+	VCS_SYNC_QUEUE_NAME: "maple-vcs-sync-local",
+}
+
+describe("classifyWorkerQueue", () => {
+	it("dispatches each configured queue by its exact name", () => {
+		expect(classifyWorkerQueue("maple-planetscale-webhooks-local", env)).toBe("planetscale-webhook")
+		expect(classifyWorkerQueue("maple-vcs-sync-local", env)).toBe("vcs-sync")
+	})
+
+	it("does not route an unknown queue through the VCS consumer", () => {
+		expect(classifyWorkerQueue("maple-unknown-local", env)).toBe("unknown")
+	})
+})

--- a/apps/api/src/queue-dispatch.ts
+++ b/apps/api/src/queue-dispatch.ts
@@ -1,0 +1,14 @@
+export type WorkerQueueKind = "planetscale-webhook" | "vcs-sync" | "unknown"
+
+export const classifyWorkerQueue = (queueName: string, env: Record<string, unknown>): WorkerQueueKind => {
+	if (
+		typeof env.PLANETSCALE_WEBHOOK_QUEUE_NAME === "string" &&
+		queueName === env.PLANETSCALE_WEBHOOK_QUEUE_NAME
+	) {
+		return "planetscale-webhook"
+	}
+	if (typeof env.VCS_SYNC_QUEUE_NAME === "string" && queueName === env.VCS_SYNC_QUEUE_NAME) {
+		return "vcs-sync"
+	}
+	return "unknown"
+}

--- a/apps/api/src/routes/planetscale-webhook.http.test.ts
+++ b/apps/api/src/routes/planetscale-webhook.http.test.ts
@@ -7,6 +7,11 @@ import { encryptAes256Gcm } from "../lib/Crypto"
 import { Database } from "../lib/DatabaseLive"
 import { Env } from "../lib/Env"
 import { cleanupTestDbs, createTestDb, type TestDb } from "../lib/test-pglite"
+import {
+	PlanetScaleWebhookQueue,
+	PlanetScaleWebhookQueueError,
+	type PlanetScaleWebhookJob,
+} from "../services/planetscale/PlanetScaleWebhookQueue"
 import { PlanetScaleWebhookRouter } from "./planetscale-webhook.http"
 
 const trackedDbs: TestDb[] = []
@@ -33,9 +38,14 @@ const makeConfig = () =>
 		}),
 	)
 
-const makeRouterLayer = (testDb: TestDb) =>
+const makeRouterLayer = (
+	testDb: TestDb,
+	send: (job: PlanetScaleWebhookJob) => Effect.Effect<void, PlanetScaleWebhookQueueError> = () =>
+		Effect.void,
+) =>
 	PlanetScaleWebhookRouter.pipe(
 		Layer.provide(testDb.layer),
+		Layer.provide(Layer.succeed(PlanetScaleWebhookQueue, { send })),
 		Layer.provide(Env.layer),
 		Layer.provide(makeConfig()),
 	)
@@ -107,6 +117,128 @@ describe("PlanetScaleWebhookRouter", () => {
 				)
 				assert.strictEqual(accepted.status, 200)
 				assert.strictEqual(yield* Effect.promise(() => accepted.text()), "ok")
+			}).pipe(Effect.ensuring(Effect.promise(dispose)))
+		}).pipe(Effect.provide(testDb.layer))
+	})
+
+	it.effect("durably enqueues issue events before returning 202", () => {
+		const testDb = createTestDb(trackedDbs)
+		const jobs: PlanetScaleWebhookJob[] = []
+		return Effect.gen(function* () {
+			const database = yield* Database
+			const encrypted = yield* encryptAes256Gcm(
+				SECRET,
+				ENCRYPTION_KEY,
+				(message) => new Error(message),
+			).pipe(Effect.orDie)
+			const now = new Date("2026-07-11T00:00:00.000Z")
+			yield* database.execute((db) =>
+				db.insert(planetscaleConnections).values({
+					id: CONNECTION_ID,
+					orgId: "org_1",
+					psOrganization: "acme",
+					connectedByUserId: "user_1",
+					webhookSecretCiphertext: encrypted.ciphertext,
+					webhookSecretIv: encrypted.iv,
+					webhookSecretTag: encrypted.tag,
+					createdAt: now,
+					updatedAt: now,
+				}),
+			)
+			const issueBody = JSON.stringify({
+				event: "branch.out_of_memory",
+				organization: "acme",
+				database: "shop",
+				resource: { name: "main" },
+			})
+			const signature = createHmac("sha256", SECRET).update(issueBody, "utf8").digest("hex")
+			const { handler, dispose } = HttpRouter.toWebHandler(
+				makeRouterLayer(testDb, (job) => Effect.sync(() => jobs.push(job))),
+				{ disableLogger: true },
+			)
+
+			yield* Effect.gen(function* () {
+				const rejected = yield* Effect.promise(() =>
+					handler(
+						new Request(`http://api.localhost${WEBHOOK_PATH}`, {
+							method: "POST",
+							headers: { "x-planetscale-signature": "invalid" },
+							body: issueBody,
+						}),
+						Context.make(Database, database),
+					),
+				)
+				assert.strictEqual(rejected.status, 401)
+				assert.strictEqual(jobs.length, 0)
+
+				const accepted = yield* Effect.promise(() =>
+					handler(
+						new Request(`http://api.localhost${WEBHOOK_PATH}`, {
+							method: "POST",
+							headers: { "x-planetscale-signature": signature },
+							body: issueBody,
+						}),
+						Context.make(Database, database),
+					),
+				)
+				assert.strictEqual(accepted.status, 202)
+				assert.strictEqual(jobs.length, 1)
+				assert.strictEqual(jobs[0]?.kind, "planetscale-webhook")
+				assert.strictEqual(jobs[0]?.orgId, "org_1")
+				assert.strictEqual(jobs[0]?.connectionId, CONNECTION_ID)
+				assert.strictEqual(jobs[0]?.payload.event, "branch.out_of_memory")
+			}).pipe(Effect.ensuring(Effect.promise(dispose)))
+		}).pipe(Effect.provide(testDb.layer))
+	})
+
+	it.effect("returns 503 when durable enqueueing fails", () => {
+		const testDb = createTestDb(trackedDbs)
+		return Effect.gen(function* () {
+			const database = yield* Database
+			const encrypted = yield* encryptAes256Gcm(
+				SECRET,
+				ENCRYPTION_KEY,
+				(message) => new Error(message),
+			).pipe(Effect.orDie)
+			const now = new Date("2026-07-11T00:00:00.000Z")
+			yield* database.execute((db) =>
+				db.insert(planetscaleConnections).values({
+					id: CONNECTION_ID,
+					orgId: "org_1",
+					psOrganization: "acme",
+					connectedByUserId: "user_1",
+					webhookSecretCiphertext: encrypted.ciphertext,
+					webhookSecretIv: encrypted.iv,
+					webhookSecretTag: encrypted.tag,
+					createdAt: now,
+					updatedAt: now,
+				}),
+			)
+			const issueBody = JSON.stringify({
+				event: "branch.anomaly",
+				organization: "acme",
+				database: "shop",
+			})
+			const signature = createHmac("sha256", SECRET).update(issueBody, "utf8").digest("hex")
+			const { handler, dispose } = HttpRouter.toWebHandler(
+				makeRouterLayer(testDb, () =>
+					Effect.fail(new PlanetScaleWebhookQueueError({ message: "queue unavailable" })),
+				),
+				{ disableLogger: true },
+			)
+
+			yield* Effect.gen(function* () {
+				const response = yield* Effect.promise(() =>
+					handler(
+						new Request(`http://api.localhost${WEBHOOK_PATH}`, {
+							method: "POST",
+							headers: { "x-planetscale-signature": signature },
+							body: issueBody,
+						}),
+						Context.make(Database, database),
+					),
+				)
+				assert.strictEqual(response.status, 503)
 			}).pipe(Effect.ensuring(Effect.promise(dispose)))
 		}).pipe(Effect.provide(testDb.layer))
 	})

--- a/apps/api/src/routes/planetscale-webhook.http.ts
+++ b/apps/api/src/routes/planetscale-webhook.http.ts
@@ -9,9 +9,9 @@ import { Env } from "../lib/Env"
 import {
 	classifyPlanetScaleEvent,
 	decodePlanetScaleWebhookPayload,
-	upsertPlanetScaleIssue,
 	verifyPlanetScaleSignature,
 } from "../services/planetscale/webhook-events"
+import { PlanetScaleWebhookQueue } from "../services/planetscale/PlanetScaleWebhookQueue"
 
 // ---------------------------------------------------------------------------
 // Public PlanetScale webhook receiver. NOT behind auth — authenticity comes
@@ -20,8 +20,8 @@ import {
 // the path resolves which org (and which secret) the delivery belongs to.
 //
 // Health events (OOM, storage thresholds, anomalies) become kind="integration"
-// triage issues; lifecycle events are acknowledged and logged. Always 2xx for
-// verified deliveries so PlanetScale doesn't retry-storm on downstream issues.
+// triage issues through a durable queue; lifecycle events are acknowledged and
+// logged. Queue failures return 503 so PlanetScale retries the delivery.
 // ---------------------------------------------------------------------------
 
 const ROUTE = "/api/integrations/planetscale/webhook/:connectionId"
@@ -34,6 +34,7 @@ export const PlanetScaleWebhookRouter = HttpRouter.use((router) =>
 	Effect.gen(function* () {
 		const database = yield* Database
 		const env = yield* Env
+		const webhookQueue = yield* PlanetScaleWebhookQueue
 		const encryptionKey = yield* parseBase64Aes256GcmKey(
 			Redacted.value(env.MAPLE_INGEST_KEY_ENCRYPTION_KEY),
 			(message) => new IntegrationsPersistenceError({ message }),
@@ -43,141 +44,163 @@ export const PlanetScaleWebhookRouter = HttpRouter.use((router) =>
 			req: HttpServerRequest.HttpServerRequest,
 		) {
 			const params = yield* HttpRouter.params
-				const connectionId = params.connectionId ?? ""
-				yield* Effect.annotateCurrentSpan({
-					"http.request.method": req.method,
-					"http.route": ROUTE,
-				})
+			const connectionId = params.connectionId ?? ""
+			yield* Effect.annotateCurrentSpan({
+				"http.request.method": req.method,
+				"http.route": ROUTE,
+			})
 
-				const reject = (status: number, reason: string, body: string) =>
-					Effect.annotateCurrentSpan({
-						"http.response.status_code": status,
-						"otel.status_code": "Ok",
-						"maple.planetscale.webhook.outcome": "rejected",
-						"maple.planetscale.webhook.reason": reason,
-					}).pipe(Effect.as(textResponse(body, status)))
+			const reject = (status: number, reason: string, body: string) =>
+				Effect.annotateCurrentSpan({
+					"http.response.status_code": status,
+					"otel.status_code": "Ok",
+					"maple.planetscale.webhook.outcome": "rejected",
+					"maple.planetscale.webhook.reason": reason,
+				}).pipe(Effect.as(textResponse(body, status)))
 
-				if (connectionId.length === 0) {
-					return yield* reject(404, "missing_connection", "Unknown webhook endpoint")
-				}
+			const unavailable = (reason: string, body: string) =>
+				Effect.annotateCurrentSpan({
+					"http.response.status_code": 503,
+					"otel.status_code": "Error",
+					"maple.planetscale.webhook.outcome": "enqueue_failed",
+					"maple.planetscale.webhook.reason": reason,
+				}).pipe(Effect.as(textResponse(body, 503)))
 
-				const rows = yield* database
-					.execute((db) =>
-						db
-							.select()
-							.from(planetscaleConnections)
-							.where(eq(planetscaleConnections.id, connectionId))
-							.limit(1),
-					)
-					.pipe(
-						Effect.mapError(
-							(error) =>
-								new IntegrationsPersistenceError({
-									message: error instanceof Error ? error.message : "Failed to load webhook connection",
-								}),
-						),
-					)
-				const connection = rows[0]
-				if (
-					connection === undefined ||
-					connection.webhookSecretCiphertext === null ||
-					connection.webhookSecretIv === null ||
-					connection.webhookSecretTag === null
-				) {
-					return yield* reject(404, "unknown_connection", "Unknown webhook endpoint")
-				}
-				yield* Effect.annotateCurrentSpan({ orgId: connection.orgId })
+			if (connectionId.length === 0) {
+				return yield* reject(404, "missing_connection", "Unknown webhook endpoint")
+			}
 
-				const bodyOpt = yield* req.text.pipe(Effect.option)
-				if (Option.isNone(bodyOpt) || bodyOpt.value.length === 0) {
-					return yield* reject(400, "empty_body", "Missing request body")
-				}
-				const rawBody = bodyOpt.value
-
-				const secret = yield* decryptAes256Gcm(
-					{
-						ciphertext: connection.webhookSecretCiphertext,
-						iv: connection.webhookSecretIv,
-						tag: connection.webhookSecretTag,
-					},
-					encryptionKey,
-					() =>
-						new IntegrationsPersistenceError({
-							message: "Failed to decrypt webhook secret",
-						}),
+			const rows = yield* database
+				.execute((db) =>
+					db
+						.select()
+						.from(planetscaleConnections)
+						.where(eq(planetscaleConnections.id, connectionId))
+						.limit(1),
 				)
-
-				const headers = req.headers as Record<string, string | undefined>
-				const signature = headers["x-planetscale-signature"]
-				if (!verifyPlanetScaleSignature(rawBody, secret, signature)) {
-					return yield* reject(401, "signature_rejected", "Invalid signature")
-				}
-
-				const payloadResult = yield* decodePlanetScaleWebhookPayload(rawBody).pipe(
-					// Log which field failed to decode — this is a public endpoint and
-					// "Unrecognized payload" alone is undebuggable.
-					Effect.tapError((error) =>
-						Effect.logInfo("PlanetScale webhook payload failed to decode").pipe(
-							Effect.annotateLogs({ connectionId, orgId: connection.orgId, error: String(error) }),
-						),
+				.pipe(
+					Effect.mapError(
+						(error) =>
+							new IntegrationsPersistenceError({
+								message:
+									error instanceof Error
+										? error.message
+										: "Failed to load webhook connection",
+							}),
 					),
-					Effect.option,
 				)
-				if (Option.isNone(payloadResult)) {
-					return yield* reject(400, "parse_rejected", "Unrecognized payload")
-				}
-				const payload = payloadResult.value
+			const connection = rows[0]
+			if (
+				connection === undefined ||
+				connection.webhookSecretCiphertext === null ||
+				connection.webhookSecretIv === null ||
+				connection.webhookSecretTag === null
+			) {
+				return yield* reject(404, "unknown_connection", "Unknown webhook endpoint")
+			}
+			yield* Effect.annotateCurrentSpan({ orgId: connection.orgId })
 
-				const classified = classifyPlanetScaleEvent(payload.event)
+			const bodyOpt = yield* req.text.pipe(Effect.option)
+			if (Option.isNone(bodyOpt) || bodyOpt.value.length === 0) {
+				return yield* reject(400, "empty_body", "Missing request body")
+			}
+			const rawBody = bodyOpt.value
+
+			const secret = yield* decryptAes256Gcm(
+				{
+					ciphertext: connection.webhookSecretCiphertext,
+					iv: connection.webhookSecretIv,
+					tag: connection.webhookSecretTag,
+				},
+				encryptionKey,
+				() =>
+					new IntegrationsPersistenceError({
+						message: "Failed to decrypt webhook secret",
+					}),
+			)
+
+			const headers = req.headers as Record<string, string | undefined>
+			const signature = headers["x-planetscale-signature"]
+			if (!verifyPlanetScaleSignature(rawBody, secret, signature)) {
+				return yield* reject(401, "signature_rejected", "Invalid signature")
+			}
+
+			const payloadResult = yield* decodePlanetScaleWebhookPayload(rawBody).pipe(
+				// Log which field failed to decode — this is a public endpoint and
+				// "Unrecognized payload" alone is undebuggable.
+				Effect.tapError((error) =>
+					Effect.logInfo("PlanetScale webhook payload failed to decode").pipe(
+						Effect.annotateLogs({ connectionId, orgId: connection.orgId, error: String(error) }),
+					),
+				),
+				Effect.option,
+			)
+			if (Option.isNone(payloadResult)) {
+				return yield* reject(400, "parse_rejected", "Unrecognized payload")
+			}
+			const payload = payloadResult.value
+
+			const classified = classifyPlanetScaleEvent(payload.event)
+			yield* Effect.annotateCurrentSpan({
+				"maple.planetscale.webhook.event": payload.event,
+				"maple.planetscale.webhook.database": payload.database ?? "",
+				"maple.planetscale.webhook.action": classified.action,
+			})
+
+			if (classified.action === "test") {
 				yield* Effect.annotateCurrentSpan({
-					"maple.planetscale.webhook.event": payload.event,
-					"maple.planetscale.webhook.database": payload.database ?? "",
-					"maple.planetscale.webhook.action": classified.action,
-				})
-
-				if (classified.action === "test") {
-					yield* Effect.annotateCurrentSpan({
-						"http.response.status_code": 200,
-						"otel.status_code": "Ok",
-						"maple.planetscale.webhook.outcome": "handled",
-					})
-					return textResponse("ok", 200)
-				}
-
-				if (classified.action === "issue") {
-					const now = yield* Clock.currentTimeMillis
-					const timestamp =
-						payload.timestamp != null && payload.timestamp > 0 ? payload.timestamp * 1000 : now
-					const result = yield* upsertPlanetScaleIssue({
-						orgId: decodeOrgIdSync(connection.orgId),
-						payload,
-						severity: classified.severity,
-						title: classified.title,
-						description: classified.describe(payload),
-						timestamp,
-					})
-					yield* Effect.annotateCurrentSpan({
-						"maple.planetscale.webhook.issue_action": result.action,
-					})
-					yield* Effect.logInfo("PlanetScale webhook event handled").pipe(
-						Effect.annotateLogs({
-							orgId: connection.orgId,
-							event: payload.event,
-							issueAction: result.action,
-						}),
-					)
-				} else {
-					yield* Effect.logInfo("PlanetScale webhook lifecycle event acknowledged").pipe(
-						Effect.annotateLogs({ orgId: connection.orgId, event: payload.event }),
-					)
-				}
-
-				yield* Effect.annotateCurrentSpan({
-					"http.response.status_code": 202,
+					"http.response.status_code": 200,
 					"otel.status_code": "Ok",
 					"maple.planetscale.webhook.outcome": "handled",
 				})
-				return textResponse("accepted", 202)
+				return textResponse("ok", 200)
+			}
+
+			if (classified.action === "issue") {
+				const now = yield* Clock.currentTimeMillis
+				const enqueued = yield* webhookQueue
+					.send({
+						kind: "planetscale-webhook",
+						orgId: decodeOrgIdSync(connection.orgId),
+						connectionId,
+						payload,
+						receivedAt: now,
+					})
+					.pipe(
+						Effect.tapError((error) =>
+							Effect.logError("PlanetScale webhook enqueue failed").pipe(
+								Effect.annotateLogs({
+									orgId: connection.orgId,
+									connectionId,
+									event: payload.event,
+									error: error.message,
+								}),
+							),
+						),
+						Effect.option,
+					)
+				if (Option.isNone(enqueued)) {
+					return yield* unavailable("queue_unavailable", "Webhook queue unavailable")
+				}
+				yield* Effect.logInfo("PlanetScale webhook event enqueued").pipe(
+					Effect.annotateLogs({
+						orgId: connection.orgId,
+						connectionId,
+						event: payload.event,
+					}),
+				)
+			} else {
+				yield* Effect.logInfo("PlanetScale webhook lifecycle event acknowledged").pipe(
+					Effect.annotateLogs({ orgId: connection.orgId, event: payload.event }),
+				)
+			}
+
+			yield* Effect.annotateCurrentSpan({
+				"http.response.status_code": 202,
+				"otel.status_code": "Ok",
+				"maple.planetscale.webhook.outcome": "handled",
+			})
+			return textResponse("accepted", 202)
 		})
 
 		yield* router.add("POST", ROUTE, handle)

--- a/apps/api/src/services/PlanetScaleConnectionService.test.ts
+++ b/apps/api/src/services/PlanetScaleConnectionService.test.ts
@@ -3,7 +3,7 @@ import { ConfigProvider, Effect, Layer, Schema } from "effect"
 import { CreateScrapeTargetRequest, OrgId, PlanetScaleMetricsTokenRequest, UserId } from "@maple/domain/http"
 import { FetchHttpClient } from "effect/unstable/http"
 import { Env } from "../lib/Env"
-import { cleanupTestDbs, createTestDb, queryFirstRow, type TestDb } from "../lib/test-pglite"
+import { cleanupTestDbs, createTestDb, executeSql, queryFirstRow, type TestDb } from "../lib/test-pglite"
 import { PlanetScaleConnectionService } from "./PlanetScaleConnectionService"
 import { PlanetScaleDiscoveryService } from "./PlanetScaleDiscoveryService"
 import { PlanetScaleOAuthService } from "./PlanetScaleOAuthService"
@@ -41,7 +41,7 @@ const makeLayer = (testDb: TestDb) => {
 	)
 	return Layer.mergeAll(
 		PlanetScaleConnectionService.layer.pipe(
-			Layer.provide(Layer.mergeAll(scrapeTargetsLive, oauthLive)),
+			Layer.provide(Layer.mergeAll(scrapeTargetsLive, discoveryLive, oauthLive)),
 		),
 		scrapeTargetsLive,
 		oauthLive,
@@ -109,7 +109,11 @@ const stubPlanetScaleApi = (options?: {
 				? new Response("up 1\n", { status: 200 })
 				: new Response("forbidden", { status: 403 })
 		}
-		if (options?.sdGroups && requestUrl.includes("api.planetscale.com") && requestUrl.includes("/metrics")) {
+		if (
+			options?.sdGroups &&
+			requestUrl.includes("api.planetscale.com") &&
+			requestUrl.includes("/metrics")
+		) {
 			return new Response(JSON.stringify(options.sdGroups), {
 				status: 200,
 				headers: { "content-type": "application/json" },
@@ -321,7 +325,11 @@ describe("PlanetScaleConnectionService", () => {
 				),
 			)
 			const row = yield* Effect.promise(() =>
-				queryFirstRow<{ auth_type: string; auth_credentials_ciphertext: string | null; enabled: boolean }>(
+				queryFirstRow<{
+					auth_type: string
+					auth_credentials_ciphertext: string | null
+					enabled: boolean
+				}>(
 					testDb,
 					"SELECT auth_type, auth_credentials_ciphertext, enabled FROM scrape_targets WHERE id = $1",
 					[enabled.scrapeTarget!.id],
@@ -439,46 +447,151 @@ describe("PlanetScaleConnectionService", () => {
 		)
 	})
 
-	it.effect("finalizeOrgSelection adopts an existing user-created target and keeps its service token", () => {
+	it.effect(
+		"finalizeOrgSelection adopts an existing user-created target and keeps its service token",
+		() => {
+			const testDb = createTestDb(trackedDbs)
+			const stub = stubPlanetScaleApi()
+
+			return Effect.gen(function* () {
+				const scrapeTargetsService = yield* ScrapeTargetsService
+				const service = yield* PlanetScaleConnectionService
+				const orgId = asOrgId("org_1")
+
+				const existing = yield* scrapeTargetsService.create(
+					orgId,
+					new CreateScrapeTargetRequest({
+						name: "Manual PlanetScale",
+						targetType: "planetscale",
+						organization: "acme",
+						authType: "token",
+						authCredentials: JSON.stringify({ tokenId: "old", tokenSecret: "old" }),
+					}),
+				)
+
+				yield* storeGrant(orgId)
+				const status = yield* service.finalizeOrgSelection(orgId, { organization: "acme" })
+
+				// Adopted in place — no second target for the same PlanetScale org, and
+				// the working service token is KEPT: it's the auth PlanetScale's metrics
+				// endpoints actually accept, so clobbering it would break scraping.
+				assert.strictEqual(status.scrapeTarget?.id, existing.id)
+				assert.strictEqual(status.metricsAuth, "service_token")
+				const list = yield* scrapeTargetsService.list(orgId)
+				assert.strictEqual(list.targets.length, 1)
+				assert.match(list.targets[0]?.managedBy ?? "", /^planetscale:/)
+				const row = yield* Effect.promise(() =>
+					queryFirstRow<{ auth_type: string; auth_credentials_ciphertext: string | null }>(
+						testDb,
+						"SELECT auth_type, auth_credentials_ciphertext FROM scrape_targets WHERE id = $1",
+						[existing.id],
+					),
+				)
+				assert.strictEqual(row?.auth_type, "token")
+				assert.isNotNull(row?.auth_credentials_ciphertext)
+			}).pipe(
+				Effect.provideService(FetchHttpClient.Fetch, stub),
+				Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+			)
+		},
+	)
+
+	it.effect("atomically rebinds to another PlanetScale organization and retires the old target", () => {
+		const testDb = createTestDb(trackedDbs)
+		const stub = stubPlanetScaleApi({
+			organizations: [
+				{ id: "psorg_1", name: "acme" },
+				{ id: "psorg_2", name: "beta" },
+			],
+		})
+
+		return Effect.gen(function* () {
+			const service = yield* PlanetScaleConnectionService
+			const scrapeTargetsService = yield* ScrapeTargetsService
+			const orgId = asOrgId("org_1")
+			yield* storeGrant(orgId)
+			const first = yield* service.finalizeOrgSelection(orgId, { organization: "acme" })
+			const firstTargetId = first.scrapeTarget!.id
+
+			const sameOrg = yield* service.finalizeOrgSelection(orgId, {
+				organization: "acme",
+				includeBranches: ["main"],
+			})
+			assert.strictEqual(sameOrg.scrapeTarget?.id, firstTargetId)
+			assert.deepStrictEqual(sameOrg.scrapeTarget?.includeBranches, ["main"])
+			assert.strictEqual((yield* scrapeTargetsService.list(orgId)).targets.length, 1)
+
+			const rebound = yield* service.finalizeOrgSelection(orgId, { organization: "beta" })
+			assert.strictEqual(rebound.organization, "beta")
+			assert.notStrictEqual(rebound.scrapeTarget?.id, firstTargetId)
+			const targets = yield* scrapeTargetsService.list(orgId)
+			assert.strictEqual(targets.targets.length, 1)
+			assert.strictEqual(targets.targets[0]?.id, rebound.scrapeTarget?.id)
+		}).pipe(
+			Effect.provideService(FetchHttpClient.Fetch, stub),
+			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+		)
+	})
+
+	it.effect("never deletes a retired target whose ownership changed", () => {
+		const testDb = createTestDb(trackedDbs)
+		const stub = stubPlanetScaleApi({
+			organizations: [
+				{ id: "psorg_1", name: "acme" },
+				{ id: "psorg_2", name: "beta" },
+			],
+		})
+
+		return Effect.gen(function* () {
+			const service = yield* PlanetScaleConnectionService
+			const scrapeTargetsService = yield* ScrapeTargetsService
+			const orgId = asOrgId("org_1")
+			yield* storeGrant(orgId)
+			const first = yield* service.finalizeOrgSelection(orgId, { organization: "acme" })
+			yield* Effect.promise(() =>
+				executeSql(testDb, "UPDATE scrape_targets SET managed_by = $1 WHERE id = $2", [
+					"planetscale:another-connection",
+					first.scrapeTarget!.id,
+				]),
+			)
+
+			const rebound = yield* service.finalizeOrgSelection(orgId, { organization: "beta" })
+			const targets = yield* scrapeTargetsService.list(orgId)
+			assert.strictEqual(targets.targets.length, 2)
+			assert.isTrue(targets.targets.some((target) => target.id === first.scrapeTarget!.id))
+			assert.isTrue(targets.targets.some((target) => target.id === rebound.scrapeTarget!.id))
+		}).pipe(
+			Effect.provideService(FetchHttpClient.Fetch, stub),
+			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+		)
+	})
+
+	it.effect("compensates a newly created target when the binding transaction fails", () => {
 		const testDb = createTestDb(trackedDbs)
 		const stub = stubPlanetScaleApi()
 
 		return Effect.gen(function* () {
-			const scrapeTargetsService = yield* ScrapeTargetsService
 			const service = yield* PlanetScaleConnectionService
+			const scrapeTargetsService = yield* ScrapeTargetsService
 			const orgId = asOrgId("org_1")
-
-			const existing = yield* scrapeTargetsService.create(
-				orgId,
-				new CreateScrapeTargetRequest({
-					name: "Manual PlanetScale",
-					targetType: "planetscale",
-					organization: "acme",
-					authType: "token",
-					authCredentials: JSON.stringify({ tokenId: "old", tokenSecret: "old" }),
-				}),
-			)
-
 			yield* storeGrant(orgId)
-			const status = yield* service.finalizeOrgSelection(orgId, { organization: "acme" })
-
-			// Adopted in place — no second target for the same PlanetScale org, and
-			// the working service token is KEPT: it's the auth PlanetScale's metrics
-			// endpoints actually accept, so clobbering it would break scraping.
-			assert.strictEqual(status.scrapeTarget?.id, existing.id)
-			assert.strictEqual(status.metricsAuth, "service_token")
-			const list = yield* scrapeTargetsService.list(orgId)
-			assert.strictEqual(list.targets.length, 1)
-			assert.match(list.targets[0]?.managedBy ?? "", /^planetscale:/)
-			const row = yield* Effect.promise(() =>
-				queryFirstRow<{ auth_type: string; auth_credentials_ciphertext: string | null }>(
-					testDb,
-					"SELECT auth_type, auth_credentials_ciphertext FROM scrape_targets WHERE id = $1",
-					[existing.id],
+			yield* Effect.promise(() =>
+				testDb.pglite.exec(
+					`CREATE FUNCTION reject_planetscale_binding() RETURNS trigger AS $$
+						BEGIN RAISE EXCEPTION 'forced binding failure'; END;
+						$$ LANGUAGE plpgsql;
+						CREATE TRIGGER reject_planetscale_binding
+						BEFORE INSERT ON planetscale_connections
+						FOR EACH ROW EXECUTE FUNCTION reject_planetscale_binding();`,
 				),
 			)
-			assert.strictEqual(row?.auth_type, "token")
-			assert.isNotNull(row?.auth_credentials_ciphertext)
+
+			const error = yield* service
+				.finalizeOrgSelection(orgId, { organization: "acme" })
+				.pipe(Effect.flip)
+			assert.strictEqual(error._tag, "@maple/http/errors/IntegrationsPersistenceError")
+			const targets = yield* scrapeTargetsService.list(orgId)
+			assert.strictEqual(targets.targets.length, 0)
 		}).pipe(
 			Effect.provideService(FetchHttpClient.Fetch, stub),
 			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
@@ -539,33 +652,36 @@ describe("PlanetScaleConnectionService", () => {
 		)
 	})
 
-	it.effect("webhookConfig decrypts the minted secret once bound, and reports unconfigured otherwise", () => {
-		const testDb = createTestDb(trackedDbs)
-		const stub = stubPlanetScaleApi()
+	it.effect(
+		"webhookConfig decrypts the minted secret once bound, and reports unconfigured otherwise",
+		() => {
+			const testDb = createTestDb(trackedDbs)
+			const stub = stubPlanetScaleApi()
 
-		return Effect.gen(function* () {
-			const service = yield* PlanetScaleConnectionService
-			const orgId = asOrgId("org_1")
+			return Effect.gen(function* () {
+				const service = yield* PlanetScaleConnectionService
+				const orgId = asOrgId("org_1")
 
-			// No binding yet → nothing to expose (exercises the null-ciphertext branch).
-			const before = yield* service.webhookConfig(orgId)
-			assert.isFalse(before.configured)
-			assert.isNull(before.path)
-			assert.isNull(before.secret)
+				// No binding yet → nothing to expose (exercises the null-ciphertext branch).
+				const before = yield* service.webhookConfig(orgId)
+				assert.isFalse(before.configured)
+				assert.isNull(before.path)
+				assert.isNull(before.secret)
 
-			yield* storeGrant(orgId)
-			yield* service.finalizeOrgSelection(orgId, { organization: "acme" })
+				yield* storeGrant(orgId)
+				yield* service.finalizeOrgSelection(orgId, { organization: "acme" })
 
-			// Bound → the secret decrypts (the only decrypt path for the webhook
-			// secret) and the delivery path is exposed.
-			const after = yield* service.webhookConfig(orgId)
-			assert.isTrue(after.configured)
-			assert.isNotNull(after.secret)
-			assert.isAbove((after.secret ?? "").length, 0)
-			assert.match(after.path ?? "", /^\/api\/integrations\/planetscale\/webhook\//)
-		}).pipe(
-			Effect.provideService(FetchHttpClient.Fetch, stub),
-			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
-		)
-	})
+				// Bound → the secret decrypts (the only decrypt path for the webhook
+				// secret) and the delivery path is exposed.
+				const after = yield* service.webhookConfig(orgId)
+				assert.isTrue(after.configured)
+				assert.isNotNull(after.secret)
+				assert.isAbove((after.secret ?? "").length, 0)
+				assert.match(after.path ?? "", /^\/api\/integrations\/planetscale\/webhook\//)
+			}).pipe(
+				Effect.provideService(FetchHttpClient.Fetch, stub),
+				Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+			)
+		},
+	)
 })

--- a/apps/api/src/services/PlanetScaleConnectionService.ts
+++ b/apps/api/src/services/PlanetScaleConnectionService.ts
@@ -25,7 +25,11 @@ import { decryptAes256Gcm, encryptAes256Gcm, parseBase64Aes256GcmKey } from "../
 import { Database } from "../lib/DatabaseLive"
 import { Env } from "../lib/Env"
 import { decodeDiscoveryConfig } from "./planetscale/discovery-config"
-import { HttpSdResponse, subTargetsFromGroup } from "./PlanetScaleDiscoveryService"
+import {
+	HttpSdResponse,
+	PlanetScaleDiscoveryService,
+	subTargetsFromGroup,
+} from "./PlanetScaleDiscoveryService"
 import { PlanetScaleOAuthService, planetScaleBearerHeader } from "./PlanetScaleOAuthService"
 import { ScrapeTargetsService } from "./ScrapeTargetsService"
 
@@ -52,7 +56,9 @@ export interface PlanetScaleDetectedPermissions {
 }
 
 export interface PlanetScaleConnectionServiceShape {
-	readonly getStatus: (orgId: OrgId) => Effect.Effect<PlanetScaleIntegrationStatus, IntegrationsPersistenceError>
+	readonly getStatus: (
+		orgId: OrgId,
+	) => Effect.Effect<PlanetScaleIntegrationStatus, IntegrationsPersistenceError>
 	/**
 	 * Bind the org's stored OAuth grant to one PlanetScale organization. Called
 	 * from the OAuth callback (single-org auto-bind) and the org-picker endpoint;
@@ -98,7 +104,9 @@ export interface PlanetScaleConnectionServiceShape {
 		orgId: OrgId,
 	) => Effect.Effect<PlanetScaleConnectionRow | null, IntegrationsPersistenceError>
 	/** Webhook endpoint path + decrypted HMAC secret for manual setup (admin-gated at the route). */
-	readonly webhookConfig: (orgId: OrgId) => Effect.Effect<
+	readonly webhookConfig: (
+		orgId: OrgId,
+	) => Effect.Effect<
 		{ readonly configured: boolean; readonly path: string | null; readonly secret: string | null },
 		IntegrationsPersistenceError
 	>
@@ -121,6 +129,7 @@ export class PlanetScaleConnectionService extends Context.Service<
 		const env = yield* Env
 		const scrapeTargetsService = yield* ScrapeTargetsService
 		const psOAuth = yield* PlanetScaleOAuthService
+		const discovery = yield* PlanetScaleDiscoveryService
 		const httpClient = yield* HttpClient.HttpClient
 		const encryptionKey = yield* parseBase64Aes256GcmKey(
 			Redacted.value(env.MAPLE_INGEST_KEY_ENCRYPTION_KEY),
@@ -196,9 +205,7 @@ export class PlanetScaleConnectionService extends Context.Service<
 					if (sd.status === 401 || sd.status === 403) return "rejected" as const
 					if (sd.status < 200 || sd.status >= 300) return "inconclusive" as const
 
-					const groups = yield* decodeHttpSd(sd.text).pipe(
-						Effect.catch(() => Effect.succeed(null)),
-					)
+					const groups = yield* decodeHttpSd(sd.text).pipe(Effect.catch(() => Effect.succeed(null)))
 					if (groups === null) return "inconclusive" as const
 
 					// subTargetsFromGroup already SSRF-validates the discovered URLs.
@@ -212,7 +219,9 @@ export class PlanetScaleConnectionService extends Context.Service<
 						: ("rejected" as const)
 				}).pipe(
 					Effect.catchTag("@maple/http/errors/IntegrationsUpstreamError", (error) =>
-						Effect.logWarning("PlanetScale data-plane scrape probe failed; keeping SD result").pipe(
+						Effect.logWarning(
+							"PlanetScale data-plane scrape probe failed; keeping SD result",
+						).pipe(
 							Effect.annotateLogs({ organization, error: error.message }),
 							Effect.as("inconclusive" as const),
 						),
@@ -368,7 +377,9 @@ export class PlanetScaleConnectionService extends Context.Service<
 					db
 						.select()
 						.from(scrapeTargets)
-						.where(and(eq(scrapeTargets.orgId, orgId), eq(scrapeTargets.targetType, "planetscale"))),
+						.where(
+							and(eq(scrapeTargets.orgId, orgId), eq(scrapeTargets.targetType, "planetscale")),
+						),
 				)
 				.pipe(Effect.mapError(toPersistenceError))
 			return (
@@ -376,17 +387,6 @@ export class PlanetScaleConnectionService extends Context.Service<
 					(row) => decodeDiscoveryConfig(row.discoveryConfigJson)?.organization === organization,
 				) ?? null
 			)
-		})
-
-		const setManagedBy = Effect.fn("PlanetScaleConnectionService.setManagedBy")(function* (
-			targetId: string,
-			managedBy: string,
-		) {
-			yield* database
-				.execute((db) =>
-					db.update(scrapeTargets).set({ managedBy }).where(eq(scrapeTargets.id, targetId)),
-				)
-				.pipe(Effect.mapError(toPersistenceError))
 		})
 
 		// Typed on the concrete scrape-target error union so a new tag added to
@@ -409,143 +409,224 @@ export class PlanetScaleConnectionService extends Context.Service<
 			}
 		}
 
-		const finalizeOrgSelection = Effect.fn("PlanetScaleConnectionService.finalizeOrgSelection")(function* (
-			orgId: OrgId,
-			request: Pick<
-				PlanetScaleSelectOrganizationRequest,
-				"organization" | "includeBranches" | "excludeBranches"
-			>,
-		) {
-			yield* Effect.annotateCurrentSpan({ orgId })
-			const organization = request.organization.trim()
+		const finalizeOrgSelection = Effect.fn("PlanetScaleConnectionService.finalizeOrgSelection")(
+			function* (
+				orgId: OrgId,
+				request: Pick<
+					PlanetScaleSelectOrganizationRequest,
+					"organization" | "includeBranches" | "excludeBranches"
+				>,
+			) {
+				yield* Effect.annotateCurrentSpan({ orgId })
+				const organization = request.organization.trim()
 
-			const { accessToken } = yield* psOAuth.getValidAccessToken(orgId)
+				const { accessToken } = yield* psOAuth.getValidAccessToken(orgId)
 
-			// The grant is the authority on which orgs may be bound — a slug outside
-			// it would provision a scrape target that 403s on every scrape.
-			const grantedOrgs = yield* psOAuth.listOrganizations(orgId)
-			if (!grantedOrgs.some((org) => org.name === organization)) {
-				return yield* Effect.fail(
-					new IntegrationsValidationError({
-						message: `The PlanetScale authorization does not grant access to organization "${organization}" — re-authorize or pick another organization.`,
-					}),
-				)
-			}
-
-			// Probe what the grant can do against this org (readMetricsEndpoints
-			// requires an actual data-plane scrape to pass — see probePermissions).
-			// The metrics endpoints only document service-token auth, so a failing
-			// bearer probe does NOT block the binding — inventory/insights/webhooks
-			// work on the grant, and scraping stays paused until a service token is
-			// added via setMetricsToken (the card's follow-up step).
-			const { permissions } = yield* probePermissions(organization, accessToken)
-
-			// Attribution comes from the grant, so finalize behaves identically when
-			// called from the tenantless OAuth callback and the picker endpoint. The
-			// grant row must exist here — getValidAccessToken just used it.
-			const connectedByUserId = yield* psOAuth.connectedByUserId(orgId)
-			if (connectedByUserId === null) {
-				return yield* Effect.fail(
-					new IntegrationsNotConnectedError({
-						message: "PlanetScale is not connected for this organization",
-					}),
-				)
-			}
-
-			const now = yield* Clock.currentTimeMillis
-			const existing = yield* selectConnection(orgId)
-			const connectionId = existing?.id ?? randomUUID()
-			const managedBy = managedByForConnection(connectionId)
-
-			// Provision or adopt the scrape target that feeds branch metrics. Managed
-			// targets carry no credentials — the scraper resolves the OAuth grant at
-			// scrape time (authType "planetscale_oauth").
-			const adoptable = yield* findAdoptableTarget(orgId, organization)
-			let scrapeTargetId: string
-			if (adoptable !== null) {
-				// An adopted row with working service-token credentials keeps them —
-				// that's the auth the metrics endpoints actually accept. Only
-				// credential-less rows switch to grant-resolved auth, and those stay
-				// enabled only if the bearer probe passed.
-				const keepsToken =
-					adoptable.authType === "token" && adoptable.authCredentialsCiphertext !== null
-				yield* scrapeTargetsService
-					.update(orgId, decodeScrapeTargetIdSync(adoptable.id), {
-						...(keepsToken ? {} : { authType: "planetscale_oauth" }),
-						...(request.includeBranches !== undefined
-							? { includeBranches: request.includeBranches }
-							: {}),
-						...(request.excludeBranches !== undefined
-							? { excludeBranches: request.excludeBranches }
-							: {}),
-						enabled: keepsToken || permissions.readMetricsEndpoints,
-					})
-					.pipe(Effect.mapError(mapScrapeTargetError))
-				scrapeTargetId = adoptable.id
-			} else {
-				const created = yield* scrapeTargetsService
-					.create(orgId, {
-						name: `PlanetScale (${organization})`,
-						targetType: "planetscale",
-						organization,
-						authType: "planetscale_oauth",
-						...(request.includeBranches !== undefined
-							? { includeBranches: request.includeBranches }
-							: {}),
-						...(request.excludeBranches !== undefined
-							? { excludeBranches: request.excludeBranches }
-							: {}),
-						// Paused until a service token arrives when the bearer probe
-						// failed — an enabled target would just 401 every scrape.
-						enabled: permissions.readMetricsEndpoints,
-					})
-					.pipe(Effect.mapError(mapScrapeTargetError))
-				scrapeTargetId = created.id
-			}
-			yield* setManagedBy(scrapeTargetId, managedBy)
-
-			if (existing !== null) {
-				yield* database
-					.execute((db) =>
-						db
-							.update(planetscaleConnections)
-							.set({
-								psOrganization: organization,
-								connectedByUserId,
-								scrapeTargetId,
-								detectedPermissionsJson: { ...permissions },
-								updatedAt: new Date(now),
-							})
-							.where(eq(planetscaleConnections.id, existing.id)),
-					)
-					.pipe(Effect.mapError(toPersistenceError))
-			} else {
-				// Per-connection webhook HMAC secret, minted once at first binding.
-				const webhookSecret = randomBytes(32).toString("hex")
-				const encryptedWebhookSecret = yield* encryptAes256Gcm(webhookSecret, encryptionKey, () =>
-					toPersistenceError(new Error("Failed to encrypt PlanetScale webhook secret")),
-				)
-				yield* database
-					.execute((db) =>
-						db.insert(planetscaleConnections).values({
-							id: connectionId,
-							orgId,
-							psOrganization: organization,
-							connectedByUserId,
-							scrapeTargetId,
-							webhookSecretCiphertext: encryptedWebhookSecret.ciphertext,
-							webhookSecretIv: encryptedWebhookSecret.iv,
-							webhookSecretTag: encryptedWebhookSecret.tag,
-							detectedPermissionsJson: { ...permissions },
-							createdAt: new Date(now),
-							updatedAt: new Date(now),
+				// The grant is the authority on which orgs may be bound — a slug outside
+				// it would provision a scrape target that 403s on every scrape.
+				const grantedOrgs = yield* psOAuth.listOrganizations(orgId)
+				if (!grantedOrgs.some((org) => org.name === organization)) {
+					return yield* Effect.fail(
+						new IntegrationsValidationError({
+							message: `The PlanetScale authorization does not grant access to organization "${organization}" — re-authorize or pick another organization.`,
 						}),
 					)
-					.pipe(Effect.mapError(toPersistenceError))
-			}
+				}
 
-			return yield* getStatus(orgId)
-		})
+				// Probe what the grant can do against this org (readMetricsEndpoints
+				// requires an actual data-plane scrape to pass — see probePermissions).
+				// The metrics endpoints only document service-token auth, so a failing
+				// bearer probe does NOT block the binding — inventory/insights/webhooks
+				// work on the grant, and scraping stays paused until a service token is
+				// added via setMetricsToken (the card's follow-up step).
+				const { permissions } = yield* probePermissions(organization, accessToken)
+
+				// Attribution comes from the grant, so finalize behaves identically when
+				// called from the tenantless OAuth callback and the picker endpoint. The
+				// grant row must exist here — getValidAccessToken just used it.
+				const connectedByUserId = yield* psOAuth.connectedByUserId(orgId)
+				if (connectedByUserId === null) {
+					return yield* Effect.fail(
+						new IntegrationsNotConnectedError({
+							message: "PlanetScale is not connected for this organization",
+						}),
+					)
+				}
+
+				const now = yield* Clock.currentTimeMillis
+				const existing = yield* selectConnection(orgId)
+				const connectionId = existing?.id ?? randomUUID()
+				const managedBy = managedByForConnection(connectionId)
+
+				// Provision or adopt the scrape target that feeds branch metrics. Managed
+				// targets carry no credentials — the scraper resolves the OAuth grant at
+				// scrape time (authType "planetscale_oauth").
+				const adoptable = yield* findAdoptableTarget(orgId, organization)
+				let scrapeTargetId: string
+				let createdTarget = false
+				if (adoptable !== null) {
+					// An adopted row with working service-token credentials keeps them —
+					// that's the auth the metrics endpoints actually accept. Only
+					// credential-less rows switch to grant-resolved auth, and those stay
+					// enabled only if the bearer probe passed.
+					const keepsToken =
+						adoptable.authType === "token" && adoptable.authCredentialsCiphertext !== null
+					yield* scrapeTargetsService
+						.update(orgId, decodeScrapeTargetIdSync(adoptable.id), {
+							...(keepsToken ? {} : { authType: "planetscale_oauth" }),
+							...(request.includeBranches !== undefined
+								? { includeBranches: request.includeBranches }
+								: {}),
+							...(request.excludeBranches !== undefined
+								? { excludeBranches: request.excludeBranches }
+								: {}),
+							enabled: keepsToken || permissions.readMetricsEndpoints,
+						})
+						.pipe(Effect.mapError(mapScrapeTargetError))
+					scrapeTargetId = adoptable.id
+				} else {
+					const created = yield* scrapeTargetsService
+						.create(orgId, {
+							name: `PlanetScale (${organization})`,
+							targetType: "planetscale",
+							organization,
+							authType: "planetscale_oauth",
+							...(request.includeBranches !== undefined
+								? { includeBranches: request.includeBranches }
+								: {}),
+							...(request.excludeBranches !== undefined
+								? { excludeBranches: request.excludeBranches }
+								: {}),
+							// Paused until a service token arrives when the bearer probe
+							// failed — an enabled target would just 401 every scrape.
+							enabled: permissions.readMetricsEndpoints,
+						})
+						.pipe(Effect.mapError(mapScrapeTargetError))
+					scrapeTargetId = created.id
+					createdTarget = true
+				}
+
+				// Encrypt before opening the transaction so it only covers database I/O.
+				// The secret is minted once and retained across organization rebindings.
+				const encryptedWebhookSecret =
+					existing === null
+						? yield* encryptAes256Gcm(randomBytes(32).toString("hex"), encryptionKey, () =>
+								toPersistenceError(new Error("Failed to encrypt PlanetScale webhook secret")),
+							)
+						: null
+
+				const retiredTargets = yield* database
+					.execute((db) =>
+						db.transaction(async (tx) => {
+							const claimed = await tx
+								.update(scrapeTargets)
+								.set({ managedBy })
+								.where(
+									and(eq(scrapeTargets.orgId, orgId), eq(scrapeTargets.id, scrapeTargetId)),
+								)
+								.returning({ id: scrapeTargets.id })
+							if (claimed.length !== 1) {
+								throw new Error(
+									"Replacement PlanetScale scrape target disappeared before binding",
+								)
+							}
+
+							if (existing !== null) {
+								const rebound = await tx
+									.update(planetscaleConnections)
+									.set({
+										psOrganization: organization,
+										connectedByUserId,
+										scrapeTargetId,
+										detectedPermissionsJson: { ...permissions },
+										updatedAt: new Date(now),
+									})
+									.where(eq(planetscaleConnections.id, existing.id))
+									.returning({ id: planetscaleConnections.id })
+								if (rebound.length !== 1) {
+									throw new Error("PlanetScale connection disappeared before rebinding")
+								}
+
+								if (
+									existing.scrapeTargetId === null ||
+									existing.scrapeTargetId === scrapeTargetId
+								) {
+									return []
+								}
+
+								// Ownership is part of the predicate: a target transferred by a
+								// concurrent operation is never removed by this connection.
+								return tx
+									.delete(scrapeTargets)
+									.where(
+										and(
+											eq(scrapeTargets.orgId, orgId),
+											eq(scrapeTargets.id, existing.scrapeTargetId),
+											eq(scrapeTargets.managedBy, managedBy),
+										),
+									)
+									.returning({ id: scrapeTargets.id })
+							}
+
+							if (encryptedWebhookSecret === null) {
+								throw new Error("Missing webhook secret for new PlanetScale connection")
+							}
+							const inserted = await tx
+								.insert(planetscaleConnections)
+								.values({
+									id: connectionId,
+									orgId,
+									psOrganization: organization,
+									connectedByUserId,
+									scrapeTargetId,
+									webhookSecretCiphertext: encryptedWebhookSecret.ciphertext,
+									webhookSecretIv: encryptedWebhookSecret.iv,
+									webhookSecretTag: encryptedWebhookSecret.tag,
+									detectedPermissionsJson: { ...permissions },
+									createdAt: new Date(now),
+									updatedAt: new Date(now),
+								})
+								.returning({ id: planetscaleConnections.id })
+							if (inserted.length !== 1) {
+								throw new Error("Failed to persist PlanetScale connection")
+							}
+							return []
+						}),
+					)
+					.pipe(
+						Effect.mapError(toPersistenceError),
+						Effect.tapError(() =>
+							createdTarget
+								? scrapeTargetsService
+										.delete(orgId, decodeScrapeTargetIdSync(scrapeTargetId))
+										.pipe(
+											Effect.catchTag(
+												"@maple/http/errors/ScrapeTargetNotFoundError",
+												() => Effect.void,
+											),
+											Effect.catch((error) =>
+												Effect.logWarning(
+													"Failed to compensate newly created PlanetScale target after binding failure",
+												).pipe(
+													Effect.annotateLogs({
+														orgId,
+														scrapeTargetId,
+														error: String(error),
+													}),
+												),
+											),
+										)
+								: Effect.void,
+						),
+					)
+
+				yield* Effect.forEach(retiredTargets, (target) => discovery.invalidate(target.id), {
+					discard: true,
+				})
+
+				return yield* getStatus(orgId)
+			},
+		)
 
 		const setMetricsToken = Effect.fn("PlanetScaleConnectionService.setMetricsToken")(function* (
 			orgId: OrgId,
@@ -588,7 +669,8 @@ export class PlanetScaleConnectionService extends Context.Service<
 			if (target === null) {
 				return yield* Effect.fail(
 					new IntegrationsPersistenceError({
-						message: "The managed scrape target is missing — disconnect and reconnect PlanetScale.",
+						message:
+							"The managed scrape target is missing — disconnect and reconnect PlanetScale.",
 					}),
 				)
 			}
@@ -612,14 +694,12 @@ export class PlanetScaleConnectionService extends Context.Service<
 				// owns it (a user-created row adopted by a *different* connection stays).
 				const target = yield* selectManagedTarget(connection)
 				if (target !== null && target.managedBy === managedByForConnection(connection.id)) {
-					yield* scrapeTargetsService
-						.delete(orgId, decodeScrapeTargetIdSync(target.id))
-						.pipe(
-							Effect.catchTag("@maple/http/errors/ScrapeTargetNotFoundError", () =>
-								Effect.succeed(undefined),
-							),
-							Effect.mapError(toPersistenceError),
-						)
+					yield* scrapeTargetsService.delete(orgId, decodeScrapeTargetIdSync(target.id)).pipe(
+						Effect.catchTag("@maple/http/errors/ScrapeTargetNotFoundError", () =>
+							Effect.succeed(undefined),
+						),
+						Effect.mapError(toPersistenceError),
+					)
 				}
 
 				yield* database

--- a/apps/api/src/services/PlanetScaleDiscoveryService.test.ts
+++ b/apps/api/src/services/PlanetScaleDiscoveryService.test.ts
@@ -52,9 +52,7 @@ const makeLayer = (testDb: TestDb, fetchStub?: typeof globalThis.fetch) => {
 		ScrapeTargetsService.layer.pipe(Layer.provide(Layer.mergeAll(discoveryLive, oauthLive))),
 		oauthLive,
 	).pipe(Layer.provide(testDb.layer), Layer.provide(Env.layer), Layer.provide(makeConfig()))
-	return fetchStub
-		? Layer.mergeAll(composed, Layer.succeed(FetchHttpClient.Fetch, fetchStub))
-		: composed
+	return fetchStub ? Layer.mergeAll(composed, Layer.succeed(FetchHttpClient.Fetch, fetchStub)) : composed
 }
 
 const asOrgId = Schema.decodeUnknownSync(OrgId)
@@ -124,8 +122,9 @@ const BRANCHES_SD_PAYLOAD = ["main", "stg", "pr-12", "pr-13"].map((branch) => ({
 	targets: [`${branch}.metrics.psdb.cloud:443`],
 	labels: {
 		__metrics_path__: "/metrics",
-		planetscale_database_branch_id: branch,
-		planetscale_database: "mydb",
+		planetscale_database_branch_id: `branch-id-${branch}`,
+		planetscale_database_name: "mydb",
+		planetscale_branch_name: branch,
 	},
 }))
 
@@ -144,11 +143,17 @@ describe("PlanetScaleDiscoveryService", () => {
 				),
 			)
 
-			assert.strictEqual(recorded[0]?.url, "https://api.planetscale.com/v1/organizations/my-org/metrics")
+			assert.strictEqual(
+				recorded[0]?.url,
+				"https://api.planetscale.com/v1/organizations/my-org/metrics",
+			)
 			assert.strictEqual(recorded[0]?.authorization, "token tok_id:tok_secret")
 
 			// The 169.254.* target is dropped by the SSRF guard.
-			assert.deepStrictEqual(entries.map((entry) => entry.subTargetKey), ["branch-1", "branch-2"])
+			assert.deepStrictEqual(
+				entries.map((entry) => entry.subTargetKey),
+				["branch-1", "branch-2"],
+			)
 			assert.strictEqual(entries[0]?.url, "https://branch-1.metrics.psdb.cloud:443/metrics")
 			assert.strictEqual(entries[1]?.url, "https://branch-2.metrics.psdb.cloud:443/metrics")
 			// `__`-prefixed Prometheus meta labels are stripped; SD labels survive.
@@ -261,10 +266,7 @@ describe("PlanetScaleDiscoveryService", () => {
 			// Base url + fiber-identity key stay param-free so identity is stable as
 			// PlanetScale rotates the signature each refresh.
 			assert.strictEqual(entries[0]?.url, "https://metrics.psdb.cloud/metrics/branch/3a1nf2gvu9rf")
-			assert.strictEqual(
-				entries[0]?.subTargetKey,
-				"metrics.psdb.cloud/metrics/branch/3a1nf2gvu9rf",
-			)
+			assert.strictEqual(entries[0]?.subTargetKey, "metrics.psdb.cloud/metrics/branch/3a1nf2gvu9rf")
 			// signedUrl carries the auth params the data plane actually verifies.
 			assert.strictEqual(
 				entries[0]?.signedUrl,
@@ -274,6 +276,8 @@ describe("PlanetScaleDiscoveryService", () => {
 			assert.deepStrictEqual(entries[0]?.labels, {
 				planetscale_branch_name: "main",
 				planetscale_database_name: "mydb",
+				planetscale_branch: "main",
+				planetscale_database: "mydb",
 			})
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
@@ -318,7 +322,10 @@ describe("PlanetScaleDiscoveryService", () => {
 				),
 			)
 
-			assert.deepStrictEqual(stale.map((entry) => entry.subTargetKey), ["branch-1", "branch-2"])
+			assert.deepStrictEqual(
+				stale.map((entry) => entry.subTargetKey),
+				["branch-1", "branch-2"],
+			)
 			const lastError = yield* discovery.lastError(row.id)
 			assert.include(lastError ?? "", "HTTP 503")
 		}).pipe(Effect.provide(makeLayer(testDb)))
@@ -390,7 +397,10 @@ describe("PlanetScaleDiscoveryService", () => {
 			).pipe(Effect.provideService(FetchHttpClient.Fetch, fetchStub))
 
 			assert.strictEqual(recorded.length, 1)
-			assert.deepStrictEqual(first?.map((entry) => entry.subTargetKey), ["branch-1", "branch-2"])
+			assert.deepStrictEqual(
+				first?.map((entry) => entry.subTargetKey),
+				["branch-1", "branch-2"],
+			)
 			assert.deepStrictEqual(second, first)
 			assert.deepStrictEqual(third, first)
 		}).pipe(Effect.provide(makeLayer(testDb)))
@@ -410,7 +420,10 @@ describe("PlanetScaleDiscoveryService", () => {
 				),
 			)
 
-			assert.deepStrictEqual(entries.map((entry) => entry.subTargetKey), ["main", "stg"])
+			assert.deepStrictEqual(
+				entries.map((entry) => entry.subTargetKey),
+				["branch-id-main", "branch-id-stg"],
+			)
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -428,7 +441,10 @@ describe("PlanetScaleDiscoveryService", () => {
 				),
 			)
 
-			assert.deepStrictEqual(entries.map((entry) => entry.subTargetKey), ["main", "stg"])
+			assert.deepStrictEqual(
+				entries.map((entry) => entry.subTargetKey),
+				["branch-id-main", "branch-id-stg"],
+			)
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
@@ -486,11 +502,11 @@ describe("PlanetScaleDiscoveryService", () => {
 
 			const sdCall = recorded.find((call) => call.url.includes("/my-org/metrics"))
 			assert.strictEqual(sdCall?.authorization, "Bearer ps-access-token")
-			assert.deepStrictEqual(entries.map((entry) => entry.subTargetKey), ["branch-1", "branch-2"])
-		}).pipe(
-			Effect.provideService(FetchHttpClient.Fetch, stub),
-			Effect.provide(makeLayer(testDb, stub)),
-		)
+			assert.deepStrictEqual(
+				entries.map((entry) => entry.subTargetKey),
+				["branch-1", "branch-2"],
+			)
+		}).pipe(Effect.provideService(FetchHttpClient.Fetch, stub), Effect.provide(makeLayer(testDb, stub)))
 	})
 
 	it.effect("invalidate drops the cache so the next discover refetches", () => {

--- a/apps/api/src/services/PlanetScaleDiscoveryService.ts
+++ b/apps/api/src/services/PlanetScaleDiscoveryService.ts
@@ -109,6 +109,13 @@ export const subTargetsFromGroup = (group: {
 		if (key.startsWith("__param_")) authParams.set(key.slice("__param_".length), value)
 		else if (!key.startsWith("__")) labels[key] = value
 	}
+	// PlanetScale's current http_sd payload names the human-readable identity
+	// labels with a `_name` suffix. Keep those canonical upstream keys and emit
+	// the historical aliases too so existing Maple dashboards continue to work.
+	const databaseName = labels.planetscale_database_name ?? labels.planetscale_database
+	const branchName = labels.planetscale_branch_name ?? labels.planetscale_branch
+	if (databaseName !== undefined) labels.planetscale_database = databaseName
+	if (branchName !== undefined) labels.planetscale_branch = branchName
 	const query = authParams.toString()
 	const branchId = sdLabels.planetscale_database_branch_id
 
@@ -156,13 +163,15 @@ const dedupeBySubTargetKey = (
 }
 
 /**
- * Branch name a filter pattern matches against: PlanetScale's http_sd exposes
- * the human branch name as `planetscale_branch`; older payloads only carry
- * `planetscale_database_branch_id`. Fall back to the sub-target key so a filter
- * never silently matches nothing.
+ * Branch name a filter pattern matches against: current PlanetScale http_sd
+ * payloads expose `planetscale_branch_name`; Maple also emits the historical
+ * `planetscale_branch` alias. Older payloads may only carry the branch id.
  */
 const branchNameForFilter = (entry: PlanetScaleSubTarget): string =>
-	entry.labels.planetscale_branch ?? entry.labels.planetscale_database_branch_id ?? entry.subTargetKey
+	entry.labels.planetscale_branch_name ??
+	entry.labels.planetscale_branch ??
+	entry.labels.planetscale_database_branch_id ??
+	entry.subTargetKey
 
 /** Glob → anchored RegExp supporting `*` (any run) and `?` (one char). */
 const globToRegExp = (pattern: string): RegExp => {
@@ -352,9 +361,7 @@ export class PlanetScaleDiscoveryService extends Context.Service<
 			if (filters.include.length === 0 && filters.exclude.length === 0) {
 				return entries
 			}
-			const kept = entries.filter((entry) =>
-				branchPassesFilters(branchNameForFilter(entry), filters),
-			)
+			const kept = entries.filter((entry) => branchPassesFilters(branchNameForFilter(entry), filters))
 			if (kept.length < entries.length) {
 				yield* Effect.logInfo("Filtered PlanetScale branches by include/exclude globs").pipe(
 					Effect.annotateLogs({

--- a/apps/api/src/services/PlanetScaleOAuthService.test.ts
+++ b/apps/api/src/services/PlanetScaleOAuthService.test.ts
@@ -33,7 +33,7 @@ interface MockOptions {
 	 * `/oauth/token/info` verdict (doorkeeper semantics: valid → 200 with token
 	 * details, invalid → 401); omitted → 500 (introspection unavailable).
 	 */
-	readonly introspection?: "valid" | "invalid"
+	readonly introspection?: "active" | "inactive" | "legacy" | "unexpected" | "invalid"
 }
 
 /**
@@ -58,6 +58,9 @@ const mockPlanetScaleFetch = (options: MockOptions = {}): typeof globalThis.fetc
 					401,
 				)
 			}
+			if (options.introspection === "inactive") return jsonResponse({ active: false })
+			if (options.introspection === "active") return jsonResponse({ active: true })
+			if (options.introspection === "unexpected") return jsonResponse({ error: "invalid_token" })
 			// Doorkeeper answers a valid token with its details — no `active` field.
 			return jsonResponse({
 				resource_owner_id: "psuser_1",
@@ -190,43 +193,46 @@ describe("PlanetScaleOAuthService", () => {
 		}).pipe(Effect.provide(makeLayer(testDb, { PLANETSCALE_OAUTH_CLIENT_ID: "ps-client-id" })))
 	})
 
-	it.effect("startConnect builds an authorize URL with the requested scope (no PKCE) and persists a state row", () => {
-		const testDb = createTestDb(trackedDbs)
-		// PlanetScale REQUIRES the scope param — the app's configured scopes are the
-		// allowed maximum, not an implicit default; omitting it fails with `invalid_scope`.
-		const scopes = "user:read_organizations organization:read_databases organization:read_branches"
-		return Effect.gen(function* () {
-			const service = yield* PlanetScaleOAuthService
-			const { redirectUrl, state } = yield* service.startConnect(
-				asOrgId("org_a"),
-				asUserId("user_a"),
-				{ callbackUrl: CALLBACK_URL, returnTo: "/integrations" },
-			)
+	it.effect(
+		"startConnect builds an authorize URL with the requested scope (no PKCE) and persists a state row",
+		() => {
+			const testDb = createTestDb(trackedDbs)
+			// PlanetScale REQUIRES the scope param — the app's configured scopes are the
+			// allowed maximum, not an implicit default; omitting it fails with `invalid_scope`.
+			const scopes = "user:read_organizations organization:read_databases organization:read_branches"
+			return Effect.gen(function* () {
+				const service = yield* PlanetScaleOAuthService
+				const { redirectUrl, state } = yield* service.startConnect(
+					asOrgId("org_a"),
+					asUserId("user_a"),
+					{ callbackUrl: CALLBACK_URL, returnTo: "/integrations" },
+				)
 
-			const url = new URL(redirectUrl)
-			// The canonical authorize host from PlanetScale's OAuth discovery doc —
-			// the auth.planetscale.com alias mints tokens the v1 API rejects.
-			assert.strictEqual(url.origin + url.pathname, "https://app.planetscale.com/oauth/authorize")
-			assert.strictEqual(url.searchParams.get("client_id"), "ps-client-id")
-			assert.strictEqual(url.searchParams.get("redirect_uri"), CALLBACK_URL)
-			assert.strictEqual(url.searchParams.get("response_type"), "code")
-			assert.strictEqual(url.searchParams.get("state"), state)
-			// Resource-prefixed, space-delimited scopes; PKCE is not part of PlanetScale's flow.
-			assert.strictEqual(url.searchParams.get("scope"), scopes)
-			assert.isNull(url.searchParams.get("code_challenge"))
+				const url = new URL(redirectUrl)
+				// The canonical authorize host from PlanetScale's OAuth discovery doc —
+				// the auth.planetscale.com alias mints tokens the v1 API rejects.
+				assert.strictEqual(url.origin + url.pathname, "https://app.planetscale.com/oauth/authorize")
+				assert.strictEqual(url.searchParams.get("client_id"), "ps-client-id")
+				assert.strictEqual(url.searchParams.get("redirect_uri"), CALLBACK_URL)
+				assert.strictEqual(url.searchParams.get("response_type"), "code")
+				assert.strictEqual(url.searchParams.get("state"), state)
+				// Resource-prefixed, space-delimited scopes; PKCE is not part of PlanetScale's flow.
+				assert.strictEqual(url.searchParams.get("scope"), scopes)
+				assert.isNull(url.searchParams.get("code_challenge"))
 
-			const row = yield* Effect.promise(() =>
-				queryFirstRow<{ org_id: string; provider: string; return_to: string | null }>(
-					testDb,
-					"SELECT org_id, provider, return_to FROM oauth_auth_states WHERE state = $1",
-					[state],
-				),
-			)
-			assert.strictEqual(row?.org_id, "org_a")
-			assert.strictEqual(row?.provider, "planetscale")
-			assert.strictEqual(row?.return_to, "/integrations")
-		}).pipe(Effect.provide(makeLayer(testDb, { ...withOAuthApp, PLANETSCALE_OAUTH_SCOPES: scopes })))
-	})
+				const row = yield* Effect.promise(() =>
+					queryFirstRow<{ org_id: string; provider: string; return_to: string | null }>(
+						testDb,
+						"SELECT org_id, provider, return_to FROM oauth_auth_states WHERE state = $1",
+						[state],
+					),
+				)
+				assert.strictEqual(row?.org_id, "org_a")
+				assert.strictEqual(row?.provider, "planetscale")
+				assert.strictEqual(row?.return_to, "/integrations")
+			}).pipe(Effect.provide(makeLayer(testDb, { ...withOAuthApp, PLANETSCALE_OAUTH_SCOPES: scopes })))
+		},
+	)
 
 	it.effect("completeConnect exchanges the code, stores the grant, and returns the orgs", () => {
 		const testDb = createTestDb(trackedDbs)
@@ -393,15 +399,46 @@ describe("PlanetScaleOAuthService", () => {
 		)
 	})
 
-	it.effect("completeConnect reports upstream (not revoked) when the auth server says the token is valid", () => {
+	it.effect(
+		"completeConnect reports upstream (not revoked) when the auth server says the token is valid",
+		() => {
+			const testDb = createTestDb(trackedDbs)
+			return Effect.gen(function* () {
+				const service = yield* PlanetScaleOAuthService
+				const { state } = yield* service.startConnect(asOrgId("org_a"), asUserId("user_a"), {
+					callbackUrl: CALLBACK_URL,
+				})
+				// The v1 API keeps rejecting a token the auth server introspects as
+				// active — "reconnect" would be a lie, so this must NOT be RevokedError.
+				const fiber = yield* Effect.forkChild(
+					service.completeConnect("auth-code", state).pipe(Effect.flip),
+					{ startImmediately: true },
+				)
+				yield* TestClock.adjust("2 seconds")
+				const error = yield* Fiber.join(fiber)
+				assert.strictEqual(error._tag, "@maple/http/errors/IntegrationsUpstreamError")
+				if (error._tag === "@maple/http/errors/IntegrationsUpstreamError") {
+					assert.include(error.message, "auth server reports it as valid")
+				}
+				assert.isFalse(yield* service.hasConnection(asOrgId("org_a")))
+			}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makeLayer(testDb, withOAuthApp),
+						withMockFetch({ organizationsUnauthorizedTimes: 2, introspection: "legacy" }),
+					),
+				),
+			)
+		},
+	)
+
+	it.effect("completeConnect honors an explicit active token-info response", () => {
 		const testDb = createTestDb(trackedDbs)
 		return Effect.gen(function* () {
 			const service = yield* PlanetScaleOAuthService
 			const { state } = yield* service.startConnect(asOrgId("org_a"), asUserId("user_a"), {
 				callbackUrl: CALLBACK_URL,
 			})
-			// The v1 API keeps rejecting a token the auth server introspects as
-			// active — "reconnect" would be a lie, so this must NOT be RevokedError.
 			const fiber = yield* Effect.forkChild(
 				service.completeConnect("auth-code", state).pipe(Effect.flip),
 				{ startImmediately: true },
@@ -409,15 +446,59 @@ describe("PlanetScaleOAuthService", () => {
 			yield* TestClock.adjust("2 seconds")
 			const error = yield* Fiber.join(fiber)
 			assert.strictEqual(error._tag, "@maple/http/errors/IntegrationsUpstreamError")
-			if (error._tag === "@maple/http/errors/IntegrationsUpstreamError") {
-				assert.include(error.message, "auth server reports it as valid")
-			}
-			assert.isFalse(yield* service.hasConnection(asOrgId("org_a")))
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
 					makeLayer(testDb, withOAuthApp),
-					withMockFetch({ organizationsUnauthorizedTimes: 2, introspection: "valid" }),
+					withMockFetch({ organizationsUnauthorizedTimes: 2, introspection: "active" }),
+				),
+			),
+		)
+	})
+
+	it.effect("completeConnect treats active:false token-info as revoked", () => {
+		const testDb = createTestDb(trackedDbs)
+		return Effect.gen(function* () {
+			const service = yield* PlanetScaleOAuthService
+			const { state } = yield* service.startConnect(asOrgId("org_a"), asUserId("user_a"), {
+				callbackUrl: CALLBACK_URL,
+			})
+			const fiber = yield* Effect.forkChild(
+				service.completeConnect("auth-code", state).pipe(Effect.flip),
+				{ startImmediately: true },
+			)
+			yield* TestClock.adjust("2 seconds")
+			const error = yield* Fiber.join(fiber)
+			assert.strictEqual(error._tag, "@maple/http/errors/IntegrationsRevokedError")
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeLayer(testDb, withOAuthApp),
+					withMockFetch({ organizationsUnauthorizedTimes: 2, introspection: "inactive" }),
+				),
+			),
+		)
+	})
+
+	it.effect("does not treat an arbitrary 2xx token-info object as valid", () => {
+		const testDb = createTestDb(trackedDbs)
+		return Effect.gen(function* () {
+			const service = yield* PlanetScaleOAuthService
+			const { state } = yield* service.startConnect(asOrgId("org_a"), asUserId("user_a"), {
+				callbackUrl: CALLBACK_URL,
+			})
+			const fiber = yield* Effect.forkChild(
+				service.completeConnect("auth-code", state).pipe(Effect.flip),
+				{ startImmediately: true },
+			)
+			yield* TestClock.adjust("2 seconds")
+			const error = yield* Fiber.join(fiber)
+			assert.strictEqual(error._tag, "@maple/http/errors/IntegrationsRevokedError")
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeLayer(testDb, withOAuthApp),
+					withMockFetch({ organizationsUnauthorizedTimes: 2, introspection: "unexpected" }),
 				),
 			),
 		)
@@ -478,8 +559,7 @@ describe("PlanetScaleOAuthService", () => {
 			// must surface as revoked, not a generic upstream failure — the picker
 			// keys its reconnect CTA on the tag.
 			const deadGrantFetch: typeof globalThis.fetch = async (input, init) => {
-				const url =
-					typeof input === "string" ? input : input instanceof URL ? input.href : input.url
+				const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url
 				if (url.includes("/v1/organizations")) {
 					return jsonResponse({ code: "unauthorized" }, 401)
 				}
@@ -514,7 +594,10 @@ describe("PlanetScaleOAuthService", () => {
 			// Two racers on an expired token: without single-flight both refresh, the
 			// loser's rotated-token 400 falsely surfaces as IntegrationsRevokedError.
 			const [a, b] = yield* Effect.all(
-				[service.getValidAccessToken(asOrgId("org_a")), service.getValidAccessToken(asOrgId("org_a"))],
+				[
+					service.getValidAccessToken(asOrgId("org_a")),
+					service.getValidAccessToken(asOrgId("org_a")),
+				],
 				{ concurrency: 2 },
 			)
 			assert.strictEqual(a.accessToken, "ps-access-token-refreshed")

--- a/apps/api/src/services/PlanetScaleOAuthService.ts
+++ b/apps/api/src/services/PlanetScaleOAuthService.ts
@@ -84,17 +84,20 @@ const OrganizationSchema = Schema.Struct({
 	name: Schema.String,
 })
 const OrganizationsPageSchema = Schema.Struct({ data: Schema.Array(OrganizationSchema) })
-const decodeOrganizationsPage = Schema.decodeUnknownEffect(
-	Schema.fromJsonString(OrganizationsPageSchema),
-)
+const decodeOrganizationsPage = Schema.decodeUnknownEffect(Schema.fromJsonString(OrganizationsPageSchema))
 
-/**
- * `GET /oauth/token/info` is doorkeeper-style: a VALID presented token answers
- * 200 with the token's details (scope, expires_in, resource_owner_id — no RFC
- * 7662 `active` field), an invalid one answers 401 `invalid_token`. The verdict
- * is therefore the status code, not a body field. Verified live 2026-07-13.
- */
 type TokenIntrospectionVerdict = "valid" | "invalid" | "unknown"
+const TokenInfoSchema = Schema.Union([
+	// PlanetScale's current public contract.
+	Schema.Struct({ active: Schema.Boolean }),
+	// Legacy Doorkeeper responses observed from the live endpoint omit `active`
+	// but identify the token's owner. Requiring that marker prevents arbitrary
+	// 2xx JSON objects from being treated as valid tokens.
+	Schema.Struct({
+		resource_owner_id: Schema.Union([Schema.String, Schema.Number]),
+	}),
+])
+const decodeTokenInfo = Schema.decodeUnknownEffect(Schema.fromJsonString(TokenInfoSchema))
 
 const CurrentUserSchema = Schema.Struct({
 	id: Schema.String,
@@ -156,9 +159,7 @@ export interface PlanetScaleOAuthServiceShape {
 	/** Whether a grant is stored for the org (drives pendingOrgSelection). */
 	readonly hasConnection: (orgId: OrgId) => Effect.Effect<boolean, IntegrationsPersistenceError>
 	/** Who authorized the stored grant (null when not connected). */
-	readonly connectedByUserId: (
-		orgId: OrgId,
-	) => Effect.Effect<string | null, IntegrationsPersistenceError>
+	readonly connectedByUserId: (orgId: OrgId) => Effect.Effect<string | null, IntegrationsPersistenceError>
 	/** Drop the stored grant. PlanetScale documents no revoke endpoint. */
 	readonly disconnect: (
 		orgId: OrgId,
@@ -196,14 +197,12 @@ export class PlanetScaleOAuthService extends Context.Service<
 				const text = yield* res.text
 				return { status: res.status, text }
 			}).pipe(
-				Effect.mapError(
-					(error) =>
-						toUpstreamError(`PlanetScale API request failed: ${error.message}`),
+				Effect.mapError((error) =>
+					toUpstreamError(`PlanetScale API request failed: ${error.message}`),
 				),
 				Effect.timeoutOrElse({
 					duration: REQUEST_TIMEOUT,
-					orElse: () =>
-						Effect.fail(toUpstreamError(`PlanetScale API request timed out: ${path}`)),
+					orElse: () => Effect.fail(toUpstreamError(`PlanetScale API request timed out: ${path}`)),
 				}),
 			)
 		})
@@ -226,10 +225,20 @@ export class PlanetScaleOAuthService extends Context.Service<
 				const res = yield* httpClient.execute(request)
 				const text = yield* res.text
 				if (res.status >= 200 && res.status < 300) {
-					// The token-info body carries scope/expiry/owner ids, never the token
-					// itself — safe (and load-bearing) to log for diagnosis.
+					const tokenInfo = yield* decodeTokenInfo(text).pipe(Effect.option)
+					if (Option.isNone(tokenInfo)) {
+						yield* Effect.logWarning("PlanetScale token introspection returned invalid JSON")
+						return "unknown" satisfies TokenIntrospectionVerdict
+					}
+					const active = "active" in tokenInfo.value ? tokenInfo.value.active : undefined
+					if (active === false) {
+						yield* Effect.logInfo("PlanetScale auth server reports an inactive token")
+						return "invalid" satisfies TokenIntrospectionVerdict
+					}
+					// `active: true` is the documented response. A missing field is the
+					// legacy Doorkeeper body observed from the live endpoint.
 					yield* Effect.logInfo("PlanetScale auth server accepted the token on introspection", {
-						body: text.slice(0, 300),
+						contract: active === true ? "active" : "legacy",
 					})
 					return "valid" satisfies TokenIntrospectionVerdict
 				}
@@ -249,10 +258,10 @@ export class PlanetScaleOAuthService extends Context.Service<
 					duration: REQUEST_TIMEOUT,
 					orElse: () => Effect.succeed("unknown" satisfies TokenIntrospectionVerdict),
 				}),
-				Effect.catchCause((cause) =>
-					Effect.logWarning("PlanetScale token introspection failed", { cause }).pipe(
-						Effect.as("unknown" satisfies TokenIntrospectionVerdict),
-					),
+				Effect.catch((error) =>
+					Effect.logWarning("PlanetScale token introspection failed", {
+						error: String(error),
+					}).pipe(Effect.as("unknown" satisfies TokenIntrospectionVerdict)),
 				),
 			)
 		})
@@ -347,11 +356,7 @@ export class PlanetScaleOAuthService extends Context.Service<
 			const stateRow = yield* oauth.requireStateRow(state)
 			yield* oauth.deleteAuthState(state)
 
-			const tokenResponse = yield* oauth.exchangeAuthorizationCode(
-				config,
-				code,
-				stateRow.redirectUri,
-			)
+			const tokenResponse = yield* oauth.exchangeAuthorizationCode(config, code, stateRow.redirectUri)
 
 			const orgId = decodeOrgId(stateRow.orgId)
 			yield* Effect.annotateCurrentSpan({ orgId })
@@ -490,9 +495,7 @@ export class PlanetScaleOAuthService extends Context.Service<
 			return yield* fetchOrganizations(accessToken)
 		})
 
-		const hasConnection = Effect.fn("PlanetScaleOAuthService.hasConnection")(function* (
-			orgId: OrgId,
-		) {
+		const hasConnection = Effect.fn("PlanetScaleOAuthService.hasConnection")(function* (orgId: OrgId) {
 			yield* Effect.annotateCurrentSpan({ orgId })
 			const row = yield* oauth.loadConnection(orgId)
 			return row !== null

--- a/apps/api/src/services/PlanetScaleService.test.ts
+++ b/apps/api/src/services/PlanetScaleService.test.ts
@@ -43,7 +43,7 @@ const makeLayer = (testDb: TestDb) => {
 	return Layer.mergeAll(
 		PlanetScaleService.layer.pipe(Layer.provide(oauthLive)),
 		PlanetScaleConnectionService.layer.pipe(
-			Layer.provide(Layer.mergeAll(scrapeTargetsLive, oauthLive)),
+			Layer.provide(Layer.mergeAll(scrapeTargetsLive, discoveryLive, oauthLive)),
 		),
 		oauthLive,
 	).pipe(Layer.provide(testDb.layer), Layer.provide(Env.layer), Layer.provide(makeConfig()))
@@ -155,8 +155,10 @@ describe("PlanetScaleService", () => {
 			const second = yield* service.pollAllOrgs()
 			assert.strictEqual(second.skipped, 1)
 			assert.strictEqual(second.refreshed, 0)
-		}).pipe(Effect.provideService(FetchHttpClient.Fetch, stub),
-			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))))
+		}).pipe(
+			Effect.provideService(FetchHttpClient.Fetch, stub),
+			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+		)
 	})
 
 	it.effect("queryInsights proxies top queries, defaulting to the production branch", () => {
@@ -216,6 +218,9 @@ describe("PlanetScaleService", () => {
 			// Branch defaulted to the inventory's production branch.
 			assert.strictEqual(result.branch, "main")
 			assert.isTrue(insightCalls[0]?.includes("/databases/main-db/branches/main/insights"))
+			const insightUrl = new URL(insightCalls[0]!)
+			assert.strictEqual(insightUrl.searchParams.get("sort"), "totalTime")
+			assert.strictEqual(insightUrl.searchParams.get("dir"), "desc")
 			assert.isNull(result.unavailableReason)
 			assert.strictEqual(result.rows.length, 1)
 			const row = result.rows[0]!
@@ -223,8 +228,10 @@ describe("PlanetScaleService", () => {
 			assert.strictEqual(row.queryCount, 420)
 			assert.strictEqual(row.p99LatencyMillis, 140)
 			assert.strictEqual(row.lastRunAt, Date.UTC(2026, 6, 10, 12, 0, 0))
-		}).pipe(Effect.provideService(FetchHttpClient.Fetch, stub),
-			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))))
+		}).pipe(
+			Effect.provideService(FetchHttpClient.Fetch, stub),
+			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+		)
 	})
 
 	it.effect("queryInsights soft-fails when the token lacks read_database", () => {
@@ -253,11 +260,13 @@ describe("PlanetScaleService", () => {
 
 			assert.strictEqual(result.rows.length, 0)
 			assert.include(result.unavailableReason ?? "", "read_database")
-		}).pipe(Effect.provideService(FetchHttpClient.Fetch, stub),
-			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))))
+		}).pipe(
+			Effect.provideService(FetchHttpClient.Fetch, stub),
+			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+		)
 	})
 
-	it.effect('queryInsights soft-fails with a not-found message on 404', () => {
+	it.effect("queryInsights soft-fails with a not-found message on 404", () => {
 		const testDb = createTestDb(trackedDbs)
 		const baseStub = stubApi({ databases: [], branchesByDatabase: {} })
 		const stub = (async (input: string | URL | Request) => {
@@ -282,12 +291,14 @@ describe("PlanetScaleService", () => {
 			})
 
 			assert.strictEqual(result.rows.length, 0)
-			assert.include(result.unavailableReason ?? "", 'no insights')
-		}).pipe(Effect.provideService(FetchHttpClient.Fetch, stub),
-			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))))
+			assert.include(result.unavailableReason ?? "", "no insights")
+		}).pipe(
+			Effect.provideService(FetchHttpClient.Fetch, stub),
+			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+		)
 	})
 
-	it.effect('queryInsights soft-fails with the upstream status on a 5xx', () => {
+	it.effect("queryInsights soft-fails with the upstream status on a 5xx", () => {
 		const testDb = createTestDb(trackedDbs)
 		const baseStub = stubApi({ databases: [], branchesByDatabase: {} })
 		const stub = (async (input: string | URL | Request) => {
@@ -312,9 +323,11 @@ describe("PlanetScaleService", () => {
 			})
 
 			assert.strictEqual(result.rows.length, 0)
-			assert.include(result.unavailableReason ?? "", 'HTTP 500')
-		}).pipe(Effect.provideService(FetchHttpClient.Fetch, stub),
-			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))))
+			assert.include(result.unavailableReason ?? "", "HTTP 500")
+		}).pipe(
+			Effect.provideService(FetchHttpClient.Fetch, stub),
+			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+		)
 	})
 
 	it.effect("queryInsights defaults to the first inventoried branch when none is production", () => {
@@ -354,8 +367,10 @@ describe("PlanetScaleService", () => {
 			assert.strictEqual(result.branch, "dev")
 			assert.isTrue(insightCalls[0]?.includes("/branches/dev/insights"))
 			assert.isNull(result.unavailableReason)
-		}).pipe(Effect.provideService(FetchHttpClient.Fetch, stub),
-			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))))
+		}).pipe(
+			Effect.provideService(FetchHttpClient.Fetch, stub),
+			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+		)
 	})
 
 	it.effect("a missing grant fails the org's tick without killing the fleet", () => {
@@ -440,7 +455,9 @@ describe("PlanetScaleService", () => {
 				rows.map((row) => row.name),
 				["main-db"],
 			)
-		}).pipe(Effect.provideService(FetchHttpClient.Fetch, stub),
-			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))))
+		}).pipe(
+			Effect.provideService(FetchHttpClient.Fetch, stub),
+			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+		)
 	})
 })

--- a/apps/api/src/services/PlanetScaleService.ts
+++ b/apps/api/src/services/PlanetScaleService.ts
@@ -186,11 +186,9 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 			})
 
 			/** Fetch all pages of a list endpoint (bounded by MAX_PAGES). */
-			const fetchAllPages = Effect.fn("PlanetScaleService.fetchAllPages")(function* <S extends Schema.Top>(
-				basePath: string,
-				authorization: string,
-				itemSchema: S,
-			) {
+			const fetchAllPages = Effect.fn("PlanetScaleService.fetchAllPages")(function* <
+				S extends Schema.Top,
+			>(basePath: string, authorization: string, itemSchema: S) {
 				const decodePage = Schema.decodeUnknownEffect(Schema.fromJsonString(PageSchema(itemSchema)))
 				const items: Array<S["Type"]> = []
 				for (let page = 1; page <= MAX_PAGES; page++) {
@@ -359,7 +357,11 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 							.update(planetscaleConnections)
 							.set(
 								error === null
-									? { lastInventoryAt: new Date(now), lastInventoryError: null, updatedAt: new Date(now) }
+									? {
+											lastInventoryAt: new Date(now),
+											lastInventoryError: null,
+											updatedAt: new Date(now),
+										}
 									: { lastInventoryError: error, updatedAt: new Date(now) },
 							)
 							.where(eq(planetscaleConnections.id, connectionId)),
@@ -607,7 +609,7 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 					`/branches/${encodeURIComponent(branch)}/insights` +
 					`?from=${encodeURIComponent(new Date(options.startTime).toISOString())}` +
 					`&to=${encodeURIComponent(new Date(options.endTime).toISOString())}` +
-					`&sort=sum_total_duration_millis&dir=desc&per_page=${limit}`
+					`&sort=totalTime&dir=desc&per_page=${limit}`
 
 				const response = yield* apiGetJson(path, authorization)
 				if (response.status < 200 || response.status >= 300) {
@@ -671,7 +673,10 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 							.select()
 							.from(planetscaleDatabases)
 							.where(
-								and(eq(planetscaleDatabases.orgId, orgId), isNull(planetscaleDatabases.deletedAt)),
+								and(
+									eq(planetscaleDatabases.orgId, orgId),
+									isNull(planetscaleDatabases.deletedAt),
+								),
 							),
 					)
 					.pipe(Effect.mapError(toPersistenceError))

--- a/apps/api/src/services/planetscale/PlanetScaleWebhookQueue.test.ts
+++ b/apps/api/src/services/planetscale/PlanetScaleWebhookQueue.test.ts
@@ -1,0 +1,69 @@
+import { assert, describe, it } from "@effect/vitest"
+import { WorkerEnvironment } from "@maple/effect-cloudflare"
+import { Effect, Layer } from "effect"
+import { PlanetScaleWebhookQueue, type PlanetScaleWebhookJob } from "./PlanetScaleWebhookQueue"
+
+const job: PlanetScaleWebhookJob = {
+	kind: "planetscale-webhook",
+	orgId: "org_1",
+	connectionId: "connection_1",
+	payload: {
+		event: "branch.anomaly",
+		organization: "acme",
+		database: "shop",
+		resource: { name: "main" },
+	},
+	receivedAt: 1_000,
+}
+
+const provideQueue = (environment: Record<string, unknown>) =>
+	Effect.provide(
+		PlanetScaleWebhookQueue.layer.pipe(Layer.provide(Layer.succeed(WorkerEnvironment, environment))),
+	)
+
+describe("PlanetScaleWebhookQueue", () => {
+	it.effect("schema-encodes the internal job onto the dedicated binding", () => {
+		const sent: unknown[] = []
+		return Effect.gen(function* () {
+			const queue = yield* PlanetScaleWebhookQueue
+			yield* queue.send(job)
+			assert.deepStrictEqual(sent, [job])
+		}).pipe(
+			provideQueue({
+				PLANETSCALE_WEBHOOK_QUEUE: {
+					send: async (body: unknown) => {
+						sent.push(body)
+					},
+				},
+			}),
+		)
+	})
+
+	it.effect("fails with a typed error when the binding is absent", () =>
+		Effect.gen(function* () {
+			const queue = yield* PlanetScaleWebhookQueue
+			const error = yield* queue.send(job).pipe(Effect.flip)
+			assert.strictEqual(error._tag, "@maple/api/services/planetscale/PlanetScaleWebhookQueueError")
+		}).pipe(provideQueue({})),
+	)
+
+	it.effect("maps binding rejections to the typed queue error", () => {
+		let attempts = 0
+		return Effect.gen(function* () {
+			const queue = yield* PlanetScaleWebhookQueue
+			const error = yield* queue.send(job).pipe(Effect.flip)
+			assert.strictEqual(error._tag, "@maple/api/services/planetscale/PlanetScaleWebhookQueueError")
+			assert.strictEqual(error.message, "simulated queue outage")
+			assert.strictEqual(attempts, 1)
+		}).pipe(
+			provideQueue({
+				PLANETSCALE_WEBHOOK_QUEUE: {
+					send: async () => {
+						attempts += 1
+						throw new Error("simulated queue outage")
+					},
+				},
+			}),
+		)
+	})
+})

--- a/apps/api/src/services/planetscale/PlanetScaleWebhookQueue.ts
+++ b/apps/api/src/services/planetscale/PlanetScaleWebhookQueue.ts
@@ -1,0 +1,63 @@
+import type { Queue } from "@cloudflare/workers-types"
+import { OrgId } from "@maple/domain/http"
+import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
+import { Context, Data, Effect, Layer, Schema } from "effect"
+import { PlanetScaleWebhookPayload } from "./webhook-events"
+
+const QUEUE_BINDING = "PLANETSCALE_WEBHOOK_QUEUE"
+
+export const PlanetScaleWebhookJob = Schema.Struct({
+	kind: Schema.Literal("planetscale-webhook"),
+	orgId: OrgId,
+	connectionId: Schema.String,
+	payload: PlanetScaleWebhookPayload,
+	receivedAt: Schema.Number,
+})
+export type PlanetScaleWebhookJob = Schema.Schema.Type<typeof PlanetScaleWebhookJob>
+
+export class PlanetScaleWebhookQueueError extends Data.TaggedError(
+	"@maple/api/services/planetscale/PlanetScaleWebhookQueueError",
+)<{
+	readonly message: string
+	readonly cause?: unknown
+}> {}
+
+export interface PlanetScaleWebhookQueueShape {
+	readonly send: (job: PlanetScaleWebhookJob) => Effect.Effect<void, PlanetScaleWebhookQueueError>
+}
+
+const encodeJob = Schema.encodeSync(PlanetScaleWebhookJob)
+
+export class PlanetScaleWebhookQueue extends Context.Service<
+	PlanetScaleWebhookQueue,
+	PlanetScaleWebhookQueueShape
+>()("@maple/api/services/planetscale/PlanetScaleWebhookQueue", {
+	make: Effect.gen(function* () {
+		const workerEnv = yield* WorkerEnvironment
+		const queue = workerEnv[QUEUE_BINDING] as Queue<unknown> | undefined
+
+		const send = Effect.fn("PlanetScaleWebhookQueue.send")(function* (job: PlanetScaleWebhookJob) {
+			yield* Effect.annotateCurrentSpan({
+				"maple.planetscale.webhook.job.kind": job.kind,
+				orgId: job.orgId,
+			})
+			if (queue === undefined) {
+				return yield* new PlanetScaleWebhookQueueError({
+					message: `Missing queue binding: ${QUEUE_BINDING}`,
+				})
+			}
+			yield* Effect.tryPromise({
+				try: () => queue.send(encodeJob(job)),
+				catch: (cause) =>
+					new PlanetScaleWebhookQueueError({
+						message: cause instanceof Error ? cause.message : "PlanetScale queue send failed",
+						cause,
+					}),
+			})
+		})
+
+		return { send } satisfies PlanetScaleWebhookQueueShape
+	}),
+}) {
+	static readonly layer = Layer.effect(this, this.make)
+}

--- a/apps/api/src/services/planetscale/webhook-events.test.ts
+++ b/apps/api/src/services/planetscale/webhook-events.test.ts
@@ -281,6 +281,55 @@ describe("upsertPlanetScaleIssue", () => {
 			assert.strictEqual(regression?.count, 1)
 		}).pipe(Effect.provide(testDb.layer))
 	})
+
+	it.effect("rolls back issue creation when its audit event fails, then retries cleanly", () => {
+		const testDb = createTestDb(trackedDbs)
+		return Effect.gen(function* () {
+			const payload = yield* decodePlanetScaleWebhookPayload(OOM_PAYLOAD)
+			const input = {
+				orgId: asOrgId("org_1"),
+				payload,
+				severity: "high" as const,
+				title: "PlanetScale branch out of memory",
+				description: "Branch main of main-db was restarted after running out of memory.",
+				timestamp: 1_000,
+			}
+			yield* Effect.promise(() =>
+				testDb.pglite.exec(`CREATE FUNCTION reject_planetscale_issue_event() RETURNS trigger AS $$
+						BEGIN RAISE EXCEPTION 'forced event failure'; END;
+						$$ LANGUAGE plpgsql;
+						CREATE TRIGGER reject_planetscale_issue_event
+						BEFORE INSERT ON error_issue_events
+						FOR EACH ROW EXECUTE FUNCTION reject_planetscale_issue_event();`),
+			)
+
+			const error = yield* upsertPlanetScaleIssue(input).pipe(Effect.flip)
+			assert.strictEqual(error._tag, "@maple/api/lib/DatabaseError")
+			const afterFailure = yield* Effect.promise(() =>
+				queryFirstRow<{ count: number }>(
+					testDb,
+					"SELECT count(*)::int AS count FROM error_issues WHERE org_id = $1",
+					[input.orgId],
+				),
+			)
+			assert.strictEqual(afterFailure?.count, 0)
+
+			yield* Effect.promise(() =>
+				testDb.pglite.exec(`DROP TRIGGER reject_planetscale_issue_event ON error_issue_events;
+						DROP FUNCTION reject_planetscale_issue_event();`),
+			)
+			const retry = yield* upsertPlanetScaleIssue(input)
+			assert.strictEqual(retry.action, "created")
+			const event = yield* Effect.promise(() =>
+				queryFirstRow<{ count: number }>(
+					testDb,
+					"SELECT count(*)::int AS count FROM error_issue_events WHERE issue_id = $1 AND type = 'created'",
+					[retry.issueId],
+				),
+			)
+			assert.strictEqual(event?.count, 1)
+		}).pipe(Effect.provide(testDb.layer))
+	})
 })
 
 describe("decodePlanetScaleWebhookPayload", () => {

--- a/apps/api/src/services/planetscale/webhook-events.ts
+++ b/apps/api/src/services/planetscale/webhook-events.ts
@@ -3,8 +3,8 @@ import type { IssueSeverity, OrgId, WorkflowState } from "@maple/domain/http"
 import { ActorId, ErrorIssueEventId, ErrorIssueId } from "@maple/domain/primitives"
 import { actors, errorIssues, errorIssueEvents, type ErrorIssueRow } from "@maple/db"
 import { and, eq, sql } from "drizzle-orm"
-import { Cause, Clock, Effect, Schema } from "effect"
-import { Database } from "../../lib/DatabaseLive"
+import { Clock, Effect, Schema } from "effect"
+import { Database, type DatabaseError } from "../../lib/DatabaseLive"
 
 /**
  * PlanetScale webhook event handling: signature verification, payload decode,
@@ -153,121 +153,108 @@ export interface UpsertPlanetScaleIssueInput {
 }
 
 export interface UpsertPlanetScaleIssueResult {
-	readonly issueId: ErrorIssueId | null
-	readonly action: "created" | "reopened" | "refreshed" | "skipped" | "error"
+	readonly issueId: ErrorIssueId
+	readonly action: "created" | "reopened" | "refreshed" | "skipped"
 }
-
-const ensureSystemIntegrationsActor = Effect.fn("planetscaleWebhook.ensureActor")(function* (orgId: OrgId) {
-	const database = yield* Database
-	const select = () =>
-		database.execute((db) =>
-			db
-				.select()
-				.from(actors)
-				.where(
-					and(
-						eq(actors.orgId, orgId),
-						eq(actors.type, "agent"),
-						eq(actors.agentName, SYSTEM_INTEGRATIONS_AGENT_NAME),
-					),
-				)
-				.limit(1),
-		)
-	const existing = yield* select()
-	if (existing[0]) return existing[0].id
-
-	const timestamp = yield* Clock.currentTimeMillis
-	yield* database.execute((db) =>
-		db
-			.insert(actors)
-			.values({
-				id: decodeActorId(randomUUID()),
-				orgId,
-				type: "agent",
-				userId: null,
-				agentName: SYSTEM_INTEGRATIONS_AGENT_NAME,
-				model: null,
-				capabilitiesJson: ["system", "integration-issues"],
-				createdBy: null,
-				createdAt: new Date(timestamp),
-				lastActiveAt: new Date(timestamp),
-			})
-			.onConflictDoNothing(),
-	)
-	const after = yield* select()
-	const row = after[0]
-	if (!row) return yield* Effect.die(new Error("Failed to ensure system-integrations actor row"))
-	return row.id
-})
-
-const recordIssueEvent = Effect.fn("planetscaleWebhook.recordIssueEvent")(function* (
-	orgId: OrgId,
-	issueId: ErrorIssueId,
-	actorId: ActorId,
-	type: "created" | "state_change" | "regression",
-	opts: {
-		readonly fromState?: WorkflowState
-		readonly toState?: WorkflowState
-		readonly payload?: Record<string, unknown>
-		readonly timestamp: number
-	},
-) {
-	const database = yield* Database
-	yield* database.execute((db) =>
-		db.insert(errorIssueEvents).values({
-			id: decodeEventId(randomUUID()),
-			orgId,
-			issueId,
-			actorId,
-			type,
-			fromState: opts.fromState ?? null,
-			toState: opts.toState ?? null,
-			payloadJson: opts.payload ?? {},
-			createdAt: new Date(opts.timestamp),
-		}),
-	)
-})
 
 /**
  * Create-or-refresh the triage issue backing a PlanetScale health event.
- * Never fails: every error path is logged and reported via `action: "error"`
- * so a broken issue write can't turn a webhook delivery into a retry storm.
+ * Database failures stay typed so the durable queue consumer can retry the
+ * delivery. The fingerprint makes successful redelivery idempotent.
  */
 export const upsertPlanetScaleIssue: (
 	input: UpsertPlanetScaleIssueInput,
-) => Effect.Effect<UpsertPlanetScaleIssueResult, never, Database> = Effect.fn(
+) => Effect.Effect<UpsertPlanetScaleIssueResult, DatabaseError, Database> = Effect.fn(
 	"planetscaleWebhook.upsertIssue",
-)(
-	function* (input: UpsertPlanetScaleIssueInput) {
-		const database = yield* Database
-		const databaseName = input.payload.database ?? "unknown"
-		const fingerprintHash = planetScaleIssueFingerprint(databaseName, input.payload.event)
-		const serviceName = `planetscale/${databaseName}`
-		const sourceRefJson = {
-			provider: "planetscale",
-			event: input.payload.event,
-			database: databaseName,
-			organization: input.payload.organization ?? null,
-			resource: input.payload.resource ?? null,
-		}
+)(function* (input: UpsertPlanetScaleIssueInput) {
+	const database = yield* Database
+	const databaseName = input.payload.database ?? "unknown"
+	const fingerprintHash = planetScaleIssueFingerprint(databaseName, input.payload.event)
+	const serviceName = `planetscale/${databaseName}`
+	const actorTimestamp = yield* Clock.currentTimeMillis
+	const sourceRefJson = {
+		provider: "planetscale",
+		event: input.payload.event,
+		database: databaseName,
+		organization: input.payload.organization ?? null,
+		resource: input.payload.resource ?? null,
+	}
 
-		const existingRows = yield* database.execute((db) =>
-			db
-				.select()
-				.from(errorIssues)
-				.where(and(eq(errorIssues.orgId, input.orgId), eq(errorIssues.fingerprintHash, fingerprintHash)))
-				.limit(1),
-		)
-		const prior: ErrorIssueRow | undefined = existingRows[0]
+	return yield* database.execute((db) =>
+		db.transaction(async (tx) => {
+			const ensureActor = async (): Promise<ActorId> => {
+				const selectActor = () =>
+					tx
+						.select()
+						.from(actors)
+						.where(
+							and(
+								eq(actors.orgId, input.orgId),
+								eq(actors.type, "agent"),
+								eq(actors.agentName, SYSTEM_INTEGRATIONS_AGENT_NAME),
+							),
+						)
+						.limit(1)
+				const existing = await selectActor()
+				if (existing[0]) return existing[0].id
+				await tx
+					.insert(actors)
+					.values({
+						id: decodeActorId(randomUUID()),
+						orgId: input.orgId,
+						type: "agent",
+						userId: null,
+						agentName: SYSTEM_INTEGRATIONS_AGENT_NAME,
+						model: null,
+						capabilitiesJson: ["system", "integration-issues"],
+						createdBy: null,
+						createdAt: new Date(actorTimestamp),
+						lastActiveAt: new Date(actorTimestamp),
+					})
+					.onConflictDoNothing()
+				const row = (await selectActor())[0]
+				if (!row) throw new Error("Failed to ensure system-integrations actor row")
+				return row.id
+			}
 
-		let issueId: ErrorIssueId
-		let action: UpsertPlanetScaleIssueResult["action"]
+			const recordEvent = (
+				issueId: ErrorIssueId,
+				actorId: ActorId,
+				type: "created" | "state_change" | "regression",
+				opts: {
+					readonly fromState?: WorkflowState
+					readonly toState?: WorkflowState
+					readonly payload?: Record<string, unknown>
+				},
+			) =>
+				tx.insert(errorIssueEvents).values({
+					id: decodeEventId(randomUUID()),
+					orgId: input.orgId,
+					issueId,
+					actorId,
+					type,
+					fromState: opts.fromState ?? null,
+					toState: opts.toState ?? null,
+					payloadJson: opts.payload ?? {},
+					createdAt: new Date(input.timestamp),
+				})
 
-		if (prior === undefined) {
-			issueId = decodeIssueId(randomUUID())
-			action = "created"
-			yield* database.execute((db) =>
-				db.insert(errorIssues).values({
+			const prior: ErrorIssueRow | undefined = (
+				await tx
+					.select()
+					.from(errorIssues)
+					.where(
+						and(
+							eq(errorIssues.orgId, input.orgId),
+							eq(errorIssues.fingerprintHash, fingerprintHash),
+						),
+					)
+					.limit(1)
+			)[0]
+
+			if (prior === undefined) {
+				const issueId = decodeIssueId(randomUUID())
+				await tx.insert(errorIssues).values({
 					id: issueId,
 					orgId: input.orgId,
 					kind: "integration",
@@ -296,88 +283,59 @@ export const upsertPlanetScaleIssue: (
 					archivedAt: null,
 					createdAt: new Date(input.timestamp),
 					updatedAt: new Date(input.timestamp),
-				}),
-			)
-			const actorId = yield* ensureSystemIntegrationsActor(input.orgId)
-			yield* recordIssueEvent(input.orgId, issueId, actorId, "created", {
-				toState: "triage",
-				payload: sourceRefJson,
-				timestamp: input.timestamp,
-			})
-		} else {
-			issueId = prior.id
-			// Mirrors the alert issue hub and the errors tick: a wontfix issue with
-			// an active (or indefinite — snoozeUntil null) snooze is left alone
-			// entirely; only done issues and wontfix issues whose snooze expired
-			// re-open on the next firing. "Won't fix" without a deadline is the
-			// operator saying "stop resurfacing this".
+				})
+				const actorId = await ensureActor()
+				await recordEvent(issueId, actorId, "created", {
+					toState: "triage",
+					payload: sourceRefJson,
+				})
+				return { issueId, action: "created" as const }
+			}
+
+			const issueId = prior.id
+			// A wontfix issue with an active or indefinite snooze stays untouched.
 			const snoozeActive =
 				prior.workflowState === "wontfix" &&
 				(prior.snoozeUntil == null || prior.snoozeUntil.getTime() > input.timestamp)
-			if (snoozeActive) {
-				return { issueId, action: "skipped" as const }
-			}
+			if (snoozeActive) return { issueId, action: "skipped" as const }
 
-			yield* database.execute((db) =>
-				db
-					.update(errorIssues)
-					.set({
-						lastSeenAt: new Date(input.timestamp),
-						occurrenceCount: sql`${errorIssues.occurrenceCount} + 1`,
-						exceptionMessage: input.description,
-						sourceRefJson,
-						updatedAt: new Date(input.timestamp),
-					})
-					.where(and(eq(errorIssues.orgId, input.orgId), eq(errorIssues.id, prior.id))),
-			)
+			await tx
+				.update(errorIssues)
+				.set({
+					lastSeenAt: new Date(input.timestamp),
+					occurrenceCount: sql`${errorIssues.occurrenceCount} + 1`,
+					exceptionMessage: input.description,
+					sourceRefJson,
+					updatedAt: new Date(input.timestamp),
+				})
+				.where(and(eq(errorIssues.orgId, input.orgId), eq(errorIssues.id, prior.id)))
 
 			const reopenFrom: WorkflowState | null =
 				prior.workflowState === "done" || prior.workflowState === "wontfix"
 					? prior.workflowState
 					: null
-			if (reopenFrom !== null) {
-				action = "reopened"
-				yield* database.execute((db) =>
-					db
-						.update(errorIssues)
-						.set({
-							workflowState: "triage",
-							resolvedAt: null,
-							resolvedByActorId: null,
-							snoozeUntil: null,
-							updatedAt: new Date(input.timestamp),
-						})
-						.where(and(eq(errorIssues.orgId, input.orgId), eq(errorIssues.id, prior.id))),
-				)
-				const actorId = yield* ensureSystemIntegrationsActor(input.orgId)
-				yield* recordIssueEvent(input.orgId, issueId, actorId, "state_change", {
-					fromState: reopenFrom,
-					toState: "triage",
-					payload: { viaRegression: true, event: input.payload.event },
-					timestamp: input.timestamp,
-				})
-				yield* recordIssueEvent(input.orgId, issueId, actorId, "regression", {
-					payload: { event: input.payload.event, database: databaseName },
-					timestamp: input.timestamp,
-				})
-			} else {
-				action = "refreshed"
-			}
-		}
+			if (reopenFrom === null) return { issueId, action: "refreshed" as const }
 
-		return { issueId, action }
-	},
-	(effect, input) =>
-		Effect.catchCause(effect, (cause) =>
-			Effect.gen(function* () {
-				yield* Effect.logError("PlanetScale webhook issue upsert failed").pipe(
-					Effect.annotateLogs({
-						orgId: input.orgId,
-						event: input.payload.event,
-						error: Cause.pretty(cause),
-					}),
-				)
-				return { issueId: null, action: "error" as const }
-			}),
-		),
-)
+			await tx
+				.update(errorIssues)
+				.set({
+					workflowState: "triage",
+					resolvedAt: null,
+					resolvedByActorId: null,
+					snoozeUntil: null,
+					updatedAt: new Date(input.timestamp),
+				})
+				.where(and(eq(errorIssues.orgId, input.orgId), eq(errorIssues.id, prior.id)))
+			const actorId = await ensureActor()
+			await recordEvent(issueId, actorId, "state_change", {
+				fromState: reopenFrom,
+				toState: "triage",
+				payload: { viaRegression: true, event: input.payload.event },
+			})
+			await recordEvent(issueId, actorId, "regression", {
+				payload: { event: input.payload.event, database: databaseName },
+			})
+			return { issueId, action: "reopened" as const }
+		}),
+	)
+})

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -14,6 +14,7 @@ import * as Etag from "effect/unstable/http/Etag"
 import * as HttpPlatform from "effect/unstable/http/HttpPlatform"
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
 import { persistSession, preloadSession, type SessionsBinding } from "./mcp/lib/session-store"
+import { classifyWorkerQueue } from "./queue-dispatch"
 
 const WorkerFileSystemLive = FileSystem.layerNoop({})
 
@@ -314,6 +315,28 @@ const handleQueue = async (
 	env: Record<string, unknown>,
 	ctx: ExecutionContext,
 ): Promise<void> => {
+	const queueKind = classifyWorkerQueue(batch.queue, env)
+	if (queueKind === "planetscale-webhook") {
+		const {
+			buildPlanetScaleWebhookLayer,
+			processPlanetScaleWebhookBatch,
+			flushPlanetScaleWebhookTelemetry,
+		} = await import("./planetscale-webhook-runtime")
+		try {
+			await runScheduledEffect(
+				buildPlanetScaleWebhookLayer(env),
+				processPlanetScaleWebhookBatch(batch),
+				ctx,
+			)
+		} finally {
+			ctx.waitUntil(flushPlanetScaleWebhookTelemetry(env))
+		}
+		return
+	}
+	if (queueKind === "unknown") {
+		throw new Error(`No queue consumer configured for "${batch.queue}"`)
+	}
+
 	const { buildVcsSyncLayer, processBatch, flushVcsTelemetry } = await import("./vcs-sync-runtime")
 	try {
 		await runScheduledEffect(buildVcsSyncLayer(env), processBatch(batch), ctx)

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -9,6 +9,8 @@
 	},
 	"vars": {
 		"API_V2_RATE_LIMIT_PARTITION": "local",
+		"PLANETSCALE_WEBHOOK_QUEUE_NAME": "maple-planetscale-webhooks-local",
+		"VCS_SYNC_QUEUE_NAME": "maple-vcs-sync-local",
 	},
 	"ratelimits": [
 		{
@@ -68,10 +70,22 @@
 	// for deploy.) No dead-letter queue: exhausted jobs are acked after recording a
 	// terminal failure in the DB (surfaced by the sync-status UI).
 	"queues": {
-		"producers": [{ "binding": "VCS_SYNC_QUEUE", "queue": "maple-vcs-sync-local" }],
+		"producers": [
+			{ "binding": "VCS_SYNC_QUEUE", "queue": "maple-vcs-sync-local" },
+			{
+				"binding": "PLANETSCALE_WEBHOOK_QUEUE",
+				"queue": "maple-planetscale-webhooks-local",
+			},
+		],
 		"consumers": [
 			{
 				"queue": "maple-vcs-sync-local",
+				"max_batch_size": 10,
+				"max_batch_timeout": 5,
+				"max_retries": 3,
+			},
+			{
+				"queue": "maple-planetscale-webhooks-local",
 				"max_batch_size": 10,
 				"max_batch_timeout": 5,
 				"max_retries": 3,

--- a/packages/query-engine/src/ch/queries/planetscale-infra.test.ts
+++ b/packages/query-engine/src/ch/queries/planetscale-infra.test.ts
@@ -13,7 +13,9 @@ describe("planetscaleInfraTimeseriesSQL", () => {
 			database: "main-db",
 		})
 		expect(sql).toContain("FROM metrics_gauge")
-		expect(sql).toContain("planetscale_database'] = 'main-db'")
+		expect(sql).toContain(
+			"coalesce(nullIf(Attributes['planetscale_database_name'], ''), Attributes['planetscale_database']) = 'main-db'",
+		)
 		// Inner per-timestamp grouping, outer bucketed aggregation.
 		expect(sql).toContain("GROUP BY t")
 		expect(sql).toContain("toStartOfInterval")

--- a/packages/query-engine/src/ch/queries/planetscale-infra.ts
+++ b/packages/query-engine/src/ch/queries/planetscale-infra.ts
@@ -60,7 +60,10 @@ export function planetscaleInfraTimeseriesSQL() {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.MetricName.in_(...ALL_METRIC_NAMES),
-			$.Attributes.get("planetscale_database").eq(param.string("database")),
+			CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_database_name"), ""),
+				$.Attributes.get("planetscale_database"),
+			).eq(param.string("database")),
 			$.TimeUnix.gte(param.dateTime("startTime")),
 			$.TimeUnix.lte(param.dateTime("endTime")),
 		])

--- a/packages/query-engine/src/ch/queries/planetscale-map.test.ts
+++ b/packages/query-engine/src/ch/queries/planetscale-map.test.ts
@@ -29,9 +29,11 @@ describe("planetscaleGaugesSQL", () => {
 		expect(sql).toContain("planetscale_mysql_replica_lag_seconds")
 		expect(sql).toContain("planetscale_postgres_replica_lag_seconds")
 		// Rows without the discovery label can't be attributed to a database.
-		expect(sql).toContain("planetscale_database'] != ''")
+		expect(sql).toContain(
+			"coalesce(nullIf(Attributes['planetscale_database_name'], ''), Attributes['planetscale_database']) != ''",
+		)
 		expect(sql).toContain("GROUP BY database")
-		expect(sql).not.toContain("planetscale_branch")
+		expect(sql).not.toContain("planetscale_branch_name")
 		expect(sql).toContain("FORMAT JSON")
 	})
 
@@ -40,9 +42,13 @@ describe("planetscaleGaugesSQL", () => {
 			...baseParams,
 			database: "main-db",
 		})
-		expect(sql).toContain("planetscale_branch']")
+		expect(sql).toContain(
+			"coalesce(nullIf(Attributes['planetscale_branch_name'], ''), Attributes['planetscale_branch'])",
+		)
 		expect(sql).toContain("GROUP BY database, branch")
-		expect(sql).toContain("planetscale_database'] = 'main-db'")
+		expect(sql).toContain(
+			"coalesce(nullIf(Attributes['planetscale_database_name'], ''), Attributes['planetscale_database']) = 'main-db'",
+		)
 	})
 
 	it("escapes single quotes in orgId", () => {

--- a/packages/query-engine/src/ch/queries/planetscale-map.ts
+++ b/packages/query-engine/src/ch/queries/planetscale-map.ts
@@ -5,8 +5,8 @@
 // from PlanetScale's Prometheus endpoints, so the service map can overlay live
 // database health onto trace-derived DB nodes and the detail panel can break a
 // database down by branch. The scraper merges PlanetScale's http_sd discovery
-// labels into every data point, so `planetscale_database` / `planetscale_branch`
-// are plain point attributes here.
+// labels into every data point. Current payloads use the `_name` suffix; the
+// legacy aliases are coalesced for already-ingested data.
 //
 // Metric names are PlanetScale's own (pass-through scrape); the registry below
 // covers both products — Vitess/MySQL and Postgres — and was pinned from
@@ -116,7 +116,10 @@ export const planetscaleBranchConnectionsRowSchema: CompiledQueryRowSchema<Plane
 export function planetscaleGaugesSQL() {
 	return from(MetricsGauge)
 		.select(($) => ({
-			database: $.Attributes.get("planetscale_database"),
+			database: CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_database_name"), ""),
+				$.Attributes.get("planetscale_database"),
+			),
 			cpuMaxPercent: CH.maxIf($.Value, $.MetricName.in_(...CPU_METRIC_NAMES)),
 			memMaxPercent: CH.maxIf($.Value, $.MetricName.in_(...MEMORY_METRIC_NAMES)),
 			replicaLagMaxSeconds: CH.maxIf($.Value, $.MetricName.in_(...REPLICA_LAG_METRIC_NAMES)),
@@ -124,7 +127,10 @@ export function planetscaleGaugesSQL() {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.MetricName.in_(...GAUGE_METRIC_NAMES),
-			$.Attributes.get("planetscale_database").neq(""),
+			CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_database_name"), ""),
+				$.Attributes.get("planetscale_database"),
+			).neq(""),
 			$.TimeUnix.gte(param.dateTime("startTime")),
 			$.TimeUnix.lte(param.dateTime("endTime")),
 		])
@@ -137,8 +143,14 @@ export function planetscaleGaugesSQL() {
 export function planetscaleBranchGaugesSQL() {
 	return from(MetricsGauge)
 		.select(($) => ({
-			database: $.Attributes.get("planetscale_database"),
-			branch: $.Attributes.get("planetscale_branch"),
+			database: CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_database_name"), ""),
+				$.Attributes.get("planetscale_database"),
+			),
+			branch: CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_branch_name"), ""),
+				$.Attributes.get("planetscale_branch"),
+			),
 			cpuMaxPercent: CH.maxIf($.Value, $.MetricName.in_(...CPU_METRIC_NAMES)),
 			memMaxPercent: CH.maxIf($.Value, $.MetricName.in_(...MEMORY_METRIC_NAMES)),
 			replicaLagMaxSeconds: CH.maxIf($.Value, $.MetricName.in_(...REPLICA_LAG_METRIC_NAMES)),
@@ -146,7 +158,10 @@ export function planetscaleBranchGaugesSQL() {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.MetricName.in_(...GAUGE_METRIC_NAMES),
-			$.Attributes.get("planetscale_database").eq(param.string("database")),
+			CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_database_name"), ""),
+				$.Attributes.get("planetscale_database"),
+			).eq(param.string("database")),
 			$.TimeUnix.gte(param.dateTime("startTime")),
 			$.TimeUnix.lte(param.dateTime("endTime")),
 		])
@@ -164,14 +179,20 @@ export function planetscaleBranchGaugesSQL() {
 export function planetscaleConnectionsSQL() {
 	const inner = from(MetricsGauge)
 		.select(($) => ({
-			database: $.Attributes.get("planetscale_database"),
+			database: CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_database_name"), ""),
+				$.Attributes.get("planetscale_database"),
+			),
 			t: $.TimeUnix,
 			totalConnections: CH.sum($.Value),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.MetricName.in_(...CONNECTION_METRIC_NAMES),
-			$.Attributes.get("planetscale_database").neq(""),
+			CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_database_name"), ""),
+				$.Attributes.get("planetscale_database"),
+			).neq(""),
 			$.TimeUnix.gte(param.dateTime("startTime")),
 			$.TimeUnix.lte(param.dateTime("endTime")),
 		])
@@ -192,15 +213,24 @@ export function planetscaleConnectionsSQL() {
 export function planetscaleBranchConnectionsSQL() {
 	const inner = from(MetricsGauge)
 		.select(($) => ({
-			database: $.Attributes.get("planetscale_database"),
-			branch: $.Attributes.get("planetscale_branch"),
+			database: CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_database_name"), ""),
+				$.Attributes.get("planetscale_database"),
+			),
+			branch: CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_branch_name"), ""),
+				$.Attributes.get("planetscale_branch"),
+			),
 			t: $.TimeUnix,
 			totalConnections: CH.sum($.Value),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.MetricName.in_(...CONNECTION_METRIC_NAMES),
-			$.Attributes.get("planetscale_database").eq(param.string("database")),
+			CH.coalesce(
+				CH.nullIf($.Attributes.get("planetscale_database_name"), ""),
+				$.Attributes.get("planetscale_database"),
+			).eq(param.string("database")),
 			$.TimeUnix.gte(param.dateTime("startTime")),
 			$.TimeUnix.lte(param.dateTime("endTime")),
 		])


### PR DESCRIPTION
## Summary

- normalize PlanetScale discovery metadata while preserving compatibility aliases and historical queryability
- make organization rebinding atomic, ownership-safe, and compensating on failed replacement bindings
- move issue-producing webhooks to a dedicated Cloudflare Queue with durable enqueueing, typed jobs, dynamic runtime dispatch, and correct acknowledgement/retry behavior
- align Query Insights sorting and token-info validation with PlanetScale API behavior
- make issue persistence and its actor/audit events transactional

## Why

The existing integration mixed canonical and legacy metric labels, could leave connection targets in an inconsistent state during organization rebinding, and persisted webhook-generated issues synchronously inside the request. It also treated some token-info and Query Insights responses differently from PlanetScale's current contract.

This change preserves public HTTP contracts and historical telemetry while making webhook delivery durable and rebinding safe. No database migration is required.

## Validation

- focused PlanetScale API, query, queue, runtime, and persistence regression suites
- `bun run typecheck` — 32/32 tasks passed
- `bun run test` — 24/24 tasks passed; API: 999 passed, 5 skipped
- `bun run build` — 9/9 tasks passed
- `git diff --check`
- diff-scoped Effect v4 review against `4.0.0-beta.93` — PASS, 10/10, no remaining Critical or Warning findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787440121&installation_model_id=427786&pr_number=254&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F254&signature=48bdd73eba71d2310dbe0beaf00267551775ea9fcc590fd43f5bd35837d04210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->