### PR TITLE
ci(preview): scheduled orphan sweep for PR-preview resources

### DIFF
--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -109,7 +109,7 @@ jobs:
             # account caps Hyperdrive configs at 25; leaked maple-db-pr-*
             # configs eventually block every new PR preview.
             - name: Sweep orphaned Hyperdrive PR configs
-              if: ${{ !cancelled() && env.CLOUDFLARE_API_TOKEN != '' }}
+              if: ${{ !cancelled() && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != '' }}
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: bun scripts/hyperdrive-orphan-sweep.ts

--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -1,0 +1,103 @@
+name: Cleanup Preview Orphans
+
+# Safety net for PR-preview resources the close-event teardown misses.
+# The `pull_request: closed` teardown in deploy-pr-preview.yml is best-effort:
+#   - GitHub silently creates NO workflow run for the `closed` event of a PR
+#     that conflicts with its base branch (stale PRs closed without merging —
+#     e.g. #111/#143/#168 never got a close run at all).
+#   - `pull_request` events execute the PR branch's OWN workflow-file version,
+#     so teardown fixes on main never retro-apply to already-open PRs
+#     (e.g. #211/#214 closed with the pre-#215 skip-chain and orphaned).
+#   - A deploy landing after close (delayed event / re-run) can recreate the
+#     branch right after teardown deleted it (e.g. #180).
+# PS-DEV branches bill for time used, so orphans cost real money every hour.
+# The same failure modes leak Electric Cloud `pr-<n>` environments (each holds
+# a PlanetScale replication slot + a plan max-databases slot) and Tinybird
+# `pr_<n>` branches (they share compute with production), so all three
+# lifecycle scripts run their `sweep` subcommand here.
+#
+# Caveat: sweep maps `pr-<n>` resource names to THIS repo's PR numbers
+# (GITHUB_REPOSITORY). If the PlanetScale database / Electric project /
+# Tinybird workspace is ever shared with another repo using the same naming
+# convention, a closed PR #N here could delete that repo's live pr-N resource.
+
+on:
+    schedule:
+        # Every 6 hours — orphaned PS-DEV branches bill continuously.
+        - cron: "17 */6 * * *"
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    pull-requests: read # sweep checks each pr-<n> branch's PR state
+    id-token: write # Infisical OIDC machine-identity auth
+
+concurrency:
+    group: cleanup-preview-orphans
+    cancel-in-progress: false
+
+jobs:
+    sweep:
+        runs-on: blacksmith-4vcpu-ubuntu-2404
+        # Deliberately NOT in the `pr-preview` environment: its required manual
+        # approval exists to keep PR-controlled code away from secrets, but this
+        # job only ever runs trusted code from main — and approval would stall
+        # every scheduled run. If the Infisical machine identity's OIDC subject
+        # is scoped to the pr-preview environment, add a subject for
+        # `repo:<org>/<repo>:ref:refs/heads/main` in Infisical.
+        env:
+            INFISICAL_ENV_SLUG: dev
+        steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+            - name: Setup mise (toolchain)
+              uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+
+            - name: Load deployment secrets from Infisical
+              uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+              with:
+                  method: "oidc"
+                  identity-id: ${{ secrets.INFISICAL_MACHINE_IDENTITY_ID }}
+                  project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
+                  env-slug: ${{ env.INFISICAL_ENV_SLUG }}
+                  export-type: "env"
+                  secret-path: "/"
+
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+
+            - name: Install PlanetScale CLI
+              if: ${{ env.PLANETSCALE_SERVICE_TOKEN != '' }}
+              uses: planetscale/setup-pscale-action@v1
+
+            # Mirrors the deploy workflow's gating: until the Infisical `dev`
+            # environment carries the PlanetScale service token, the sweep SKIPs
+            # cleanly instead of failing on every schedule tick.
+            - name: Sweep orphaned PlanetScale PR branches
+              if: ${{ env.PLANETSCALE_SERVICE_TOKEN != '' }}
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: bun scripts/planetscale-pr-branch.ts sweep
+
+            # Gated like the deploy workflow's Electric steps: until Infisical
+            # carries ELECTRIC_API_TOKEN (+ ELECTRIC_PROJECT_ID), skip cleanly.
+            # `!cancelled()` keeps the later sweeps running even when an earlier
+            # one fails — the sweeps are independent safety nets.
+            - name: Sweep orphaned Electric Cloud PR environments
+              if: ${{ !cancelled() && env.ELECTRIC_API_TOKEN != '' }}
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: bun scripts/electric-pr-branch.ts sweep
+
+            # The single-file installer used by deploy-pr-preview.yml — branch
+            # commands live in the real `tb` CLI, not `bunx tinybird`.
+            - name: Install Tinybird CLI
+              if: ${{ !cancelled() && env.TINYBIRD_TOKEN != '' }}
+              run: curl https://tinybird.co | sh
+
+            - name: Sweep orphaned Tinybird PR branches
+              if: ${{ !cancelled() && env.TINYBIRD_TOKEN != '' }}
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: bun scripts/tinybird-pr-branch.ts sweep

--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -101,3 +101,15 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: bun scripts/tinybird-pr-branch.ts sweep
+
+            # Hyperdrive is the one preview resource `alchemy destroy` alone
+            # owns — and close runs execute the PR branch's OLD workflow, so
+            # branches predating the placeholder-MAPLE_PG_URL destroy fix can
+            # NEVER tear down (rerunning them fails identically forever). The
+            # account caps Hyperdrive configs at 25; leaked maple-db-pr-*
+            # configs eventually block every new PR preview.
+            - name: Sweep orphaned Hyperdrive PR configs
+              if: ${{ !cancelled() && env.CLOUDFLARE_API_TOKEN != '' }}
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: bun scripts/hyperdrive-orphan-sweep.ts

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -166,9 +166,10 @@ jobs:
               if: ${{ !cancelled() && github.event.action == 'closed' && env.PLANETSCALE_SERVICE_TOKEN != '' }}
               run: bun scripts/planetscale-pr-branch.ts down "$PR_NUMBER"
 
-            # Delete the Electric Cloud environment `pr-<n>` (cascades its source).
-            # Each source holds a PlanetScale replication slot and a plan
-            # max-databases slot, so teardown on close is mandatory.
+            # Delete the Electric Cloud environment `pr-<n>` (its services are
+            # deleted first — Electric refuses to delete an env holding
+            # services). Each source holds a PlanetScale replication slot and a
+            # plan max-databases slot, so teardown on close is mandatory.
             - name: Remove Electric Cloud PR source
               if: ${{ !cancelled() && github.event.action == 'closed' && env.ELECTRIC_API_TOKEN != '' }}
               run: bun scripts/electric-pr-branch.ts down "$PR_NUMBER"

--- a/packages/db/scripts/reset-preview-branch.ts
+++ b/packages/db/scripts/reset-preview-branch.ts
@@ -133,7 +133,7 @@ const main = async () => {
 		// Empty `public` object-by-object. Tables first with CASCADE (takes FKs
 		// and dependent views along), then whatever remains of each class.
 		// Composite row-types of tables vanish with their table, so the type
-		// drop pass only targets standalone enums/domains (drizzle-kit's pgEnum).
+		// sweep only targets standalone enums/domains (drizzle-kit's pgEnum).
 		const dropObjects = async (
 			label: string,
 			listQuery: Promise<{ name: string }[]>,
@@ -214,11 +214,11 @@ const main = async () => {
 			WHERE n.nspname = 'public' AND c.relkind IN ('r', 'v', 'm', 'S', 'p', 'f')
 		`
 		if (Number(remaining?.count ?? 0) > 0) {
-			fail(`public schema still holds ${remaining?.count} objects after the drop pass`)
+			fail(`public schema still holds ${remaining?.count} objects after the sweep`)
 		}
 		console.log(`→ public schema emptied`)
 
-		// Drop replication slots orphaned by torn-down Electric sources.
+		// Sweep replication slots orphaned by torn-down Electric sources.
 		// pg_drop_replication_slot needs the REPLICATION attribute, which the
 		// main role deliberately lacks (and which is never inherited through
 		// `postgres` membership) — the caller passes the replication-role
@@ -237,7 +237,7 @@ const main = async () => {
 			}
 		} catch (error) {
 			console.log(
-				`⚠ could not drop inactive replication slots (${(error as Error).message}) — a stale slot pins WAL for the branch's lifetime; continuing`,
+				`⚠ could not sweep inactive replication slots (${(error as Error).message}) — a stale slot pins WAL for the branch's lifetime; continuing`,
 			)
 		} finally {
 			if (slotSql !== sql) await slotSql.end()

--- a/packages/db/scripts/reset-preview-branch.ts
+++ b/packages/db/scripts/reset-preview-branch.ts
@@ -108,7 +108,7 @@ const main = async () => {
 			) owned
 			JOIN pg_roles r ON r.oid = owned.oid
 			WHERE NOT pg_has_role(current_user, r.oid, 'USAGE')
-				AND r.rolname NOT LIKE ${"pg\\_%"}
+				AND r.rolname NOT LIKE 'pg\\_%'
 		`
 		for (const { owner } of owners) {
 			try {
@@ -197,7 +197,7 @@ const main = async () => {
 			SELECT n.nspname FROM pg_namespace n
 			JOIN pg_roles r ON r.oid = n.nspowner
 			WHERE n.nspname NOT IN ('public', 'information_schema')
-				AND n.nspname NOT LIKE ${"pg\\_%"}
+				AND n.nspname NOT LIKE 'pg\\_%'
 				AND (r.rolname = 'postgres' OR pg_has_role(current_user, r.oid, 'USAGE'))
 		`
 		for (const { nspname } of extraSchemas) {

--- a/packages/db/scripts/reset-preview-branch.ts
+++ b/packages/db/scripts/reset-preview-branch.ts
@@ -249,4 +249,17 @@ const main = async () => {
 	}
 }
 
-await main()
+try {
+	await main()
+} catch (error) {
+	// postgres.js errors carry the failing statement — surface it, because the
+	// server's own error report doesn't (run 30083630959: a nondeterministic
+	// `malformed array literal: ""` for "parameter $2" that no query in this
+	// script sends — suspected PlanetScale-side DDL interception; this makes
+	// the next occurrence self-identifying).
+	const query = (error as { query?: unknown }).query
+	const parameters = (error as { parameters?: unknown }).parameters
+	if (query !== undefined) console.error(`✗ failing query: ${String(query).slice(0, 500)}`)
+	if (parameters !== undefined) console.error(`✗ query parameters: ${JSON.stringify(parameters)}`)
+	throw error
+}

--- a/scripts/electric-pr-branch.ts
+++ b/scripts/electric-pr-branch.ts
@@ -24,9 +24,10 @@
  * apps/electric-sync worker to this source (see apps/electric-sync/alchemy.run.ts).
  *
  * `down` deletes every `pr-<n>`/`pr-<n>-*` environment (called on PR close,
- * after `alchemy:destroy:pr`). Environment deletion cascades its services. Each
- * source counts against the Electric plan's max-databases cap and holds a
- * PlanetScale replication slot, so `down` on close is mandatory.
+ * after `alchemy:destroy:pr`), deleting its services first — Electric refuses
+ * to delete an environment that still holds services (`--force` does not
+ * cascade). Each source counts against the Electric plan's max-databases cap
+ * and holds a PlanetScale replication slot, so `down` on close is mandatory.
  *
  * `sweep` deletes every `pr-<n>`/`pr-<n>-*` environment whose PR is already
  * closed. The close-event teardown is best-effort only (GitHub creates no
@@ -421,6 +422,12 @@ const findEnvironments = (projectId: string, base: string): ReadonlyArray<{ id: 
 }
 
 const deleteEnvironment = (env: { id: string; name: string }): void => {
+	// Electric refuses to delete an environment that still holds services —
+	// "Cannot delete environment with existing services. Delete all services
+	// first." (run 30081184677, PR #255 close) — `--force` does NOT cascade.
+	// Drop the services first; each freed service also releases its PlanetScale
+	// replication slot and plan max-databases slot.
+	resetServices(env.id)
 	const removed = runElectric(["environments", "delete", env.id, "--force"])
 	if (removed.exitCode !== 0 && !isNotFound(removed)) {
 		fail(`Failed to delete Electric environment ${env.name} (${env.id})`)

--- a/scripts/electric-pr-branch.ts
+++ b/scripts/electric-pr-branch.ts
@@ -4,8 +4,9 @@
  * Sibling of scripts/planetscale-pr-branch.ts and scripts/tinybird-pr-branch.ts
  * with the same up/down contract.
  *
- *   bun scripts/electric-pr-branch.ts up   <pr-number>
- *   bun scripts/electric-pr-branch.ts down <pr-number>
+ *   bun scripts/electric-pr-branch.ts up    <pr-number>
+ *   bun scripts/electric-pr-branch.ts down  <pr-number>
+ *   bun scripts/electric-pr-branch.ts sweep
  *
  * `up` ensures an Electric Cloud **environment** for this PR and (re)creates the
  * Postgres **service** (the sync "source") inside it, pointed at this PR's
@@ -26,6 +27,13 @@
  * after `alchemy:destroy:pr`). Environment deletion cascades its services. Each
  * source counts against the Electric plan's max-databases cap and holds a
  * PlanetScale replication slot, so `down` on close is mandatory.
+ *
+ * `sweep` deletes every `pr-<n>`/`pr-<n>-*` environment whose PR is already
+ * closed. The close-event teardown is best-effort only (GitHub creates no
+ * `closed` run for conflicted PRs; close runs execute the PR branch's own old
+ * workflow version; post-close redeploys recreate resources) — the scheduled
+ * cleanup-preview-orphans workflow runs `sweep` as the safety net, mirroring
+ * scripts/planetscale-pr-branch.ts.
  *
  * Depends on the PlanetScale `up` step having exported MAPLE_PG_URL (the direct
  * 5432 connection string) and the `drizzle-kit migrate` step having applied
@@ -78,7 +86,7 @@
 import { spawnSync } from "node:child_process"
 import { appendFileSync } from "node:fs"
 
-type Subcommand = "up" | "down"
+type Subcommand = "up" | "down" | "sweep"
 
 const FAILURE = 1
 // Short grace for eventual consistency on env-name conflicts before falling
@@ -101,10 +109,13 @@ const fail = (message: string): never => {
 
 const parseArgs = (): { subcommand: Subcommand; environmentName: string } => {
 	const [, , rawSubcommand, rawPr] = process.argv
-	if (rawSubcommand !== "up" && rawSubcommand !== "down") {
+	if (rawSubcommand !== "up" && rawSubcommand !== "down" && rawSubcommand !== "sweep") {
 		fail(
-			`Usage: bun scripts/electric-pr-branch.ts <up|down> <pr-number> (got "${rawSubcommand ?? ""}")`,
+			`Usage: bun scripts/electric-pr-branch.ts <up|down> <pr-number> | sweep (got "${rawSubcommand ?? ""}")`,
 		)
+	}
+	if (rawSubcommand === "sweep") {
+		return { subcommand: "sweep", environmentName: "" }
 	}
 	// PR number is digits only and the only untrusted input that lands in a name.
 	const prNumber = (rawPr ?? "").trim()
@@ -747,6 +758,95 @@ const up = async (environmentName: string): Promise<void> => {
 	console.log(`✓ Electric environment ${environmentName} ready; preview electric-sync will bind to it.`)
 }
 
+/**
+ * PR state via the GitHub REST API. Returns "unknown" when no token/repo is
+ * available (local runs) or the API call fails — callers must treat "unknown"
+ * as "don't block", never as "closed". Same contract as
+ * scripts/planetscale-pr-branch.ts.
+ */
+const fetchPrState = async (prNumber: string): Promise<"open" | "closed" | "unknown"> => {
+	const repo = process.env.GITHUB_REPOSITORY?.trim()
+	const token = (process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN)?.trim()
+	if (!repo || !token) return "unknown"
+	try {
+		const response = await fetch(`https://api.github.com/repos/${repo}/pulls/${prNumber}`, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+		})
+		if (!response.ok) {
+			console.log(`⚠ Could not look up PR #${prNumber} state (HTTP ${response.status})`)
+			return "unknown"
+		}
+		const parsed = (await response.json()) as { state?: string }
+		return parsed.state === "open" ? "open" : parsed.state === "closed" ? "closed" : "unknown"
+	} catch (error) {
+		console.log(
+			`⚠ Could not look up PR #${prNumber} state (${error instanceof Error ? error.message : String(error)})`,
+		)
+		return "unknown"
+	}
+}
+
+/**
+ * Delete every `pr-<n>`/`pr-<n>-*` environment whose PR is closed. Only names
+ * matching the PR shape (base `pr-<digits>` plus its suffix-fallback variants
+ * `pr-<digits>-*`) are candidates — anything else in the project is never
+ * touched. Environments whose PR state cannot be determined are skipped
+ * (deleting on uncertainty risks tearing down a live preview).
+ */
+const sweep = async (): Promise<void> => {
+	requireEnv("ELECTRIC_API_TOKEN")
+	const projectId = requireEnv("ELECTRIC_PROJECT_ID")
+	// The PR-state lookup is the sweep's only guard against deleting a LIVE
+	// preview; without a token everything resolves to "unknown" and the run
+	// green-no-ops forever. Fail loudly instead — this is the safety net.
+	if (!process.env.GITHUB_REPOSITORY?.trim() || !(process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN)?.trim()) {
+		fail("sweep requires GITHUB_REPOSITORY and GITHUB_TOKEN (or GH_TOKEN) to check PR state")
+	}
+	const listed = runElectric(["environments", "list", "--project", projectId, "--json"], { secret: true })
+	if (listed.exitCode !== 0) {
+		if (isNotFound(listed)) {
+			console.log("✓ No environments to sweep")
+			return
+		}
+		fail(`Failed to list Electric environments (exit ${listed.exitCode})`)
+	}
+	const candidates = asArray(parseJson(listed.stdout, "environments list")).flatMap((entry) => {
+		const id = pick(entry, "id", "environmentId")
+		const name = pick(entry, "name")
+		const match = name ? /^pr-(\d+)(?:-|$)/.exec(name) : null
+		return id && name && match ? [{ id, name, prNumber: match[1] as string }] : []
+	})
+	console.log(
+		`Found ${candidates.length} pr-* environment(s): ${candidates.map((c) => c.name).join(", ") || "—"}`,
+	)
+
+	const failures: string[] = []
+	for (const candidate of candidates) {
+		const state = await fetchPrState(candidate.prNumber)
+		if (state === "open") {
+			console.log(`… keeping ${candidate.name} (PR #${candidate.prNumber} is open)`)
+			continue
+		}
+		if (state === "unknown") {
+			console.log(`⚠ skipping ${candidate.name} (PR #${candidate.prNumber} state unknown)`)
+			continue
+		}
+		console.log(`… deleting orphan ${candidate.name} (PR #${candidate.prNumber} is closed)`)
+		const removed = runElectric(["environments", "delete", candidate.id, "--force"])
+		if (removed.exitCode !== 0 && !isNotFound(removed)) {
+			failures.push(candidate.name)
+		}
+	}
+	if (failures.length > 0) {
+		fail(`Failed to delete orphan environment(s): ${failures.join(", ")}`)
+	}
+	console.log("✓ Sweep complete")
+}
+
 const down = (environmentName: string): void => {
 	requireEnv("ELECTRIC_API_TOKEN")
 	const projectId = requireEnv("ELECTRIC_PROJECT_ID")
@@ -761,6 +861,8 @@ const main = async (): Promise<void> => {
 	const { subcommand, environmentName } = parseArgs()
 	if (subcommand === "up") {
 		await up(environmentName)
+	} else if (subcommand === "sweep") {
+		await sweep()
 	} else {
 		down(environmentName)
 	}

--- a/scripts/electric-pr-branch.ts
+++ b/scripts/electric-pr-branch.ts
@@ -843,6 +843,10 @@ const sweep = async (): Promise<void> => {
 			continue
 		}
 		console.log(`… deleting orphan ${candidate.name} (PR #${candidate.prNumber} is closed)`)
+		// The canonical orphan (leaked from a failed close-teardown) still has
+		// its source attached, and Electric refuses to delete an environment
+		// holding services — drop them first, same as deleteEnvironment().
+		resetServices(candidate.id)
 		const removed = runElectric(["environments", "delete", candidate.id, "--force"])
 		if (removed.exitCode !== 0 && !isNotFound(removed)) {
 			failures.push(candidate.name)

--- a/scripts/hyperdrive-orphan-sweep.ts
+++ b/scripts/hyperdrive-orphan-sweep.ts
@@ -121,7 +121,12 @@ const main = async (): Promise<void> => {
 	if (!listed.ok) {
 		fail(`Could not list Hyperdrive configs (HTTP ${listed.status}): ${JSON.stringify(listed.errors)}`)
 	}
-	const configs = (Array.isArray(listed.result) ? listed.result : []) as ReadonlyArray<HyperdriveConfig>
+	// A success response whose `result` isn't an array means the API shape
+	// changed under us — fail loudly rather than green-no-op'ing the safety net.
+	if (!Array.isArray(listed.result)) {
+		fail(`Unexpected Hyperdrive list response shape (result is ${typeof listed.result}, expected array)`)
+	}
+	const configs = listed.result as ReadonlyArray<HyperdriveConfig>
 	const candidates = configs
 		.map((config) => ({
 			id: config.id ?? "",

--- a/scripts/hyperdrive-orphan-sweep.ts
+++ b/scripts/hyperdrive-orphan-sweep.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env bun
+/**
+ * Sweep orphaned per-PR Cloudflare Hyperdrive configs.
+ *
+ *   bun scripts/hyperdrive-orphan-sweep.ts
+ *
+ * PR-preview stages get an alchemy-managed Hyperdrive config named
+ * `maple-db-pr-<n>` (packages/infra/src/cloudflare/stage.ts,
+ * resolveHyperdriveName). `alchemy destroy --stage pr-<n>` deletes it on PR
+ * close — but the close-event teardown is best-effort (see
+ * cleanup-preview-orphans.yml), and worse than the other resources: close
+ * runs execute the PR branch's OWN workflow/alchemy.run.ts version, and
+ * branches predating the placeholder-MAPLE_PG_URL destroy fix fail with
+ * "Missing required deployment env: MAPLE_PG_URL" on every rerun, forever
+ * (runs 29737841130/29528075804 attempt 2). The account allows 25 Hyperdrive
+ * configs total, so leaked `maple-db-pr-*` configs eventually block EVERY new
+ * PR preview with "This account has reached its limit for how many
+ * Hyperdrives it can have (25)" (run 30077724144, PR #257).
+ *
+ * There is no up/down here — alchemy owns the config's lifecycle; this script
+ * exists only as the sweep safety net. Deletion is double-gated like the
+ * sibling sweeps: the config name must match `maple-db-pr-<digits>` exactly
+ * (prd `maple-prd`, stg `maple-db-stg`, and dev `maple-db-dev-<name>` can
+ * never match), AND the GitHub API must affirmatively report that PR closed —
+ * unknown/open → keep. Deleting a config out from under a later alchemy
+ * destroy of the same stage is fine: alchemy tolerates already-deleted
+ * resources.
+ *
+ * Auth: CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID (the same credentials
+ * the deploy workflow's alchemy steps use), GITHUB_REPOSITORY +
+ * GITHUB_TOKEN/GH_TOKEN for the PR-state gate.
+ */
+
+const FAILURE = 1
+
+const fail = (message: string): never => {
+	console.error(`✗ ${message}`)
+	process.exit(FAILURE)
+}
+
+const requireEnv = (key: string): string => {
+	const value = process.env[key]?.trim()
+	if (!value) {
+		return fail(`Missing required env: ${key}`)
+	}
+	return value
+}
+
+/**
+ * PR state via the GitHub REST API. Returns "unknown" when the API call
+ * fails — callers must treat "unknown" as "don't delete", never as "closed".
+ * Same contract as the sibling sweeps in scripts/planetscale-pr-branch.ts.
+ */
+const fetchPrState = async (prNumber: string): Promise<"open" | "closed" | "unknown"> => {
+	const repo = process.env.GITHUB_REPOSITORY?.trim()
+	const token = (process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN)?.trim()
+	if (!repo || !token) return "unknown"
+	try {
+		const response = await fetch(`https://api.github.com/repos/${repo}/pulls/${prNumber}`, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+		})
+		if (!response.ok) {
+			console.log(`⚠ Could not look up PR #${prNumber} state (HTTP ${response.status})`)
+			return "unknown"
+		}
+		const parsed = (await response.json()) as { state?: string }
+		return parsed.state === "open" ? "open" : parsed.state === "closed" ? "closed" : "unknown"
+	} catch (error) {
+		console.log(
+			`⚠ Could not look up PR #${prNumber} state (${error instanceof Error ? error.message : String(error)})`,
+		)
+		return "unknown"
+	}
+}
+
+interface HyperdriveConfig {
+	readonly id?: string
+	readonly name?: string
+}
+
+const cfRequest = async (
+	token: string,
+	path: string,
+	init?: RequestInit,
+): Promise<{ ok: boolean; status: number; result: unknown; errors: unknown }> => {
+	const response = await fetch(`https://api.cloudflare.com/client/v4${path}`, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+			...(init?.headers ?? {}),
+		},
+	})
+	const body = (await response.json().catch(() => ({}))) as {
+		success?: boolean
+		result?: unknown
+		errors?: unknown
+	}
+	return {
+		ok: response.ok && body.success !== false,
+		status: response.status,
+		result: body.result,
+		errors: body.errors,
+	}
+}
+
+const main = async (): Promise<void> => {
+	// Same guard as the sibling sweeps: without the PR-state gate every config
+	// resolves to "unknown" and the run green-no-ops forever.
+	if (!process.env.GITHUB_REPOSITORY?.trim() || !(process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN)?.trim()) {
+		fail("sweep requires GITHUB_REPOSITORY and GITHUB_TOKEN (or GH_TOKEN) to check PR state")
+	}
+	const token = requireEnv("CLOUDFLARE_API_TOKEN")
+	const accountId = requireEnv("CLOUDFLARE_ACCOUNT_ID")
+
+	const listed = await cfRequest(token, `/accounts/${accountId}/hyperdrive/configs`)
+	if (!listed.ok) {
+		fail(`Could not list Hyperdrive configs (HTTP ${listed.status}): ${JSON.stringify(listed.errors)}`)
+	}
+	const configs = (Array.isArray(listed.result) ? listed.result : []) as ReadonlyArray<HyperdriveConfig>
+	const candidates = configs
+		.map((config) => ({
+			id: config.id ?? "",
+			name: config.name ?? "",
+			match: /^maple-db-pr-(\d+)$/.exec(config.name ?? ""),
+		}))
+		.filter(
+			(entry): entry is { id: string; name: string; match: RegExpExecArray } =>
+				entry.match !== null && entry.id.length > 0,
+		)
+	console.log(
+		`Found ${configs.length} Hyperdrive config(s), ${candidates.length} maple-db-pr-*: ${candidates.map((c) => c.name).join(", ") || "—"}`,
+	)
+
+	const failures: string[] = []
+	for (const { id, name, match } of candidates) {
+		const state = await fetchPrState(match[1] as string)
+		if (state === "open") {
+			console.log(`… keeping ${name} (PR #${match[1]} is open)`)
+			continue
+		}
+		if (state === "unknown") {
+			console.log(`⚠ skipping ${name} (PR #${match[1]} state unknown)`)
+			continue
+		}
+		console.log(`… deleting orphan ${name} (PR #${match[1]} is closed)`)
+		const removed = await cfRequest(token, `/accounts/${accountId}/hyperdrive/configs/${id}`, {
+			method: "DELETE",
+		})
+		if (!removed.ok && removed.status !== 404) {
+			console.log(`✗ delete failed (HTTP ${removed.status}): ${JSON.stringify(removed.errors)}`)
+			failures.push(name)
+		}
+	}
+	if (failures.length > 0) {
+		fail(`Failed to delete orphan Hyperdrive config(s): ${failures.join(", ")}`)
+	}
+	console.log("✓ Sweep complete")
+}
+
+await main()

--- a/scripts/planetscale-pr-branch.ts
+++ b/scripts/planetscale-pr-branch.ts
@@ -3,8 +3,9 @@
  * Per-PR PlanetScale Postgres branch lifecycle for the PR-preview deploy.
  * Sibling of scripts/tinybird-pr-branch.ts with the same up/down contract.
  *
- *   bun scripts/planetscale-pr-branch.ts up   <pr-number>
- *   bun scripts/planetscale-pr-branch.ts down <pr-number>
+ *   bun scripts/planetscale-pr-branch.ts up    <pr-number>
+ *   bun scripts/planetscale-pr-branch.ts down  <pr-number>
+ *   bun scripts/planetscale-pr-branch.ts sweep
  *
  * `up` ensures an ephemeral PlanetScale branch `pr-<n>` exists and is EMPTY,
  * mints a branch credential, and exports `MAPLE_PG_URL` (one connection string,
@@ -29,6 +30,14 @@
  * credentials. PS-DEV branches bill for time used, so `down` on close is
  * mandatory.
  *
+ * `sweep` deletes every `pr-<n>` branch whose PR is already closed. The
+ * close-event teardown is best-effort only — GitHub silently creates NO
+ * `pull_request: closed` run for a PR that conflicts with its base (so stale
+ * PRs closed without merging never tear down), and close runs on old branches
+ * execute the branch's own (possibly pre-fix) workflow version. The scheduled
+ * cleanup-preview-orphans workflow runs `sweep` as the safety net for
+ * everything the event-driven path misses.
+ *
  * `up` additionally refuses to provision when the PR is already closed (when a
  * GitHub token is available to check) — a delayed/re-run deploy landing after
  * the close-event teardown would otherwise silently recreate the branch with
@@ -42,7 +51,7 @@ import { spawnSync } from "node:child_process"
 import { appendFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 
-type Subcommand = "up" | "down"
+type Subcommand = "up" | "down" | "sweep"
 
 const FAILURE = 1
 // Our own polling budget on top of `pscale branch create --wait`'s built-in
@@ -58,10 +67,13 @@ const fail = (message: string): never => {
 
 const parseArgs = (): { subcommand: Subcommand; prNumber: string } => {
 	const [, , rawSubcommand, rawPr] = process.argv
-	if (rawSubcommand !== "up" && rawSubcommand !== "down") {
+	if (rawSubcommand !== "up" && rawSubcommand !== "down" && rawSubcommand !== "sweep") {
 		fail(
-			`Usage: bun scripts/planetscale-pr-branch.ts <up|down> <pr-number> (got "${rawSubcommand ?? ""}")`,
+			`Usage: bun scripts/planetscale-pr-branch.ts <up|down> <pr-number> | sweep (got "${rawSubcommand ?? ""}")`,
 		)
+	}
+	if (rawSubcommand === "sweep") {
+		return { subcommand: "sweep", prNumber: "" }
 	}
 	const prNumber = (rawPr ?? "").trim()
 	if (!/^\d+$/.test(prNumber)) {
@@ -371,6 +383,59 @@ const fetchPrState = async (prNumber: string): Promise<"open" | "closed" | "unkn
 }
 
 /**
+ * Delete every `pr-<n>` branch whose PR is closed. Only branches matching the
+ * exact `pr-<digits>` shape are considered — `main`, `stg`, and anything else
+ * are never candidates. Branches whose PR state cannot be determined are
+ * skipped (deleting on uncertainty risks tearing down a live preview).
+ */
+const sweepOrphanBranches = async (database: string): Promise<void> => {
+	// The PR-state lookup is the sweep's only guard against deleting a LIVE
+	// preview; without a token every branch resolves to "unknown" and the run
+	// green-no-ops forever — the exact failure class this safety net exists to
+	// catch. Fail loudly instead.
+	if (!process.env.GITHUB_REPOSITORY?.trim() || !(process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN)?.trim()) {
+		fail("sweep requires GITHUB_REPOSITORY and GITHUB_TOKEN (or GH_TOKEN) to check PR state")
+	}
+	const list = runPscale(["branch", "list", database, "--format", "json"], { secret: true })
+	if (list.exitCode !== 0) {
+		fail(`Could not list branches of database ${database}`)
+	}
+	let branches: ReadonlyArray<{ name?: string }>
+	try {
+		branches = JSON.parse(list.stdout) as ReadonlyArray<{ name?: string }>
+	} catch {
+		return fail("Could not parse `pscale branch list --format json` output")
+	}
+	const candidates = branches
+		.map((branch) => branch.name ?? "")
+		.map((name) => ({ name, match: /^pr-(\d+)$/.exec(name) }))
+		.filter((entry): entry is { name: string; match: RegExpExecArray } => entry.match !== null)
+	console.log(`Found ${candidates.length} pr-* branch(es): ${candidates.map((c) => c.name).join(", ") || "—"}`)
+
+	const failures: string[] = []
+	for (const { name, match } of candidates) {
+		const state = await fetchPrState(match[1] as string)
+		if (state === "open") {
+			console.log(`… keeping ${name} (PR #${match[1]} is open)`)
+			continue
+		}
+		if (state === "unknown") {
+			console.log(`⚠ skipping ${name} (PR #${match[1]} state unknown)`)
+			continue
+		}
+		console.log(`… deleting orphan ${name} (PR #${match[1]} is closed)`)
+		const remove = runPscale(["branch", "delete", database, name, "--force"])
+		if (remove.exitCode !== 0 && !isNotFound(remove)) {
+			failures.push(name)
+		}
+	}
+	if (failures.length > 0) {
+		fail(`Failed to delete orphan branch(es): ${failures.join(", ")}`)
+	}
+	console.log("✓ Sweep complete")
+}
+
+/**
  * Create the branch and wait until it's ready. Tolerates "already exists"
  * (a concurrent/earlier create) and the CLI's own `--wait` timeout — in both
  * cases the branch is (still) provisioning, so `waitUntilReady` takes over.
@@ -400,7 +465,7 @@ const resetBranchInPlace = (connectionUrl: string, replicationUrl?: string): boo
 		env: {
 			...process.env,
 			DATABASE_URL: connectionUrl,
-			// The inactive-slot cleanup needs the REPLICATION attribute the main
+			// The inactive-slot sweep needs the REPLICATION attribute the main
 			// role deliberately lacks.
 			...(replicationUrl ? { REPLICATION_DATABASE_URL: replicationUrl } : {}),
 		},
@@ -412,6 +477,10 @@ const main = async () => {
 	const { subcommand, prNumber } = parseArgs()
 	const database = process.env.PLANETSCALE_DATABASE?.trim() || "maple"
 	const branchName = `pr-${prNumber}`
+
+	if (subcommand === "sweep") {
+		return sweepOrphanBranches(database)
+	}
 
 	if (subcommand === "up") {
 		// A deploy landing after the PR closed (delayed event, re-run, approval
@@ -445,7 +514,7 @@ const main = async () => {
 			const credential = createCredential(database, branchName)
 			await ensureClusterParameters(database, branchName, credential.url)
 			// The replication credential is minted BEFORE the reset so the reset's
-			// inactive-slot cleanup can run with the REPLICATION attribute (the main
+			// inactive-slot sweep can run with the REPLICATION attribute (the main
 			// role deliberately lacks it). If the reset fails, the fallback's
 			// branch delete revokes both roles and fresh ones are minted after the
 			// recreate.

--- a/scripts/tinybird-pr-branch.ts
+++ b/scripts/tinybird-pr-branch.ts
@@ -2,8 +2,9 @@
 /**
  * Per-PR Tinybird branch lifecycle for the PR-preview deploy.
  *
- *   bun scripts/tinybird-pr-branch.ts up   <pr-number>
- *   bun scripts/tinybird-pr-branch.ts down <pr-number>
+ *   bun scripts/tinybird-pr-branch.ts up    <pr-number>
+ *   bun scripts/tinybird-pr-branch.ts down  <pr-number>
+ *   bun scripts/tinybird-pr-branch.ts sweep
  *
  * `up` creates (or reuses) an ephemeral Tinybird branch `pr_<n>` seeded with the
  * latest production partition (`--last-partition`), deploys this PR's project
@@ -12,6 +13,13 @@
  * (api/web/alerting/chat-agent + Rust ingest) to the branch instead of prod.
  *
  * `down` removes the branch (called on PR close, after `alchemy:destroy:pr`).
+ *
+ * `sweep` removes every `pr_<n>` branch whose PR is already closed. The
+ * close-event teardown is best-effort only (GitHub creates no `closed` run for
+ * conflicted PRs; close runs execute the PR branch's own old workflow version;
+ * post-close redeploys recreate resources) — the scheduled
+ * cleanup-preview-orphans workflow runs `sweep` as the safety net, mirroring
+ * scripts/planetscale-pr-branch.ts.
  *
  * Auth: the PARENT (prod) workspace host+token arrive via the incoming
  * TINYBIRD_HOST / TINYBIRD_TOKEN (Infisical `preview` environment). We use them to drive the
@@ -25,14 +33,19 @@
 import { spawnSync } from "node:child_process"
 import { appendFileSync } from "node:fs"
 
-type Subcommand = "up" | "down"
+type Subcommand = "up" | "down" | "sweep"
 
 const FAILURE = 1
 
 const parseArgs = (): { subcommand: Subcommand; branchName: string; prNumber: string } => {
 	const [, , rawSubcommand, rawPr] = process.argv
-	if (rawSubcommand !== "up" && rawSubcommand !== "down") {
-		fail(`Usage: bun scripts/tinybird-pr-branch.ts <up|down> <pr-number> (got "${rawSubcommand ?? ""}")`)
+	if (rawSubcommand !== "up" && rawSubcommand !== "down" && rawSubcommand !== "sweep") {
+		fail(
+			`Usage: bun scripts/tinybird-pr-branch.ts <up|down> <pr-number> | sweep (got "${rawSubcommand ?? ""}")`,
+		)
+	}
+	if (rawSubcommand === "sweep") {
+		return { subcommand: "sweep", branchName: "", prNumber: "" }
 	}
 	// PR numbers are digits only; this is also the only untrusted input that ends
 	// up in a branch name, so keep it strictly numeric.
@@ -40,7 +53,7 @@ const parseArgs = (): { subcommand: Subcommand; branchName: string; prNumber: st
 	if (!/^\d+$/.test(prNumber)) {
 		fail(`Expected a numeric PR number, got "${rawPr ?? ""}"`)
 	}
-	return { subcommand: rawSubcommand, branchName: `pr_${prNumber}`, prNumber }
+	return { subcommand: rawSubcommand as Subcommand, branchName: `pr_${prNumber}`, prNumber }
 }
 
 const fail = (message: string): never => {
@@ -203,9 +216,95 @@ const down = (branchName: string): void => {
 	console.log(`✓ Tinybird branch ${branchName} removed (or already gone).`)
 }
 
+/**
+ * PR state via the GitHub REST API. Returns "unknown" when no token/repo is
+ * available (local runs) or the API call fails — callers must treat "unknown"
+ * as "don't block", never as "closed". Same contract as
+ * scripts/planetscale-pr-branch.ts.
+ */
+const fetchPrState = async (prNumber: string): Promise<"open" | "closed" | "unknown"> => {
+	const repo = process.env.GITHUB_REPOSITORY?.trim()
+	const token = (process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN)?.trim()
+	if (!repo || !token) return "unknown"
+	try {
+		const response = await fetch(`https://api.github.com/repos/${repo}/pulls/${prNumber}`, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+		})
+		if (!response.ok) {
+			console.log(`⚠ Could not look up PR #${prNumber} state (HTTP ${response.status})`)
+			return "unknown"
+		}
+		const parsed = (await response.json()) as { state?: string }
+		return parsed.state === "open" ? "open" : parsed.state === "closed" ? "closed" : "unknown"
+	} catch (error) {
+		console.log(
+			`⚠ Could not look up PR #${prNumber} state (${error instanceof Error ? error.message : String(error)})`,
+		)
+		return "unknown"
+	}
+}
+
+/**
+ * Remove every `pr_<n>` branch whose PR is closed. `tb branch ls` prints a
+ * human-readable table (no JSON mode), so candidate names are extracted by the
+ * exact `pr_<digits>` token shape — `main` and any other branch name are never
+ * candidates. Branches whose PR state cannot be determined are skipped
+ * (deleting on uncertainty risks tearing down a live preview).
+ */
+const sweep = async (): Promise<void> => {
+	// The PR-state lookup is the sweep's only guard against deleting a LIVE
+	// preview; without a token every branch resolves to "unknown" and the run
+	// green-no-ops forever. Fail loudly instead — this is the safety net.
+	if (!process.env.GITHUB_REPOSITORY?.trim() || !(process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN)?.trim()) {
+		fail("sweep requires GITHUB_REPOSITORY and GITHUB_TOKEN (or GH_TOKEN) to check PR state")
+	}
+	const parent = { host: requireEnv("TINYBIRD_HOST"), token: requireEnv("TINYBIRD_TOKEN") }
+	const listed = runTb(parent, ["branch", "ls"])
+	if (listed.exitCode !== 0) {
+		fail("Failed to list Tinybird branches.")
+	}
+	const candidates = [
+		...new Map(
+			[...listed.stdout.matchAll(/\bpr_(\d+)\b/g)].map((match) => [
+				match[0],
+				{ name: match[0], prNumber: match[1] as string },
+			]),
+		).values(),
+	]
+	console.log(`Found ${candidates.length} pr_* branch(es): ${candidates.map((c) => c.name).join(", ") || "—"}`)
+
+	const failures: string[] = []
+	for (const candidate of candidates) {
+		const state = await fetchPrState(candidate.prNumber)
+		if (state === "open") {
+			console.log(`… keeping ${candidate.name} (PR #${candidate.prNumber} is open)`)
+			continue
+		}
+		if (state === "unknown") {
+			console.log(`⚠ skipping ${candidate.name} (PR #${candidate.prNumber} state unknown)`)
+			continue
+		}
+		console.log(`… deleting orphan ${candidate.name} (PR #${candidate.prNumber} is closed)`)
+		const removed = runTb(parent, ["branch", "rm", candidate.name, "--yes"])
+		if (removed.exitCode !== 0 && !isNotFound(removed)) {
+			failures.push(candidate.name)
+		}
+	}
+	if (failures.length > 0) {
+		fail(`Failed to remove orphan branch(es): ${failures.join(", ")}`)
+	}
+	console.log("✓ Sweep complete")
+}
+
 const { subcommand, branchName } = parseArgs()
 if (subcommand === "up") {
 	up(branchName)
+} else if (subcommand === "sweep") {
+	await sweep()
 } else {
 	down(branchName)
 }


### PR DESCRIPTION
The scheduled orphan-sweep safety net for PR-preview resources, split out of #255 (now merged) and rebased onto main.

## What it adds
- `sweep` subcommand on all three lifecycle scripts — PlanetScale (`pr-<n>` branches), Electric Cloud (`pr-<n>`/`pr-<n>-*` environments), Tinybird (`pr_<n>` branches) — deleting resources whose PR is already closed.
- **`scripts/hyperdrive-orphan-sweep.ts`** — sweeps leaked `maple-db-pr-<n>` Cloudflare Hyperdrive configs. The account caps Hyperdrive configs at 25 and this class of orphan **blocks every new PR preview** once hit (run 30077724144 on this very PR: `This account has reached its limit for how many Hyperdrives it can have (25)`).
- `.github/workflows/cleanup-preview-orphans.yml` — scheduled every 6h + `workflow_dispatch`, running all four sweeps with per-credential gating.

## Why the close-event teardown isn't enough
- GitHub silently creates **no** `closed` run for a PR that conflicts with its base.
- Close runs execute the PR branch's **own old workflow version** — branches predating the placeholder-`MAPLE_PG_URL` destroy fix fail `alchemy destroy` with `Missing required deployment env: MAPLE_PG_URL` on **every rerun, forever** (verified: runs 29737841130, 29528075804, 29513331600, 29509138151, 29454609796, 29458336010, 29416609163 — all failed identically on attempt 2). Those orphans are unreachable except by a sweep running current-main code.
- Post-close redeploys can re-provision resources after teardown already ran.

## Safety: every deletion is double-gated
1. Exact preview-shaped name match (`pr-<n>` / `pr_<n>` / `maple-db-pr-<n>` anchored regexes) — `main`, `stg`, `maple-prd`, `maple-db-stg`, `maple-db-dev-*` can never match.
2. The GitHub API must affirmatively report that PR **closed** — `unknown`/open → keep; a missing `GITHUB_TOKEN` hard-fails the run instead of silently no-op'ing.

## Note on this PR's own preview deploy
It needs a free Hyperdrive slot to go green — the exact resource the leak exhausted (chicken-and-egg). Either free one `maple-db-pr-<closed-n>` config manually first, or merge with the preview check red and immediately `gh workflow run cleanup-preview-orphans.yml` — the sweep then frees all ~9 leaked slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)