### PR TITLE
ci(preview): harden the branch-reset scripts (PR #255 follow-ups)

### DIFF
--- a/packages/db/scripts/normalize-preview-ownership.ts
+++ b/packages/db/scripts/normalize-preview-ownership.ts
@@ -40,6 +40,16 @@ const main = async (): Promise<void> => {
 		console.error("✗ DATABASE_URL is not set — pass the PR branch connection string (MAPLE_PG_URL)")
 		process.exit(1)
 	}
+	// Tripwire (same as reset-preview-branch.ts): reassigning ownership is far
+	// less destructive than the reset, but run against prod/stg it would still
+	// silently rewrite object ownership. Only ever meant for ephemeral
+	// PR-preview branches, driven by CI.
+	if (!process.env.CI && process.env.RESET_PREVIEW_CONFIRM !== "1") {
+		console.error(
+			"✗ Refusing to run: this reassigns ownership of everything CURRENT_USER owns in the target database. Set RESET_PREVIEW_CONFIRM=1 to confirm DATABASE_URL points at a disposable preview branch (CI runs set CI).",
+		)
+		process.exit(1)
+	}
 	const sql = postgres(url, { max: 1, fetch_types: false })
 	try {
 		const [who] = await sql`

--- a/packages/db/scripts/reset-preview-branch.ts
+++ b/packages/db/scripts/reset-preview-branch.ts
@@ -193,11 +193,20 @@ const main = async () => {
 		// this, the replayed CREATE SCHEMA migration would hit duplicate_object
 		// on every reused-branch deploy — with no recreate fallback, because the
 		// emptiness verification below only inspects `public`.
+		//
+		// RESET_PRESERVE_SCHEMAS (comma-separated) is the ops lever for the day
+		// PlanetScale ships a `postgres`-owned vendor schema this heuristic would
+		// otherwise take out — those names are skipped without a code change.
+		const preservedSchemas = (process.env.RESET_PRESERVE_SCHEMAS ?? "")
+			.split(",")
+			.map((name) => name.trim())
+			.filter(Boolean)
 		const extraSchemas = await sql<{ nspname: string }[]>`
 			SELECT n.nspname FROM pg_namespace n
 			JOIN pg_roles r ON r.oid = n.nspowner
 			WHERE n.nspname NOT IN ('public', 'information_schema')
 				AND n.nspname NOT LIKE ${"pg\\_%"}
+				AND n.nspname != ALL(${preservedSchemas})
 				AND (r.rolname = 'postgres' OR pg_has_role(current_user, r.oid, 'USAGE'))
 		`
 		for (const { nspname } of extraSchemas) {
@@ -207,11 +216,22 @@ const main = async () => {
 
 		// The reset only succeeded if public is actually empty now — anything
 		// left (an owner we couldn't assume, an object class this script doesn't
-		// know) must push the caller onto the delete → recreate fallback.
+		// know) must push the caller onto the delete → recreate fallback. Count
+		// relations AND routines AND standalone enum/domain types: a surviving
+		// enum would otherwise sail past this check and hit duplicate_object at
+		// migrate replay, where there is no recreate fallback anymore.
 		const [remaining] = await sql<{ count: string }[]>`
-			SELECT count(*)::int AS count FROM pg_class c
-			JOIN pg_namespace n ON n.oid = c.relnamespace
-			WHERE n.nspname = 'public' AND c.relkind IN ('r', 'v', 'm', 'S', 'p', 'f')
+			SELECT (
+				(SELECT count(*) FROM pg_class c
+					JOIN pg_namespace n ON n.oid = c.relnamespace
+					WHERE n.nspname = 'public' AND c.relkind IN ('r', 'v', 'm', 'S', 'p', 'f'))
+				+ (SELECT count(*) FROM pg_proc p
+					JOIN pg_namespace n ON n.oid = p.pronamespace
+					WHERE n.nspname = 'public')
+				+ (SELECT count(*) FROM pg_type t
+					JOIN pg_namespace n ON n.oid = t.typnamespace
+					WHERE n.nspname = 'public' AND t.typtype IN ('e', 'd'))
+			)::int AS count
 		`
 		if (Number(remaining?.count ?? 0) > 0) {
 			fail(`public schema still holds ${remaining?.count} objects after the drop pass`)

--- a/scripts/electric-pr-branch.ts
+++ b/scripts/electric-pr-branch.ts
@@ -636,19 +636,18 @@ const up = async (environmentName: string): Promise<void> => {
 	// v0.0.10 result: { id, status, sourceSecret } — the postgres service IS the
 	// shape-API source, so its id is the `source_id` the sync worker forwards.
 	const service = parseJson(createdSvc.stdout, "services create postgres")
-	const sourceId = pick(service, "id", "serviceId", "sourceId")
 	// Fail fast on a CLI output-shape drift: without an id the activation wait
 	// below would be skipped and the run would only die much later (after the
 	// publication-mirror poll) with a message that buries the actual cause.
-	if (!sourceId) {
+	const sourceId =
+		pick(service, "id", "serviceId", "sourceId") ??
 		fail(
 			"`electric services create postgres --json` returned no service id — cannot wait for activation or resolve the source",
 		)
-	}
 	let secret = pick(service, "sourceSecret", "secret", "source_secret")
 
 	// 3b. Wait for the service to become active before the alchemy deploy binds it.
-	if (sourceId) {
+	{
 		const deadline = Date.now() + ACTIVE_TIMEOUT_MS
 		let lastStatus = pick(service, "status") ?? "unknown"
 		console.log(`… service ${sourceId} status: ${lastStatus}`)
@@ -723,15 +722,15 @@ const up = async (environmentName: string): Promise<void> => {
 	}
 
 	// 4. Fetch the source secret if `create` didn't already return it.
-	if (!secret && sourceId) {
+	if (!secret) {
 		const fetched = runElectric(["services", "get-secret", sourceId, "--json"], { secret: true })
 		if (fetched.exitCode !== 0) {
 			fail(`Failed to fetch the source secret for service ${sourceId}`)
 		}
 		secret = pick(parseJson(fetched.stdout, "services get-secret"), "secret", "sourceSecret")
 	}
-	if (!sourceId || !secret) {
-		fail("Could not resolve the Electric source_id + secret from the CLI output")
+	if (!secret) {
+		fail("Could not resolve the Electric source secret from the CLI output")
 	}
 
 	// 5. Hand the source creds to the rest of the workflow. alchemy binds these to
@@ -739,7 +738,7 @@ const up = async (environmentName: string): Promise<void> => {
 	maskAndExport(
 		{
 			ELECTRIC_URL: electricUrl,
-			ELECTRIC_SOURCE_ID: sourceId as string,
+			ELECTRIC_SOURCE_ID: sourceId,
 			ELECTRIC_SECRET: secret as string,
 		},
 		[secret as string],


### PR DESCRIPTION
The four non-blocking follow-ups from the #255 review:

1. **Tripwire on `normalize-preview-ownership.ts`** — same `CI || RESET_PREVIEW_CONFIRM=1` guard as the reset script. Ownership reassignment is low-harm, but bun auto-loads `.env` and mise loads `.env.local`, so a dev shell can silently carry a real `DATABASE_URL`; the script now refuses outside CI without explicit confirmation.
2. **Wider emptiness verification in `reset-preview-branch.ts`** — the post-drop check now counts routines and standalone enum/domain types alongside `pg_class` relations. Previously a surviving enum (e.g. an owner the reset couldn't assume) passed verification and only failed later as `duplicate_object` at migrate replay — past the point where the delete → recreate fallback exists.
3. **`RESET_PRESERVE_SCHEMAS` escape hatch** — comma-separated schema names exempted from the extra-schema drop, so a future `postgres`-owned PlanetScale vendor schema can be protected without a code change.
4. **Dead-code cleanup in `electric-pr-branch.ts`** — `sourceId` resolves via `?? fail(...)` so it's typed `string` outright; the dead `if (sourceId)` wrapper and downstream re-checks are gone.

Verification: the four scripts pass `tsc --strict` (they're excluded from CI typecheck as bun runtime scripts), and both tripwires + the usage guard were smoke-run locally (refuse with exit 1 before any connection is made).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787476154&installation_model_id=427786&pr_number=258&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F258&signature=c88f89011932cd8b42a8822deb909111a131e2f0911cca55fbc5bbe55953d0a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->