### PR TITLE
Instrument the ingest request path with per-stage spans

### DIFF
--- a/apps/ingest/src/autumn.rs
+++ b/apps/ingest/src/autumn.rs
@@ -297,9 +297,13 @@ impl AutumnEntitlements {
     /// customer data.
     pub async fn is_allowed(&self, org_id: &str, feature_id: &str) -> bool {
         let cache_key = format!("{org_id}:{feature_id}");
+        // Recorded on `ingest.entitlement_check` when this runs under the HTTP
+        // path; a no-op elsewhere (the field is only declared on that span).
         if let Some(allowed) = self.cache.get(&cache_key).await {
+            tracing::Span::current().record("maple.ingest.cache_hit", true);
             return allowed;
         }
+        tracing::Span::current().record("maple.ingest.cache_hit", false);
 
         let allowed = self.fetch_allowed(org_id, feature_id).await;
         self.cache.insert(cache_key, allowed).await;

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -32,7 +32,11 @@ use flate2::Compression;
 use hmac::{Hmac, Mac};
 use maple_ingest::clickhouse_insert_mappings::SCHEMA_VERSION as CLICKHOUSE_SCHEMA_VERSION;
 use maple_ingest::metrics;
-use maple_ingest::otel::{build_resource, forward_client_span, ResourceConfig};
+use maple_ingest::otel::{
+    accept_internal_span, auth_internal_span, build_resource, decode_internal_span,
+    entitlement_internal_span, forward_client_span, grpc_server_span, parse_internal_span,
+    record_stage_error, resolve_config_internal_span, ResourceConfig,
+};
 use maple_ingest::telemetry::{
     AttributeMappingRule, ClickHouseBreakerConfig, ClickHouseTarget, ClickHouseTargetProvider,
     DatasourceNames, ExportDestination, MappingOperation, MappingSourceContext, PipelineError,
@@ -940,6 +944,56 @@ fn otel_status_for_rejection(status: u16) -> &'static str {
     }
 }
 
+/// gRPC counterpart of `otel_status_for_rejection`, applying the same rule: a
+/// caller-caused rejection leaves the SERVER span `Ok`, only a server-side
+/// failure is `Error`. `accept_grpc_decoded` maps the pipeline's 429 to
+/// `ResourceExhausted` and everything else to `Unavailable`, so the split here
+/// mirrors the 4xx/5xx split on the HTTP path.
+fn grpc_otel_status_for_rejection(code: tonic::Code) -> &'static str {
+    match code {
+        tonic::Code::Unauthenticated
+        | tonic::Code::PermissionDenied
+        | tonic::Code::ResourceExhausted
+        | tonic::Code::InvalidArgument
+        | tonic::Code::NotFound
+        | tonic::Code::FailedPrecondition
+        | tonic::Code::OutOfRange
+        | tonic::Code::Cancelled => "Ok",
+        _ => "Error",
+    }
+}
+
+/// Fully-qualified `rpc.service` names, per the OTel semantic conventions.
+const GRPC_TRACE_SERVICE: &str = "opentelemetry.proto.collector.trace.v1.TraceService";
+const GRPC_LOGS_SERVICE: &str = "opentelemetry.proto.collector.logs.v1.LogsService";
+const GRPC_METRICS_SERVICE: &str = "opentelemetry.proto.collector.metrics.v1.MetricsService";
+
+/// Record the resolved caller on the current gRPC server span, mirroring what
+/// `handle_signal_inner` records on the HTTP one.
+fn record_grpc_identity(resolved: &ResolvedIngestKey) {
+    let span = Span::current();
+    span.record("maple.org_id", resolved.org_id.as_str());
+    span.record("maple.ingest.key_type", resolved.key_type.as_str());
+}
+
+/// Fill in the deferred outcome fields on a gRPC server span. Generic over the
+/// response body so the three OTLP services share one implementation.
+fn record_grpc_outcome<T>(span: &Span, result: &Result<tonic::Response<T>, tonic::Status>) {
+    match result {
+        Ok(_) => {
+            span.record("rpc.grpc.status_code", tonic::Code::Ok as i32);
+            span.record("otel.status_code", "Ok");
+        }
+        Err(status) => {
+            let code = status.code();
+            span.record("rpc.grpc.status_code", code as i32);
+            span.record("error.type", code.description());
+            span.record("otel.status_description", status.message());
+            span.record("otel.status_code", grpc_otel_status_for_rejection(code));
+        }
+    }
+}
+
 /// Map a telemetry pipeline rejection to the client-facing HTTP error.
 ///
 /// Transient queue conditions (`Throttled` = per-org byte cap, `Backpressure` =
@@ -1062,9 +1116,15 @@ fn init_tracing(
         }
     };
 
+    // Sized for the per-request child spans (ingest.authenticate / .decode /
+    // .parse / .accept / .encode_rows / .wal_commit): a request emits ~7 spans,
+    // not 1. At 2048 the queue held only a few seconds of that volume, so a
+    // brief export stall silently dropped spans — parents and children alike.
+    // Head volume is controlled by OTEL_TRACES_SAMPLER / _ARG, which the SDK
+    // reads via TracerProviderBuilder's derived Default.
     let batch_config = BatchConfigBuilder::default()
-        .with_max_queue_size(2048)
-        .with_max_export_batch_size(512)
+        .with_max_queue_size(8192)
+        .with_max_export_batch_size(1024)
         .with_scheduled_delay(Duration::from_secs(5))
         .build();
 
@@ -1511,21 +1571,30 @@ impl opentelemetry_proto::tonic::collector::trace::v1::trace_service_server::Tra
         >,
         tonic::Status,
     > {
-        let resolved = resolve_grpc_ingest_key(&self.state, request.metadata()).await?;
-        let mut inner = request.into_inner();
-        enrich_trace_request(&mut inner, &resolved);
-        accept_grpc_decoded(
-            &self.state,
-            Signal::Traces,
-            DecodedPayload::Traces(inner),
-            &resolved,
-        )
-        .await?;
-        Ok(tonic::Response::new(
-            opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceResponse {
-                partial_success: None,
-            },
-        ))
+        let span = grpc_server_span(GRPC_TRACE_SERVICE, "traces");
+        let span_handle = span.clone();
+        let result = async {
+            let resolved = resolve_grpc_ingest_key(&self.state, request.metadata()).await?;
+            let mut inner = request.into_inner();
+            enrich_trace_request(&mut inner, &resolved);
+            record_grpc_identity(&resolved);
+            accept_grpc_decoded(
+                &self.state,
+                Signal::Traces,
+                DecodedPayload::Traces(inner),
+                &resolved,
+            )
+            .await?;
+            Ok(tonic::Response::new(
+                opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceResponse {
+                    partial_success: None,
+                },
+            ))
+        }
+        .instrument(span)
+        .await;
+        record_grpc_outcome(&span_handle, &result);
+        result
     }
 }
 
@@ -1540,21 +1609,30 @@ impl opentelemetry_proto::tonic::collector::logs::v1::logs_service_server::LogsS
         tonic::Response<opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceResponse>,
         tonic::Status,
     > {
-        let resolved = resolve_grpc_ingest_key(&self.state, request.metadata()).await?;
-        let mut inner = request.into_inner();
-        enrich_logs_request(&mut inner, &resolved);
-        accept_grpc_decoded(
-            &self.state,
-            Signal::Logs,
-            DecodedPayload::Logs(inner),
-            &resolved,
-        )
-        .await?;
-        Ok(tonic::Response::new(
-            opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceResponse {
-                partial_success: None,
-            },
-        ))
+        let span = grpc_server_span(GRPC_LOGS_SERVICE, "logs");
+        let span_handle = span.clone();
+        let result = async {
+            let resolved = resolve_grpc_ingest_key(&self.state, request.metadata()).await?;
+            let mut inner = request.into_inner();
+            enrich_logs_request(&mut inner, &resolved);
+            record_grpc_identity(&resolved);
+            accept_grpc_decoded(
+                &self.state,
+                Signal::Logs,
+                DecodedPayload::Logs(inner),
+                &resolved,
+            )
+            .await?;
+            Ok(tonic::Response::new(
+                opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceResponse {
+                    partial_success: None,
+                },
+            ))
+        }
+        .instrument(span)
+        .await;
+        record_grpc_outcome(&span_handle, &result);
+        result
     }
 }
 
@@ -1571,21 +1649,30 @@ impl opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_server:
         >,
         tonic::Status,
     > {
-        let resolved = resolve_grpc_ingest_key(&self.state, request.metadata()).await?;
-        let mut inner = request.into_inner();
-        enrich_metrics_request(&mut inner, &resolved);
-        accept_grpc_decoded(
-            &self.state,
-            Signal::Metrics,
-            DecodedPayload::Metrics(inner),
-            &resolved,
-        )
-        .await?;
-        Ok(tonic::Response::new(
-            opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceResponse {
-                partial_success: None,
-            },
-        ))
+        let span = grpc_server_span(GRPC_METRICS_SERVICE, "metrics");
+        let span_handle = span.clone();
+        let result = async {
+            let resolved = resolve_grpc_ingest_key(&self.state, request.metadata()).await?;
+            let mut inner = request.into_inner();
+            enrich_metrics_request(&mut inner, &resolved);
+            record_grpc_identity(&resolved);
+            accept_grpc_decoded(
+                &self.state,
+                Signal::Metrics,
+                DecodedPayload::Metrics(inner),
+                &resolved,
+            )
+            .await?;
+            Ok(tonic::Response::new(
+                opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceResponse {
+                    partial_success: None,
+                },
+            ))
+        }
+        .instrument(span)
+        .await;
+        record_grpc_outcome(&span_handle, &result);
+        result
     }
 }
 
@@ -2408,12 +2495,20 @@ async fn handle_signal_inner(
     }
 
     let key_resolve_start = Instant::now();
+    // Own span so a cache miss that falls through to PSBouncer is attributable
+    // per-request, not just visible in the key_resolution_duration histogram.
+    // `postgres.query` (see `postgres_client_span`) nests under this on a miss.
+    let auth_span = auth_internal_span();
+    let auth_span_handle = auth_span.clone();
     let resolved_key = state
         .resolver
         .resolve_ingest_key(&ingest_key)
+        .instrument(auth_span)
         .await
         .map_err(|error| {
             error!(error = %error, "Ingest key resolution failed");
+            // The resolver being down is our fault (503), unlike a bad key.
+            record_stage_error(&auth_span_handle, "auth_unavailable", &error, true);
             (
                 ApiError::service_unavailable("Ingest authentication unavailable"),
                 "auth",
@@ -2421,9 +2516,19 @@ async fn handle_signal_inner(
         })?
         .ok_or_else(|| {
             warn!("Unknown ingest key");
+            record_stage_error(&auth_span_handle, "auth", "Unknown ingest key", false);
             (ApiError::unauthorized("Invalid ingest key"), "auth")
         })?;
     metrics::key_resolution_duration(key_resolve_start.elapsed().as_secs_f64());
+    auth_span_handle.record("maple.ingest.key_type", resolved_key.key_type.as_str());
+    // Truncated HMAC, not the key itself — enough to find the row in Postgres.
+    auth_span_handle.record("maple.ingest.key_id", resolved_key.key_id.as_str());
+    auth_span_handle.record("maple.org_id", resolved_key.org_id.as_str());
+    auth_span_handle.record("maple.ingest.self_managed", resolved_key.self_managed);
+    auth_span_handle.record(
+        "maple.ingest.clickhouse_ready",
+        resolved_key.clickhouse_ready,
+    );
 
     Span::current().record("maple.org_id", &resolved_key.org_id.as_str());
     Span::current().record("maple.ingest.key_type", resolved_key.key_type.as_str());
@@ -2444,10 +2549,16 @@ async fn handle_signal_inner(
     // AUTUMN_ENFORCE_LIMITS=true and AUTUMN_SECRET_KEY is set.
     if let Some(entitlements) = &state.autumn_entitlements {
         let feature_id = signal.path();
-        if !entitlements
+        // Parent for the existing `autumn.check` client span, so a cache miss
+        // that blocks on Autumn is visible even when the HTTP call itself is fast.
+        let entitlement_span = entitlement_internal_span(feature_id);
+        let entitlement_span_handle = entitlement_span.clone();
+        let allowed = entitlements
             .is_allowed(&resolved_key.org_id, feature_id)
-            .await
-        {
+            .instrument(entitlement_span)
+            .await;
+        entitlement_span_handle.record("maple.billing.allowed", allowed);
+        if !allowed {
             warn!(
                 org_id = %resolved_key.org_id,
                 feature_id,
@@ -2515,12 +2626,21 @@ async fn handle_signal_inner(
     metrics::request_body_bytes(signal.path(), body.len() as u64);
 
     // --- Decode ---
-    let decoded_payload = decode_payload(&body, content_encoding.as_deref()).map_err(|e| {
-        warn!(body_bytes = body.len(), "Failed to decode payload");
-        (e, "decode")
-    })?;
-
     let encoding_label = content_encoding.as_deref().unwrap_or("identity");
+    // Synchronous, so the span is entered rather than instrumented. Scoped so the
+    // span closes on the decompress itself and not on the rest of the handler.
+    let decoded_payload = {
+        let decode_span = decode_internal_span(encoding_label, body.len());
+        let _guard = decode_span.enter();
+        let decoded_payload = decode_payload(&body, content_encoding.as_deref()).map_err(|e| {
+            warn!(body_bytes = body.len(), "Failed to decode payload");
+            record_stage_error(&decode_span, "decode", &e.message, false);
+            (e, "decode")
+        })?;
+        decode_span.record("maple.ingest.decoded_bytes", decoded_payload.len());
+        decoded_payload
+    };
+
     Span::current().record("maple.ingest.decoded_bytes", decoded_payload.len());
     debug!(
         decoded_bytes = decoded_payload.len(),
@@ -2530,20 +2650,29 @@ async fn handle_signal_inner(
     metrics::decoded_body_bytes(signal.path(), decoded_payload.len() as u64);
 
     // --- Enrich ---
-    let decoded =
-        decode_and_enrich_payload(signal, payload_format, &decoded_payload, &resolved_key)
-            .map_err(|e| {
-                warn!(
-                    format = payload_format.label(),
-                    signal = signal.path(),
-                    org_id = resolved_key.org_id.as_str(),
-                    key_type = resolved_key.key_type.as_str(),
-                    decoded_bytes = decoded_payload.len(),
-                    reason = %e.message,
-                    "Invalid OTLP payload"
-                );
-                (e, "enrich")
-            })?;
+    let decoded = {
+        let parse_span = parse_internal_span(payload_format.label(), signal.path());
+        let _guard = parse_span.enter();
+        let decoded =
+            decode_and_enrich_payload(signal, payload_format, &decoded_payload, &resolved_key)
+                .map_err(|e| {
+                    warn!(
+                        format = payload_format.label(),
+                        signal = signal.path(),
+                        org_id = resolved_key.org_id.as_str(),
+                        key_type = resolved_key.key_type.as_str(),
+                        decoded_bytes = decoded_payload.len(),
+                        reason = %e.message,
+                        "Invalid OTLP payload"
+                    );
+                    // The reason previously only reached the log; on the span it
+                    // is what tells you *why* a customer's SDK is being rejected.
+                    record_stage_error(&parse_span, "enrich", &e.message, false);
+                    (e, "enrich")
+                })?;
+        parse_span.record("maple.ingest.item_count", decoded.item_count());
+        decoded
+    };
     let item_count = decoded.item_count();
 
     Span::current().record("maple.ingest.item_count", item_count);
@@ -3424,7 +3553,9 @@ async fn process_decoded_payload(
     Span::current().record("maple.ingest.destination", destination.as_str());
 
     if uses_native_pipeline_for(state.config.write_mode, destination) {
-        accept_native_decoded_payload(state, signal, decoded, resolved_key, destination).await?;
+        accept_native_decoded_payload(state, signal, decoded, resolved_key, destination)
+            .instrument(accept_internal_span(signal.path(), destination.as_str()))
+            .await?;
         if destination == ExportDestination::ClickHouse {
             return Ok(StatusCode::OK.into_response());
         }
@@ -3464,14 +3595,29 @@ async fn accept_native_decoded_payload(
     let native_start = Instant::now();
     let stats = match decoded {
         DecodedPayload::Traces(request) => {
-            let policy = state
-                .sampling_resolver
-                .resolve_policy(&resolved_key.org_id)
-                .await;
-            let attribute_mappings = state
-                .attribute_mapping_resolver
-                .resolve_mappings(&resolved_key.org_id)
-                .await;
+            // Both lookups are 30s-TTL cached; the span exists so a TTL miss that
+            // stalls on PSBouncer is attributable instead of vanishing into
+            // native_accept_duration.
+            let config_span = resolve_config_internal_span();
+            let config_span_handle = config_span.clone();
+            let (policy, attribute_mappings) = async {
+                let policy = state
+                    .sampling_resolver
+                    .resolve_policy(&resolved_key.org_id)
+                    .await;
+                let attribute_mappings = state
+                    .attribute_mapping_resolver
+                    .resolve_mappings(&resolved_key.org_id)
+                    .await;
+                (policy, attribute_mappings)
+            }
+            .instrument(config_span)
+            .await;
+            config_span_handle.record("maple.ingest.sampling_ratio", policy.trace_sample_ratio);
+            config_span_handle.record(
+                "maple.ingest.attribute_mapping_count",
+                attribute_mappings.len(),
+            );
             pipeline
                 .accept_traces_to(
                     &resolved_key.org_id,
@@ -3500,6 +3646,12 @@ async fn accept_native_decoded_payload(
             signal = signal.path(),
             org_id = %resolved_key.org_id,
             "Native telemetry pipeline rejected payload"
+        );
+        record_stage_error(
+            &Span::current(),
+            error.kind(),
+            &error.to_string(),
+            error.is_server_fault(),
         );
         api_error
     })?;
@@ -3553,10 +3705,14 @@ impl OrgRoutingResolver {
 
 impl IngestKeyResolver {
     async fn resolve_ingest_key(&self, raw_key: &str) -> Result<Option<ResolvedIngestKey>, String> {
+        // Recorded on `ingest.authenticate` when this runs under the HTTP path;
+        // a no-op elsewhere (the field is only declared on that span).
         if let Some(identity) = self.cache.get(raw_key).await {
+            Span::current().record("maple.ingest.cache_hit", true);
             let routing = self.routing.resolve_org_routing(&identity.org_id).await?;
             return Ok(Some(identity.into_resolved(routing)));
         }
+        Span::current().record("maple.ingest.cache_hit", false);
 
         let key_type = infer_ingest_key_type(raw_key);
         let Some(key_type) = key_type else {
@@ -5340,6 +5496,206 @@ mod tests {
             "connector identity should stay cached while routing refreshes"
         );
         assert_eq!(store.routing_fetches.load(Ordering::Relaxed), 1);
+    }
+
+    /// Records `(thread, span name, parent span name)` for every span opened
+    /// while it is installed, so a test can assert the shape of the trace rather
+    /// than just that individual spans exist.
+    ///
+    /// Installed as the *global* default rather than a thread-local one: callsite
+    /// interest is cached process-wide, so with a thread-local subscriber a
+    /// sibling test reaching a span macro first caches `Interest::never` and the
+    /// span silently never gets created for us. `set_global_default` rebuilds
+    /// that cache. The cost is that concurrently-running tests land in the same
+    /// capture, which is why every record is tagged with its thread.
+    /// One opened span: the thread that opened it, its name, and its parent's
+    /// name (`None` for a root).
+    type CapturedSpan = (std::thread::ThreadId, String, Option<String>);
+
+    #[derive(Clone, Default)]
+    struct SpanTreeCapture {
+        spans: Arc<std::sync::Mutex<Vec<CapturedSpan>>>,
+    }
+
+    static SPAN_TREE_CAPTURE: std::sync::OnceLock<SpanTreeCapture> = std::sync::OnceLock::new();
+
+    /// Install the capture globally, once per test process.
+    fn install_span_capture() -> &'static SpanTreeCapture {
+        SPAN_TREE_CAPTURE.get_or_init(|| {
+            let capture = SpanTreeCapture::default();
+            tracing::subscriber::set_global_default(
+                tracing_subscriber::registry().with(capture.clone()),
+            )
+            .expect("no other test may install a global subscriber");
+            capture
+        })
+    }
+
+    impl SpanTreeCapture {
+        /// Scoped to the calling thread. `#[tokio::test]` uses a current-thread
+        /// runtime, so the handler and the export worker it spawns both run here,
+        /// while other tests' spans are filtered out.
+        fn parent_of(&self, name: &str) -> Option<Option<String>> {
+            let this_thread = std::thread::current().id();
+            self.spans
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|(thread, span, _)| *thread == this_thread && span == name)
+                .map(|(_, _, parent)| parent.clone())
+        }
+
+        fn assert_child_of(&self, child: &str, parent: &str) {
+            let observed = self
+                .parent_of(child)
+                .unwrap_or_else(|| panic!("span `{child}` was never created"));
+            assert_eq!(
+                observed.as_deref(),
+                Some(parent),
+                "span `{child}` should be a child of `{parent}`"
+            );
+        }
+    }
+
+    impl<S> tracing_subscriber::Layer<S> for SpanTreeCapture
+    where
+        S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    {
+        fn on_new_span(
+            &self,
+            _attrs: &tracing::span::Attributes<'_>,
+            id: &tracing::Id,
+            ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let Some(span) = ctx.span(id) else {
+                return;
+            };
+            let parent = span.parent().map(|parent| parent.name().to_string());
+            self.spans.lock().unwrap().push((
+                std::thread::current().id(),
+                span.name().to_string(),
+                parent,
+            ));
+        }
+    }
+
+    /// The whole point of the child spans: a single slow request must show *which*
+    /// stage was slow. Without this the trace collapses to one server span and the
+    /// per-stage histograms are the only signal, which cannot attribute an
+    /// individual request.
+    /// `PipelineError::is_server_fault` decides the span status and
+    /// `api_error_from_pipeline` decides the HTTP status. They encode the same
+    /// judgement in two places, so a new variant that gets one right and the
+    /// other wrong would mislabel error dashboards.
+    #[test]
+    fn pipeline_error_fault_split_matches_http_status() {
+        for error in [
+            PipelineError::Backpressure("lane full"),
+            PipelineError::Throttled("org cap"),
+            PipelineError::QueueUnavailable("wal io".to_string()),
+            PipelineError::Encode("bad row".to_string()),
+        ] {
+            let status = api_error_from_pipeline(&error).status.as_u16();
+            assert_eq!(
+                error.is_server_fault(),
+                status >= 500,
+                "{} maps to HTTP {status} but reports is_server_fault()={}",
+                error.kind(),
+                error.is_server_fault()
+            );
+            assert_eq!(
+                otel_status_for_rejection(status),
+                if error.is_server_fault() {
+                    "Error"
+                } else {
+                    "Ok"
+                },
+                "span status for {} disagrees with the HTTP rule",
+                error.kind()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn native_request_emits_a_span_per_pipeline_stage() {
+        let (ch_tx, mut ch_rx) = tokio::sync::mpsc::unbounded_channel();
+        let ch_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let ch_addr = ch_listener.local_addr().unwrap();
+        let ch_app = Router::new()
+            .route("/", post(fake_clickhouse_import))
+            .with_state(ch_tx);
+        tokio::spawn(async move {
+            axum::serve(ch_listener, ch_app).await.unwrap();
+        });
+
+        let queue_dir = unique_main_test_dir("span-tree");
+        let store = Arc::new(FakeKeyStore::default());
+        let raw_key = "maple_sk_test_span_tree";
+        store.insert_private(
+            raw_key,
+            KeyRow {
+                org_id: "org_span_tree".to_string(),
+                self_managed: true,
+                clickhouse_ready: true,
+            },
+        );
+        store.insert_clickhouse_target(
+            "org_span_tree",
+            ClickHouseTargetRow {
+                ch_url: format!("http://{ch_addr}"),
+                ch_user: "ingest".to_string(),
+                ch_password_ciphertext: None,
+                ch_password_iv: None,
+                ch_password_tag: None,
+                ch_database: "maple".to_string(),
+                schema_version: CLICKHOUSE_SCHEMA_VERSION.to_string(),
+            },
+        );
+        let state = test_app_state(
+            Arc::clone(&store),
+            queue_dir.clone(),
+            "http://127.0.0.1:1".to_string(),
+            Duration::from_millis(5),
+        )
+        .await;
+
+        let capture = install_span_capture();
+
+        // Stands in for the `ingest` server span that handle_signal creates.
+        let server_span = tracing::info_span!("ingest");
+        let (response, item_count, _, _) = handle_signal_inner(
+            &state,
+            &test_headers(raw_key),
+            Bytes::from(test_log_request("span tree").encode_to_vec()),
+            Signal::Logs,
+        )
+        .instrument(server_span)
+        .await
+        .expect("request should be accepted through the native ClickHouse path");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(item_count, 1);
+
+        capture.assert_child_of("ingest.authenticate", "ingest");
+        capture.assert_child_of("ingest.decode", "ingest");
+        capture.assert_child_of("ingest.parse", "ingest");
+        capture.assert_child_of("ingest.accept", "ingest");
+        capture.assert_child_of("ingest.encode_rows", "ingest.accept");
+        capture.assert_child_of("ingest.wal_commit", "ingest.accept");
+
+        // The export lane drains asynchronously, so its batch is deliberately a
+        // root: one batch aggregates frames from many requests and cannot be
+        // parented under any single one.
+        tokio::time::timeout(Duration::from_secs(2), ch_rx.recv())
+            .await
+            .expect("ready org should write to ClickHouse")
+            .expect("ClickHouse channel should stay open");
+        assert_eq!(
+            capture.parent_of("ingest.export_batch"),
+            Some(None),
+            "export batches must stay root spans and link back instead"
+        );
     }
 
     #[tokio::test]

--- a/apps/ingest/src/otel.rs
+++ b/apps/ingest/src/otel.rs
@@ -38,7 +38,8 @@ pub fn build_resource(cfg: ResourceConfig) -> Resource {
     // shells out to git at runtime).
     attrs.push(KeyValue::new(
         "vcs.repository.url.full",
-        env::var("VCS_REPOSITORY_URL").unwrap_or_else(|_| "https://github.com/Makisuo/maple".to_string()),
+        env::var("VCS_REPOSITORY_URL")
+            .unwrap_or_else(|_| "https://github.com/Makisuo/maple".to_string()),
     ));
     if let Some(revision) = detect_head_revision() {
         attrs.push(KeyValue::new("vcs.ref.head.revision", revision));
@@ -50,9 +51,14 @@ pub fn build_resource(cfg: ResourceConfig) -> Resource {
 /// Commit SHA of the running build, from the deploy platform's env vars —
 /// mirrors lib/effect-sdk/src/server/resource.ts (`COMMIT_SHA` chain).
 fn detect_head_revision() -> Option<String> {
-    ["COMMIT_SHA", "RAILWAY_GIT_COMMIT_SHA", "RENDER_GIT_COMMIT", "GITHUB_SHA"]
-        .iter()
-        .find_map(|key| env::var(key).ok().filter(|v| !v.is_empty()))
+    [
+        "COMMIT_SHA",
+        "RAILWAY_GIT_COMMIT_SHA",
+        "RENDER_GIT_COMMIT",
+        "GITHUB_SHA",
+    ]
+    .iter()
+    .find_map(|key| env::var(key).ok().filter(|v| !v.is_empty()))
 }
 
 /// Mirrors lib/effect-sdk/src/server/platform.ts platform detection — first
@@ -183,6 +189,24 @@ fn rustc_version() -> &'static str {
     option_env!("CARGO_PKG_RUST_VERSION").unwrap_or("unknown")
 }
 
+/// Record a failed stage on `span`.
+///
+/// `error.type` and `otel.status_description` are recorded unconditionally so
+/// the failure is always searchable and always carries its reason. The span
+/// status follows the same rule the server span uses (`otel_status_for_rejection`
+/// in main.rs): only a server-side fault is `Error`. A caller-caused rejection —
+/// bad key, undecodable body, invalid OTLP, per-org throttle — leaves the span
+/// `Ok`, because error dashboards count `StatusCode='Error'` and would otherwise
+/// be flooded by things working exactly as designed.
+pub fn record_stage_error(span: &Span, error_type: &str, detail: &str, server_fault: bool) {
+    span.record("error.type", error_type);
+    span.record("otel.status_description", detail);
+    span.record(
+        "otel.status_code",
+        if server_fault { "Error" } else { "Ok" },
+    );
+}
+
 /// Downstream-forward client-kind span. `peer_service` is the canonical name of
 /// the destination service as it appears in the service map (see
 /// `.agents/skills/maple-telemetry-conventions/rules/service-map-attribution.md`
@@ -210,6 +234,205 @@ pub fn forward_client_span(
     )
 }
 
+/// OTLP-over-gRPC server span. The tonic server has no tracing layer, so without
+/// this the gRPC path's `postgres.query` / `forward` / `ingest.*` spans become
+/// disconnected roots. Mirrors the HTTP `ingest` span, with rpc semconv in place
+/// of http.
+pub fn grpc_server_span(rpc_service: &'static str, signal_path: &'static str) -> Span {
+    info_span!(
+        "ingest.grpc",
+        otel.name = %format_args!("{rpc_service}/Export"),
+        otel.kind = "server",
+        otel.status_code = Empty,
+        otel.status_description = Empty,
+        "rpc.system" = "grpc",
+        "rpc.service" = rpc_service,
+        "rpc.method" = "Export",
+        "rpc.grpc.status_code" = Empty,
+        "error.type" = Empty,
+        "maple.signal" = signal_path,
+        "maple.org_id" = Empty,
+        "maple.ingest.key_type" = Empty,
+        "maple.ingest.destination" = Empty,
+    )
+}
+
+/// Ingest-key resolution. Wraps the moka lookup and, on a miss, the HMAC hash
+/// plus the PSBouncer roundtrip — so `postgres.query` nests under this rather
+/// than hanging directly off the server span.
+pub fn auth_internal_span() -> Span {
+    info_span!(
+        "ingest.authenticate",
+        otel.kind = "internal",
+        otel.status_code = Empty,
+        otel.status_description = Empty,
+        "error.type" = Empty,
+        "maple.ingest.cache_hit" = Empty,
+        "maple.ingest.key_type" = Empty,
+        "maple.ingest.key_id" = Empty,
+        "maple.org_id" = Empty,
+        "maple.ingest.self_managed" = Empty,
+        "maple.ingest.clickhouse_ready" = Empty,
+    )
+}
+
+/// Autumn entitlement gate. Parent of the `autumn.check` client span, which only
+/// fires on an entitlement-cache miss.
+pub fn entitlement_internal_span(signal_path: &'static str) -> Span {
+    info_span!(
+        "ingest.entitlement_check",
+        otel.kind = "internal",
+        "maple.signal" = signal_path,
+        "maple.ingest.cache_hit" = Empty,
+        "maple.billing.allowed" = Empty,
+    )
+}
+
+/// Request-body decompression (gzip/deflate).
+pub fn decode_internal_span(content_encoding: &str, body_size: usize) -> Span {
+    info_span!(
+        "ingest.decode",
+        otel.kind = "internal",
+        otel.status_code = Empty,
+        otel.status_description = Empty,
+        "error.type" = Empty,
+        "maple.ingest.content_encoding" = content_encoding,
+        "http.request.body.size" = body_size,
+        "maple.ingest.decoded_bytes" = Empty,
+    )
+}
+
+/// Protobuf/JSON decode plus resource-attribute enrichment.
+pub fn parse_internal_span(payload_format: &'static str, signal_path: &'static str) -> Span {
+    info_span!(
+        "ingest.parse",
+        otel.kind = "internal",
+        otel.status_code = Empty,
+        otel.status_description = Empty,
+        "error.type" = Empty,
+        "maple.ingest.payload_format" = payload_format,
+        "maple.signal" = signal_path,
+        "maple.ingest.item_count" = Empty,
+    )
+}
+
+/// Native pipeline accept — row encoding, backpressure, quota and WAL commit.
+/// Mirrors the `ingest_native_accept_duration_seconds` histogram boundary.
+pub fn accept_internal_span(signal_path: &'static str, destination: &'static str) -> Span {
+    info_span!(
+        "ingest.accept",
+        otel.kind = "internal",
+        otel.status_code = Empty,
+        otel.status_description = Empty,
+        "error.type" = Empty,
+        "maple.signal" = signal_path,
+        "maple.ingest.destination" = destination,
+        "maple.ingest.native_rows" = Empty,
+        "maple.ingest.sampled_dropped" = Empty,
+    )
+}
+
+/// OTLP → NDJSON row encoding, including trace sampling and attribute mapping.
+/// Synchronous CPU work, so callers enter this rather than instrumenting.
+pub fn encode_rows_internal_span(signal_path: &'static str) -> Span {
+    info_span!(
+        "ingest.encode_rows",
+        otel.kind = "internal",
+        otel.status_code = Empty,
+        otel.status_description = Empty,
+        "error.type" = Empty,
+        "maple.signal" = signal_path,
+        "maple.ingest.row_count" = Empty,
+        "maple.ingest.frame_count" = Empty,
+        "maple.ingest.sampled_dropped" = Empty,
+        // Encoded NDJSON size. Compare against `ingest.decode`'s
+        // `maple.ingest.decoded_bytes` to spot encode amplification.
+        "maple.ingest.payload_bytes" = Empty,
+    )
+}
+
+/// Backpressure reservation, per-org queue quota, and the durable WAL append
+/// (the `fsync` runs on a blocking thread, but the span wraps the await so its
+/// wall time is still captured). No single shard attribute: one commit can fan
+/// out across shards, so `maple.ingest.shard`/`lane` are only recorded for the
+/// frame that failed, which is the one you need when debugging.
+pub fn wal_commit_internal_span(destination: &'static str) -> Span {
+    info_span!(
+        "ingest.wal_commit",
+        otel.kind = "internal",
+        otel.status_code = Empty,
+        otel.status_description = Empty,
+        "error.type" = Empty,
+        "maple.ingest.destination" = destination,
+        "maple.ingest.frame_count" = Empty,
+        // How many frames were durably committed before a mid-loop rejection.
+        // A commit is not atomic, so on a 429 this is the difference between
+        // "nothing landed" and "half the payload landed".
+        "maple.ingest.frames_committed" = Empty,
+        "maple.ingest.queued_bytes" = Empty,
+        // Only set on the failing frame.
+        "maple.ingest.shard" = Empty,
+        "maple.ingest.lane" = Empty,
+        "maple.ingest.datasource" = Empty,
+        // Only set on a quota rejection, so you can see how far over the cap
+        // the org was rather than just that it was over.
+        "maple.ingest.org_queue_bytes" = Empty,
+        "maple.ingest.org_queue_limit_bytes" = Empty,
+    )
+}
+
+/// One export attempt against Tinybird or ClickHouse.
+///
+/// One span per *attempt*, not per batch, so a retry storm is visible as a
+/// sequence rather than one long opaque span. `maple.ingest.outcome` is the
+/// field to filter on: `delivered` | `retry` | `dropped` | `shed_circuit_open`.
+/// Only a terminal `dropped` sets `Error` — a retry that later succeeds is not
+/// a failure of the batch, and marking every attempt `Error` would turn a
+/// self-healing blip into an error-rate spike.
+pub fn export_client_span(
+    span_name: &'static str,
+    peer_service: &'static str,
+    datasource: &str,
+    attempt: u32,
+    rows: usize,
+    body_size: usize,
+) -> Span {
+    info_span!(
+        "export",
+        otel.name = span_name,
+        otel.kind = "client",
+        otel.status_code = Empty,
+        otel.status_description = Empty,
+        "error.type" = Empty,
+        "http.request.method" = "POST",
+        "http.request.body.size" = body_size,
+        "http.response.status_code" = Empty,
+        "peer.service" = peer_service,
+        // Recorded by the caller: for ClickHouse it is only known after the
+        // per-org target resolves.
+        "server.address" = Empty,
+        "db.system.name" = Empty,
+        "db.operation.name" = Empty,
+        "db.namespace" = Empty,
+        "maple.ingest.datasource" = datasource,
+        "maple.ingest.attempt" = attempt,
+        "maple.ingest.row_count" = rows,
+        "maple.ingest.outcome" = Empty,
+        "maple.org_id" = Empty,
+    )
+}
+
+/// Per-org sampling-policy and attribute-mapping cache lookups. Parent of
+/// `postgres.query` when either 30s TTL expires.
+pub fn resolve_config_internal_span() -> Span {
+    info_span!(
+        "ingest.resolve_config",
+        otel.kind = "internal",
+        "maple.ingest.sampling_ratio" = Empty,
+        "maple.ingest.attribute_mapping_count" = Empty,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -219,6 +442,172 @@ mod tests {
             .iter()
             .find(|(k, _)| k.as_str() == key)
             .map(|(_, v)| v.to_string())
+    }
+
+    /// `tracing` only accepts `record()` for fields declared when the span was
+    /// constructed; recording anything else is a silent no-op. That is not a
+    /// compile error and produces no warning, so every deferred field has to be
+    /// asserted here against the site that fills it in.
+    fn assert_declares(span: &Span, fields: &[&str]) {
+        for field in fields {
+            assert!(
+                span.has_field(*field),
+                "span is missing field `{field}`; Span::record for it would silently no-op"
+            );
+        }
+    }
+
+    #[test]
+    fn accept_span_declares_fields_recorded_by_the_native_path() {
+        // Filled in by accept_native_decoded_payload (main.rs). These two were
+        // previously recorded on the server span, which never declared them —
+        // the attributes silently never appeared on any span.
+        assert_declares(
+            &accept_internal_span("traces", "clickhouse"),
+            &[
+                "maple.ingest.native_rows",
+                "maple.ingest.sampled_dropped",
+                "maple.ingest.destination",
+                "maple.signal",
+            ],
+        );
+    }
+
+    #[test]
+    fn auth_span_declares_fields_recorded_by_the_resolver() {
+        // `maple.ingest.cache_hit` is recorded from inside
+        // IngestKeyResolver::resolve_ingest_key; the rest by handle_signal_inner.
+        assert_declares(
+            &auth_internal_span(),
+            &[
+                "maple.ingest.cache_hit",
+                "maple.ingest.key_type",
+                "maple.ingest.key_id",
+                "maple.org_id",
+                "maple.ingest.self_managed",
+                "maple.ingest.clickhouse_ready",
+            ],
+        );
+    }
+
+    /// Every span that `record_stage_error` can be called on must declare its
+    /// three fields, or a failure records nothing at all — the worst case, since
+    /// that is exactly when the span is being read.
+    #[test]
+    fn every_fallible_span_declares_the_stage_error_fields() {
+        let fields = ["error.type", "otel.status_code", "otel.status_description"];
+        for span in [
+            auth_internal_span(),
+            decode_internal_span("gzip", 1),
+            parse_internal_span("protobuf", "traces"),
+            accept_internal_span("traces", "clickhouse"),
+            encode_rows_internal_span("traces"),
+            wal_commit_internal_span("tinybird"),
+            export_client_span("tinybird.export", "tinybird", "spans", 0, 1, 1),
+            grpc_server_span("svc", "traces"),
+        ] {
+            assert_declares(&span, &fields);
+        }
+    }
+
+    #[test]
+    fn wal_commit_span_declares_its_rejection_diagnostics() {
+        // Recorded by commit_frames / record_failing_frame / reserve_org_queue_bytes.
+        assert_declares(
+            &wal_commit_internal_span("clickhouse"),
+            &[
+                "maple.ingest.frames_committed",
+                "maple.ingest.shard",
+                "maple.ingest.lane",
+                "maple.ingest.datasource",
+                "maple.ingest.org_queue_bytes",
+                "maple.ingest.org_queue_limit_bytes",
+            ],
+        );
+    }
+
+    #[test]
+    fn export_span_declares_fields_recorded_by_both_destinations() {
+        // post_tinybird records the http/outcome fields; post_clickhouse also
+        // records the db.* and org fields via clickhouse_export_span.
+        assert_declares(
+            &export_client_span("clickhouse.export", "clickhouse", "spans", 2, 10, 100),
+            &[
+                "http.response.status_code",
+                "server.address",
+                "maple.ingest.outcome",
+                "maple.org_id",
+                "db.system.name",
+                "db.operation.name",
+                "db.namespace",
+            ],
+        );
+    }
+
+    #[test]
+    fn entitlement_span_declares_fields_recorded_by_the_billing_gate() {
+        // `maple.ingest.cache_hit` is recorded from inside
+        // AutumnEntitlements::is_allowed.
+        assert_declares(
+            &entitlement_internal_span("traces"),
+            &["maple.ingest.cache_hit", "maple.billing.allowed"],
+        );
+    }
+
+    #[test]
+    fn payload_spans_declare_their_deferred_fields() {
+        assert_declares(
+            &decode_internal_span("gzip", 1024),
+            &["maple.ingest.decoded_bytes"],
+        );
+        assert_declares(
+            &parse_internal_span("protobuf", "traces"),
+            &["maple.ingest.item_count"],
+        );
+        assert_declares(
+            &resolve_config_internal_span(),
+            &[
+                "maple.ingest.sampling_ratio",
+                "maple.ingest.attribute_mapping_count",
+            ],
+        );
+    }
+
+    #[test]
+    fn pipeline_spans_declare_fields_recorded_by_telemetry() {
+        // record_encode_stats and commit_frames (telemetry.rs).
+        assert_declares(
+            &encode_rows_internal_span("traces"),
+            &[
+                "maple.ingest.row_count",
+                "maple.ingest.frame_count",
+                "maple.ingest.sampled_dropped",
+            ],
+        );
+        assert_declares(
+            &wal_commit_internal_span("tinybird"),
+            &["maple.ingest.frame_count", "maple.ingest.queued_bytes"],
+        );
+    }
+
+    #[test]
+    fn grpc_span_declares_fields_recorded_by_the_tonic_services() {
+        // record_grpc_identity and record_grpc_outcome (main.rs).
+        assert_declares(
+            &grpc_server_span(
+                "opentelemetry.proto.collector.trace.v1.TraceService",
+                "traces",
+            ),
+            &[
+                "maple.org_id",
+                "maple.ingest.key_type",
+                "maple.ingest.destination",
+                "rpc.grpc.status_code",
+                "error.type",
+                "otel.status_code",
+                "otel.status_description",
+            ],
+        );
     }
 
     #[test]

--- a/apps/ingest/src/telemetry.rs
+++ b/apps/ingest/src/telemetry.rs
@@ -9,10 +9,14 @@ use std::time::{Duration, Instant};
 
 use crate::clickhouse_insert_mappings::{self, InsertMapping};
 use crate::metrics;
+use crate::otel::{
+    encode_rows_internal_span, export_client_span, record_stage_error, wal_commit_internal_span,
+};
 use crc32fast::Hasher as Crc32;
 use dashmap::DashMap;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use opentelemetry::trace::{SpanContext, TraceContextExt};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
@@ -28,6 +32,7 @@ use serde_json::{json, Map, Value};
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tracing::{error, info, warn, Instrument};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 const WAL_MAGIC: &[u8; 4] = b"MTW1";
 const WAL_V1_HEADER_LEN: usize = 20;
@@ -73,6 +78,90 @@ const LANES_PER_SHARD: usize = ExportDestination::ALL.len();
 /// `[shard0:tinybird, shard0:clickhouse, shard1:tinybird, ...]`.
 fn lane_index(shard: usize, destination: ExportDestination) -> usize {
     shard * LANES_PER_SHARD + destination.lane_ordinal()
+}
+
+/// The OTel SDK's default `max_links_per_span`. A single batch can carry
+/// thousands of frames, so links are capped here rather than silently dropped
+/// by the SDK; `maple.ingest.source_trace_count` reports what was truncated.
+const MAX_EXPORT_BATCH_LINKS: usize = 128;
+
+/// Distinct source trace contexts in a batch, deduped by trace id and capped.
+/// Returns the links to attach plus the total distinct count before truncation.
+fn collect_source_links(frames: &[QueuedFrame]) -> (Vec<SpanContext>, usize) {
+    let mut seen = std::collections::HashSet::new();
+    let mut links = Vec::new();
+    for frame in frames {
+        let Some(ctx) = frame.source_span.as_ref() else {
+            continue;
+        };
+        if !seen.insert(ctx.trace_id()) {
+            continue;
+        }
+        if links.len() < MAX_EXPORT_BATCH_LINKS {
+            links.push(ctx.clone());
+        }
+    }
+    (links, seen.len())
+}
+
+/// Host portion of a URL for the `server.address` span attribute, so the service
+/// map attributes a self-hosted or local endpoint to the right host instead of a
+/// hardcoded vendor domain. Falls back to `"unknown"` on an unparseable URL —
+/// this only feeds telemetry and must never fail the export.
+fn host_of(url: &str) -> String {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(|host| host.to_string()))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// One `clickhouse.export` attempt span. Built in several places in the retry
+/// loop because a ClickHouse batch can terminate before any HTTP call is made
+/// (circuit shed, unresolvable target, rejected endpoint) and those drops still
+/// need to be visible.
+fn clickhouse_export_span(
+    org_id: &str,
+    datasource: &str,
+    attempt: u32,
+    rows: usize,
+    compressed: &bytes::Bytes,
+) -> tracing::Span {
+    let span = export_client_span(
+        "clickhouse.export",
+        "clickhouse",
+        datasource,
+        attempt,
+        rows,
+        compressed.len(),
+    );
+    span.record("maple.org_id", org_id);
+    span.record("db.system.name", "clickhouse");
+    span.record("db.operation.name", "INSERT");
+    span
+}
+
+/// Pin the frame that failed onto the current `ingest.wal_commit` span. A commit
+/// fans out across shards, so only the failing frame's coordinates are useful.
+fn record_failing_frame(shard: usize, lane: usize, datasource: &str) {
+    let span = tracing::Span::current();
+    span.record("maple.ingest.shard", shard);
+    span.record("maple.ingest.lane", lane);
+    span.record("maple.ingest.datasource", datasource);
+}
+
+/// Fill in the deferred fields on an `ingest.encode_rows` span. Shared by the
+/// three OTLP accept paths, which differ only in which encoder they call.
+fn record_encode_stats(span: &tracing::Span, frames: &[EncodedFrame], stats: &AcceptStats) {
+    span.record("maple.ingest.row_count", stats.rows);
+    span.record("maple.ingest.frame_count", frames.len());
+    span.record("maple.ingest.sampled_dropped", stats.dropped);
+    span.record(
+        "maple.ingest.payload_bytes",
+        frames
+            .iter()
+            .map(|frame| frame.payload.len())
+            .sum::<usize>(),
+    );
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -478,6 +567,30 @@ impl std::fmt::Display for PipelineError {
 
 impl std::error::Error for PipelineError {}
 
+impl PipelineError {
+    /// Stable label for the `error.type` span attribute and log fields.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Backpressure(_) => "backpressure",
+            Self::Throttled(_) => "throttle",
+            Self::QueueUnavailable(_) => "queue_unavailable",
+            Self::Encode(_) => "encode",
+        }
+    }
+
+    /// Whether this is the gateway's fault rather than the caller's.
+    ///
+    /// Must stay in lockstep with `api_error_from_pipeline` in main.rs, which
+    /// maps the same split to 503 vs 429 — the two are asserted to agree in
+    /// `pipeline_error_fault_split_matches_http_status`.
+    pub fn is_server_fault(&self) -> bool {
+        match self {
+            Self::Backpressure(_) | Self::Throttled(_) => false,
+            Self::QueueUnavailable(_) | Self::Encode(_) => true,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct AcceptStats {
     pub rows: usize,
@@ -513,6 +626,11 @@ struct QueuedFrame {
     datasource: String,
     row_count: usize,
     payload: Vec<u8>,
+    /// Trace context of the request that enqueued this frame, so the export
+    /// batch can link back to it. In-memory only — deliberately not part of the
+    /// WAL frame, because a frame replayed after a restart belongs to a trace
+    /// that ended long ago. Replayed frames carry `None`.
+    source_span: Option<SpanContext>,
 }
 
 #[derive(Debug)]
@@ -615,13 +733,19 @@ impl TelemetryPipeline {
         attribute_mappings: &[AttributeMappingRule],
         destination: ExportDestination,
     ) -> Result<AcceptStats, PipelineError> {
-        let (frames, stats) = encode_traces(
-            &self.inner.cfg.datasources,
-            org_id,
-            request,
-            sampling_policy,
-            attribute_mappings,
-        )?;
+        let (frames, stats) = {
+            let span = encode_rows_internal_span("traces");
+            let _guard = span.enter();
+            let (frames, stats) = encode_traces(
+                &self.inner.cfg.datasources,
+                org_id,
+                request,
+                sampling_policy,
+                attribute_mappings,
+            )?;
+            record_encode_stats(&span, &frames, &stats);
+            (frames, stats)
+        };
         self.commit_frames(frames, destination).await?;
         Ok(stats)
     }
@@ -641,7 +765,13 @@ impl TelemetryPipeline {
         request: &ExportLogsServiceRequest,
         destination: ExportDestination,
     ) -> Result<AcceptStats, PipelineError> {
-        let (frames, stats) = encode_logs(&self.inner.cfg.datasources, org_id, request)?;
+        let (frames, stats) = {
+            let span = encode_rows_internal_span("logs");
+            let _guard = span.enter();
+            let (frames, stats) = encode_logs(&self.inner.cfg.datasources, org_id, request)?;
+            record_encode_stats(&span, &frames, &stats);
+            (frames, stats)
+        };
         self.commit_frames(frames, destination).await?;
         Ok(stats)
     }
@@ -661,7 +791,13 @@ impl TelemetryPipeline {
         request: &ExportMetricsServiceRequest,
         destination: ExportDestination,
     ) -> Result<AcceptStats, PipelineError> {
-        let (frames, stats) = encode_metrics(&self.inner.cfg.datasources, org_id, request)?;
+        let (frames, stats) = {
+            let span = encode_rows_internal_span("metrics");
+            let _guard = span.enter();
+            let (frames, stats) = encode_metrics(&self.inner.cfg.datasources, org_id, request)?;
+            record_encode_stats(&span, &frames, &stats);
+            (frames, stats)
+        };
         self.commit_frames(frames, destination).await?;
         Ok(stats)
     }
@@ -713,45 +849,86 @@ impl TelemetryPipeline {
             return Ok(());
         }
 
-        for mut frame in frames {
-            frame.destination = destination;
-            let shard = (frame.routing_key as usize) % self.inner.cfg.wal_shards;
-            // Route to the destination's own lane so a stalled ClickHouse export
-            // cannot fill the Tinybird channel for the same shard (and vice versa).
-            let lane = lane_index(shard, destination);
-            let sender = self.inner.lane_senders[lane].clone();
-            let permit = match sender.try_reserve_owned() {
-                Ok(permit) => permit,
-                Err(_) => {
-                    metrics::backpressure_shed(
-                        &frame.org_id,
-                        frame.destination.as_str(),
-                        frame.signal.as_str(),
-                    );
-                    return Err(PipelineError::Backpressure("Telemetry queue is full"));
-                }
-            };
-            let queued_bytes = frame.payload.len() as u64;
-            self.reserve_org_queue_bytes(&frame.org_id, queued_bytes)?;
-            let (start, end) = self.inner.wal.append(lane, &frame).await.map_err(|error| {
-                self.release_org_queue_bytes(&frame.org_id, queued_bytes);
-                PipelineError::QueueUnavailable(error)
-            })?;
-            permit.send(QueuedFrame {
-                shard,
-                start,
-                end,
-                org_id: frame.org_id,
-                queued_bytes,
-                signal: frame.signal,
-                destination: frame.destination,
-                datasource: frame.datasource,
-                row_count: frame.row_count,
-                payload: frame.payload,
-            });
-        }
+        let span = wal_commit_internal_span(destination.as_str());
+        let span_handle = span.clone();
+        let frame_count = frames.len();
+        let mut committed_bytes = 0u64;
+        let mut frames_committed = 0usize;
+        // Captured before entering the WAL span so the link points at the
+        // request's server span, not at `ingest.wal_commit` itself. An unsampled
+        // context would produce a link to a span that was never exported.
+        let source_span = tracing::Span::current()
+            .context()
+            .span()
+            .span_context()
+            .clone();
+        let source_span = source_span.is_sampled().then_some(source_span);
 
-        Ok(())
+        let result = async {
+            for mut frame in frames {
+                frame.destination = destination;
+                let shard = (frame.routing_key as usize) % self.inner.cfg.wal_shards;
+                // Route to the destination's own lane so a stalled ClickHouse export
+                // cannot fill the Tinybird channel for the same shard (and vice versa).
+                let lane = lane_index(shard, destination);
+                let sender = self.inner.lane_senders[lane].clone();
+                let permit = match sender.try_reserve_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        metrics::backpressure_shed(
+                            &frame.org_id,
+                            frame.destination.as_str(),
+                            frame.signal.as_str(),
+                        );
+                        // Which lane is full is the whole question when debugging
+                        // a 429: a stalled BYO-ClickHouse target backs up only its
+                        // own lane, and this is what shows that.
+                        record_failing_frame(shard, lane, &frame.datasource);
+                        return Err(PipelineError::Backpressure("Telemetry queue is full"));
+                    }
+                };
+                let queued_bytes = frame.payload.len() as u64;
+                self.reserve_org_queue_bytes(&frame.org_id, queued_bytes)
+                    .inspect_err(|_| record_failing_frame(shard, lane, &frame.datasource))?;
+                let (start, end) = self.inner.wal.append(lane, &frame).await.map_err(|error| {
+                    self.release_org_queue_bytes(&frame.org_id, queued_bytes);
+                    record_failing_frame(shard, lane, &frame.datasource);
+                    PipelineError::QueueUnavailable(error)
+                })?;
+                committed_bytes += queued_bytes;
+                frames_committed += 1;
+                permit.send(QueuedFrame {
+                    shard,
+                    start,
+                    end,
+                    org_id: frame.org_id,
+                    queued_bytes,
+                    signal: frame.signal,
+                    destination: frame.destination,
+                    datasource: frame.datasource,
+                    row_count: frame.row_count,
+                    payload: frame.payload,
+                    source_span: source_span.clone(),
+                });
+            }
+
+            Ok(())
+        }
+        .instrument(span)
+        .await;
+
+        span_handle.record("maple.ingest.frame_count", frame_count);
+        span_handle.record("maple.ingest.frames_committed", frames_committed);
+        span_handle.record("maple.ingest.queued_bytes", committed_bytes);
+        if let Err(error) = &result {
+            record_stage_error(
+                &span_handle,
+                error.kind(),
+                &error.to_string(),
+                error.is_server_fault(),
+            );
+        }
+        result
     }
 
     fn reserve_org_queue_bytes(&self, org_id: &str, bytes: u64) -> Result<(), PipelineError> {
@@ -769,6 +946,15 @@ impl TelemetryPipeline {
             let current = counter.load(Ordering::Relaxed);
             if current.saturating_add(bytes) > self.inner.cfg.org_queue_max_bytes {
                 metrics::org_throttled(org_id, "queue_bytes");
+                // Recorded on `ingest.wal_commit`: how far over the cap this org
+                // actually was, so a throttle can be told apart from a cap that
+                // is simply set too low.
+                let span = tracing::Span::current();
+                span.record("maple.ingest.org_queue_bytes", current);
+                span.record(
+                    "maple.ingest.org_queue_limit_bytes",
+                    self.inner.cfg.org_queue_max_bytes,
+                );
                 return Err(PipelineError::Throttled(
                     "Telemetry org queue byte limit exceeded",
                 ));
@@ -1075,6 +1261,8 @@ fn replay_shard(lane: usize, lane_ref: &WalShard) -> Result<Vec<QueuedFrame>, St
             datasource: frame.datasource,
             row_count: frame.row_count,
             payload: frame.payload,
+            // Replayed from disk after a restart: the originating trace is gone.
+            source_span: None,
         });
         offset = frame.end;
     }
@@ -1360,6 +1548,7 @@ impl ExportWorker {
     async fn run(mut self) {
         let mut buffer = Vec::new();
         while let Some(frame) = self.receiver.recv().await {
+            let batch_started = Instant::now();
             buffer.push(frame);
             let deadline = sleep(self.cfg.batch_max_wait);
             tokio::pin!(deadline);
@@ -1377,14 +1566,40 @@ impl ExportWorker {
 
             let frames = std::mem::take(&mut buffer);
             let batch_size = frames.len();
+            let batch_wait = batch_started.elapsed();
+            // A batch aggregates frames from many requests, so it stays a root
+            // span and links back to its sources rather than parenting under an
+            // arbitrarily-chosen one.
+            let (links, source_trace_count) = collect_source_links(&frames);
             let span = tracing::info_span!(
                 "ingest.export_batch",
                 otel.kind = "internal",
+                otel.status_code = tracing::field::Empty,
+                otel.status_description = tracing::field::Empty,
+                "error.type" = tracing::field::Empty,
                 "maple.ingest.shard" = self.shard,
+                "maple.ingest.lane" = self.lane,
                 "maple.ingest.destination" = self.destination.as_str(),
                 "maple.ingest.frame_count" = batch_size,
+                "maple.ingest.row_count" = frames.iter().map(|f| f.row_count).sum::<usize>(),
+                "maple.ingest.payload_bytes" =
+                    frames.iter().map(|f| f.payload.len()).sum::<usize>(),
+                // How long the batch sat in the lane before the worker picked it
+                // up — the difference between "export is slow" and "the queue is
+                // backed up", which the duration alone cannot tell you.
+                "maple.ingest.batch_wait_ms" = batch_wait.as_millis() as u64,
+                "maple.ingest.linked_traces" = links.len(),
+                "maple.ingest.source_trace_count" = source_trace_count,
             );
+            for link in links {
+                span.add_link(link);
+            }
+            let span_handle = span.clone();
             if let Err(error) = self.export_and_mark(frames).instrument(span).await {
+                // Reaching here means the WAL cursor did not advance, so the
+                // batch will be replayed — distinct from a per-destination drop,
+                // which returns Ok and is recorded on the export span.
+                record_stage_error(&span_handle, "export_batch", &error, true);
                 error!(shard = self.shard, error = %error, "Telemetry export worker failed batch");
             }
         }
@@ -1474,16 +1689,22 @@ impl ExportWorker {
         let compressed = bytes::Bytes::from(gzip(body)?);
         let max_attempts = self.cfg.export_max_attempts;
         let mut attempt = 0u32;
+        // The real host, not a hardcoded one — self-hosted and local Tinybird
+        // endpoints were previously all reported as `api.tinybird.co`, which
+        // makes the span useless for telling environments apart.
+        let server_address = host_of(&url);
         loop {
             let started = Instant::now();
-            let span = tracing::info_span!(
+            let span = export_client_span(
                 "tinybird.export",
-                otel.kind = "client",
-                "http.request.method" = "POST",
-                "server.address" = "api.tinybird.co",
-                "peer.service" = "tinybird",
-                "maple.ingest.datasource" = datasource,
+                "tinybird",
+                datasource,
+                attempt,
+                rows,
+                compressed.len(),
             );
+            span.record("server.address", server_address.as_str());
+            let span_handle = span.clone();
             let response = self
                 .http
                 .post(&url)
@@ -1498,6 +1719,8 @@ impl ExportWorker {
             let last_status: String;
             match response {
                 Ok(response) if response.status().is_success() => {
+                    span_handle.record("http.response.status_code", response.status().as_u16());
+                    span_handle.record("maple.ingest.outcome", "delivered");
                     metrics::tinybird_export_succeeded(
                         datasource,
                         started.elapsed().as_secs_f64(),
@@ -1508,6 +1731,11 @@ impl ExportWorker {
                 Ok(response) if response.status().is_client_error() => {
                     let status = response.status().as_u16();
                     let body = response.text().await.unwrap_or_default();
+                    span_handle.record("http.response.status_code", status);
+                    span_handle.record("maple.ingest.outcome", "dropped");
+                    // Terminal: these rows are gone. 4xx from Tinybird means we
+                    // sent bad data, so this one is genuinely ours.
+                    record_stage_error(&span_handle, "non_retryable", &body, true);
                     metrics::tinybird_export_dropped(datasource, &status.to_string(), rows as u64);
                     warn!(datasource, status, body = %body, rows, "Dropping non-retryable Tinybird batch");
                     return Ok(());
@@ -1515,11 +1743,17 @@ impl ExportWorker {
                 Ok(response) => {
                     let status = response.status().as_u16();
                     last_status = status.to_string();
+                    span_handle.record("http.response.status_code", status);
+                    span_handle.record("maple.ingest.outcome", "retry");
+                    span_handle.record("error.type", "upstream_5xx");
                     metrics::tinybird_export_retry(datasource, &last_status);
                     warn!(datasource, status, attempt, "Retrying Tinybird batch");
                 }
                 Err(error) => {
                     last_status = "transport".to_string();
+                    span_handle.record("maple.ingest.outcome", "retry");
+                    span_handle.record("error.type", "transport");
+                    span_handle.record("otel.status_description", error.to_string().as_str());
                     metrics::tinybird_export_retry(datasource, &last_status);
                     warn!(datasource, attempt, error = %error, "Retrying Tinybird batch after transport error");
                 }
@@ -1527,6 +1761,13 @@ impl ExportWorker {
 
             attempt = attempt.saturating_add(1);
             if attempt >= max_attempts {
+                span_handle.record("maple.ingest.outcome", "dropped");
+                record_stage_error(
+                    &span_handle,
+                    "retries_exhausted",
+                    &format!("{attempt} attempts, last status {last_status}"),
+                    true,
+                );
                 metrics::tinybird_export_dropped(datasource, "retries_exhausted", rows as u64);
                 error!(
                     datasource,
@@ -1571,6 +1812,11 @@ impl ExportWorker {
             // the retry budget. This bounds how long one unhealthy BYO-ClickHouse
             // target can starve co-sharded ClickHouse orgs.
             if self.clickhouse_breakers.decide(org_id, Instant::now()) == BreakerDecision::Shed {
+                // A shed makes no HTTP call, but it silently discards customer
+                // data — emit a span anyway or the drop is invisible in traces.
+                let span = clickhouse_export_span(org_id, datasource, attempt, rows, &compressed);
+                span.record("maple.ingest.outcome", "shed_circuit_open");
+                record_stage_error(&span, "circuit_open", "target circuit breaker open", true);
                 metrics::clickhouse_export_dropped(datasource, "circuit_open", rows as u64);
                 warn!(
                     org_id,
@@ -1588,10 +1834,20 @@ impl ExportWorker {
                 backoff(attempt).await;
             }
 
+            // Created before target resolution so `postgres.query` from the
+            // resolver nests under it and a resolution stall is attributable.
+            let span = clickhouse_export_span(org_id, datasource, attempt, rows, &compressed);
+
             let started = Instant::now();
-            let target = match self.resolve_clickhouse_target(org_id).await {
+            let target = match self
+                .resolve_clickhouse_target(org_id)
+                .instrument(span.clone())
+                .await
+            {
                 Ok(Some(target)) => target,
                 Ok(None) => {
+                    span.record("maple.ingest.outcome", "retry");
+                    span.record("error.type", "target_unavailable");
                     metrics::clickhouse_export_retry(datasource, "target_unavailable");
                     warn!(
                         org_id,
@@ -1602,6 +1858,13 @@ impl ExportWorker {
                     self.clickhouse_breakers.on_failure(org_id, Instant::now());
                     attempt = attempt.saturating_add(1);
                     if attempt >= max_attempts {
+                        span.record("maple.ingest.outcome", "dropped");
+                        record_stage_error(
+                            &span,
+                            "target_unavailable_exhausted",
+                            "no ready ClickHouse target resolved",
+                            true,
+                        );
                         metrics::clickhouse_export_dropped(
                             datasource,
                             "target_unavailable_exhausted",
@@ -1619,6 +1882,9 @@ impl ExportWorker {
                     continue;
                 }
                 Err(error) => {
+                    span.record("maple.ingest.outcome", "retry");
+                    span.record("error.type", "target_error");
+                    span.record("otel.status_description", error.as_str());
                     metrics::clickhouse_export_retry(datasource, "target_error");
                     warn!(
                         org_id,
@@ -1630,6 +1896,8 @@ impl ExportWorker {
                     self.clickhouse_breakers.on_failure(org_id, Instant::now());
                     attempt = attempt.saturating_add(1);
                     if attempt >= max_attempts {
+                        span.record("maple.ingest.outcome", "dropped");
+                        record_stage_error(&span, "target_error_exhausted", &error, true);
                         metrics::clickhouse_export_dropped(
                             datasource,
                             "target_error_exhausted",
@@ -1648,12 +1916,16 @@ impl ExportWorker {
                     continue;
                 }
             };
+            span.record("server.address", host_of(&target.endpoint).as_str());
+            span.record("db.namespace", target.database.as_str());
 
             let sql = build_clickhouse_insert_sql(mapping, org_id);
             let endpoint_url = target.endpoint.trim_end_matches('/').to_string();
             let mut request_url = match url::Url::parse(&endpoint_url) {
                 Ok(url) => url,
                 Err(error) => {
+                    span.record("maple.ingest.outcome", "dropped");
+                    record_stage_error(&span, "invalid_url", &error.to_string(), true);
                     metrics::clickhouse_export_dropped(datasource, "invalid_url", rows as u64);
                     error!(
                         org_id,
@@ -1667,6 +1939,13 @@ impl ExportWorker {
                 }
             };
             if !target.password.is_empty() && request_url.scheme() != "https" {
+                span.record("maple.ingest.outcome", "dropped");
+                record_stage_error(
+                    &span,
+                    "insecure_endpoint",
+                    "password-authenticated endpoint must use https",
+                    true,
+                );
                 metrics::clickhouse_export_dropped(datasource, "insecure_endpoint", rows as u64);
                 error!(
                     org_id,
@@ -1700,18 +1979,11 @@ impl ExportWorker {
                 request = request.header("X-ClickHouse-Key", target.password.as_str());
             }
 
-            let span = tracing::info_span!(
-                "clickhouse.export",
-                otel.kind = "client",
-                "http.request.method" = "POST",
-                "db.system.name" = "clickhouse",
-                "db.operation.name" = "INSERT",
-                "peer.service" = "clickhouse",
-                "maple.ingest.datasource" = datasource,
-            );
-            let response = request.send().instrument(span).await;
+            let response = request.send().instrument(span.clone()).await;
             match response {
                 Ok(response) if response.status().is_success() => {
+                    span.record("http.response.status_code", response.status().as_u16());
+                    span.record("maple.ingest.outcome", "delivered");
                     let bucket = status_bucket(response.status().as_u16());
                     metrics::clickhouse_export_succeeded(
                         datasource,
@@ -1727,9 +1999,12 @@ impl ExportWorker {
                     let status_code = status.as_u16();
                     let bucket = status_bucket(status_code);
                     let body = response.text().await.unwrap_or_default();
+                    span.record("http.response.status_code", status_code);
                     if !is_retryable_clickhouse_status(status_code) {
                         // Non-retryable (4xx) is the batch's fault, not the
                         // target's health — drop it without tripping the breaker.
+                        span.record("maple.ingest.outcome", "dropped");
+                        record_stage_error(&span, "non_retryable", &body, true);
                         metrics::clickhouse_export_dropped(datasource, bucket, rows as u64);
                         warn!(
                             org_id,
@@ -1741,6 +2016,9 @@ impl ExportWorker {
                         );
                         return Ok(ClickHouseExportOutcome::Dropped);
                     }
+                    span.record("maple.ingest.outcome", "retry");
+                    span.record("error.type", "upstream_5xx");
+                    span.record("otel.status_description", body.as_str());
                     metrics::clickhouse_export_retry(datasource, bucket);
                     warn!(
                         org_id,
@@ -1754,6 +2032,9 @@ impl ExportWorker {
                     last_status = bucket.to_string();
                 }
                 Err(error) => {
+                    span.record("maple.ingest.outcome", "retry");
+                    span.record("error.type", "transport");
+                    span.record("otel.status_description", error.to_string().as_str());
                     metrics::clickhouse_export_retry(datasource, "transport");
                     warn!(
                         org_id,
@@ -1769,6 +2050,13 @@ impl ExportWorker {
 
             attempt = attempt.saturating_add(1);
             if attempt >= max_attempts {
+                span.record("maple.ingest.outcome", "dropped");
+                record_stage_error(
+                    &span,
+                    "retries_exhausted",
+                    &format!("{attempt} attempts, last status {last_status}"),
+                    true,
+                );
                 metrics::clickhouse_export_dropped(datasource, "retries_exhausted", rows as u64);
                 error!(
                     org_id,
@@ -2607,6 +2895,62 @@ mod tests {
     use opentelemetry_proto::tonic::resource::v1::Resource;
     use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span, Status};
     use std::collections::HashMap;
+
+    fn sampled_context(trace: u128, span: u64) -> SpanContext {
+        SpanContext::new(
+            opentelemetry::trace::TraceId::from(trace),
+            opentelemetry::trace::SpanId::from(span),
+            opentelemetry::trace::TraceFlags::SAMPLED,
+            false,
+            opentelemetry::trace::TraceState::default(),
+        )
+    }
+
+    fn queued_frame_with_source(source_span: Option<SpanContext>) -> QueuedFrame {
+        QueuedFrame {
+            shard: 0,
+            start: 0,
+            end: 0,
+            org_id: "org_test".to_string(),
+            queued_bytes: 0,
+            signal: TelemetrySignal::Traces,
+            destination: ExportDestination::Tinybird,
+            datasource: "spans".to_string(),
+            row_count: 0,
+            payload: Vec::new(),
+            source_span,
+        }
+    }
+
+    #[test]
+    fn collect_source_links_dedupes_by_trace_id() {
+        // One request commits several frames (one per shard), so a batch holds
+        // many frames sharing a trace. The batch should link to it once.
+        let mut frames: Vec<QueuedFrame> = (1..=5)
+            .map(|i| queued_frame_with_source(Some(sampled_context(1, i))))
+            .collect();
+        frames.push(queued_frame_with_source(Some(sampled_context(2, 99))));
+        // Replayed-from-WAL frames carry no context and must not be linked.
+        frames.push(queued_frame_with_source(None));
+
+        let (links, total) = collect_source_links(&frames);
+        assert_eq!(links.len(), 2);
+        assert_eq!(total, 2);
+    }
+
+    #[test]
+    fn collect_source_links_caps_but_reports_the_true_total() {
+        let overflow = MAX_EXPORT_BATCH_LINKS + 10;
+        let frames: Vec<QueuedFrame> = (1..=overflow)
+            .map(|i| queued_frame_with_source(Some(sampled_context(i as u128, 1))))
+            .collect();
+
+        let (links, total) = collect_source_links(&frames);
+        // Truncated to the SDK's max_links_per_span, but the span still reports
+        // how many sources there really were.
+        assert_eq!(links.len(), MAX_EXPORT_BATCH_LINKS);
+        assert_eq!(total, overflow);
+    }
 
     #[derive(Debug)]
     struct FakeTinybirdImport {


### PR DESCRIPTION
## Why

An individual `POST /v1/traces` trace collapsed to **one span**. Verified against production before the change (`service.name=ingest`, `deployment.environment=production`):

| Trace | Spans |
|---|---|
| `POST /v1/traces` fast path, 2.5ms | 1 span, zero children |
| `POST /v1/traces` slow path, 187.6ms | 2 spans — the child is `postgres.query` @ 187.5ms |
| `ingest.export_batch`, 46.5ms | 3 spans, but a **separate root trace** |

It was not an exporter problem — the spans were never created. There are no `#[instrument]` attributes in the crate, and the OTLP path created exactly one span whose three possible children are each suppressed at steady state (`postgres.query` only on a cache miss, `autumn.check` only when `AUTUMN_ENFORCE_LIMITS=true`, `forward` only for non-ClickHouse orgs). Everything between "request arrives" and "bytes committed to WAL" ran bare inside the server span.

The per-stage histograms (`ingest_key_resolution_duration_seconds`, `ingest_native_accept_duration_seconds`, …) already gave p95 per stage globally. What was missing was per-request attribution: you could see *that* key resolution was slow at p99, never *that this request* was.

## What changed

**Child spans on the synchronous path.** `ingest.authenticate` / `.entitlement_check` / `.decode` / `.parse` / `.accept` / `.resolve_config` / `.encode_rows` / `.wal_commit`. Boundaries coincide with the existing duration histograms, so span and metric always agree and no new stopwatch logic was added. Sub-microsecond header/integer checks (body-size, content-type, in-flight limiter) deliberately get no span — they stay parent-span attributes.

**Failure annotation.** Every fallible stage records `error.type` and the rejection reason, which previously only reached a `warn!` log. Span status follows the rule already established by `otel_status_for_rejection`: only a server-side fault is `Error`, so caller-caused rejections stay `Ok` and don't flood the error dashboards. `PipelineError` gained `kind()` / `is_server_fault()`, with a test asserting that split can't drift from `api_error_from_pipeline`'s 429/503 mapping.

**Export batches link back to their sources.** `ingest.export_batch` stays a root — a batch aggregates frames from many requests and can't be parented under any one of them — and carries OTel span links instead, deduped by trace id and capped at the SDK's 128-link limit with `source_trace_count` reporting truncation. The context rides on `QueuedFrame` in memory only, never in the WAL frame, so frames replayed after a restart correctly carry none.

**Diagnostic attributes**, chosen for the questions that actually come up:

- `ingest.wal_commit` — `frames_committed` (a commit isn't atomic; on a 429 this is the difference between "nothing landed" and "half landed"), the failing frame's `shard`/`lane`/`datasource`, and on a quota rejection `org_queue_bytes` vs `org_queue_limit_bytes`
- `ingest.export_batch` — `row_count`, `payload_bytes`, `lane`, `batch_wait_ms` (separates "export is slow" from "queue is backed up")
- `ingest.authenticate` — `key_id`, the truncated HMAC already used in logs, to find the Postgres row without the key itself
- Export attempts — `attempt`, `row_count`, request/response sizes and status, and `outcome` (`delivered` / `retry` / `dropped` / `shed_circuit_open`)

**Fixes found along the way**

- ClickHouse drops that never issue an HTTP call (circuit-breaker shed, unresolvable target, rejected endpoint) produced **no span at all**. They now emit one — a silent discard of customer data is exactly what needs to be visible.
- `server.address` on Tinybird export spans was hardcoded to `api.tinybird.co`, mis-attributing self-hosted and local endpoints.
- `maple.ingest.native_rows` and `maple.ingest.sampled_dropped` were recorded on a span that never declared them, so both writes were **silent no-ops** and the attributes never appeared anywhere. Moved onto `ingest.accept`, which declares them.
- The gRPC path emitted **zero** spans, leaving `postgres.query` / `forward` as orphan roots. Added server spans to the three tonic services.
- `BatchSpanProcessor` raised to 8192/1024. A request now emits ~7 spans instead of 1; at 2048 the queue held only a few seconds of that volume, so a brief export stall dropped spans silently.

## Verification

Run against a local OTLP collector that decodes the real exported protobuf — not just the in-process span tree.

Happy path, 6 requests → 62 spans where it used to be 6:

```
5x  POST /v1/traces        parent=<root>
5x    ingest.authenticate  parent=POST /v1/traces
5x    ingest.decode        parent=POST /v1/traces
5x    ingest.parse         parent=POST /v1/traces
5x    ingest.accept        parent=POST /v1/traces
5x      ingest.resolve_config  parent=ingest.accept
6x      ingest.encode_rows     parent=ingest.accept
6x      ingest.wal_commit      parent=ingest.accept
6x  ingest.export_batch    parent=<root>   links=1
6x    tinybird.export      parent=ingest.export_batch
```

Failure paths, captured from the same run:

| Case | Span | Recorded |
|---|---|---|
| Unknown key (401) | `ingest.authenticate` | `error.type=auth`, `cache_hit=false`, status `Ok` |
| Bad gzip (400) | `ingest.decode` | `error.type=decode`, `content_encoding=gzip`, status `Ok` |
| Bad OTLP (400) | `ingest.parse` | `error.type=enrich` + rejection reason, status `Ok` |
| Tinybird 4xx drop | `tinybird.export` | `outcome=dropped`, status `Error`, message = upstream error text |

- 90 tests pass, stable across repeated runs (test count 83 → 90).
- `cargo bench --bench ingest_bench`: no measurable overhead (p=0.31 / 0.21, point estimates slightly negative) on a 4.6ms fsync-dominated path.
- Clippy is at exactly the 9 pre-existing findings on this crate — zero new. Note `cargo clippy -- -D warnings` does not pass on this crate today and did not before this change either.

## Reviewer notes

**Before merging, set `OTEL_TRACES_SAMPLER=parentbased_traceidratio` + `OTEL_TRACES_SAMPLER_ARG` in the Railway env.** No code change is needed — the SDK already reads them via `TracerProviderBuilder`'s derived `Default` — but this change roughly triples self-telemetry span volume (~104 → ~300 spans/s at current traffic). The queue bump absorbs a burst; head sampling is the real control.

**Terminal export drops will now surface as `Error` spans.** That's intended — data loss should be loud — but it is a visible change to the error dashboards, and it won't be zero: `ingest_clickhouse_export_dropped_total` climbed from 216,840 to 734,587 rows over the course of today (flat 14:00–19:00 UTC, then a burst). That is real, ongoing ClickHouse export data loss that is currently invisible in traces. Not investigated here — it's out of scope for this change, but worth a look.

One test-only wrinkle worth a glance: the span-tree test installs a **global** subscriber rather than a thread-local one. Callsite interest is cached process-wide, so with `set_default` a sibling test reaching a span macro first caches `Interest::never` and the span silently never gets created — the test was flaky 4 runs in 5. The global capture tags every record with its thread so concurrent tests filter out. Stable across 8 consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787696483&installation_model_id=427786&pr_number=267&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F267&signature=a1ac1d26e0c2fdf09dce71f6f28c9b22438dea9cace572330a8487484c2749d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->