### PR TITLE
fix(ci): unblock the orphan sweep by borrowing `pr-preview` (stopgap)

### DIFF
--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -39,12 +39,18 @@ concurrency:
 jobs:
     sweep:
         runs-on: blacksmith-4vcpu-ubuntu-2404
-        # Deliberately NOT in the `pr-preview` environment: its required manual
-        # approval exists to keep PR-controlled code away from secrets, but this
-        # job only ever runs trusted code from main — and approval would stall
-        # every scheduled run. If the Infisical machine identity's OIDC subject
-        # is scoped to the pr-preview environment, add a subject for
-        # `repo:<org>/<repo>:ref:refs/heads/main` in Infisical.
+        # MUST declare an environment, or Infisical rejects the OIDC token with
+        # 403 "Access denied: OIDC subject not allowed". GitHub derives the token's
+        # `sub` from the job: `repo:<org>/<repo>:environment:<name>` when an
+        # environment is set, `repo:<org>/<repo>:ref:refs/heads/main` otherwise.
+        # The machine identity only allowlists the `environment:` form (which is
+        # why deploy-prd/stg/pr-preview authenticate and an environment-less job
+        # cannot), so running bare silently broke every scheduled sweep.
+        # `pr-preview` is the right one to borrow: same `dev` Infisical env slug
+        # as deploy-pr-preview, and these are the very resources being swept.
+        # It carries no required reviewers and no deployment branch policy, so
+        # scheduled runs are not gated on approval.
+        environment: pr-preview
         env:
             INFISICAL_ENV_SLUG: dev
         steps:

--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -46,11 +46,20 @@ jobs:
         # The machine identity only allowlists the `environment:` form (which is
         # why deploy-prd/stg/pr-preview authenticate and an environment-less job
         # cannot), so running bare silently broke every scheduled sweep.
-        # `pr-preview` is the right one to borrow: same `dev` Infisical env slug
-        # as deploy-pr-preview, and these are the very resources being swept.
-        # It carries no required reviewers and no deployment branch policy, so
-        # scheduled runs are not gated on approval.
-        environment: pr-preview
+        #
+        # `maintenance` is a DEDICATED environment, deliberately not `pr-preview`:
+        # deploy-pr-preview.yml requires `pr-preview` to be approval-gated so
+        # PR-controlled code can't reach Infisical secrets unreviewed, and an
+        # approval gate on an unattended cron run would stall it forever —
+        # silently restoring the exact breakage this workflow exists to prevent.
+        #
+        # Two invariants keep this working; both live outside the repo:
+        #   1. `maintenance` must NEVER gain required reviewers or a deployment
+        #      branch policy (Settings > Environments) — scheduled runs have no
+        #      human to approve them.
+        #   2. `repo:<org>/<repo>:environment:maintenance` must stay allowlisted
+        #      as an OIDC subject on the Infisical machine identity.
+        environment: maintenance
         env:
             INFISICAL_ENV_SLUG: dev
         steps:

--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -39,27 +39,26 @@ concurrency:
 jobs:
     sweep:
         runs-on: blacksmith-4vcpu-ubuntu-2404
-        # MUST declare an environment, or Infisical rejects the OIDC token with
-        # 403 "Access denied: OIDC subject not allowed". GitHub derives the token's
-        # `sub` from the job: `repo:<org>/<repo>:environment:<name>` when an
-        # environment is set, `repo:<org>/<repo>:ref:refs/heads/main` otherwise.
-        # The machine identity only allowlists the `environment:` form (which is
-        # why deploy-prd/stg/pr-preview authenticate and an environment-less job
-        # cannot), so running bare silently broke every scheduled sweep.
+        # Deliberately NO `environment:`. GitHub derives the Infisical OIDC
+        # token's `sub` claim from the job shape:
+        #     with `environment: <name>` -> repo:<org>/<repo>:environment:<name>
+        #     without                    -> repo:<org>/<repo>:ref:refs/heads/<branch>
+        # Scheduled runs always execute the default branch, so this job's subject
+        # is `repo:<org>/<repo>:ref:refs/heads/main`. That subject MUST stay
+        # allowlisted on the Infisical machine identity — without it the secrets
+        # step fails with 403 "Access denied: OIDC subject not allowed", and since
+        # it is the first step, EVERY sweep below is skipped: the safety net stops
+        # running while orphaned PS-DEV branches keep billing.
         #
-        # `maintenance` is a DEDICATED environment, deliberately not `pr-preview`:
-        # deploy-pr-preview.yml requires `pr-preview` to be approval-gated so
-        # PR-controlled code can't reach Infisical secrets unreviewed, and an
-        # approval gate on an unattended cron run would stall it forever —
-        # silently restoring the exact breakage this workflow exists to prevent.
+        # Don't "fix" a 403 here by borrowing an environment. `pr-preview` must
+        # stay approval-gated (see deploy-pr-preview.yml) to keep PR-controlled
+        # code away from these secrets, and an approval gate on an unattended cron
+        # run stalls it until the deployment expires — silently recreating the
+        # breakage this workflow exists to prevent. Fix the allowlist instead.
         #
-        # Two invariants keep this working; both live outside the repo:
-        #   1. `maintenance` must NEVER gain required reviewers or a deployment
-        #      branch policy (Settings > Environments) — scheduled runs have no
-        #      human to approve them.
-        #   2. `repo:<org>/<repo>:environment:maintenance` must stay allowlisted
-        #      as an OIDC subject on the Infisical machine identity.
-        environment: maintenance
+        # Testing: `workflow_dispatch` from a non-default branch yields
+        # `...:ref:refs/heads/<that-branch>`, which is NOT allowlisted. Dispatch
+        # from main.
         env:
             INFISICAL_ENV_SLUG: dev
         steps:

--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -39,26 +39,30 @@ concurrency:
 jobs:
     sweep:
         runs-on: blacksmith-4vcpu-ubuntu-2404
-        # Deliberately NO `environment:`. GitHub derives the Infisical OIDC
-        # token's `sub` claim from the job shape:
+        # ⚠️ STOPGAP. This job borrows `pr-preview` purely to shape its Infisical
+        # OIDC subject — it deploys nothing and reads no environment secrets.
+        #
+        # GitHub derives the token's `sub` claim from the job shape:
         #     with `environment: <name>` -> repo:<org>/<repo>:environment:<name>
         #     without                    -> repo:<org>/<repo>:ref:refs/heads/<branch>
-        # Scheduled runs always execute the default branch, so this job's subject
-        # is `repo:<org>/<repo>:ref:refs/heads/main`. That subject MUST stay
-        # allowlisted on the Infisical machine identity — without it the secrets
-        # step fails with 403 "Access denied: OIDC subject not allowed", and since
-        # it is the first step, EVERY sweep below is skipped: the safety net stops
-        # running while orphaned PS-DEV branches keep billing.
+        # Only the environment form is allowlisted on the machine identity, so an
+        # environment-less job fails the secrets step with 403 "Access denied:
+        # OIDC subject not allowed" — and because that step is FIRST, every sweep
+        # below is skipped while orphaned PS-DEV branches keep billing.
         #
-        # Don't "fix" a 403 here by borrowing an environment. `pr-preview` must
-        # stay approval-gated (see deploy-pr-preview.yml) to keep PR-controlled
-        # code away from these secrets, and an approval gate on an unattended cron
-        # run stalls it until the deployment expires — silently recreating the
-        # breakage this workflow exists to prevent. Fix the allowlist instead.
+        # ⚠️ This creates a CONFLICT with deploy-pr-preview.yml, which requires
+        # `pr-preview` to be approval-gated so PR-controlled code can't reach
+        # these secrets unreviewed. This job requires the opposite: no required
+        # reviewers. A cron run has no human to approve it, so a gate parks it in
+        # `waiting` until the deployment expires — silently restoring the exact
+        # breakage this workflow exists to prevent. Both cannot hold at once.
         #
-        # Testing: `workflow_dispatch` from a non-default branch yields
-        # `...:ref:refs/heads/<that-branch>`, which is NOT allowlisted. Dispatch
-        # from main.
+        # PROPER FIX (needs Infisical dashboard access): allowlist the subject
+        # `repo:<org>/<repo>:ref:refs/heads/main`, then delete the `environment:`
+        # line below. The job then needs no environment at all and `pr-preview`
+        # is free to regain its gate. Until then, do not add required reviewers
+        # to `pr-preview`.
+        environment: pr-preview # STOPGAP — remove once the ref subject is allowlisted
         env:
             INFISICAL_ENV_SLUG: dev
         steps:

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -25,6 +25,14 @@ jobs:
         # `pr-preview` environment must require manual approval in repo settings.
         # This blocks PR-controlled code (install scripts, build steps) from
         # accessing Infisical secrets until a maintainer reviews the diff.
+        #
+        # ⚠️ NOT CURRENTLY CONFIGURED, and adding it right now would break the
+        # scheduled orphan sweep: cleanup-preview-orphans.yml temporarily borrows
+        # this environment to satisfy the Infisical OIDC subject allowlist, and a
+        # cron run has no human to approve it — it would park in `waiting` until
+        # the deployment expires. Decouple that job first (allowlist the subject
+        # `repo:<org>/<repo>:ref:refs/heads/main` in Infisical and drop its
+        # `environment:` line), THEN add required reviewers here.
         # `url` surfaces the deployed web app as a clickable deployment on the PR
         # (empty on `closed`, when the deploy step is skipped).
         environment:


### PR DESCRIPTION
> **This is a deliberate stopgap.** It repairs the sweep with no dashboard access required. It also knowingly re-creates a coupling that must be undone later — see *Follow-up* at the bottom. Merging is safe; leaving it forever is not.

## The bug

**Every** scheduled `Cleanup Preview Orphans` run has failed — 12 for 12 ([latest](https://github.com/MapleTechLabs/maple/actions/runs/30257042719)). Each dies ~20s in, at *Load deployment secrets from Infisical*:

```
##[error]Access denied: OIDC subject not allowed.
{"statusCode": 403, "message": "Access denied: OIDC subject not allowed.", "error": "ForbiddenError"}
```

The secrets step is first, so **every sweep step after it is skipped**. The safety net for orphaned PlanetScale branches, Electric Cloud environments, Tinybird branches, and Hyperdrive configs has not run at all. PS-DEV branches bill continuously and Hyperdrive configs are capped at 25 per account — this fails in the expensive direction while looking like a routine red check.

> Unrelated: the log tail also shows `fatal: No url found for submodule path '.context/alchemy-effect/vendor/alchemy' in .gitmodules`. That is a **post-job cleanup warning** (a gitlink in the index with no `.gitmodules`), not this failure.

## Root cause

GitHub derives the OIDC token's `sub` claim from the job shape:

| job declares | `sub` claim |
| --- | --- |
| `environment: <name>` | `repo:<org>/<repo>:environment:<name>` |
| *(no environment)* | `repo:<org>/<repo>:ref:refs/heads/<branch>` |

The Infisical machine identity only allowlists the **environment** form. That is why `deploy-prd` (`production`), `deploy-stg` (`staging`) and `deploy-pr-preview` (`pr-preview`) all authenticate, and this job — the only Infisical consumer without an environment — never could. The repo uses the default subject template (`use_default: true`), so no custom claim is involved.

## The fix (and why this one)

Declare `environment: pr-preview`, reusing a subject that is **already allowlisted**. No Infisical change, so this lands immediately.

The clean fix is to allowlist `repo:MapleTechLabs/maple:ref:refs/heads/main` and drop the environment entirely — the job deploys nothing and reads no environment secrets, so an environment is pure ceremony to shape a claim. That needs dashboard access which isn't available right now, hence the stopgap.

`Production` was the other reusable subject (`staging` does not exist as an environment — 404 — and `Deploy STG` is `disabled_manually`), but a cleanup cron authenticating as production, and emitting a Production deployment record every 6 hours, is worse.

Verified `pr-preview` has **no** environment-scoped secrets or variables, so secret resolution is unchanged — only the OIDC subject differs.

## The tradeoff, stated plainly

[Devin flagged this coupling](https://github.com/MapleTechLabs/maple/pull/268) on an earlier revision and was right. `deploy-pr-preview.yml:25-27` requires `pr-preview` to be approval-gated so PR-controlled code can't reach Infisical secrets unreviewed. This job requires the opposite — no required reviewers, because a cron run has no human to approve it and would park in `waiting` until the deployment expired.

Both cannot hold. Accepted knowingly, and documented in **both** files so it can't rot into looking intentional:

- the sweep is marked `STOPGAP` with the exact removal steps;
- `deploy-pr-preview.yml` now warns that its own stated control **cannot be enabled** until the sweep is decoupled first.

Note that gate is not configured today (`protection_rules: []`), so this PR does not weaken anything currently in force — it does block restoring it until the follow-up lands.

## Verification

Unlike the ref-based approach, an environment subject is branch-independent, so this **can** be tested before merge:

```
gh workflow run cleanup-preview-orphans.yml --ref ci/orphan-sweep-oidc-subject
```

Expect the sweep steps to newly execute. After days of never running, the first green run may delete a real backlog of orphans — intended, but worth watching the first time. No regression risk: the workflow currently fails 100% of the time.

## Follow-up (required)

1. Allowlist subject `repo:MapleTechLabs/maple:ref:refs/heads/main` on the Infisical machine identity.
2. Delete the `environment: pr-preview` line from `cleanup-preview-orphans.yml`.
3. Add required reviewers to `pr-preview`, restoring the control `deploy-pr-preview.yml` documents.

Strictly in that order — 3 before 2 breaks the sweep again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)