### PR TITLE
fix(web): stop the investigation header and chips overflowing, and give the rail the run

### DIFF
--- a/apps/web/src/components/ai-elements/suggestion.test.tsx
+++ b/apps/web/src/components/ai-elements/suggestion.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { Suggestion } from "./suggestion"
+
+afterEach(() => {
+	cleanup()
+})
+
+const LONG =
+	"Diagnose subscriptions-api public endpoints (GET /public/v1/users/:appUserIdOrDeviceId/entitlements)"
+
+/**
+ * A class-contract test, not a layout one — jsdom applies no stylesheet, so it
+ * cannot measure the overflow this guards against (the browser pass does that).
+ * What it can pin is the combination that caused it: `whitespace-normal` lets
+ * text wrap, `buttonVariants({size:"sm"})` pins the pill to `sm:h-7`, and
+ * `twMerge` cannot reconcile the two because they are different modifier groups.
+ * Reintroducing either half fails here.
+ */
+describe("Suggestion", () => {
+	it("never lets its text wrap", () => {
+		render(<Suggestion suggestion={LONG} />)
+		const pill = screen.getByRole("button")
+		expect(pill.className).not.toContain("whitespace-normal")
+		expect(pill.className).not.toContain("h-auto")
+	})
+
+	it("truncates the label rather than growing the pill", () => {
+		render(<Suggestion suggestion={LONG} />)
+		const label = screen.getByText(LONG)
+		expect(label.className).toContain("truncate")
+		expect(label.className).toContain("min-w-0")
+	})
+
+	it("keeps the full text reachable when it truncates", () => {
+		render(<Suggestion suggestion={LONG} />)
+		expect(screen.getByRole("button").getAttribute("title")).toBe(LONG)
+	})
+
+	it("leaves the title off when the caller supplies its own label", () => {
+		render(<Suggestion suggestion={LONG}>Short label</Suggestion>)
+		expect(screen.getByRole("button").getAttribute("title")).toBeNull()
+	})
+})

--- a/apps/web/src/components/ai-elements/suggestion.tsx
+++ b/apps/web/src/components/ai-elements/suggestion.tsx
@@ -19,6 +19,18 @@ export type SuggestionProps = Omit<ComponentProps<typeof Button>, "onClick"> & {
 	onClick?: (suggestion: string) => void
 }
 
+/**
+ * A one-line pill. Deliberately not a wrapping one: this previously set
+ * `h-auto … whitespace-normal`, and `twMerge` does resolve `h-auto` against the
+ * `h-8` in `buttonVariants({size:"sm"})` — but that variant also carries
+ * `sm:h-7`, which is a *different* modifier group and survives the merge. Above
+ * 640px the pill stayed locked at 1.75rem while its text wrapped freely, so long
+ * suggestions spilled over the border and collided with the row below.
+ *
+ * So the height belongs to the size variant and the text truncates instead. The
+ * cap is a backstop — a suggestion long enough to reach it is a generator bug
+ * (see `investigationSuggestions`), not something to design around.
+ */
 export const Suggestion = ({
 	suggestion,
 	onClick,
@@ -34,17 +46,15 @@ export const Suggestion = ({
 
 	return (
 		<Button
-			className={cn(
-				"h-auto min-h-7 max-w-full cursor-pointer whitespace-normal rounded-full px-4 py-1.5 text-left",
-				className,
-			)}
+			className={cn("max-w-[min(100%,24rem)] cursor-pointer rounded-full px-3.5", className)}
 			onClick={handleClick}
 			size={size}
+			title={children ? undefined : suggestion}
 			type="button"
 			variant={variant}
 			{...props}
 		>
-			{children || suggestion}
+			<span className="min-w-0 truncate">{children || suggestion}</span>
 		</Button>
 	)
 }

--- a/apps/web/src/components/anomalies/anomaly-sidebar.tsx
+++ b/apps/web/src/components/anomalies/anomaly-sidebar.tsx
@@ -17,6 +17,7 @@ import {
 	TRIAGE_STATUS_CHIP,
 } from "./anomaly-format"
 import { ServiceDot } from "@maple/ui/components/service-dot"
+import { DetailRail } from "@/components/common/detail-rail"
 
 export function AnomalySidebar({
 	incident,
@@ -40,7 +41,7 @@ export function AnomalySidebar({
 
 	return (
 		<div className="flex h-full w-72 shrink-0 flex-col overflow-y-auto border-l bg-card/30">
-			<SidebarGroup label="Actions">
+			<DetailRail.Group label="Actions">
 				{isOpen ? (
 					<Button
 						size="sm"
@@ -68,10 +69,10 @@ export function AnomalySidebar({
 						Unlink {shortIssueId(incident.errorIssueId)}
 					</Button>
 				)}
-			</SidebarGroup>
+			</DetailRail.Group>
 
-			<SidebarGroup label="Details">
-				<Row label="State">
+			<DetailRail.Group label="Details">
+				<DetailRail.Row label="State">
 					<span className="text-right text-sm text-foreground">
 						{isStale
 							? `stale · last seen ${formatRelativeTime(incident.lastTriggeredAt)}`
@@ -79,11 +80,11 @@ export function AnomalySidebar({
 								? "open"
 								: "resolved"}
 					</span>
-				</Row>
-				<Row label="Signal">
+				</DetailRail.Row>
+				<DetailRail.Row label="Signal">
 					<span className="text-sm text-foreground">{SIGNAL_LABEL[incident.signalType]}</span>
-				</Row>
-				<Row label="Severity">
+				</DetailRail.Row>
+				<DetailRail.Row label="Severity">
 					<span
 						className={cn(
 							"text-sm font-medium",
@@ -92,32 +93,32 @@ export function AnomalySidebar({
 					>
 						{incident.severity}
 					</span>
-				</Row>
-				<Row label="Service" title={incident.serviceName}>
+				</DetailRail.Row>
+				<DetailRail.Row label="Service" title={incident.serviceName}>
 					<span className="flex min-w-0 items-center gap-2">
 						<ServiceDot serviceName={incident.serviceName} className="size-1.5" />
 						<span className="truncate text-sm text-foreground">{incident.serviceName}</span>
 					</span>
-				</Row>
-				<Row label="Environment">
+				</DetailRail.Row>
+				<DetailRail.Row label="Environment">
 					<span className="text-sm text-foreground">{incident.deploymentEnv || "—"}</span>
-				</Row>
-				<Row label="Detector" title={incident.detectorKey}>
+				</DetailRail.Row>
+				<DetailRail.Row label="Detector" title={incident.detectorKey}>
 					<code className="block max-w-full truncate font-mono text-xs text-muted-foreground">
 						{incident.detectorKey}
 					</code>
-				</Row>
+				</DetailRail.Row>
 				{incident.fingerprintHash !== null ? (
-					<Row label="Fingerprint" title={incident.fingerprintHash}>
+					<DetailRail.Row label="Fingerprint" title={incident.fingerprintHash}>
 						<code className="block max-w-full truncate font-mono text-xs text-muted-foreground">
 							{incident.fingerprintHash}
 						</code>
-					</Row>
+					</DetailRail.Row>
 				) : null}
-			</SidebarGroup>
+			</DetailRail.Group>
 
-			<SidebarGroup label="Values">
-				<Row label="Observed">
+			<DetailRail.Group label="Values">
+				<DetailRail.Row label="Observed">
 					<span
 						className={cn(
 							"font-mono text-sm tabular-nums",
@@ -126,23 +127,23 @@ export function AnomalySidebar({
 					>
 						{fmt(incident.lastObservedValue)}
 					</span>
-				</Row>
-				<Row label="At open">
+				</DetailRail.Row>
+				<DetailRail.Row label="At open">
 					<span className="font-mono text-sm tabular-nums text-muted-foreground">
 						{fmt(incident.openedValue)}
 					</span>
-				</Row>
-				<Row label="Baseline">
+				</DetailRail.Row>
+				<DetailRail.Row label="Baseline">
 					<span className="font-mono text-sm tabular-nums text-muted-foreground">
 						{fmt(incident.baselineMedian)}
 					</span>
-				</Row>
-				<Row label="Threshold">
+				</DetailRail.Row>
+				<DetailRail.Row label="Threshold">
 					<span className="font-mono text-sm tabular-nums text-muted-foreground">
 						{fmt(incident.thresholdValue)}
 					</span>
-				</Row>
-				<Row label="Deviation">
+				</DetailRail.Row>
+				<DetailRail.Row label="Deviation">
 					<span
 						className={cn(
 							"font-mono text-sm tabular-nums",
@@ -151,16 +152,16 @@ export function AnomalySidebar({
 					>
 						{dev.label}
 					</span>
-				</Row>
-				<Row label="Samples">
+				</DetailRail.Row>
+				<DetailRail.Row label="Samples">
 					<span className="font-mono text-sm tabular-nums text-muted-foreground">
 						{incident.lastSampleCount.toLocaleString()}
 					</span>
-				</Row>
-			</SidebarGroup>
+				</DetailRail.Row>
+			</DetailRail.Group>
 
 			{incident.fingerprints.length > 1 ? (
-				<SidebarGroup label={`Grouped errors · ${incident.fingerprints.length}`}>
+				<DetailRail.Group label={`Grouped errors · ${incident.fingerprints.length}`}>
 					{incident.fingerprints.map((fingerprint) => (
 						<div
 							key={fingerprint.fingerprintHash}
@@ -198,45 +199,45 @@ export function AnomalySidebar({
 							</span>
 						</div>
 					))}
-				</SidebarGroup>
+				</DetailRail.Group>
 			) : null}
 
-			<SidebarGroup label="Timing">
-				<Row label="First triggered" title={new Date(incident.firstTriggeredAt).toLocaleString()}>
+			<DetailRail.Group label="Timing">
+				<DetailRail.Row label="First triggered" title={new Date(incident.firstTriggeredAt).toLocaleString()}>
 					<span className="text-right text-sm tabular-nums text-foreground">
 						{formatRelativeTime(incident.firstTriggeredAt)}
 					</span>
-				</Row>
+				</DetailRail.Row>
 				{incident.reopenCount > 0 && incident.lastReopenedAt !== null ? (
-					<Row label="Reopened" title={new Date(incident.lastReopenedAt).toLocaleString()}>
+					<DetailRail.Row label="Reopened" title={new Date(incident.lastReopenedAt).toLocaleString()}>
 						<span className="text-right text-sm tabular-nums text-muted-foreground">
 							{formatRelativeTime(incident.lastReopenedAt)}
 							{incident.reopenCount > 1 ? ` (×${incident.reopenCount})` : ""}
 						</span>
-					</Row>
+					</DetailRail.Row>
 				) : null}
-				<Row label="Last triggered" title={new Date(incident.lastTriggeredAt).toLocaleString()}>
+				<DetailRail.Row label="Last triggered" title={new Date(incident.lastTriggeredAt).toLocaleString()}>
 					<span className="text-right text-sm tabular-nums text-foreground">
 						{formatRelativeTime(incident.lastTriggeredAt)}
 					</span>
-				</Row>
+				</DetailRail.Row>
 				{incident.resolvedAt !== null ? (
-					<Row label="Resolved" title={new Date(incident.resolvedAt).toLocaleString()}>
+					<DetailRail.Row label="Resolved" title={new Date(incident.resolvedAt).toLocaleString()}>
 						<span className="text-right text-sm tabular-nums text-muted-foreground">
 							{formatRelativeTime(incident.resolvedAt)}
 						</span>
-					</Row>
+					</DetailRail.Row>
 				) : null}
 				{incident.resolveReason !== null ? (
-					<Row label="Reason">
+					<DetailRail.Row label="Reason">
 						<span className="text-right text-sm text-muted-foreground">
 							{RESOLVE_REASON_LABEL[incident.resolveReason]}
 						</span>
-					</Row>
+					</DetailRail.Row>
 				) : null}
-			</SidebarGroup>
+			</DetailRail.Group>
 
-			<SidebarGroup label="Triage">
+			<DetailRail.Group label="Triage">
 				{triageChip ? (
 					<span
 						className={cn(
@@ -249,27 +250,9 @@ export function AnomalySidebar({
 				) : (
 					<p className="text-xs text-muted-foreground">No AI triage has run for this incident.</p>
 				)}
-			</SidebarGroup>
+			</DetailRail.Group>
 		</div>
 	)
 }
 
-function SidebarGroup({ label, children }: { label: string; children: React.ReactNode }) {
-	return (
-		<section className="flex flex-col gap-2 border-b border-border/40 p-4 last:border-b-0">
-			<h3 className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-				{label}
-			</h3>
-			<div className="flex flex-col gap-1">{children}</div>
-		</section>
-	)
-}
 
-function Row({ label, title, children }: { label: string; title?: string; children: React.ReactNode }) {
-	return (
-		<div title={title} className="grid min-h-8 grid-cols-[88px_1fr] items-center gap-x-3 py-0.5">
-			<span className="text-xs text-muted-foreground">{label}</span>
-			<div className="flex min-w-0 items-center justify-end">{children}</div>
-		</div>
-	)
-}

--- a/apps/web/src/components/chat/diagnosis-report-card.tsx
+++ b/apps/web/src/components/chat/diagnosis-report-card.tsx
@@ -3,8 +3,9 @@ import { Card } from "@maple/ui/components/ui/card"
 import type { AiTriageResult } from "@maple/domain/http"
 import { PulseIcon } from "@/components/icons"
 
-const CONFIDENCE_TONE: Record<string, string> = {
-	high: "text-severity-ok",
+/** Shared with the investigation rail so the card and the rail never disagree. */
+export const CONFIDENCE_TONE: Record<string, string> = {
+	high: "text-success",
 	medium: "text-severity-warn",
 	low: "text-muted-foreground",
 }

--- a/apps/web/src/components/chat/investigation-context.test.ts
+++ b/apps/web/src/components/chat/investigation-context.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+
+import {
+	chipPhrase,
+	chipScope,
+	investigationSuggestions,
+	type InvestigationContext,
+} from "./investigation-context"
+
+const alert = (overrides: Partial<InvestigationContext> = {}): InvestigationContext => ({
+	kind: "alert",
+	id: "inc_1",
+	title: "p99 latency breached",
+	severity: "critical",
+	status: "Firing",
+	facts: [],
+	...overrides,
+})
+
+/**
+ * The paragraph a system-seeded investigation actually carried in `snapshot.scope`,
+ * which `Diagnose ${scope}` rendered verbatim into a chip.
+ */
+const PARAGRAPH =
+	"subscriptions-api public endpoints (GET /public/v1/users/:appUserIdOrDeviceId/entitlements " +
+	"and POST /public/v1/redeem) are experiencing severe tail latency (p99 > 10 s) for a large " +
+	"fraction of traffic (≈77 k samples in the 10-min alert window)."
+
+describe("chipScope", () => {
+	it("keeps a short scope untouched", () => {
+		expect(chipScope("subscriptions-api")).toBe("subscriptions-api")
+	})
+
+	it("reduces a paragraph to its subject", () => {
+		expect(chipScope(PARAGRAPH)).toBe("subscriptions-api")
+	})
+
+	it("keeps a multi-word clause that is short enough to be a real scope", () => {
+		expect(chipScope("checkout-api /v1/orders")).toBe("checkout-api /v1/orders")
+	})
+
+	it("hard-caps a single token with nowhere to cut", () => {
+		const scope = chipScope("a".repeat(200))
+		expect(scope).toHaveLength(32)
+		expect(scope.endsWith("…")).toBe(true)
+	})
+
+	it("falls back to the raw text when the head is empty", () => {
+		expect(chipScope("(all)")).toBe("(all)")
+	})
+})
+
+describe("chipPhrase", () => {
+	it("keeps a short exception message whole", () => {
+		expect(chipPhrase("The connection was closed.")).toBe("The connection was closed.")
+	})
+
+	it("truncates a message rather than lifting a word out of it", () => {
+		const label = chipPhrase('{ "namespace": "config-api", "group": "v1-web-paywall-domain" }')
+		expect(label).toHaveLength(36)
+		expect(label.startsWith('{ "namespace"')).toBe(true)
+	})
+
+	it("stops at the first line", () => {
+		expect(chipPhrase("Boom\n  at handler (app.ts:12)")).toBe("Boom")
+	})
+})
+
+describe("investigationSuggestions", () => {
+	it("uses the latency branch once the signal is known", () => {
+		const suggestions = investigationSuggestions(
+			alert({ signalType: "p99_latency", scope: "subscriptions-api" }),
+		)
+		expect(suggestions).toContain("Slowest operations in subscriptions-api right now")
+		expect(suggestions.some((s) => s.startsWith("Diagnose "))).toBe(false)
+	})
+
+	it("keeps every suggestion short enough for a one-line chip", () => {
+		const suggestions = investigationSuggestions(
+			alert({ signalType: "p99_latency", scope: PARAGRAPH }),
+		)
+		for (const suggestion of suggestions) {
+			expect(suggestion.length).toBeLessThanOrEqual(72)
+		}
+	})
+
+	it("offers follow-ups on the report instead of asking for a diagnosis it already has", () => {
+		const suggestions = investigationSuggestions(
+			alert({ scope: PARAGRAPH, aiSuspectedCause: "Vitess cluster degradation" }),
+		)
+		expect(suggestions).toContain("What would confirm this?")
+		expect(suggestions.some((s) => s.includes("public endpoints"))).toBe(false)
+	})
+
+	it("clamps a JSON-blob exception message out of the error prompts", () => {
+		const suggestions = investigationSuggestions(
+			alert({
+				kind: "error",
+				title: '{ "namespace": "config-api", "group": "v1-web-paywall-domain", "groupKey": "superwall" }',
+			}),
+		)
+		for (const suggestion of suggestions) {
+			expect(suggestion.length).toBeLessThanOrEqual(72)
+		}
+	})
+
+	it("still falls back to the generic branch when no signal is carried", () => {
+		expect(investigationSuggestions(alert({ scope: "checkout-api" }))).toEqual([
+			"Diagnose checkout-api",
+			"Recent errors in checkout-api",
+			"Slowest traces in checkout-api",
+		])
+	})
+})

--- a/apps/web/src/components/chat/investigation-context.ts
+++ b/apps/web/src/components/chat/investigation-context.ts
@@ -132,10 +132,58 @@ const KIND_NOUN: Record<InvestigationKind, string> = {
 
 export const investigationNoun = (kind: InvestigationKind): string => KIND_NOUN[kind]
 
+/**
+ * A scope short enough to sit inside a chip. `scope` is free text: an alert group
+ * key is a handful of characters, but a system-seeded investigation can carry a
+ * whole sentence the model wrote, and `Slowest traces in ${scope}` then renders a
+ * paragraph as a button. Cut at the first clause boundary — the head of such a
+ * sentence is reliably the subject ("subscriptions-api public endpoints (GET …)"
+ * → "subscriptions-api") — then hard-cap whatever survives.
+ */
+const CHIP_SCOPE_MAX = 32
+
+export const chipScope = (raw: string): string => {
+	const head = raw.split(/[(\n,;—]/)[0]!.trim()
+	const text = head.length > 0 ? head : raw.trim()
+	if (text.length <= CHIP_SCOPE_MAX) return text
+	// A clause this long isn't a scope, it's a sentence — and the subject of that
+	// sentence is its first word ("subscriptions-api public endpoints …" →
+	// "subscriptions-api"). Prefer that whole word over a mid-word ellipsis.
+	const first = text.split(/\s+/)[0]!
+	return first.length > CHIP_SCOPE_MAX ? `${first.slice(0, CHIP_SCOPE_MAX - 1).trimEnd()}…` : first
+}
+
+const CHIP_PHRASE_MAX = 36
+
+/**
+ * The same problem as {@link chipScope} for a different field. An error
+ * investigation's title is the exception message, which is routinely a sentence
+ * and sometimes a blob of JSON, and `Sample stack traces for ${title}` inherits
+ * whatever it is. Unlike a scope there is no subject word to lift out — the
+ * front of a message *is* the identifying part — so this truncates instead.
+ */
+export const chipPhrase = (raw: string): string => {
+	const text = raw.split("\n")[0]!.trim()
+	return text.length > CHIP_PHRASE_MAX ? `${text.slice(0, CHIP_PHRASE_MAX - 1).trimEnd()}…` : text
+}
+
 /** Starter prompts tuned to the kind + signal + scope of the investigation. */
 export const investigationSuggestions = (ctx: InvestigationContext): string[] => {
-	const scope = ctx.scope ?? ctx.refs?.serviceName ?? "the affected service"
+	const rawScope = ctx.scope ?? ctx.refs?.serviceName
+	const scope = rawScope ? chipScope(rawScope) : "the affected service"
 	const windowM = ctx.windowMinutes ?? 15
+
+	// A diagnosis is already on screen, so "Diagnose X" is the one thing left to
+	// ask. Push on the report instead: the useful next move against an AI
+	// conclusion is corroborating or breaking it.
+	if (ctx.aiSuspectedCause) {
+		return [
+			"What would confirm this?",
+			"What else could explain it?",
+			"Show the supporting traces",
+			"What should we do first?",
+		]
+	}
 
 	if (ctx.kind === "freeform") {
 		return [
@@ -147,9 +195,10 @@ export const investigationSuggestions = (ctx: InvestigationContext): string[] =>
 	}
 
 	if (ctx.kind === "error") {
+		const error = chipPhrase(ctx.title)
 		return [
-			`Sample stack traces for ${ctx.title}`,
-			`When did ${ctx.title} start?`,
+			`Sample stack traces for ${error}`,
+			`When did ${error} start?`,
 			`Which release introduced this?`,
 			`Group these errors by endpoint`,
 		]

--- a/apps/web/src/components/common/detail-rail.tsx
+++ b/apps/web/src/components/common/detail-rail.tsx
@@ -1,0 +1,65 @@
+import type * as React from "react"
+
+import { cn } from "@maple/ui/lib/utils"
+
+/* -------------------------------------------------------------------------------------------------
+ * DetailRail — the label/value rail every detail page hangs off its trailing edge.
+ *
+ * `Group` and `Row` existed as byte-identical private copies in the anomaly
+ * sidebar, the issue sidebar and the recommendation route, which is how the
+ * investigation page ended up reaching for stacked `Card`s instead and reading
+ * like a different product. They live here now.
+ *
+ * Deliberately *not* the outer container: each page wraps this in its own aside
+ * (widths, borders and backgrounds differ, and `PageLayout.RightSidebar` already
+ * owns that job on some of them). Only the two repeated pieces are shared.
+ * -----------------------------------------------------------------------------------------------*/
+
+function Group({
+	label,
+	children,
+	className,
+}: {
+	label: string
+	children: React.ReactNode
+	className?: string
+}) {
+	return (
+		<section
+			data-slot="detail-rail-group"
+			className={cn("flex flex-col gap-2 border-b border-border/40 p-4 last:border-b-0", className)}
+		>
+			<h3 className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+				{label}
+			</h3>
+			<div className="flex flex-col gap-1">{children}</div>
+		</section>
+	)
+}
+
+function Row({
+	label,
+	title,
+	children,
+	/** Width of the label column. Narrow rails (recommendations) run tighter. */
+	labelWidth = "88px",
+}: {
+	label: string
+	title?: string
+	children: React.ReactNode
+	labelWidth?: string
+}) {
+	return (
+		<div
+			data-slot="detail-rail-row"
+			title={title}
+			className="grid min-h-8 items-center gap-x-3 py-0.5"
+			style={{ gridTemplateColumns: `${labelWidth} 1fr` }}
+		>
+			<span className="text-xs text-muted-foreground">{label}</span>
+			<div className="flex min-w-0 items-center justify-end">{children}</div>
+		</div>
+	)
+}
+
+export const DetailRail = { Group, Row }

--- a/apps/web/src/components/errors/issue-sidebar.tsx
+++ b/apps/web/src/components/errors/issue-sidebar.tsx
@@ -14,6 +14,7 @@ import { LeaseHud } from "./lease-hud"
 import { SEVERITY_LABEL, SEVERITY_ORDER, SEVERITY_SOURCE_LABEL, SEVERITY_TONE } from "./severity-badge"
 import { StateSelect } from "./state-select"
 import { ServiceDot } from "@maple/ui/components/service-dot"
+import { DetailRail } from "@/components/common/detail-rail"
 
 type Busy = "state" | "claim" | "release" | "heartbeat" | "comment" | "severity" | "investigation" | null
 
@@ -46,15 +47,15 @@ export function IssueSidebar({
 
 	return (
 		<div className="flex h-full w-72 shrink-0 flex-col overflow-y-auto border-l bg-card/30">
-			<SidebarGroup label="Details">
-				<Row label="Status">
+			<DetailRail.Group label="Details">
+				<DetailRail.Row label="Status">
 					<StateSelect
 						current={issue.workflowState}
 						disabled={busy === "state"}
 						onChange={onTransition}
 					/>
-				</Row>
-				<Row label="Severity">
+				</DetailRail.Row>
+				<DetailRail.Row label="Severity">
 					<div className="flex w-full flex-col items-end gap-0.5">
 						<Select
 							value={issue.severity ?? SEVERITY_NONE}
@@ -83,30 +84,30 @@ export function IssueSidebar({
 							</span>
 						) : null}
 					</div>
-				</Row>
-				<Row label="Priority">
+				</DetailRail.Row>
+				<DetailRail.Row label="Priority">
 					<span className="flex items-center gap-2">
 						<PriorityBarsIcon level={priority} size={12} />
 						<span className="text-sm text-foreground">{PRIORITY_LABEL[priority]}</span>
 					</span>
-				</Row>
-				<Row label="Assignee">
+				</DetailRail.Row>
+				<DetailRail.Row label="Assignee">
 					<ActorChip actor={issue.assignedActor} />
-				</Row>
-				<Row label="Service" title={issue.serviceName}>
+				</DetailRail.Row>
+				<DetailRail.Row label="Service" title={issue.serviceName}>
 					<span className="flex min-w-0 items-center gap-2">
 						<ServiceDot serviceName={issue.serviceName} className="size-1.5" />
 						<span className="truncate text-sm text-foreground">{issue.serviceName}</span>
 					</span>
-				</Row>
-				<Row label="Issue ID">
+				</DetailRail.Row>
+				<DetailRail.Row label="Issue ID">
 					<code className="font-mono text-xs tabular-nums text-muted-foreground">
 						{shortIssueId(issue.id)}
 					</code>
-				</Row>
-			</SidebarGroup>
+				</DetailRail.Row>
+			</DetailRail.Group>
 
-			<SidebarGroup label="Lease">
+			<DetailRail.Group label="Lease">
 				{issue.leaseHolder && issue.leaseExpiresAt ? (
 					<div className="space-y-2">
 						<LeaseHud
@@ -142,62 +143,44 @@ export function IssueSidebar({
 				) : (
 					<p className="text-xs text-muted-foreground">Unclaimed</p>
 				)}
-			</SidebarGroup>
+			</DetailRail.Group>
 
-			<SidebarGroup label="Activity">
-				<Row label="Events (total)">
+			<DetailRail.Group label="Activity">
+				<DetailRail.Row label="Events (total)">
 					<span className="text-right tabular-nums text-foreground">
 						{issue.occurrenceCount.toLocaleString()}
 					</span>
-				</Row>
-				<Row label="Events (window)">
+				</DetailRail.Row>
+				<DetailRail.Row label="Events (window)">
 					<span className="text-right tabular-nums text-foreground">
 						{totalInWindow.toLocaleString()}
 					</span>
-				</Row>
-				<Row
+				</DetailRail.Row>
+				<DetailRail.Row
 					label="First seen"
 					title={new Date(normalizeTimestampInput(issue.firstSeenAt)).toLocaleString()}
 				>
 					<span className="text-right tabular-nums text-muted-foreground">
 						{formatRelativeTime(issue.firstSeenAt)}
 					</span>
-				</Row>
-				<Row
+				</DetailRail.Row>
+				<DetailRail.Row
 					label="Last seen"
 					title={new Date(normalizeTimestampInput(issue.lastSeenAt)).toLocaleString()}
 				>
 					<span className="text-right tabular-nums text-foreground">
 						{formatRelativeTime(issue.lastSeenAt)}
 					</span>
-				</Row>
-			</SidebarGroup>
+				</DetailRail.Row>
+			</DetailRail.Group>
 
 			{issue.notes ? (
-				<SidebarGroup label="Notes">
+				<DetailRail.Group label="Notes">
 					<IssueNotesCallout notes={issue.notes} />
-				</SidebarGroup>
+				</DetailRail.Group>
 			) : null}
 		</div>
 	)
 }
 
-function SidebarGroup({ label, children }: { label: string; children: React.ReactNode }) {
-	return (
-		<section className="flex flex-col gap-2 border-b border-border/40 p-4 last:border-b-0">
-			<h3 className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-				{label}
-			</h3>
-			<div className="flex flex-col gap-1">{children}</div>
-		</section>
-	)
-}
 
-function Row({ label, title, children }: { label: string; title?: string; children: React.ReactNode }) {
-	return (
-		<div title={title} className="grid min-h-8 grid-cols-[88px_1fr] items-center gap-x-3 py-0.5">
-			<span className="text-xs text-muted-foreground">{label}</span>
-			<div className="flex min-w-0 items-center justify-end">{children}</div>
-		</div>
-	)
-}

--- a/apps/web/src/components/investigations/investigation-rail.tsx
+++ b/apps/web/src/components/investigations/investigation-rail.tsx
@@ -1,0 +1,388 @@
+import type { ReactNode } from "react"
+import { Link } from "@tanstack/react-router"
+import type { V2Investigation } from "@maple/domain/http/v2"
+import type { IssueEscalationAttemptDocument } from "@maple/domain/http"
+import { Button } from "@maple/ui/components/ui/button"
+import { cn } from "@maple/ui/lib/utils"
+import { formatDuration, formatNumber } from "@maple/ui/format"
+import { formatRelativeTime, toEpochMs } from "@maple/ui/time-format"
+
+import { DetailRail } from "@/components/common/detail-rail"
+import { CONFIDENCE_TONE } from "@/components/chat/diagnosis-report-card"
+import { SEVERITY_LABEL, SEVERITY_TONE } from "@/components/errors/severity-badge"
+import { Result, useAtomValue } from "@/lib/effect-atom"
+import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { investigationOriginLabel } from "./investigation-status"
+
+/**
+ * What the transcript doesn't say. The transcript is the investigation's
+ * argument; this rail is its record — who opened it, how long the pass took,
+ * what it cost, what it points at, and whether anyone was told.
+ *
+ * Most of this was on the wire and rendered nowhere: `created_at`,
+ * `diagnosed_at`, the token counts, `report.severityAssessment`, the incident
+ * and issue IDs, and — worst — `error`, so a failed pass offered a Retry button
+ * and never said what went wrong.
+ */
+export function InvestigationRail({
+	investigation,
+	busy,
+	onResolve,
+	onRestart,
+}: {
+	investigation: V2Investigation
+	busy: boolean
+	onResolve: () => void
+	onRestart: () => void
+}) {
+	const { snapshot, subject, report } = investigation
+	const isResolved = investigation.status === "resolved"
+	const issueId = subject.type === "incident" ? subject.issue_id : null
+
+	return (
+		<div className="flex flex-col">
+			<DetailRail.Group label="Actions">
+				{isResolved || investigation.status === "failed" ? (
+					<Button size="sm" className="w-full" onClick={onRestart} disabled={busy}>
+						{isResolved ? "Reopen" : "Retry"}
+					</Button>
+				) : (
+					<Button size="sm" variant="outline" className="w-full" onClick={onResolve} disabled={busy}>
+						Resolve
+					</Button>
+				)}
+			</DetailRail.Group>
+
+			<DetailRail.Group label="Run">
+				{issueId ? (
+					<EscalatedRunSpine investigation={investigation} issueId={issueId} />
+				) : (
+					<RunSpine investigation={investigation} attempt={null} />
+				)}
+			</DetailRail.Group>
+
+			{report ? (
+				<DetailRail.Group label="Diagnosis">
+					<DetailRail.Row label="Confidence">
+						<span
+							className={cn(
+								"text-sm font-medium capitalize",
+								CONFIDENCE_TONE[report.confidence] ?? "text-foreground",
+							)}
+						>
+							{report.confidence}
+						</span>
+					</DetailRail.Row>
+					<DetailRail.Row label="AI severity">
+						<span
+							className={cn(
+								"rounded px-1.5 py-0.5 text-xs font-medium",
+								SEVERITY_TONE[report.severityAssessment],
+							)}
+						>
+							{SEVERITY_LABEL[report.severityAssessment]}
+						</span>
+					</DetailRail.Row>
+					{investigation.model ? (
+						<DetailRail.Row label="Model" title={investigation.model}>
+							<code className="block max-w-full truncate font-mono text-xs text-muted-foreground">
+								{investigation.model}
+							</code>
+						</DetailRail.Row>
+					) : null}
+					<TokenRow investigation={investigation} />
+				</DetailRail.Group>
+			) : null}
+
+			<DetailRail.Group label="Subject">
+				<DetailRail.Row label="Origin">
+					<span className="text-sm text-foreground">
+						{investigationOriginLabel(investigation.seeded_by)}
+					</span>
+				</DetailRail.Row>
+				{subject.type === "incident" ? (
+					<DetailRail.Row label="Incident" title={subject.incident_id}>
+						<code className="block max-w-full truncate font-mono text-xs text-muted-foreground">
+							{subject.incident_id}
+						</code>
+					</DetailRail.Row>
+				) : null}
+				{issueId ? (
+					<DetailRail.Row label="Issue" title={issueId}>
+						<Link
+							to="/errors/issues/$issueId"
+							params={{ issueId }}
+							className="block max-w-full truncate font-mono text-xs text-primary hover:underline"
+						>
+							{issueId}
+						</Link>
+					</DetailRail.Row>
+				) : null}
+				{snapshot.references.length > 0 ? (
+					<div className="mt-1 flex flex-col gap-1">
+						{snapshot.references.map((reference) => (
+							<ReferenceLink key={reference.url} label={reference.label} url={reference.url} />
+						))}
+					</div>
+				) : null}
+			</DetailRail.Group>
+		</div>
+	)
+}
+
+/** Both counts or neither — a lone number reads as a total and misleads. */
+function TokenRow({ investigation }: { investigation: V2Investigation }) {
+	const { input_tokens: input, output_tokens: output } = investigation
+	if (input === null && output === null) return null
+	return (
+		<DetailRail.Row label="Tokens">
+			<span className="truncate font-mono text-xs text-muted-foreground tabular-nums">
+				{input === null ? "—" : formatNumber(input)} in ·{" "}
+				{output === null ? "—" : formatNumber(output)} out
+			</span>
+		</DetailRail.Row>
+	)
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * Run spine
+ * -----------------------------------------------------------------------------------------------*/
+
+interface SpineNode {
+	key: string
+	label: string
+	/** Instant to stamp the node with, when the event has one. */
+	at?: string
+	dot: string
+	/** Elapsed time to the *next* node, rendered on the connector below this one. */
+	gap?: string
+	detail?: ReactNode
+}
+
+/**
+ * The diagnostic pass as the sequence it actually is. The elapsed time sits on
+ * the connector between Opened and Diagnosed rather than in a stat row, because
+ * that is what it is — the gap between two events, not a standalone metric. It
+ * is also the number the product is about, and until now nothing rendered it.
+ *
+ * Escalation is the spine's terminal event rather than a separate card: it is
+ * the last thing that happened in the same run.
+ */
+function RunSpine({
+	investigation,
+	attempt,
+}: {
+	investigation: V2Investigation
+	attempt: IssueEscalationAttemptDocument | null
+}) {
+	const nodes: SpineNode[] = []
+
+	const openedMs = toEpochMs(investigation.created_at)
+	const diagnosedMs = investigation.diagnosed_at ? toEpochMs(investigation.diagnosed_at) : null
+	const elapsed =
+		diagnosedMs !== null && Number.isFinite(openedMs) && diagnosedMs >= openedMs
+			? formatDuration(diagnosedMs - openedMs)
+			: null
+
+	nodes.push({
+		key: "opened",
+		label: "Opened",
+		at: investigation.created_at,
+		dot: "bg-muted-foreground/50",
+		...(elapsed ? { gap: elapsed } : {}),
+	})
+
+	if (investigation.status === "investigating") {
+		nodes.push({
+			key: "investigating",
+			label: "Investigating…",
+			dot: "bg-primary animate-pulse",
+		})
+	}
+
+	if (investigation.diagnosed_at) {
+		nodes.push({
+			key: "diagnosed",
+			label: "Diagnosed",
+			at: investigation.diagnosed_at,
+			dot: "bg-success",
+		})
+	}
+
+	if (attempt) {
+		nodes.push({
+			key: "escalation",
+			label: ESCALATION_LABEL[attempt.status],
+			...(attempt.processedAt ? { at: attempt.processedAt } : {}),
+			dot: attempt.status === "failed" ? "bg-destructive" : "bg-muted-foreground/50",
+			detail: <EscalationDetail attempt={attempt} />,
+		})
+	}
+
+	if (investigation.status === "failed") {
+		nodes.push({
+			key: "failed",
+			label: "Pass failed",
+			at: investigation.updated_at,
+			dot: "bg-destructive",
+			detail: investigation.error ? (
+				<p className="mt-1 break-words text-xs text-destructive">{investigation.error}</p>
+			) : (
+				<p className="mt-1 text-xs text-muted-foreground">
+					No failure reason was recorded. Retry to run the pass again.
+				</p>
+			),
+		})
+	}
+
+	if (investigation.status === "resolved") {
+		nodes.push({
+			key: "resolved",
+			label: "Resolved",
+			at: investigation.updated_at,
+			dot: "bg-muted-foreground/30",
+		})
+	}
+
+	return (
+		<ol className="flex flex-col">
+			{nodes.map((node, index) => {
+				const isLast = index === nodes.length - 1
+				return (
+					<li key={node.key} className={cn("relative flex gap-3", isLast ? "pb-0" : "pb-3")}>
+						{isLast ? null : (
+							<span
+								className="absolute bottom-0 left-[3px] top-3.5 w-px bg-border"
+								aria-hidden
+							/>
+						)}
+						<span
+							className={cn("mt-[7px] size-[7px] shrink-0 rounded-full", node.dot)}
+							aria-hidden
+						/>
+						<div className="min-w-0 flex-1">
+							<div className="flex items-baseline justify-between gap-2">
+								<span className="truncate text-xs text-foreground">{node.label}</span>
+								{node.at ? (
+									<time
+										dateTime={node.at}
+										title={new Date(toEpochMs(node.at)).toLocaleString()}
+										className="shrink-0 font-mono text-[11px] text-muted-foreground"
+									>
+										{formatRelativeTime(node.at)}
+									</time>
+								) : null}
+							</div>
+							{node.detail}
+							{node.gap ? (
+								<p className="mt-1 leading-none">
+									<span className="font-mono text-xs font-medium text-foreground">
+										{node.gap}
+									</span>{" "}
+									<span className="text-[11px] text-muted-foreground">to diagnosis</span>
+								</p>
+							) : null}
+						</div>
+					</li>
+				)
+			})}
+		</ol>
+	)
+}
+
+const ESCALATION_LABEL: Record<IssueEscalationAttemptDocument["status"], string> = {
+	queued: "Escalation queued",
+	sent: "Escalated",
+	skipped: "Escalation skipped",
+	failed: "Escalation failed",
+}
+
+const DELIVERY_TONE: Record<string, string> = {
+	delivered: "text-success",
+	failed: "text-destructive",
+	disabled: "text-muted-foreground",
+	missing: "text-muted-foreground",
+}
+
+function EscalationDetail({ attempt }: { attempt: IssueEscalationAttemptDocument }) {
+	return (
+		<div className="mt-1.5 flex flex-col gap-1">
+			{attempt.deliveries.map((delivery) => (
+				<div key={delivery.destinationId} className="flex flex-col">
+					<div className="flex items-baseline justify-between gap-2 text-[11px]">
+						<span className="min-w-0 truncate text-muted-foreground">
+							{delivery.destinationName ?? delivery.destinationId}
+						</span>
+						<span className={cn("shrink-0", DELIVERY_TONE[delivery.status])}>
+							{delivery.status}
+						</span>
+					</div>
+					{delivery.error ? (
+						<p className="break-words text-[11px] text-destructive/80">{delivery.error}</p>
+					) : null}
+				</div>
+			))}
+			<p className="text-[11px] text-muted-foreground">
+				{attempt.attempts} attempt{attempt.attempts === 1 ? "" : "s"}
+				{attempt.skipReason ? ` · ${attempt.skipReason.replaceAll("_", " ")}` : ""}
+			</p>
+		</div>
+	)
+}
+
+/**
+ * The escalation attempt is a separate request, so the spine renders without it
+ * and gains its terminal node when the query lands — `orElse` returns the spine
+ * rather than null, or the whole run history would blank while one optional
+ * lookup is in flight.
+ */
+function EscalatedRunSpine({
+	investigation,
+	issueId,
+}: {
+	investigation: V2Investigation
+	issueId: NonNullable<Extract<V2Investigation["subject"], { type: "incident" }>["issue_id"]>
+}) {
+	const result = useAtomValue(
+		MapleApiAtomClient.query("errors", "listIssueEscalations", {
+			params: { issueId },
+			reactivityKeys: [`errorIssue:${issueId}:escalations`],
+		}),
+	)
+	return Result.builder(result)
+		.onSuccess((response) => (
+			<RunSpine
+				investigation={investigation}
+				attempt={
+					response.attempts.find(
+						(candidate) => candidate.investigationId === investigation.id,
+					) ?? null
+				}
+			/>
+		))
+		.orElse(() => <RunSpine investigation={investigation} attempt={null} />)
+}
+
+/**
+ * Snapshot references are app-relative paths written by the API, so they route
+ * through the SPA. An absolute URL leaves the app and gets a plain anchor.
+ */
+function ReferenceLink({ label, url }: { label: string; url: string }) {
+	if (!url.startsWith("/")) {
+		return (
+			<a
+				href={url}
+				rel="noreferrer"
+				className="block truncate text-xs text-primary hover:underline"
+				target="_blank"
+			>
+				{label}
+			</a>
+		)
+	}
+	return (
+		<Link to={url} className="block truncate text-xs text-primary hover:underline">
+			{label}
+		</Link>
+	)
+}

--- a/apps/web/src/components/investigations/investigation-status.tsx
+++ b/apps/web/src/components/investigations/investigation-status.tsx
@@ -12,7 +12,7 @@ type InvestigationStatus = V2Investigation["status"]
  */
 const STATUS: Record<InvestigationStatus, { label: string; tone: string }> = {
 	investigating: { label: "In progress", tone: "bg-primary/10 text-primary" },
-	diagnosed: { label: "Diagnosed", tone: "bg-severity-ok/10 text-severity-ok" },
+	diagnosed: { label: "Diagnosed", tone: "bg-success/10 text-success" },
 	resolved: { label: "Resolved", tone: "bg-muted text-muted-foreground" },
 	failed: { label: "Failed", tone: "bg-destructive/10 text-destructive" },
 }

--- a/apps/web/src/components/investigations/investigation-view.tsx
+++ b/apps/web/src/components/investigations/investigation-view.tsx
@@ -1,12 +1,8 @@
 import { useMemo, useState } from "react"
-import { Link } from "@tanstack/react-router"
 import { Exit } from "effect"
-import { Result, useAtomSet, useAtomValue } from "@/lib/effect-atom"
+import { useAtomSet } from "@/lib/effect-atom"
 import type { V2Investigation } from "@maple/domain/http/v2"
 import type { IssueSeverity } from "@maple/domain/http"
-import { Button } from "@maple/ui/components/ui/button"
-import { Card } from "@maple/ui/components/ui/card"
-import { Separator } from "@maple/ui/components/ui/separator"
 import { toast } from "sonner"
 
 import { ChatConversation } from "@/components/chat/chat-conversation"
@@ -14,14 +10,9 @@ import { FlueClientProvider } from "@/components/chat/flue-client-provider"
 import type { InvestigationContext } from "@/components/chat/investigation-context"
 import { SeverityBadge } from "@/components/errors/severity-badge"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
-import { formatRelativeTime } from "@maple/ui/time-format"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
-import {
-	InvestigationStatusBadge,
-	investigationKindLabel,
-	investigationOriginLabel,
-} from "./investigation-status"
+import { InvestigationRail } from "./investigation-rail"
+import { InvestigationStatusBadge, investigationKindLabel } from "./investigation-status"
 
 const factKey = (label: string) =>
 	label
@@ -29,19 +20,46 @@ const factKey = (label: string) =>
 		.replace(/[^a-z0-9]+/g, "_")
 		.replace(/^_|_$/g, "")
 
+/**
+ * An investigation's title is whatever named its subject — for an error that's
+ * the exception message, which can be a line of JSON. `BreadcrumbList` wraps by
+ * design, so an unclamped title spills the trail out of the fixed `h-16` bar.
+ * Clamping loses nothing: the full title is the `<h1>` directly beneath it.
+ */
+const breadcrumbLabel = (title: string): string => {
+	const line = title.split("\n")[0]!.trim()
+	return line.length > 64 ? `${line.slice(0, 63).trimEnd()}…` : line
+}
+
 /** Only the four canonical severities render as a badge; anything else is unset. */
 const asIssueSeverity = (value: string | null | undefined): IssueSeverity | null =>
 	value === "critical" || value === "high" || value === "medium" || value === "low" ? value : null
 
+/**
+ * Read a snapshot fact by label. The snapshot is the only place the signal type
+ * survives — it isn't a column on the investigation — and both writers emit it
+ * under a "Signal" label (the alert route client-side, `snapshotFor` in the API),
+ * so matching on the label recovers it for either origin.
+ */
+const factValue = (
+	facts: V2Investigation["snapshot"]["facts"],
+	label: string,
+): string | undefined => facts.find((fact) => fact.label.toLowerCase() === label)?.value
+
 const contextFromInvestigation = (investigation: V2Investigation): InvestigationContext => {
 	const subject = investigation.subject
 	const kind = subject.type === "freeform" ? "freeform" : subject.incident_kind
+	// Without this the signal is always unknown, every alert falls through to
+	// `investigationSuggestions`' generic branch, and its per-signal prompts are
+	// dead code on the one page that should use them.
+	const signalType = factValue(investigation.snapshot.facts, "signal")
 	return {
 		kind,
 		id: subject.type === "freeform" ? investigation.id : subject.incident_id,
 		title: investigation.snapshot.title,
 		severity: investigation.severity ?? investigation.snapshot.severity ?? "unclassified",
 		status: investigation.status,
+		...(signalType ? { signalType } : {}),
 		...(investigation.snapshot.scope ? { scope: investigation.snapshot.scope } : {}),
 		facts: investigation.snapshot.facts.map((fact) => ({
 			key: factKey(fact.label),
@@ -70,8 +88,9 @@ const contextFromInvestigation = (investigation: V2Investigation): Investigation
 /**
  * One investigation, as a workspace rather than a document: the header states the
  * subject, the transcript owns the rest of the viewport and its own scrolling, and
- * the rail carries only what the transcript doesn't — provenance, references and
- * escalation. Nothing appears twice.
+ * the rail carries everything the transcript doesn't — the run's history, what it
+ * cost, what it points at, and the actions that change its state. Nothing appears
+ * twice.
  */
 export function InvestigationView({
 	investigation,
@@ -125,25 +144,17 @@ export function InvestigationView({
 			<DashboardLayout.Breadcrumbs
 				items={[
 					{ label: "Investigations", href: "/investigations" },
-					{ label: investigation.snapshot.title },
+					{ label: breadcrumbLabel(investigation.snapshot.title) },
 				]}
 			/>
 			<DashboardLayout.Body>
 				<DashboardLayout.Content>
+					{/* No actions here: Resolve/Reopen/Retry live in the rail, beneath the
+					    run history they act on. The header states the subject and nothing else. */}
 					<DashboardLayout.Sticky>
 						<DashboardLayout.Header
 							titleContent={<InvestigationHeading investigation={investigation} />}
-						>
-							{isResolved || investigation.status === "failed" ? (
-								<Button size="sm" onClick={handleRestart} disabled={busy}>
-									{isResolved ? "Reopen" : "Retry"}
-								</Button>
-							) : (
-								<Button size="sm" variant="outline" onClick={handleResolve} disabled={busy}>
-									Resolve
-								</Button>
-							)}
-						</DashboardLayout.Header>
+						/>
 					</DashboardLayout.Sticky>
 					{/* `Fill`, not `Scroll`: the transcript scrolls itself. Nesting it in a
 					    scrolling page is what previously needed a `calc(100dvh - 12rem)`
@@ -163,8 +174,13 @@ export function InvestigationView({
 						</FlueClientProvider>
 					</DashboardLayout.Fill>
 				</DashboardLayout.Content>
-				<DashboardLayout.RightPanel title="Investigation context">
-					<ContextRail investigation={investigation} />
+				<DashboardLayout.RightPanel title="Investigation context" width="w-80">
+					<InvestigationRail
+						investigation={investigation}
+						busy={busy}
+						onResolve={handleResolve}
+						onRestart={handleRestart}
+					/>
 				</DashboardLayout.RightPanel>
 			</DashboardLayout.Body>
 		</DashboardLayout.Root>
@@ -191,8 +207,16 @@ function InvestigationHeading({ investigation }: { investigation: V2Investigatio
 			<div className="flex flex-wrap items-center gap-2">
 				<InvestigationStatusBadge status={investigation.status} />
 				{severity ? <SeverityBadge severity={severity} /> : null}
+				{/* `scope` is free text and a system-seeded investigation can carry a
+				    whole paragraph of it. One line, always — the full string is on the
+				    title, and the diagnosis card states the scope properly anyway. */}
 				{snapshot.scope ? (
-					<span className="font-mono text-xs text-muted-foreground">{snapshot.scope}</span>
+					<span
+						title={snapshot.scope}
+						className="min-w-0 max-w-[28rem] truncate font-mono text-xs text-muted-foreground"
+					>
+						{snapshot.scope}
+					</span>
 				) : null}
 			</div>
 			{snapshot.facts.length > 0 ? (
@@ -200,148 +224,17 @@ function InvestigationHeading({ investigation }: { investigation: V2Investigatio
 					{snapshot.facts.map((fact) => (
 						<span key={`${fact.label}:${fact.value}`}>
 							{fact.label}{" "}
-							<span className="font-mono font-medium text-foreground">{fact.value}</span>
+							{/* `inline-block`, or `truncate`'s overflow rules do nothing here. */}
+							<span
+								title={fact.value}
+								className="inline-block max-w-[16rem] truncate align-bottom font-mono font-medium text-foreground"
+							>
+								{fact.value}
+							</span>
 						</span>
 					))}
 				</p>
 			) : null}
 		</div>
 	)
-}
-
-/**
- * What the transcript doesn't say: where this investigation came from, which model
- * produced it, what it links to, and whether an escalation went out.
- */
-function ContextRail({ investigation }: { investigation: V2Investigation }) {
-	const { snapshot } = investigation
-	return (
-		<div className="space-y-4 p-4">
-			<Card className="gap-0 p-4 text-xs">
-				<dl className="grid grid-cols-[6rem_minmax(0,1fr)] gap-x-3 gap-y-2">
-					<dt className="text-muted-foreground">Origin</dt>
-					<dd className="text-foreground">{investigationOriginLabel(investigation.seeded_by)}</dd>
-					<dt className="text-muted-foreground">Updated</dt>
-					<dd className="text-foreground">{formatRelativeTime(investigation.updated_at)}</dd>
-					{investigation.confidence ? (
-						<>
-							<dt className="text-muted-foreground">Confidence</dt>
-							<dd className="capitalize text-foreground">{investigation.confidence}</dd>
-						</>
-					) : null}
-					{investigation.model ? (
-						<>
-							<dt className="text-muted-foreground">Model</dt>
-							<dd className="break-all font-mono text-[11px] text-foreground">
-								{investigation.model}
-							</dd>
-						</>
-					) : null}
-				</dl>
-				{snapshot.references.length > 0 ? (
-					<>
-						<Separator className="my-3" />
-						<div className="space-y-1.5">
-							{snapshot.references.map((reference) => (
-								<ReferenceLink
-									key={reference.url}
-									label={reference.label}
-									url={reference.url}
-								/>
-							))}
-						</div>
-					</>
-				) : null}
-			</Card>
-			<EscalationAudit investigation={investigation} />
-		</div>
-	)
-}
-
-/**
- * Snapshot references are app-relative paths written by the API, so they route
- * through the SPA. An absolute URL leaves the app and gets a plain anchor.
- */
-function ReferenceLink({ label, url }: { label: string; url: string }) {
-	if (!url.startsWith("/")) {
-		return (
-			<a
-				href={url}
-				rel="noreferrer"
-				className="block truncate text-primary hover:underline"
-				target="_blank"
-			>
-				{label}
-			</a>
-		)
-	}
-	return (
-		<Link to={url} className="block truncate text-primary hover:underline">
-			{label}
-		</Link>
-	)
-}
-
-function EscalationAudit({ investigation }: { investigation: V2Investigation }) {
-	const issueId = investigation.subject.type === "incident" ? investigation.subject.issue_id : null
-	if (!issueId) return null
-	return <IssueEscalationAudit investigation={investigation} issueId={issueId} />
-}
-
-function IssueEscalationAudit({
-	investigation,
-	issueId,
-}: {
-	investigation: V2Investigation
-	issueId: NonNullable<Extract<V2Investigation["subject"], { type: "incident" }>["issue_id"]>
-}) {
-	const result = useAtomValue(
-		MapleApiAtomClient.query("errors", "listIssueEscalations", {
-			params: { issueId },
-			reactivityKeys: [`errorIssue:${issueId}:escalations`],
-		}),
-	)
-	return Result.builder(result)
-		.onSuccess((response) => {
-			const attempt = response.attempts.find(
-				(candidate) => candidate.investigationId === investigation.id,
-			)
-			if (!attempt) return null
-			return (
-				<Card className="gap-2 p-4 text-xs">
-					<div className="flex items-center justify-between">
-						<span className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-							Escalation
-						</span>
-						<span className="capitalize text-muted-foreground">{attempt.status}</span>
-					</div>
-					<ul className="space-y-1">
-						{attempt.deliveries.map((delivery) => (
-							<li
-								key={delivery.destinationId}
-								className="flex items-center justify-between gap-2"
-							>
-								<span className="min-w-0 truncate text-foreground">
-									{delivery.destinationName ?? delivery.destinationId}
-								</span>
-								<span
-									className={
-										delivery.status === "delivered"
-											? "text-severity-ok"
-											: "text-destructive"
-									}
-								>
-									{delivery.status}
-								</span>
-							</li>
-						))}
-					</ul>
-					<p className="text-muted-foreground">
-						{attempt.attempts} attempt{attempt.attempts === 1 ? "" : "s"}
-						{attempt.skipReason ? ` · ${attempt.skipReason.replaceAll("_", " ")}` : ""}
-					</p>
-				</Card>
-			)
-		})
-		.orElse(() => null)
 }

--- a/apps/web/src/components/layout/dashboard-layout.tsx
+++ b/apps/web/src/components/layout/dashboard-layout.tsx
@@ -222,8 +222,21 @@ function Fill({ children }: { children: React.ReactNode }) {
 }
 
 /** Trailing context rail. Inline above `lg`, a sheet behind a header trigger below it. */
-function RightPanel({ children, title }: { children: React.ReactNode; title?: string }) {
-	return <PageLayout.RightSidebar title={title}>{children}</PageLayout.RightSidebar>
+function RightPanel({
+	children,
+	title,
+	/** Widen past the `w-72` default where the rail carries the page's substance. */
+	width,
+}: {
+	children: React.ReactNode
+	title?: string
+	width?: string
+}) {
+	return (
+		<PageLayout.RightSidebar title={title} width={width}>
+			{children}
+		</PageLayout.RightSidebar>
+	)
 }
 
 export const DashboardLayout = {

--- a/apps/web/src/components/settings/org-clickhouse-settings-section.tsx
+++ b/apps/web/src/components/settings/org-clickhouse-settings-section.tsx
@@ -436,7 +436,7 @@ export function OrgClickHouseSettingsSection({ isAdmin, hasEntitlement }: OrgCli
 													{entry.status === "up_to_date" ? (
 														<CircleCheckIcon
 															size={14}
-															className="text-severity-ok shrink-0"
+															className="text-success shrink-0"
 														/>
 													) : entry.status === "missing" ? (
 														<CircleXmarkIcon

--- a/apps/web/src/routes/recommendations/$recommendationKey.tsx
+++ b/apps/web/src/routes/recommendations/$recommendationKey.tsx
@@ -38,6 +38,12 @@ import {
 	XmarkIcon,
 } from "@/components/icons"
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard"
+import { DetailRail } from "@/components/common/detail-rail"
+
+/** This rail runs a narrower label column than the shared default. */
+const Row = (props: Omit<React.ComponentProps<typeof DetailRail.Row>, "labelWidth">) => (
+	<DetailRail.Row labelWidth="64px" {...props} />
+)
 
 export const Route = createFileRoute("/recommendations/$recommendationKey")({
 	component: RecommendationDetailPage,
@@ -477,7 +483,7 @@ function DetailSidebar({
 
 	return (
 		<div className="flex h-full w-80 shrink-0 flex-col overflow-y-auto border-l bg-card/30">
-			<SidebarGroup label="Details">
+			<DetailRail.Group label="Details">
 				<Row label="Status">
 					<Badge variant={status.variant}>{status.label}</Badge>
 				</Row>
@@ -503,9 +509,9 @@ function DetailSidebar({
 						{issue.source_key}
 					</code>
 				</Row>
-			</SidebarGroup>
+			</DetailRail.Group>
 
-			<SidebarGroup label="How this resolves">
+			<DetailRail.Group label="How this resolves">
 				<ul className="flex flex-col gap-1.5 text-xs leading-relaxed text-muted-foreground">
 					{[
 						"the deprecated key stops appearing on your spans",
@@ -520,9 +526,9 @@ function DetailSidebar({
 						</li>
 					))}
 				</ul>
-			</SidebarGroup>
+			</DetailRail.Group>
 
-			<SidebarGroup label="Action">
+			<DetailRail.Group label="Action">
 				{isLive ? (
 					<div className="flex flex-col gap-3">
 						<p className="flex items-center gap-2 text-sm text-success">
@@ -573,7 +579,7 @@ function DetailSidebar({
 						</Button>
 					</div>
 				)}
-			</SidebarGroup>
+			</DetailRail.Group>
 		</div>
 	)
 }
@@ -667,22 +673,4 @@ function SectionHeader({ label }: { label: string }) {
 	)
 }
 
-function SidebarGroup({ label, children }: { label: string; children: React.ReactNode }) {
-	return (
-		<section className="flex flex-col gap-2 border-b border-border/40 p-4 last:border-b-0">
-			<h3 className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-				{label}
-			</h3>
-			<div className="flex flex-col gap-1">{children}</div>
-		</section>
-	)
-}
 
-function Row({ label, title, children }: { label: string; title?: string; children: React.ReactNode }) {
-	return (
-		<div title={title} className="grid min-h-8 grid-cols-[64px_1fr] items-center gap-x-3 py-0.5">
-			<span className="text-xs text-muted-foreground">{label}</span>
-			<div className="flex min-w-0 items-center justify-end">{children}</div>
-		</div>
-	)
-}


### PR DESCRIPTION
The investigation detail page shipped in #270 with suggestion chips whose text spilled out of their pills and a context rail showing four rows. Both had concrete causes.

| before | after |
|---|---|
| paragraph scope wrapping ~5 lines, chips colliding, rail = 4 rows | scope on one truncated line, chips one line each, rail carries the run |

## The chips were a `twMerge` trap

`Suggestion` set `h-auto … whitespace-normal`. `twMerge` *does* resolve `h-auto` against the `h-8` in `buttonVariants({size:"sm"})` — but that variant also carries **`sm:h-7`, a different modifier group that survives the merge**. Above 640px the pill stayed pinned at 1.75rem while its text wrapped freely, so long chips spilled over the border into the row below. Chips are one line now and the height belongs to the size variant.

Worth knowing generally: any `Button` caller passing `h-auto` alongside a size variant hits this.

## The content was the deeper cause

`investigationSuggestions` interpolates `snapshot.scope`, which is unbounded free text (`Schema.String`) — a system-seeded investigation can carry a whole paragraph the model wrote. And `contextFromInvestigation` never populated `signalType`, so **every alert fell through to the generic `Diagnose ${scope}` branch** and the tuned per-signal prompts were dead code on the one page meant to use them.

- the signal is recovered from `snapshot.facts` (both writers emit a `Signal` label)
- `chipScope` / `chipPhrase` clamp free text before it reaches a prompt
- a diagnosed investigation now offers follow-ups on its report ("What would confirm this?") instead of asking for a diagnosis already on screen

## The rail ignored most of the model

It now reads as the record of the run: a spine with **time-to-diagnosis printed on the connector** between Opened and Diagnosed, then confidence, the AI's own severity call, model, token cost, and the incident/issue IDs. `error`, `diagnosed_at`, the token counts and both join IDs previously rendered nowhere — a failed pass offered a Retry button and never said why.

Escalation folds into the spine as its terminal event rather than sitting in a second card, and per-delivery `error` is surfaced.

## Two fixes fell out along the way

- **`severity-ok` is not a real token.** The set is trace/debug/info/warn/error/fatal, so `bg-severity-ok` / `text-severity-ok` were silent no-ops in five places — including the "Diagnosed" badge and the high-confidence tone, which were rendering colourless. Switched to the real `success` token.
- **The breadcrumb wrapped out of the fixed `h-16` bar** on error investigations whose title is a line of JSON. The label this page passes is clamped; `BreadcrumbList` is left alone since it wraps by design.

## Reviewer notes

- **Actions moved into the rail** (requested). Below `lg` the rail collapses to a sheet, so Resolve/Retry sit one tap behind the header's "Open context" button — verified reachable, but it is a demotion versus the header. Follows existing precedent in `AnomalySidebar` and `issue-sidebar`.
- **`DetailRail` extraction**: `SidebarGroup`/`Row` were byte-identical private copies in three files. Promoted to `components/common/detail-rail.tsx` and the copies deleted — pure delete-and-import, no visual change to the anomaly, issue or recommendation rails. Each page keeps its own outer wrapper; `Row` takes `labelWidth` (default `88px`, recommendations `64px`).
- `suggestion.test.tsx` is a **class-contract** test, not a layout one — jsdom applies no stylesheet, so it pins the class combination that caused the overflow rather than measuring it.

## Testing

- 61 tests pass across the touched areas; `bun typecheck --filter=@maple/web` clean
- Reproduced the original case in the browser by creating an investigation carrying the paragraph scope verbatim: **~5 wrapped lines → 1 truncated line**, no chip overflow at 1280 or 640, no horizontal page scroll
- Verified the `failed` state renders its reason (`workflow_binding_unavailable`) and the `investigating` state renders its live node — the two states with no rendering before
- Confirmed all three migrated rails (anomaly, issue, recommendations) still render identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787772941&installation_model_id=427786&pr_number=272&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F272&signature=e562ac473c622e3dbe2a21659b5880194b43ab243e9e47e8697cc66e2105c41e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->