### PR TITLE
feat: fold the four signals into an Explore section

### DIFF
--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -25,12 +25,7 @@ import {
 	SunIcon,
 } from "@/components/icons"
 import { openGlobalChat } from "@/components/chat/global-chat-sheet"
-import {
-	investigateNavItems,
-	mainNavItems,
-	topologyNavItems,
-	visibleSignalsNavItems,
-} from "@/components/dashboard/nav-items"
+import { paletteNavItems } from "@/components/dashboard/nav-items"
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences"
 import { useDashboardsRead } from "@/hooks/use-dashboard-store"
 import { useInfraEnabled } from "@/hooks/use-infra-enabled"
@@ -143,29 +138,18 @@ function PaletteContent({
 	}, [close, toggle])
 
 	const entries = useMemo<PaletteEntry[]>(() => {
-		const navItems = [
-			...mainNavItems,
-			...topologyNavItems,
-			...visibleSignalsNavItems({ infraEnabled }),
-			...investigateNavItems,
-		]
+		// Sections *and* their children — Traces, Logs, Metrics, Replays, Hosts,
+		// the K8s lists and the integration pages are all reachable by name here,
+		// which is what lets the sidebar fold them into two sections.
 		const navigation: PaletteEntry[] = [
-			...navItems.map((item) => ({
-				id: `nav:${item.href}`,
+			...paletteNavItems({ infraEnabled }).map((item) => ({
+				id: item.id,
 				title: item.title,
 				group: "Navigation" as const,
 				keywords: `go to ${item.title}`,
 				icon: item.icon,
 				href: item.href,
 			})),
-			{
-				id: "nav:/dashboards",
-				title: "Dashboards",
-				group: "Navigation",
-				keywords: "go to all dashboards",
-				icon: GridSquareCirclePlusIcon,
-				href: "/dashboards",
-			},
 			{
 				id: "nav:/settings",
 				title: "Settings",

--- a/apps/web/src/components/command-palette/global-shortcuts.tsx
+++ b/apps/web/src/components/command-palette/global-shortcuts.tsx
@@ -16,10 +16,19 @@ const KeyboardShortcutsDialog = lazy(() =>
 )
 
 const SHOW_SHORTCUTS_EVENT = "maple:show-keyboard-shortcuts"
+const OPEN_PALETTE_EVENT = "maple:open-command-palette"
 
 /** Open the keyboard-shortcuts help dialog from anywhere (e.g. the sidebar Support menu). */
 export function showKeyboardShortcuts() {
 	document.dispatchEvent(new CustomEvent(SHOW_SHORTCUTS_EVENT))
+}
+
+/**
+ * Open ⌘K from anywhere. The sidebar's search row is the only discoverable
+ * entry point to the palette — without it the shortcut is keyboard-only folklore.
+ */
+export function openCommandPalette() {
+	document.dispatchEvent(new CustomEvent(OPEN_PALETTE_EVENT))
 }
 
 function focusSearch() {
@@ -52,6 +61,7 @@ export function GlobalShortcuts() {
 
 	useMountEffect(() => {
 		const onShow = () => setShortcutsOpen(true)
+		const onOpenPalette = () => setPaletteOpen(true)
 		const onKeyDown = (event: KeyboardEvent) => {
 			const key = event.key.toLowerCase()
 			const mod = event.metaKey || event.ctrlKey
@@ -81,9 +91,11 @@ export function GlobalShortcuts() {
 			}
 		}
 		document.addEventListener(SHOW_SHORTCUTS_EVENT, onShow)
+		document.addEventListener(OPEN_PALETTE_EVENT, onOpenPalette)
 		document.addEventListener("keydown", onKeyDown)
 		return () => {
 			document.removeEventListener(SHOW_SHORTCUTS_EVENT, onShow)
+			document.removeEventListener(OPEN_PALETTE_EVENT, onOpenPalette)
 			document.removeEventListener("keydown", onKeyDown)
 		}
 	})

--- a/apps/web/src/components/dashboard/app-sidebar.tsx
+++ b/apps/web/src/components/dashboard/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react"
+import { memo, useMemo } from "react"
 import { Link, useRouterState } from "@tanstack/react-router"
 import { useUser, useClerk } from "@clerk/clerk-react"
 import {
@@ -6,20 +6,19 @@ import {
 	DiscordIcon,
 	EnvelopeIcon,
 	GearIcon,
-	LogoutIcon,
-	ChevronUpIcon,
-	ChevronRightIcon,
 	GridSquareCirclePlusIcon,
+	KeyboardIcon,
+	LogoutIcon,
+	MagnifierIcon,
 } from "@/components/icons"
 import {
-	investigateNavItems,
-	mainNavItems,
-	topologyNavItems,
-	visibleSignalsNavItems,
-	type NavSubItem,
+	isNavItemActive,
+	isPathActive,
+	navGroups,
+	type NavGroup,
+	type NavItem,
 } from "@/components/dashboard/nav-items"
-import { showKeyboardShortcuts } from "@/components/command-palette/global-shortcuts"
-import { KeyboardIcon } from "@/components/icons"
+import { openCommandPalette, showKeyboardShortcuts } from "@/components/command-palette/global-shortcuts"
 import { OrgSwitcher } from "@/components/dashboard/org-switcher"
 import { ThemeToggle } from "@/components/dashboard/theme-toggle"
 import {
@@ -47,20 +46,51 @@ import {
 	SidebarMenuSub,
 	SidebarMenuSubButton,
 	SidebarMenuSubItem,
+	useSidebar,
 } from "@maple/ui/components/ui/sidebar"
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@maple/ui/components/ui/collapsible"
+import { Badge } from "@maple/ui/components/ui/badge"
+import { Kbd } from "@maple/ui/components/ui/kbd"
 import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 import { clearSelfHostedSessionToken } from "@/lib/services/common/self-hosted-auth"
 import { useDashboardsRead } from "@/hooks/use-dashboard-store"
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences"
 import { useInfraEnabled } from "@/hooks/use-infra-enabled"
-import { Badge } from "@maple/ui/components/ui/badge"
 
-function UserAvatar({ imageUrl, initials, name }: { imageUrl?: string; initials: string; name: string }) {
+/**
+ * A 2px lane is reserved on every row so icons share one vertical line whether
+ * or not the row is selected — only the active row paints it. Squaring the left
+ * corners is what makes it read as a rail against the sidebar edge rather than
+ * a rounded sliver floating inside the pill. `--sidebar-primary` was defined in
+ * tokens.css and consumed by nothing before this; it is the one thing that
+ * distinguishes "selected" from "hovered", which otherwise share a fill.
+ */
+const RAIL_LANE = "relative before:absolute before:inset-y-0 before:left-0 before:w-0.5"
+const ACTIVE_RAIL = `${RAIL_LANE} data-[active=true]:rounded-l-none data-[active=true]:before:bg-sidebar-primary`
+
+/** Group labels sit below the items they name, not level with them. */
+const GROUP_LABEL = "h-6 text-muted-foreground"
+
+/** Beyond this the Pinned list stops being a shortcut and becomes a second list. */
+const MAX_PINNED = 5
+
+function UserAvatar({
+	imageUrl,
+	initials,
+	name,
+	className,
+}: {
+	imageUrl?: string
+	initials: string
+	name: string
+	className?: string
+}) {
+	const base = className ?? "size-6 rounded-md text-[10px]"
 	return imageUrl ? (
-		<img src={imageUrl} alt={name} className="size-8 shrink-0 rounded-md object-cover" />
+		<img alt={name} className={`${base} shrink-0 object-cover`} src={imageUrl} />
 	) : (
-		<div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground text-xs font-medium">
+		<div
+			className={`${base} flex shrink-0 items-center justify-center bg-muted font-medium text-muted-foreground`}
+		>
 			{initials}
 		</div>
 	)
@@ -85,27 +115,28 @@ function UserMenu() {
 			<DropdownMenuTrigger
 				render={
 					<SidebarMenuButton
-						size="lg"
 						className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+						tooltip={name}
 					/>
 				}
 			>
 				<UserAvatar imageUrl={imageUrl} initials={initials} name={name} />
-				<div className="grid flex-1 text-left text-sm leading-tight">
-					<span className="truncate font-medium">{name}</span>
-					{email && <span className="truncate text-xs text-muted-foreground">{email}</span>}
-				</div>
-				<ChevronUpIcon size={16} className="ml-auto" />
+				<span className="truncate font-medium">{name}</span>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent side="top" align="start" sideOffset={4} className="min-w-56">
+			<DropdownMenuContent align="start" className="min-w-56" side="top" sideOffset={4}>
 				<DropdownMenuGroup>
 					<DropdownMenuLabel>
 						<div className="flex items-center gap-2 py-1 text-left text-sm">
-							<UserAvatar imageUrl={imageUrl} initials={initials} name={name} />
+							<UserAvatar
+								className="size-8 rounded-md text-xs"
+								imageUrl={imageUrl}
+								initials={initials}
+								name={name}
+							/>
 							<div className="grid flex-1 text-left text-sm leading-tight">
 								<span className="truncate font-medium">{name}</span>
 								{email && (
-									<span className="truncate text-xs text-muted-foreground">{email}</span>
+									<span className="truncate text-muted-foreground text-xs">{email}</span>
 								)}
 							</div>
 						</div>
@@ -150,18 +181,15 @@ function GuestMenu() {
 			<DropdownMenuTrigger
 				render={
 					<SidebarMenuButton
-						size="lg"
 						className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+						tooltip="Root"
 					/>
 				}
 			>
 				<UserAvatar initials="RT" name="Root" />
-				<div className="grid flex-1 text-left text-sm leading-tight">
-					<span className="truncate font-medium">Root</span>
-				</div>
-				<ChevronUpIcon size={16} className="ml-auto" />
+				<span className="truncate font-medium">Root</span>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent side="top" align="start" sideOffset={4} className="min-w-56">
+			<DropdownMenuContent align="start" className="min-w-56" side="top" sideOffset={4}>
 				<DropdownMenuGroup>
 					<ThemeToggle />
 				</DropdownMenuGroup>
@@ -189,241 +217,300 @@ function GuestMenu() {
 	)
 }
 
+/**
+ * ⌘K is the escape hatch that lets the nav stay short, so it needs to be
+ * visible rather than folklore. Collapses to the magnifier alone on the rail.
+ */
+function SearchRow() {
+	return (
+		<SidebarMenu>
+			<SidebarMenuItem>
+				<SidebarMenuButton
+					className="border border-sidebar-border bg-background text-muted-foreground hover:bg-background hover:text-foreground"
+					onClick={openCommandPalette}
+					tooltip="Search"
+				>
+					<MagnifierIcon size={16} />
+					<span className="flex-1 text-left">Search</span>
+					<Kbd className="group-data-[collapsible=icon]:hidden">⌘K</Kbd>
+				</SidebarMenuButton>
+			</SidebarMenuItem>
+		</SidebarMenu>
+	)
+}
+
+function NavRow({ item, currentPath }: { item: NavItem; currentPath: string }) {
+	const { state, isMobile } = useSidebar()
+	const isActive = isNavItemActive(currentPath, item)
+	const subItems = item.subItems
+	const collapsed = state === "collapsed" && !isMobile
+
+	// Longest match wins: Infrastructure's Hosts child is `/infra`, which
+	// prefixes every one of its siblings, so a plain match would light up two
+	// rows on /infra/kubernetes/pods.
+	const activeSubHref = useMemo(() => {
+		let best: string | undefined
+		for (const sub of subItems ?? []) {
+			if (!isPathActive(currentPath, sub.href)) continue
+			if (best === undefined || sub.href.length > best.length) best = sub.href
+		}
+		return best
+	}, [subItems, currentPath])
+
+	// The sub-list can't render at 48px, so the rail turns the row into a menu.
+	// Without this, every child route is stranded while the sidebar is collapsed
+	// — which is the state Infrastructure ships in today.
+	if (collapsed && subItems && subItems.length > 0) {
+		return (
+			<SidebarMenuItem>
+				<DropdownMenu>
+					<DropdownMenuTrigger
+						render={<SidebarMenuButton className={ACTIVE_RAIL} isActive={isActive} />}
+					>
+						<item.icon size={18} />
+						<span>{item.title}</span>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="start" className="min-w-44" side="right" sideOffset={4}>
+						{/* Base UI scopes labels to a group — a bare DropdownMenuLabel
+						    throws MenuGroupContext is missing. */}
+						<DropdownMenuGroup>
+							<DropdownMenuLabel>{item.title}</DropdownMenuLabel>
+							{subItems.map((sub) => (
+								<DropdownMenuItem key={sub.title} render={<Link to={sub.href} />}>
+									{sub.icon ? <sub.icon size={16} /> : null}
+									{sub.title}
+								</DropdownMenuItem>
+							))}
+						</DropdownMenuGroup>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</SidebarMenuItem>
+		)
+	}
+
+	// While a section is open the rail belongs to the child you're actually on,
+	// not the parent — otherwise two amber bars compete and neither points at
+	// the current page. The open parent keeps the fill.
+	const isOpen = Boolean(subItems && subItems.length > 0 && isActive)
+
+	return (
+		<SidebarMenuItem>
+			<SidebarMenuButton
+				className={isOpen ? RAIL_LANE : ACTIVE_RAIL}
+				isActive={isActive}
+				render={<Link to={item.href} />}
+				tooltip={item.title}
+			>
+				<item.icon size={18} />
+				<span>{item.title}</span>
+			</SidebarMenuButton>
+			{item.badge ? (
+				<SidebarMenuBadge>
+					<Badge className="h-4 px-1.5 py-0 font-medium text-[10px]" variant="secondary">
+						{item.badge}
+					</Badge>
+				</SidebarMenuBadge>
+			) : null}
+			{subItems && isActive ? (
+				<SidebarMenuSub>
+					{subItems.map((sub) => (
+						<SidebarMenuSubItem key={sub.title}>
+							<SidebarMenuSubButton
+								className={`${ACTIVE_RAIL} [&>svg]:text-current`}
+								isActive={sub.href === activeSubHref}
+								render={<Link to={sub.href} />}
+							>
+								{sub.icon ? <sub.icon className="size-3.5" /> : null}
+								<span>{sub.title}</span>
+							</SidebarMenuSubButton>
+						</SidebarMenuSubItem>
+					))}
+				</SidebarMenuSub>
+			) : null}
+		</SidebarMenuItem>
+	)
+}
+
+function NavGroupSection({ group, currentPath }: { group: NavGroup; currentPath: string }) {
+	return (
+		<SidebarGroup>
+			{group.label ? (
+				<SidebarGroupLabel className={GROUP_LABEL}>{group.label}</SidebarGroupLabel>
+			) : null}
+			<SidebarGroupContent>
+				<SidebarMenu>
+					{group.items.map((item) => (
+						<NavRow currentPath={currentPath} item={item} key={item.title} />
+					))}
+				</SidebarMenu>
+			</SidebarGroupContent>
+		</SidebarGroup>
+	)
+}
+
+/**
+ * Replaces the old inline dashboards list, which had no ceiling — every
+ * dashboard in the org landed in the sidebar behind a 160px scroll region with
+ * a mask fade, nested inside the sidebar's own scroll region. This is curated,
+ * capped, and reports the true total in its header.
+ *
+ * Hidden on the collapsed rail: with dashboards-only pins every glyph is the
+ * same grid mark, so a column of them conveys nothing. Worth revisiting once
+ * pins can hold services (which carry a coloured ServiceDot).
+ */
+function PinnedGroup({ currentPath }: { currentPath: string }) {
+	const { dashboards, isLoading } = useDashboardsRead()
+	const { favorites } = useDashboardPreferences()
+
+	const pinned = useMemo(() => dashboards.filter((d) => favorites.has(d.id)), [dashboards, favorites])
+	const visible = pinned.slice(0, MAX_PINNED)
+	const overflow = pinned.length - visible.length
+	const activeDashboardId = currentPath.match(/^\/dashboards\/([^/]+)/)?.[1]
+
+	if (isLoading) return null
+
+	return (
+		<SidebarGroup className="group-data-[collapsible=icon]:hidden">
+			<SidebarGroupLabel className={GROUP_LABEL}>
+				<span className="flex-1">Pinned</span>
+				{pinned.length > 0 ? <span className="font-normal tabular-nums">{pinned.length}</span> : null}
+			</SidebarGroupLabel>
+			<SidebarGroupContent>
+				{visible.length === 0 ? (
+					<p className="rounded-md border border-sidebar-border border-dashed px-2.5 py-2 text-[11px] text-muted-foreground leading-relaxed">
+						Pin a dashboard to keep it here.
+					</p>
+				) : (
+					<SidebarMenu>
+						{visible.map((dashboard) => (
+							<SidebarMenuItem key={dashboard.id}>
+								<SidebarMenuButton
+									className={ACTIVE_RAIL}
+									isActive={activeDashboardId === dashboard.id}
+									render={
+										<Link
+											params={{ dashboardId: dashboard.id }}
+											to="/dashboards/$dashboardId"
+										/>
+									}
+									size="sm"
+								>
+									<GridSquareCirclePlusIcon className="size-3.5 text-muted-foreground" />
+									<span>{dashboard.name}</span>
+								</SidebarMenuButton>
+							</SidebarMenuItem>
+						))}
+						{overflow > 0 ? (
+							<SidebarMenuItem>
+								<SidebarMenuButton
+									className={`${ACTIVE_RAIL} text-muted-foreground`}
+									render={<Link to="/dashboards" />}
+									size="sm"
+								>
+									<span className="size-3.5 shrink-0" />
+									<span>{overflow} more…</span>
+								</SidebarMenuButton>
+							</SidebarMenuItem>
+						) : null}
+					</SidebarMenu>
+				)}
+			</SidebarGroupContent>
+		</SidebarGroup>
+	)
+}
+
+/** Settings and help stop scrolling away by leaving SidebarContent entirely. */
+function SupportMenu() {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger
+				render={
+					<SidebarMenuButton
+						className="size-8 w-8 shrink-0 justify-center p-0 group-data-[collapsible=icon]:w-full"
+						tooltip="Support"
+					/>
+				}
+			>
+				<CircleQuestionIcon size={16} />
+				<span className="sr-only">Support</span>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" side="top" sideOffset={4}>
+				<DropdownMenuGroup>
+					<DropdownMenuItem
+						render={
+							<a
+								aria-label="Community Discord"
+								href="https://discord.gg/BnXjKuwJqP"
+								rel="noopener noreferrer"
+								target="_blank"
+							/>
+						}
+					>
+						<DiscordIcon size={16} />
+						Community Discord
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						render={<a aria-label="Email Support" href="mailto:support@maple.dev" />}
+					>
+						<EnvelopeIcon size={16} />
+						Email Support
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={showKeyboardShortcuts}>
+						<KeyboardIcon size={16} />
+						Keyboard shortcuts
+						<DropdownMenuShortcut>?</DropdownMenuShortcut>
+					</DropdownMenuItem>
+				</DropdownMenuGroup>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	)
+}
+
+function FooterCluster({ currentPath }: { currentPath: string }) {
+	return (
+		<SidebarMenu>
+			<SidebarMenuItem className="flex items-center gap-1 group-data-[collapsible=icon]:flex-col">
+				<div className="min-w-0 flex-1 group-data-[collapsible=icon]:w-full group-data-[collapsible=icon]:flex-none">
+					{isClerkAuthEnabled ? <UserMenu /> : <GuestMenu />}
+				</div>
+				<SidebarMenuButton
+					className={`${ACTIVE_RAIL} size-8 w-8 shrink-0 justify-center p-0 group-data-[collapsible=icon]:w-full`}
+					isActive={isPathActive(currentPath, "/settings")}
+					render={<Link to="/settings" />}
+					tooltip="Settings"
+				>
+					<GearIcon size={16} />
+					<span className="sr-only">Settings</span>
+				</SidebarMenuButton>
+				<SupportMenu />
+			</SidebarMenuItem>
+		</SidebarMenu>
+	)
+}
+
 // Memoized: DashboardLayout renders this inside every page, so without memo the
 // sidebar's ~500-fiber subtree rerenders on every page-level state change
 // (refresh version bumps, search-param updates, query settles). The selector
 // (instead of bare useRouterState) keeps it quiet during loader/pending ticks.
 export const AppSidebar = memo(function AppSidebar() {
 	const currentPath = useRouterState({ select: (s) => s.location.pathname })
-	const { dashboards, isLoading } = useDashboardsRead()
-	const { favorites } = useDashboardPreferences()
-
-	const dashboardMatch = currentPath.match(/^\/dashboards\/([^/]+)/)
-	const activeDashboardId = dashboardMatch?.[1]
-
-	const favoriteDashboards = dashboards.filter((d) => favorites.has(d.id))
-	const otherDashboards = dashboards.filter((d) => !favorites.has(d.id))
-
 	const infraEnabled = useInfraEnabled()
-	const signalsItems = visibleSignalsNavItems({ infraEnabled })
+	const groups = useMemo(() => navGroups({ infraEnabled }), [infraEnabled])
 
 	return (
 		<Sidebar collapsible="icon">
 			<SidebarHeader>
 				<OrgSwitcher />
+				<SearchRow />
 			</SidebarHeader>
 			<SidebarContent>
-				<SidebarGroup>
-					<SidebarGroupContent>
-						<SidebarMenu>
-							{mainNavItems.map((item) => {
-								const isActive = currentPath === item.href
-								return (
-									<SidebarMenuItem key={item.title}>
-										<SidebarMenuButton
-											render={<Link to={item.href} />}
-											tooltip={item.title}
-											isActive={isActive}
-										>
-											<item.icon size={18} />
-											<span>{item.title}</span>
-										</SidebarMenuButton>
-									</SidebarMenuItem>
-								)
-							})}
-						</SidebarMenu>
-					</SidebarGroupContent>
-				</SidebarGroup>
-
-				{[topologyNavItems, signalsItems, investigateNavItems].map((group) => (
-					<SidebarGroup key={group[0].title}>
-						<SidebarGroupContent>
-							<SidebarMenu>
-								{group.map((item) => {
-									const isActive = currentPath.startsWith(item.href)
-									const subItems =
-										"subItems" in item
-											? (item.subItems as NavSubItem[] | undefined)
-											: undefined
-									return (
-										<SidebarMenuItem key={item.title}>
-											<SidebarMenuButton
-												render={<Link to={item.href} />}
-												tooltip={item.title}
-												isActive={isActive}
-											>
-												<item.icon size={18} />
-												<span>{item.title}</span>
-											</SidebarMenuButton>
-											{"badge" in item && (item.badge as string) ? (
-												<SidebarMenuBadge>
-													<Badge
-														variant="secondary"
-														className="text-[10px] px-1.5 py-0 h-4 font-medium"
-													>
-														{item.badge as string}
-													</Badge>
-												</SidebarMenuBadge>
-											) : null}
-											{subItems && isActive ? (
-												<SidebarMenuSub>
-													{subItems.map((sub) => {
-														const subActive =
-															sub.href === item.href
-																? currentPath === item.href ||
-																	currentPath === `${item.href}/`
-																: currentPath.startsWith(sub.href)
-														return (
-															<SidebarMenuSubItem key={sub.title}>
-																<SidebarMenuSubButton
-																	render={<Link to={sub.href} />}
-																	isActive={subActive}
-																>
-																	{sub.icon ? <sub.icon size={14} /> : null}
-																	<span>{sub.title}</span>
-																</SidebarMenuSubButton>
-															</SidebarMenuSubItem>
-														)
-													})}
-												</SidebarMenuSub>
-											) : null}
-										</SidebarMenuItem>
-									)
-								})}
-							</SidebarMenu>
-						</SidebarGroupContent>
-					</SidebarGroup>
+				{groups.map((group) => (
+					<NavGroupSection currentPath={currentPath} group={group} key={group.id} />
 				))}
-
-				<Collapsible defaultOpen className="group/dashboards flex flex-col">
-					<SidebarGroup className="flex flex-col">
-						<SidebarGroupLabel render={<CollapsibleTrigger />}>
-							<GridSquareCirclePlusIcon size={14} className="mr-1 !size-3.5" />
-							Dashboards
-							<ChevronRightIcon
-								size={14}
-								className="ml-auto !size-3.5 transition-transform group-data-[open]/dashboards:rotate-90"
-							/>
-						</SidebarGroupLabel>
-						<CollapsibleContent className="flex flex-col">
-							<SidebarGroupContent className="flex flex-col">
-								<SidebarMenu className="flex flex-col">
-									<SidebarMenuItem>
-										<SidebarMenuButton
-											render={<Link to="/dashboards" />}
-											tooltip="All Dashboards"
-											isActive={
-												currentPath === "/dashboards" ||
-												currentPath === "/dashboards/"
-											}
-										>
-											<GridSquareCirclePlusIcon size={18} />
-											<span>All Dashboards</span>
-										</SidebarMenuButton>
-									</SidebarMenuItem>
-									{!isLoading && dashboards.length > 0 && (
-										<SidebarMenuSub className="max-h-40 overflow-y-auto [mask-image:linear-gradient(to_bottom,transparent_0,black_8px,black_calc(100%-8px),transparent_100%)]">
-											{favoriteDashboards.map((dashboard) => (
-												<SidebarMenuSubItem key={dashboard.id}>
-													<SidebarMenuSubButton
-														render={
-															<Link
-																to="/dashboards/$dashboardId"
-																params={{ dashboardId: dashboard.id }}
-															/>
-														}
-														isActive={activeDashboardId === dashboard.id}
-													>
-														<span className="text-amber-500 mr-1">&#9733;</span>
-														<span>{dashboard.name}</span>
-													</SidebarMenuSubButton>
-												</SidebarMenuSubItem>
-											))}
-											{otherDashboards.map((dashboard) => (
-												<SidebarMenuSubItem key={dashboard.id}>
-													<SidebarMenuSubButton
-														render={
-															<Link
-																to="/dashboards/$dashboardId"
-																params={{ dashboardId: dashboard.id }}
-															/>
-														}
-														isActive={activeDashboardId === dashboard.id}
-													>
-														<span>{dashboard.name}</span>
-													</SidebarMenuSubButton>
-												</SidebarMenuSubItem>
-											))}
-										</SidebarMenuSub>
-									)}
-								</SidebarMenu>
-							</SidebarGroupContent>
-						</CollapsibleContent>
-					</SidebarGroup>
-				</Collapsible>
-
-				<SidebarGroup>
-					<SidebarGroupContent>
-						<SidebarMenu>
-							<SidebarMenuItem>
-								<DropdownMenu>
-									<DropdownMenuTrigger render={<SidebarMenuButton tooltip="Support" />}>
-										<CircleQuestionIcon size={18} />
-										<span>Support</span>
-									</DropdownMenuTrigger>
-									<DropdownMenuContent side="right" align="start" sideOffset={4}>
-										<DropdownMenuGroup>
-											<DropdownMenuItem
-												render={
-													<a
-														href="https://discord.gg/BnXjKuwJqP"
-														target="_blank"
-														rel="noopener noreferrer"
-														aria-label="Community Discord"
-													/>
-												}
-											>
-												<DiscordIcon size={16} />
-												Community Discord
-											</DropdownMenuItem>
-											<DropdownMenuItem
-												render={
-													<a
-														href="mailto:support@maple.dev"
-														aria-label="Email Support"
-													/>
-												}
-											>
-												<EnvelopeIcon size={16} />
-												Email Support
-											</DropdownMenuItem>
-											<DropdownMenuItem onClick={showKeyboardShortcuts}>
-												<KeyboardIcon size={16} />
-												Keyboard shortcuts
-												<DropdownMenuShortcut>?</DropdownMenuShortcut>
-											</DropdownMenuItem>
-										</DropdownMenuGroup>
-									</DropdownMenuContent>
-								</DropdownMenu>
-							</SidebarMenuItem>
-							<SidebarMenuItem>
-								<SidebarMenuButton
-									render={<Link to="/settings" />}
-									tooltip="Settings"
-									isActive={currentPath.startsWith("/settings")}
-								>
-									<GearIcon size={18} />
-									<span>Settings</span>
-								</SidebarMenuButton>
-							</SidebarMenuItem>
-						</SidebarMenu>
-					</SidebarGroupContent>
-				</SidebarGroup>
+				<PinnedGroup currentPath={currentPath} />
 			</SidebarContent>
-			<SidebarFooter>
-				<SidebarMenu>
-					<SidebarMenuItem>{isClerkAuthEnabled ? <UserMenu /> : <GuestMenu />}</SidebarMenuItem>
-				</SidebarMenu>
+			<SidebarFooter className="border-sidebar-border border-t">
+				<FooterCluster currentPath={currentPath} />
 			</SidebarFooter>
 		</Sidebar>
 	)

--- a/apps/web/src/components/dashboard/app-sidebar.tsx
+++ b/apps/web/src/components/dashboard/app-sidebar.tsx
@@ -65,7 +65,7 @@ import { useInfraEnabled } from "@/hooks/use-infra-enabled"
  * distinguishes "selected" from "hovered", which otherwise share a fill.
  */
 const RAIL_LANE = "relative before:absolute before:inset-y-0 before:left-0 before:w-0.5"
-const ACTIVE_RAIL = `${RAIL_LANE} data-[active=true]:rounded-l-none data-[active=true]:before:bg-sidebar-primary`
+const ACTIVE_RAIL = `${RAIL_LANE} data-[active=true]:rounded-l-none data-[active=true]:before:bg-sidebar-primary data-[active=true]:text-sidebar-primary`
 
 /** Group labels sit below the items they name, not level with them. */
 const GROUP_LABEL = "h-6 text-muted-foreground"
@@ -312,11 +312,21 @@ function NavRow({ item, currentPath }: { item: NavItem; currentPath: string }) {
 				</SidebarMenuBadge>
 			) : null}
 			{subItems && isActive ? (
-				<SidebarMenuSub>
+				// The guide line *is* the rail: each child owns a 2px segment of it,
+				// so the selected one lights the track itself instead of parking a
+				// second amber bar a few pixels beside it.
+				<SidebarMenuSub className="mx-0 ms-4 translate-x-0 gap-0 border-l-0 px-0 py-0">
 					{subItems.map((sub) => (
-						<SidebarMenuSubItem key={sub.title}>
+						<SidebarMenuSubItem
+							className={
+								sub.href === activeSubHref
+									? "border-sidebar-primary border-l-2 ps-2.5"
+									: "border-sidebar-border border-l-2 ps-2.5"
+							}
+							key={sub.title}
+						>
 							<SidebarMenuSubButton
-								className={`${ACTIVE_RAIL} [&>svg]:text-current`}
+								className="translate-x-0 data-[active=true]:text-sidebar-primary [&>svg]:text-current"
 								isActive={sub.href === activeSubHref}
 								render={<Link to={sub.href} />}
 							>

--- a/apps/web/src/components/dashboard/app-sidebar.tsx
+++ b/apps/web/src/components/dashboard/app-sidebar.tsx
@@ -364,9 +364,13 @@ function NavGroupSection({ group, currentPath }: { group: NavGroup; currentPath:
  * a mask fade, nested inside the sidebar's own scroll region. This is curated,
  * capped, and reports the true total in its header.
  *
- * Hidden on the collapsed rail: with dashboards-only pins every glyph is the
- * same grid mark, so a column of them conveys nothing. Worth revisiting once
- * pins can hold services (which carry a coloured ServiceDot).
+ * Labelled "Pinned dashboards" rather than "Pinned" because dashboards are all
+ * it holds today — broaden the label at the same time the group starts taking
+ * services and saved views, not before.
+ *
+ * Hidden on the collapsed rail for the same reason: with dashboards-only pins
+ * every glyph is the same grid mark, so a column of them conveys nothing.
+ * Services would bring a coloured ServiceDot and make the rail worth having.
  */
 function PinnedGroup({ currentPath }: { currentPath: string }) {
 	const { dashboards, isLoading } = useDashboardsRead()
@@ -382,7 +386,7 @@ function PinnedGroup({ currentPath }: { currentPath: string }) {
 	return (
 		<SidebarGroup className="group-data-[collapsible=icon]:hidden">
 			<SidebarGroupLabel className={GROUP_LABEL}>
-				<span className="flex-1">Pinned</span>
+				<span className="flex-1">Pinned dashboards</span>
 				{pinned.length > 0 ? <span className="font-normal tabular-nums">{pinned.length}</span> : null}
 			</SidebarGroupLabel>
 			<SidebarGroupContent>

--- a/apps/web/src/components/dashboard/nav-items.test.ts
+++ b/apps/web/src/components/dashboard/nav-items.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest"
+import { isNavItemActive, isPathActive, navGroups, paletteNavItems, type NavItem } from "./nav-items"
+
+const enabled = { infraEnabled: true }
+const gated = { infraEnabled: false }
+
+function findItem(flags: { infraEnabled: boolean }, title: string): NavItem {
+	const item = navGroups(flags)
+		.flatMap((group) => group.items)
+		.find((candidate) => candidate.title === title)
+	if (!item) throw new Error(`no nav item titled ${title}`)
+	return item
+}
+
+describe("isPathActive", () => {
+	it("matches a route and its descendants", () => {
+		expect(isPathActive("/services", "/services")).toBe(true)
+		expect(isPathActive("/services/checkout-svc", "/services")).toBe(true)
+	})
+
+	it("does not let a route claim a sibling that shares its prefix", () => {
+		// The bug this replaces: a bare startsWith made /services light up on
+		// /service-map, and would have on any future /services-foo route.
+		expect(isPathActive("/service-map", "/services")).toBe(false)
+		expect(isPathActive("/servicesomething", "/services")).toBe(false)
+	})
+
+	it("treats the root as exact", () => {
+		expect(isPathActive("/", "/")).toBe(true)
+		expect(isPathActive("/traces", "/")).toBe(false)
+	})
+})
+
+describe("isNavItemActive", () => {
+	it("keeps Explore active on every signal, not just its own href", () => {
+		const explore = findItem(enabled, "Explore")
+		for (const path of ["/traces", "/logs", "/metrics", "/replays"]) {
+			expect(isNavItemActive(path, explore)).toBe(true)
+		}
+		expect(isNavItemActive("/services", explore)).toBe(false)
+	})
+
+	it("keeps Explore active on a signal's detail route", () => {
+		expect(isNavItemActive("/logs/abc123", findItem(enabled, "Explore"))).toBe(true)
+	})
+
+	it("keeps Infrastructure active across its children", () => {
+		const infra = findItem(enabled, "Infrastructure")
+		expect(isNavItemActive("/infra", infra)).toBe(true)
+		expect(isNavItemActive("/infra/kubernetes/pods", infra)).toBe(true)
+		expect(isNavItemActive("/infra/planetscale", infra)).toBe(true)
+	})
+})
+
+describe("navGroups", () => {
+	it("renders nine top-level rows at rest", () => {
+		const rows = navGroups(enabled).flatMap((group) => group.items)
+		expect(rows.map((item) => item.title)).toEqual([
+			"Overview",
+			"Services",
+			"Service Map",
+			"Infrastructure",
+			"Explore",
+			"Dashboards",
+			"Investigations",
+			"Errors",
+			"Alerts",
+		])
+	})
+
+	it("keeps the Infrastructure row when the agent pages are gated off", () => {
+		// The row must survive so the sidebar's shape doesn't change when the
+		// Clerk flag resolves — only the children it offers do.
+		const infra = findItem(gated, "Infrastructure")
+		expect(infra.subItems?.map((sub) => sub.title)).toEqual(["Cloudflare", "PlanetScale"])
+		expect(infra.href).toBe("/infra/cloudflare")
+	})
+})
+
+describe("paletteNavItems", () => {
+	it("keeps every destination the sidebar folded into a section reachable by name", () => {
+		const titles = paletteNavItems(enabled).map((entry) => entry.title)
+		for (const title of [
+			"Traces",
+			"Logs",
+			"Metrics",
+			"Replays",
+			"Hosts",
+			"K8s Pods",
+			"K8s Nodes",
+			"K8s Workloads",
+			"Cloudflare",
+			"PlanetScale",
+		]) {
+			expect(titles).toContain(title)
+		}
+	})
+
+	it("points the signal entries at their own routes", () => {
+		const entries = paletteNavItems(enabled)
+		expect(entries.find((e) => e.title === "Logs")?.href).toBe("/logs")
+		expect(entries.find((e) => e.title === "Replays")?.href).toBe("/replays")
+	})
+
+	it("emits no duplicate ids", () => {
+		const ids = paletteNavItems(enabled).map((entry) => entry.id)
+		expect(new Set(ids).size).toBe(ids.length)
+	})
+
+	it("drops the gated infra children", () => {
+		const titles = paletteNavItems(gated).map((entry) => entry.title)
+		expect(titles).not.toContain("K8s Pods")
+		expect(titles).toContain("Cloudflare")
+	})
+})

--- a/apps/web/src/components/dashboard/nav-items.ts
+++ b/apps/web/src/components/dashboard/nav-items.ts
@@ -5,7 +5,9 @@ import {
 	CloudflareIcon,
 	ComputerIcon,
 	FileIcon,
+	GridSquareCirclePlusIcon,
 	HouseIcon,
+	LayersIcon,
 	MagnifierCheckIcon,
 	NetworkNodesIcon,
 	PlanetScaleIcon,
@@ -14,12 +16,6 @@ import {
 	ServerIcon,
 } from "@/components/icons"
 
-export interface NavItem {
-	title: string
-	href: string
-	icon: typeof PulseIcon
-}
-
 export interface NavSubItem {
 	title: string
 	href: string
@@ -27,109 +23,172 @@ export interface NavSubItem {
 	icon?: typeof PulseIcon
 }
 
-interface SignalsNavItem extends NavItem {
-	badge?: string
+export interface NavItem {
+	title: string
+	href: string
+	icon: typeof PulseIcon
+	/**
+	 * Children revealed underneath the row while the section is active. A
+	 * section counts as active when the path matches its own href *or* any
+	 * child's, so a parent whose href follows its first child still lights up
+	 * on the siblings.
+	 */
 	subItems?: NavSubItem[]
+	badge?: string
 }
 
-export const mainNavItems: NavItem[] = [
-	{
-		title: "Overview",
-		href: "/",
-		icon: HouseIcon,
-	},
-]
+export interface NavGroup {
+	/** Stable key — labels are optional, so never key off them. */
+	id: string
+	/** Rendered uppercase. Omitted for the lead group so Overview reads as the root. */
+	label?: string
+	items: NavItem[]
+}
 
-export const topologyNavItems: NavItem[] = [
-	{
-		title: "Services",
-		href: "/services",
-		icon: ServerIcon,
-	},
-	{
-		title: "Service Map",
-		href: "/service-map",
-		icon: NetworkNodesIcon,
-	},
-]
+const overviewItem: NavItem = {
+	title: "Overview",
+	href: "/",
+	icon: HouseIcon,
+}
 
-const signalsNavItems: SignalsNavItem[] = [
-	{
-		title: "Traces",
-		href: "/traces",
-		icon: PulseIcon,
-	},
-	{
-		title: "Logs",
-		href: "/logs",
-		icon: FileIcon,
-	},
-	{
-		title: "Metrics",
-		href: "/metrics",
-		icon: ChartLineIcon,
-	},
-	{
-		title: "Replays",
-		href: "/replays",
-		icon: PlayRotateClockwiseIcon,
-	},
-	{
-		title: "Infrastructure",
-		href: "/infra",
-		icon: ComputerIcon,
-		subItems: [
-			{ title: "Hosts", href: "/infra" },
-			{ title: "K8s Pods", href: "/infra/kubernetes/pods" },
-			{ title: "K8s Nodes", href: "/infra/kubernetes/nodes" },
-			{ title: "K8s Workloads", href: "/infra/kubernetes/workloads" },
-			{ title: "Cloudflare", href: "/infra/cloudflare", icon: CloudflareIcon },
-			{ title: "PlanetScale", href: "/infra/planetscale", icon: PlanetScaleIcon },
-		],
-	},
-]
-
-export const investigateNavItems: NavItem[] = [
-	{
-		title: "Investigations",
-		href: "/investigations",
-		icon: MagnifierCheckIcon,
-	},
-	{
-		title: "Errors",
-		href: "/errors",
-		icon: CircleWarningIcon,
-	},
-	// Anomalies is reachable at /anomalies but hidden from the sidebar until the
-	// detector has been validated against production baselines.
-	// {
-	// 	title: "Anomalies",
-	// 	href: "/anomalies",
-	// 	icon: ChartBarTrendUpIcon,
-	// },
-	{
-		title: "Alerts",
-		href: "/alerts",
-		icon: BellIcon,
-	},
-]
+const infrastructureItem: NavItem = {
+	title: "Infrastructure",
+	href: "/infra",
+	icon: ComputerIcon,
+	subItems: [
+		{ title: "Hosts", href: "/infra" },
+		{ title: "K8s Pods", href: "/infra/kubernetes/pods" },
+		{ title: "K8s Nodes", href: "/infra/kubernetes/nodes" },
+		{ title: "K8s Workloads", href: "/infra/kubernetes/workloads" },
+		{ title: "Cloudflare", href: "/infra/cloudflare", icon: CloudflareIcon },
+		{ title: "PlanetScale", href: "/infra/planetscale", icon: PlanetScaleIcon },
+	],
+}
 
 /**
- * Signals items with org feature gates applied (matches the sidebar's
- * filtering). `infra_monitoring` gates the host/k8s agent pages only —
- * Cloudflare/PlanetScale analytics come from integrations, not the infra
- * agent, so when infra is off the Infrastructure entry collapses to just the
- * integration pages (which gate themselves on connection status).
+ * Traces, Logs, Metrics and Replays are one interaction — pick a time range,
+ * filter, scan a list, open one — sharing a toolbar and a filter column. They
+ * read as one section with four children rather than four top-level rows, using
+ * the same reveal-when-active pattern Infrastructure already uses. The parent
+ * href follows its first child; the underlying routes are unchanged.
  */
-export function visibleSignalsNavItems(flags: { infraEnabled: boolean }) {
-	if (flags.infraEnabled) return signalsNavItems
-	return signalsNavItems.map((item) => {
-		if (item.href !== "/infra") return item
-		const subItems = item.subItems?.filter(
-			(sub) => sub.href.startsWith("/infra/cloudflare") || sub.href.startsWith("/infra/planetscale"),
-		)
-		// The parent click target follows the first surviving integration page
-		// instead of hardcoding one of them.
-		return { ...item, href: subItems?.[0]?.href ?? "/infra/cloudflare", subItems }
-	})
+const exploreItem: NavItem = {
+	title: "Explore",
+	href: "/traces",
+	icon: LayersIcon,
+	subItems: [
+		{ title: "Traces", href: "/traces", icon: PulseIcon },
+		{ title: "Logs", href: "/logs", icon: FileIcon },
+		{ title: "Metrics", href: "/metrics", icon: ChartLineIcon },
+		{ title: "Replays", href: "/replays", icon: PlayRotateClockwiseIcon },
+	],
+}
+
+/**
+ * `infra_monitoring` gates the host/k8s agent pages only — Cloudflare and
+ * PlanetScale analytics come from integrations, not the infra agent, so when
+ * infra is off the section collapses to just the integration pages (which gate
+ * themselves on connection status). The row itself never disappears, so the
+ * sidebar's shape does not change when the flag resolves.
+ */
+function visibleInfrastructureItem(flags: { infraEnabled: boolean }): NavItem {
+	if (flags.infraEnabled) return infrastructureItem
+	const subItems = infrastructureItem.subItems?.filter(
+		(sub) => sub.href.startsWith("/infra/cloudflare") || sub.href.startsWith("/infra/planetscale"),
+	)
+	// The parent click target follows the first surviving integration page
+	// instead of hardcoding one of them.
+	return { ...infrastructureItem, href: subItems?.[0]?.href ?? "/infra/cloudflare", subItems }
+}
+
+/**
+ * The sidebar's information architecture, and the single source the command
+ * palette flattens. Anomalies is reachable at /anomalies but stays out of both
+ * until the detector has been validated against production baselines.
+ */
+export function navGroups(flags: { infraEnabled: boolean }): NavGroup[] {
+	return [
+		{ id: "overview", items: [overviewItem] },
+		{
+			id: "monitor",
+			label: "Monitor",
+			items: [
+				{ title: "Services", href: "/services", icon: ServerIcon },
+				{ title: "Service Map", href: "/service-map", icon: NetworkNodesIcon },
+				visibleInfrastructureItem(flags),
+			],
+		},
+		{
+			id: "analyze",
+			label: "Analyze",
+			items: [
+				exploreItem,
+				{ title: "Dashboards", href: "/dashboards", icon: GridSquareCirclePlusIcon },
+			],
+		},
+		{
+			id: "triage",
+			label: "Triage",
+			items: [
+				{ title: "Investigations", href: "/investigations", icon: MagnifierCheckIcon },
+				{ title: "Errors", href: "/errors", icon: CircleWarningIcon },
+				{ title: "Alerts", href: "/alerts", icon: BellIcon },
+			],
+		},
+	]
+}
+
+/**
+ * Segment-aware prefix match. A bare `startsWith` lets /services claim
+ * /service-map the moment two top-level routes share a prefix.
+ */
+export function isPathActive(currentPath: string, href: string): boolean {
+	if (href === "/") return currentPath === "/" || currentPath === ""
+	return currentPath === href || currentPath.startsWith(`${href}/`)
+}
+
+/** A section is active on its own href or on any of its children's. */
+export function isNavItemActive(currentPath: string, item: NavItem): boolean {
+	if (isPathActive(currentPath, item.href)) return true
+	return item.subItems?.some((sub) => isPathActive(currentPath, sub.href)) ?? false
+}
+
+export interface PaletteNavEntry {
+	id: string
+	title: string
+	href: string
+	icon?: typeof PulseIcon
+}
+
+/**
+ * Flattened nav for ⌘K: every section *and* every child. Collapsing four rows
+ * into Explore must not cost a user the ability to type "logs" — the children
+ * are the entries that keep muscle memory working, and they were never in the
+ * palette before this.
+ */
+export function paletteNavItems(flags: { infraEnabled: boolean }): PaletteNavEntry[] {
+	const entries: PaletteNavEntry[] = []
+	const seen = new Set<string>()
+	const push = (entry: PaletteNavEntry) => {
+		const key = `${entry.title}:${entry.href}`
+		if (seen.has(key)) return
+		seen.add(key)
+		entries.push(entry)
+	}
+
+	for (const group of navGroups(flags)) {
+		for (const item of group.items) {
+			push({ id: `nav:${item.title}`, title: item.title, href: item.href, icon: item.icon })
+			for (const sub of item.subItems ?? []) {
+				push({
+					id: `nav:${item.title}:${sub.title}`,
+					title: sub.title,
+					href: sub.href,
+					icon: sub.icon ?? item.icon,
+				})
+			}
+		}
+	}
+
+	return entries
 }

--- a/apps/web/src/components/icons/layers.tsx
+++ b/apps/web/src/components/icons/layers.tsx
@@ -1,6 +1,29 @@
 import type { IconProps } from "./icon"
 
-const paths: ReadonlyArray<string> = ["M12 3L21 8L12 13L3 8L12 3Z", "M3 13L12 18L21 13"]
+// Nucleo Pixel Essential — "layers" (set 8, 24 grid), ported to currentColor.
+// Ordered top to bottom; every segment sits on an even pixel so the stack stays
+// crisp at 16 and 18px.
+const paths: ReadonlyArray<string> = [
+	"M13 3L11 3",
+	"M9 5L8 5",
+	"M16 5L15 5",
+	"M6 7L5 7",
+	"M19 7L18 7",
+	"M3 9L2 9",
+	"M22 9L21 9",
+	"M6 11L5 11",
+	"M19 11L18 11",
+	"M9 13L8 13",
+	"M16 13L15 13",
+	"M3 15L2 15",
+	"M13 15L11 15",
+	"M22 15L21 15",
+	"M6 17L5 17",
+	"M19 17L18 17",
+	"M9 19L8 19",
+	"M16 19L15 19",
+	"M13 21L11 21",
+]
 
 function LayersIcon({ size = 24, className, ...props }: IconProps) {
 	return (
@@ -15,14 +38,7 @@ function LayersIcon({ size = 24, className, ...props }: IconProps) {
 			{...props}
 		>
 			{paths.map((d, i) => (
-				<path
-					key={i}
-					d={d}
-					stroke="currentColor"
-					strokeWidth="2"
-					strokeLinecap="square"
-					strokeLinejoin="round"
-				/>
+				<path key={i} d={d} stroke="currentColor" strokeWidth="2" strokeLinecap="square" />
 			))}
 		</svg>
 	)


### PR DESCRIPTION
## Why

The sidebar had grown to **15 rows across five groups, only one of which was labelled** — four new areas landed in three months and each one arrived as another flat row. Traces, Logs, Metrics and Replays are one interaction (pick a time range, filter, scan a list, open one) and already share a toolbar and a filter column, so four permanent rows was a poor trade.

Designed in Paper first — [Maple — Sidebar](https://app.paper.design/file/01KYMH2KADEX2HJG1599H1FRE9) has the current-state annotation, the alternative that was rejected, the spec, and the states.

## What changed

**Nine rows at rest**, grouped under Monitor / Analyze / Triage:

```
           Search…                    ⌘K
           Overview
MONITOR    Services · Service Map · Infrastructure
ANALYZE    Explore · Dashboards
TRIAGE     Investigations · Errors · Alerts
PINNED     ★ curated, capped at five
[footer]   user menu ·············· ⚙ ?
```

Explore reveals Traces / Logs / Metrics / Replays when you're inside it — **the reveal Infrastructure already used**, so the sidebar now has one nesting rule instead of a special case.

Alongside that:

- **Selected and hovered stop looking identical.** Active rows take a 2px `--sidebar-primary` rail — a token defined in `tokens.css` and consumed by nothing until now. When a section is open the rail belongs to the active *child*, so it points at the page you're on rather than the section.
- **Active matching is segment-aware.** A bare `startsWith` let `/services` claim `/service-map`; children resolve by longest match so Hosts (`/infra`) no longer lights up alongside `/infra/kubernetes/pods`.
- **The dashboards list becomes a Pinned group** — favourites only, capped at five, true total in the header, one overflow row. Replaces a 160px scroll region with a mask fade nested inside the sidebar's own scroll region.
- **A visible search row opens ⌘K**, which was keyboard-only and undiscoverable. That's what licenses a shorter nav.
- **Support and Settings move to the footer**, so the two rows a stuck user reaches for stop scrolling off-screen.
- **The collapsed rail turns a section into a flyout menu.** `SidebarMenuSub` is `hidden` in icon mode, so Infrastructure's children were unreachable whenever the sidebar was collapsed — that's a pre-existing bug this fixes.

## Routes are unchanged

Explore's `href` follows its first child (`/traces`) and its children point at the existing `/traces`, `/logs`, `/metrics`, `/replays` — exactly as Infrastructure's `href` follows Hosts. **No `/explore/*` scheme and no redirects.** The design proposed that URL migration; it would mean moving four route trees and every inbound link, so it's deliberately left as a separate change rather than bundled in here.

## Nothing leaves ⌘K

The palette now flattens sections *and* their children. Traces, Logs, Metrics, Replays, Hosts, the three K8s lists and the integration pages are all reachable by name — **several of them for the first time**, since sub-items were never in the palette before.

## Two deliberate deviations from the approved design

1. **No signal switcher in the page toolbar.** The design had a segmented control there; with the sidebar carrying the switcher, two controls for one state is worse than one. The Explore page header reads `Explore / Traces` instead.
2. **Pinned is hidden on the 48px rail.** The design showed pins as glyphs, but phase 1 is dashboards-only, so every glyph is the same grid mark and a column of them conveys nothing. Worth revisiting once pins can hold services (which carry a coloured `ServiceDot`).

## Testing

`nav-items.test.ts` — 12 tests covering path matching and ⌘K parity, the two things that would regress silently. **The sidebar had no tests before this.**

Verified in the running app, not just typechecked:

- `/traces` opens Explore with all four signals revealed; the rail lands on the child — computed style confirms Infrastructure `rgba(0,0,0,0)` vs K8s Pods `oklch(0.714 0.154 59)`.
- On `/infra/kubernetes/pods` only K8s Pods is active.
- Search row opens the palette; typing "replay" surfaces Replays.
- Collapsed rail flyout lists a section's children.
- Pinned with 7 favourites → header 7, five rows, `2 more…`.

One bug typecheck couldn't catch, found in the browser: Base UI scopes `DropdownMenuLabel` to a group, so the flyout's bare label threw `MenuGroupContext is missing` and tripped the error boundary. Fixed; console is clean.

## Reviewer notes

- `nav-items.ts` is effectively rewritten — `navGroups()` is the single source the sidebar renders and the palette flattens.
- Worth a look at how `ACTIVE_RAIL` / `RAIL_LANE` compose onto `sidebarMenuButtonVariants`; the 2px lane is reserved on every row so icons share one vertical line whether or not the row is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787853366&installation_model_id=427786&pr_number=274&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F274&signature=38db9cf3ca0fe1268b6cd4bd83749d17d96f019491be8e5c111a3f2f1de996d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->