### PR TITLE
fix(deploy): stop MAPLE_ENVIRONMENT being overridable by a stray env var

### DIFF
--- a/apps/alerting/alchemy.run.ts
+++ b/apps/alerting/alchemy.run.ts
@@ -100,7 +100,13 @@ export const createAlertingWorker = ({ stage, mapleDb, chatFlue }: CreateAlertin
 				MAPLE_APP_BASE_URL: process.env.MAPLE_APP_BASE_URL?.trim() || "https://app.maple.dev",
 				EMAIL_FROM: process.env.EMAIL_FROM?.trim() || "Maple <notifications@noreply.maple.dev>",
 				...optionalPlain("MAPLE_ENDPOINT"),
-				...optionalPlain("MAPLE_ENVIRONMENT", resolveDeploymentEnvironment(stage)),
+				// Derived from the stage, deliberately NOT `optionalPlain` — that helper
+				// lets `process.env` win over the fallback, so a stray
+				// MAPLE_ENVIRONMENT=production in a pr-N deploy environment would open
+				// both email gates at once (the worker's scheduled() early-return and
+				// EmailService.emailAllowed both derive from this one value), leaving
+				// the prd-only EMAIL binding as the sole guard.
+				MAPLE_ENVIRONMENT: resolveDeploymentEnvironment(stage),
 				// Non-prod stages skip all crons (they share live org data via the prod
 				// DB); set to "1" on a stage to deliberately exercise crons there.
 				...optionalPlain("MAPLE_ALERTING_ALLOW_NONPROD"),

--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -208,7 +208,11 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 				SERVICE_OPERATIONS_ROLLUP_ENABLED:
 					process.env.SERVICE_OPERATIONS_ROLLUP_ENABLED?.trim() || "false",
 				...optionalPlain("MAPLE_ENDPOINT"),
-				...optionalPlain("MAPLE_ENVIRONMENT", resolveDeploymentEnvironment(stage)),
+				// Derived from the stage, deliberately NOT `optionalPlain` — that helper
+				// lets `process.env` win over the fallback, so a stray
+				// MAPLE_ENVIRONMENT=production in a pr-N deploy environment would open
+				// EmailService.emailAllowed on a stage that shares live org data.
+				MAPLE_ENVIRONMENT: resolveDeploymentEnvironment(stage),
 				...optionalPlain("COMMIT_SHA"),
 				MAPLE_INGEST_KEY: Redacted.make(requireEnv("MAPLE_OTEL_INGEST_KEY")),
 				...optionalSecret("MAPLE_ROOT_PASSWORD"),


### PR DESCRIPTION
## The bug

Both email-capable workers passed `MAPLE_ENVIRONMENT` through `optionalPlain`:

```ts
const optionalPlain = (key: string, fallback?: string) => {
    const value = process.env[key]?.trim() || fallback   // ← process.env wins
    return value ? { [key]: value } : {}
}
```

So `optionalPlain("MAPLE_ENVIRONMENT", resolveDeploymentEnvironment(stage))` doesn't mean "use the stage" — it means "use `process.env` if present, otherwise the stage." The stage-derived value is the fallback, not the source of truth.

## Why it matters

Both non-production email gates derive from that one variable:

- `apps/alerting/src/worker.ts` — the `scheduled()` early return that skips all crons off production
- `apps/api/src/lib/EmailService.ts` — `emailAllowed`, which `isConfigured` depends on

A stray `MAPLE_ENVIRONMENT=production` reaching a `pr-N` or `stg` deploy environment opens **both at once**. Preview and staging stages run the same digest and onboarding crons against branched databases that still hold real Clerk members, so at that point the only remaining guard is the absence of the prd-only `EMAIL` binding — one config line away from a duplicate mailing to real users.

## The fix

Derive it from the stage, non-overridable, in both workers. The prd-only binding gating stays as defence in depth; it's just no longer load-bearing on its own.

`chat-flue` and `electric-sync` use the same `optionalPlain` pattern but have no `EMAIL` binding and no email gate, so they're left alone — worth a follow-up only if consistency is wanted for its own sake.

## Provenance

Found while designing non-prod containment for a third-party email vendor, which needed an equivalent guard and had no Cloudflare binding to lean on. That vendor work has been dropped — onboarding will instead move to a Cloudflare Workflow with durable `step.sleep`, since the machinery is largely already there. This bug predates that whole exercise and stands on its own.

## Verification

Config-only change, no runtime code touched. `tsc --noEmit` clean on `apps/api` and `apps/alerting`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788037565&installation_model_id=427786&pr_number=284&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F284&signature=a912f66285cff756a7d7fd870910b338d7c59986104fb5398b33a7a1e37f729c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->