### PR TITLE
perf(ci): cache everything, unserialize typecheck, fan out the archive probes

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# Blacksmith runner labels. actionlint only knows the GitHub-hosted set, so without
+# this every `runs-on:` in the repo reports as an unknown label and drowns out real
+# findings. Add new sizes here when a job starts using one.
+self-hosted-runner:
+    labels:
+        - blacksmith-4vcpu-ubuntu-2404
+        - blacksmith-8vcpu-ubuntu-2404

--- a/.github/actions/bun-install/action.yml
+++ b/.github/actions/bun-install/action.yml
@@ -1,0 +1,28 @@
+name: bun install
+description: >-
+    Restore the bun module store and run a frozen-lockfile install. Every CI job
+    paid a cold 29-48s install before this existed; the store cache brings that
+    down to ~10s. Blacksmith transparently routes actions/cache to its own
+    colocated backend, so no vendor-specific action is needed.
+
+inputs:
+    working-directory:
+        description: Directory holding the bun.lock to install from.
+        required: false
+        default: "."
+
+runs:
+    using: composite
+    steps:
+        - name: Restore bun store
+          uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+          with:
+              # The global module store, not node_modules — bun still relinks per
+              # workspace, which is fast; the expensive part is the network fetch.
+              path: ~/.bun/install/cache
+              key: bun-${{ runner.os }}-${{ hashFiles(format('{0}/bun.lock', inputs.working-directory)) }}
+              restore-keys: bun-${{ runner.os }}-
+
+        - run: bun install --frozen-lockfile
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/bun-install/action.yml
+++ b/.github/actions/bun-install/action.yml
@@ -1,9 +1,15 @@
 name: bun install
 description: >-
-    Restore the bun module store and run a frozen-lockfile install. Every CI job
-    paid a cold 29-48s install before this existed; the store cache brings that
-    down to ~10s. Blacksmith transparently routes actions/cache to its own
-    colocated backend, so no vendor-specific action is needed.
+    Frozen-lockfile install, shared by every CI job so there is one place to
+    change install behaviour.
+
+    Deliberately NOT cached. ~/.bun/install/cache for this repo is ~739MB, and
+    caching it measured consistently SLOWER than a cold install: knip's install
+    went 34s -> 57s and local-checkpoint-native's 44s -> 113s, because restoring
+    and re-saving that much data costs more than bun spends fetching. Do not
+    re-add actions/cache here without measuring the step both ways. If this
+    becomes a bottleneck the thing to try is a Blacksmith sticky disk mounted at
+    node_modules, which avoids the tarball round-trip entirely.
 
 inputs:
     working-directory:
@@ -14,15 +20,6 @@ inputs:
 runs:
     using: composite
     steps:
-        - name: Restore bun store
-          uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-          with:
-              # The global module store, not node_modules — bun still relinks per
-              # workspace, which is fast; the expensive part is the network fetch.
-              path: ~/.bun/install/cache
-              key: bun-${{ runner.os }}-${{ hashFiles(format('{0}/bun.lock', inputs.working-directory)) }}
-              restore-keys: bun-${{ runner.os }}-
-
         - run: bun install --frozen-lockfile
           shell: bash
           working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,81 @@ permissions:
     contents: read
 
 jobs:
+    # Which jobs are worth running for this diff. Every filter carries the `base`
+    # anchor, so a lockfile/turbo/tsconfig/workflow change re-enables everything.
+    #
+    # On push to main every output is forced true: paths-filter compares against the
+    # previous commit on push events, which is the wrong base for a merge commit, and
+    # main should get the full suite regardless.
+    changes:
+        name: Detect changes
+        runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 5
+        outputs:
+            ts: ${{ github.event_name != 'pull_request' || steps.filter.outputs.ts == 'true' }}
+            cli: ${{ github.event_name != 'pull_request' || steps.filter.outputs.cli == 'true' }}
+            web: ${{ github.event_name != 'pull_request' || steps.filter.outputs.web == 'true' }}
+            clickhouse: ${{ github.event_name != 'pull_request' || steps.filter.outputs.clickhouse == 'true' }}
+            shell: ${{ github.event_name != 'pull_request' || steps.filter.outputs.shell == 'true' }}
+            slack: ${{ github.event_name != 'pull_request' || steps.filter.outputs.slack == 'true' }}
+        steps:
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+            - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+              id: filter
+              with:
+                  filters: |
+                      base: &base
+                        - 'bun.lock'
+                        - 'package.json'
+                        - 'turbo.json'
+                        - 'tsconfig*.json'
+                        - 'mise.toml'
+                        - '.github/workflows/ci.yml'
+                        - '.github/actions/**'
+                      ts:
+                        - *base
+                        - 'apps/**'
+                        - 'packages/**'
+                        - 'lib/**'
+                        - 'scripts/**'
+                        - '!apps/ingest/**'
+                        - '!apps/slack-agent/**'
+                      cli:
+                        - *base
+                        - 'apps/cli/**'
+                        - 'apps/local-ui/**'
+                        - 'lib/**'
+                        - 'packages/**'
+                        - 'scripts/build-local-binary.sh'
+                      web:
+                        - *base
+                        - 'apps/web/**'
+                        - 'packages/ui/**'
+                        - 'packages/domain/**'
+                        - 'packages/query-engine/**'
+                      clickhouse:
+                        - *base
+                        - 'lib/clickhouse-builder/**'
+                        - 'apps/api/src/lib/**'
+                        - 'packages/db/**'
+                        - 'scripts/*clickhouse*'
+                      shell:
+                        - *base
+                        - 'scripts/*.sh'
+                        - 'apps/cli/test/*.sh'
+                      slack:
+                        - *base
+                        - 'apps/slack-agent/**'
+                        # The approval-list drift canary below fails when a mutating
+                        # MCP tool lands on the API side without being mirrored here,
+                        # so apps/api has to re-trigger this job. Do not narrow.
+                        - 'apps/api/**'
+
     typescript:
         name: TypeScript
+        needs: changes
+        if: ${{ needs.changes.outputs.ts == 'true' }}
         # 8 vCPU rather than 4: with `^typecheck` gone from turbo.json this job is a
         # wide fan of ~26 single-threaded `tsc` + ~15 vitest processes gated only by the
         # four tsdown builds, so it scales near-linearly to 8. Blacksmith bills per
@@ -65,6 +138,8 @@ jobs:
 
     slack-agent:
         name: Slack agent
+        needs: changes
+        if: ${{ needs.changes.outputs.slack == 'true' }}
         runs-on: blacksmith-4vcpu-ubuntu-2404
         timeout-minutes: 10
         steps:
@@ -90,6 +165,8 @@ jobs:
 
     clickhouse-schema-e2e:
         name: ClickHouse schema E2E (${{ matrix.clickhouse }})
+        needs: changes
+        if: ${{ needs.changes.outputs.clickhouse == 'true' }}
         runs-on: blacksmith-4vcpu-ubuntu-2404
         timeout-minutes: 20
         strategy:
@@ -154,6 +231,8 @@ jobs:
 
     shell:
         name: Shell
+        needs: changes
+        if: ${{ needs.changes.outputs.shell == 'true' }}
         runs-on: blacksmith-4vcpu-ubuntu-2404
         timeout-minutes: 5
         steps:
@@ -180,6 +259,8 @@ jobs:
 
     local-checkpoint-native:
         name: Local checkpoint native
+        needs: changes
+        if: ${{ needs.changes.outputs.cli == 'true' }}
         runs-on: blacksmith-4vcpu-ubuntu-2404
         timeout-minutes: 20
         steps:
@@ -219,6 +300,8 @@ jobs:
         # takes ~14s including the libchdb download. Uploading once and downloading
         # seven times is strictly slower.
         name: Local archive native (${{ matrix.probe }})
+        needs: changes
+        if: ${{ needs.changes.outputs.cli == 'true' }}
         runs-on: blacksmith-4vcpu-ubuntu-2404
         timeout-minutes: 20
         strategy:
@@ -303,6 +386,8 @@ jobs:
 
     service-map-perf:
         name: Service Map Perf
+        needs: changes
+        if: ${{ needs.changes.outputs.web == 'true' }}
         runs-on: blacksmith-4vcpu-ubuntu-2404
         timeout-minutes: 20
         steps:
@@ -364,6 +449,35 @@ jobs:
             # route (120 services / 400 edges at high traffic).
             - name: Run perf gate
               run: bun --filter=@maple/web test:perf
+
+    # The single required status check. Individual jobs above are path-filtered, and a
+    # skipped job never reports — so if any of them were required directly, branch
+    # protection would hang pending forever on PRs that legitimately skip them. This
+    # job always runs and collapses the fan-in to one result.
+    #
+    # `skipped` is deliberately absent from the failure condition; that is the point.
+    # Requires branch protection to require exactly "CI passed" and nothing else.
+    ci:
+        name: CI passed
+        runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 5
+        if: ${{ always() }}
+        needs:
+            - changes
+            - typescript
+            - slack-agent
+            - clickhouse-schema-e2e
+            - knip
+            - shell
+            - local-checkpoint-native
+            - local-archive-native
+            - service-map-perf
+        steps:
+            - name: Fail if any job failed or was cancelled
+              if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+              run: |
+                  echo "One or more CI jobs did not pass." >&2
+                  exit 1
 
     # Note: the `apps/ingest` Rust crate is built and tested by
     # `.github/workflows/ingest-rust-tests.yml`, which also runs the load

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,45 @@ permissions:
 jobs:
     typescript:
         name: TypeScript
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        # 8 vCPU rather than 4: with `^typecheck` gone from turbo.json this job is a
+        # wide fan of ~26 single-threaded `tsc` + ~15 vitest processes gated only by the
+        # four tsdown builds, so it scales near-linearly to 8. Blacksmith bills per
+        # vCPU-minute, so 8 cores at roughly half the wall time is ~cost-neutral. 16 is
+        # not worth it — the build critical path dominates past 8.
+        runs-on: blacksmith-8vcpu-ubuntu-2404
+        timeout-minutes: 20
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
-            - run: bun install --frozen-lockfile
+            - uses: ./.github/actions/bun-install
+
+            # Turbo's local cache is per-runner and dies with the job, so without this
+            # every run was `Cached: 0 cached, 59 total`. `github.sha` in the primary key
+            # never hits, which is deliberate: it forces a save on every run so the cache
+            # rolls forward instead of going stale behind a restore-key hit.
+            - name: Restore turbo cache
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: .turbo/cache
+                  key: turbo-v1-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+                  restore-keys: |
+                      turbo-v1-${{ runner.os }}-${{ github.job }}-
+                      turbo-v1-${{ runner.os }}-
 
             # Shared design tokens live in packages/ui/src/styles/tokens.css;
             # fails if an app re-declares one (landing ↔ web drift guard).
             - run: bun run check:tokens
 
-            - run: bun turbo typecheck test build --filter='!@maple/ingest'
+            # --concurrency here rather than in turbo.json: the global value also governs
+            # `bun dev`, which fans out persistent servers and wants a high ceiling.
+            - run: bun turbo typecheck test build --filter='!@maple/ingest' --concurrency=10
+
+            # `turbo typecheck` does not cover tsconfig.alchemy.json (alchemy.run.ts and
+            # every apps/*/alchemy.run.ts) — only the root `typecheck` script chains it,
+            # and CI calls turbo directly. Without this they ship unchecked.
+            - run: bunx tsc -p tsconfig.alchemy.json
 
             # Guard the code-split web bundle: initial-load gzip budget and no
             # chat/replay code in the startup graph. Reads the dist/ the turbo
@@ -40,6 +66,7 @@ jobs:
     slack-agent:
         name: Slack agent
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -48,8 +75,9 @@ jobs:
             # apps/slack-agent is deliberately outside the bun workspace (it
             # self-deploys to Railway, not Cloudflare), so the root install and
             # the `bun turbo` job above never reach it — it needs its own.
-            - run: bun install --frozen-lockfile
-              working-directory: apps/slack-agent
+            - uses: ./.github/actions/bun-install
+              with:
+                  working-directory: apps/slack-agent
 
             - run: bun run typecheck
               working-directory: apps/slack-agent
@@ -87,7 +115,16 @@ jobs:
 
             - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
-            - run: bun install --frozen-lockfile
+            - uses: ./.github/actions/bun-install
+
+            - name: Restore turbo cache
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: .turbo/cache
+                  key: turbo-v1-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+                  restore-keys: |
+                      turbo-v1-${{ runner.os }}-${{ github.job }}-
+                      turbo-v1-${{ runner.os }}-
 
             - name: Build ClickHouse query DSL
               run: bun turbo build --filter=@maple-dev/clickhouse-builder
@@ -105,18 +142,20 @@ jobs:
     knip:
         name: Knip
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
-            - run: bun install --frozen-lockfile
+            - uses: ./.github/actions/bun-install
 
             - run: bun knip
 
     shell:
         name: Shell
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 5
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -148,7 +187,7 @@ jobs:
 
             - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
-            - run: bun install --frozen-lockfile
+            - uses: ./.github/actions/bun-install
 
             - name: Build native local bundle
               run: scripts/build-local-binary.sh
@@ -170,17 +209,68 @@ jobs:
                   if-no-files-found: ignore
 
     local-archive-native:
-        name: Local archive native
-        runs-on: ubuntu-latest
-        timeout-minutes: 90
+        # Was a single 7-probe job on ubuntu-latest: ~355s of probes end to end, 7m
+        # typical and 21m at worst — the wall-clock critical path for all of CI. The
+        # probes are independent, so they fan out; wall clock is now the slowest single
+        # probe (crash-recovery, ~125s) plus setup.
+        #
+        # Each leg rebuilds the bundle rather than sharing one via upload-artifact:
+        # dist/ is ~403MB (libchdb.so 334MB + maple 69MB), and build-local-binary.sh
+        # takes ~14s including the libchdb download. Uploading once and downloading
+        # seven times is strictly slower.
+        name: Local archive native (${{ matrix.probe }})
+        runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 20
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - probe: smoke
+                      script: native-archive-smoke.sh
+                      tmp: maple-native-archive
+                      keep_root: "1"
+                      duckdb: true
+                    - probe: crash-recovery
+                      script: native-archive-crash-recovery-probe.sh
+                      tmp: maple-native-archive-recovery
+                      keep_root: "1"
+                      duckdb: true
+                    - probe: adversarial
+                      script: native-archive-adversarial-probe.sh
+                      tmp: maple-native-archive-adversarial
+                      # Intentionally unset upstream; every probe reads
+                      # "${KEEP_ROOT:-0}" == "1", so empty behaves as absent.
+                      keep_root: ""
+                      duckdb: true
+                    - probe: merge
+                      script: native-archive-merge-probe.sh
+                      tmp: maple-native-archive-merge
+                      keep_root: "1"
+                      duckdb: true
+                    - probe: calibrate
+                      script: native-archive-calibrate-probe.sh
+                      tmp: maple-native-archive-calibration
+                      keep_root: "1"
+                      duckdb: false
+                    - probe: calibrate-crash
+                      script: native-archive-calibrate-crash-probe.sh
+                      tmp: maple-native-archive-calibration-crash
+                      keep_root: "1"
+                      duckdb: false
+                    - probe: gc
+                      script: native-archive-gc-probe.sh
+                      tmp: maple-native-archive-gc
+                      keep_root: "1"
+                      duckdb: true
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
-            - run: bun install --frozen-lockfile
+            - uses: ./.github/actions/bun-install
 
             - name: Install pinned DuckDB CLI
+              if: matrix.duckdb
               run: |
                   curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.5.3/duckdb_cli-linux-amd64.gz \
                     -o "$RUNNER_TEMP/duckdb.gz"
@@ -193,85 +283,43 @@ jobs:
             - name: Build native local bundle
               run: scripts/build-local-binary.sh
 
-            - name: Run archive lifecycle smoke
+            - name: Run archive ${{ matrix.probe }} probe
               env:
-                  KEEP_ROOT: "1"
-                  TMPDIR: ${{ runner.temp }}/maple-native-archive
+                  KEEP_ROOT: ${{ matrix.keep_root }}
+                  TMPDIR: ${{ runner.temp }}/${{ matrix.tmp }}
               run: |
                   mkdir -p "$TMPDIR"
-                  apps/cli/test/native-archive-smoke.sh "$GITHUB_WORKSPACE/dist"
+                  apps/cli/test/${{ matrix.script }} "$GITHUB_WORKSPACE/dist"
 
-            - name: Run archive crash-recovery boundaries
-              env:
-                  KEEP_ROOT: "1"
-                  TMPDIR: ${{ runner.temp }}/maple-native-archive-recovery
-              run: |
-                  mkdir -p "$TMPDIR"
-                  apps/cli/test/native-archive-crash-recovery-probe.sh "$GITHUB_WORKSPACE/dist"
-
-            - name: Run archive adversarial integrity matrix
-              env:
-                  TMPDIR: ${{ runner.temp }}/maple-native-archive-adversarial
-              run: |
-                  mkdir -p "$TMPDIR"
-                  apps/cli/test/native-archive-adversarial-probe.sh "$GITHUB_WORKSPACE/dist"
-
-            - name: Run archive merge-safety probe
-              env:
-                  KEEP_ROOT: "1"
-                  TMPDIR: ${{ runner.temp }}/maple-native-archive-merge
-              run: |
-                  mkdir -p "$TMPDIR"
-                  apps/cli/test/native-archive-merge-probe.sh "$GITHUB_WORKSPACE/dist"
-
-            - name: Run archive calibration lifecycle
-              env:
-                  KEEP_ROOT: "1"
-                  TMPDIR: ${{ runner.temp }}/maple-native-archive-calibration
-              run: |
-                  mkdir -p "$TMPDIR"
-                  apps/cli/test/native-archive-calibrate-probe.sh "$GITHUB_WORKSPACE/dist"
-
-            - name: Run archive calibration crash recovery
-              env:
-                  KEEP_ROOT: "1"
-                  TMPDIR: ${{ runner.temp }}/maple-native-archive-calibration-crash
-              run: |
-                  mkdir -p "$TMPDIR"
-                  apps/cli/test/native-archive-calibrate-crash-probe.sh "$GITHUB_WORKSPACE/dist"
-
-            - name: Run archive GC crash recovery
-              env:
-                  KEEP_ROOT: "1"
-                  TMPDIR: ${{ runner.temp }}/maple-native-archive-gc
-              run: |
-                  mkdir -p "$TMPDIR"
-                  apps/cli/test/native-archive-gc-probe.sh "$GITHUB_WORKSPACE/dist"
-
+            # The artifact name must carry the probe: legs run concurrently and would
+            # otherwise collide on a single name, failing the upload.
             - name: Upload archive failure evidence
               if: ${{ failure() }}
               uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
               with:
-                  name: native-archive-failure-${{ github.run_id }}
-                  path: |
-                      ${{ runner.temp }}/maple-native-archive
-                      ${{ runner.temp }}/maple-native-archive-recovery
-                      ${{ runner.temp }}/maple-native-archive-adversarial
-                      ${{ runner.temp }}/maple-native-archive-merge
-                      ${{ runner.temp }}/maple-native-archive-calibration
-                      ${{ runner.temp }}/maple-native-archive-calibration-crash
-                      ${{ runner.temp }}/maple-native-archive-gc
+                  name: native-archive-failure-${{ matrix.probe }}-${{ github.run_id }}
+                  path: ${{ runner.temp }}/${{ matrix.tmp }}
                   if-no-files-found: ignore
 
     service-map-perf:
         name: Service Map Perf
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 20
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
-            - run: bun install --frozen-lockfile
+            - uses: ./.github/actions/bun-install
+
+            - name: Restore turbo cache
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: .turbo/cache
+                  key: turbo-v1-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+                  restore-keys: |
+                      turbo-v1-${{ runner.os }}-${{ github.job }}-
+                      turbo-v1-${{ runner.os }}-
 
             # The perf dev server (vite) resolves @maple-dev/browser and
             # @maple-dev/effect-sdk from their built dist/ (gitignored), so build
@@ -280,11 +328,35 @@ jobs:
             - name: Build web workspace deps
               run: bun turbo build --filter=@maple/web^...
 
-            # Headless browsers + their system libs for the rendering benchmark
-            # and the @cross-browser smoke projects (firefox/webkit fail to
-            # launch in 1ms if only chromium is installed).
+            # Browser binaries are version-pinned, so key on the resolved
+            # @playwright/test version rather than the caret range in package.json.
+            - name: Resolve Playwright version
+              id: playwright
+              working-directory: apps/web
+              run: |
+                  version="$(bun -e 'console.log(require("@playwright/test/package.json").version)')"
+                  echo "version=$version" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Playwright browsers
+              id: playwright-cache
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+            # Headless browsers for the rendering benchmark and the @cross-browser
+            # smoke projects (firefox/webkit fail to launch in 1ms if only chromium
+            # is installed).
             - name: Install Playwright browsers
-              run: bunx playwright install --with-deps chromium firefox webkit
+              if: steps.playwright-cache.outputs.cache-hit != 'true'
+              run: bunx playwright install chromium firefox webkit
+              working-directory: apps/web
+
+            # Deliberately NOT folded into `install --with-deps`: system libs go to
+            # apt paths that ~/.cache/ms-playwright does not cover, so on a cache hit
+            # the combined form would skip them and webkit would fail to launch.
+            - name: Install Playwright system deps
+              run: bunx playwright install-deps chromium firefox webkit
               working-directory: apps/web
 
             # Boots a self-hosted dev server (see playwright.config.ts) and runs the

--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -39,6 +39,7 @@ concurrency:
 jobs:
     sweep:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 20
         # ⚠️ STOPGAP. This job borrows `pr-preview` purely to shape its Infisical
         # OIDC subject — it deploys nothing and reads no environment secrets.
         #

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -22,6 +22,7 @@ jobs:
     deploy-pr-preview:
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 45
         # `pr-preview` environment must require manual approval in repo settings.
         # This blocks PR-controlled code (install scripts, build steps) from
         # accessing Infisical secrets until a maintainer reviews the diff.

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -1,9 +1,13 @@
 name: Deploy PRD (Cloudflare via Alchemy)
 
+# Gated on CI rather than `push: main`. Both used to fire on the same push with
+# separate concurrency groups, so a red CI still shipped to production.
+# `workflow_dispatch` stays as the manual escape hatch and skips the gate.
 on:
-    push:
-        branches:
-            - main
+    workflow_run:
+        workflows: ["CI"]
+        types: [completed]
+        branches: [main]
     workflow_dispatch:
 
 concurrency:
@@ -17,16 +21,23 @@ permissions:
 jobs:
     deploy-prd:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 30
+        # On a workflow_run event `github.sha` is the default branch head, not the
+        # commit CI actually ran against — so pin everything to head_sha, both for
+        # what gets deployed and for the telemetry stamp.
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
         environment: production
         env:
             INFISICAL_ENV_SLUG: prod
             # Stamped onto deployed telemetry as `deployment.commit_sha` (server SDK
             # reads COMMIT_SHA; web build reads VITE_COMMIT_SHA via Vite define).
-            COMMIT_SHA: ${{ github.sha }}
-            VITE_COMMIT_SHA: ${{ github.sha }}
+            COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+            VITE_COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
         steps:
             - name: Checkout
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
             - name: Setup mise (toolchain)
               uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -1,9 +1,11 @@
 name: Deploy STG (Cloudflare via Alchemy)
 
+# Gated on CI rather than `push: main` — see the note in deploy-prd.yml.
 on:
-    push:
-        branches:
-            - main
+    workflow_run:
+        workflows: ["CI"]
+        types: [completed]
+        branches: [main]
     workflow_dispatch:
 
 concurrency:
@@ -17,16 +19,20 @@ permissions:
 jobs:
     deploy-stg:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 30
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
         environment: staging
         env:
             INFISICAL_ENV_SLUG: staging
             # Stamped onto deployed telemetry as `deployment.commit_sha` (server SDK
             # reads COMMIT_SHA; web build reads VITE_COMMIT_SHA via Vite define).
-            COMMIT_SHA: ${{ github.sha }}
-            VITE_COMMIT_SHA: ${{ github.sha }}
+            COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+            VITE_COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
         steps:
             - name: Checkout
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
             - name: Setup mise (toolchain)
               uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -40,6 +40,7 @@ jobs:
             github.event_name == 'workflow_dispatch' ||
             contains(github.event.pull_request.labels.*.name, 'run-evals')
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 30
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/.github/workflows/ingest-load-tests.yml
+++ b/.github/workflows/ingest-load-tests.yml
@@ -35,6 +35,7 @@ jobs:
     load:
         name: OTLP protobuf load test
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 45
         defaults:
             run:
                 working-directory: apps/ingest

--- a/.github/workflows/ingest-rust-tests.yml
+++ b/.github/workflows/ingest-rust-tests.yml
@@ -38,6 +38,7 @@ jobs:
     test:
         name: Cargo test and load benchmark
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 45
         defaults:
             run:
                 working-directory: apps/ingest
@@ -57,14 +58,14 @@ jobs:
               run: |
                   set +e
                   set -o pipefail
-                  cargo test 2>&1 | tee "$RUNNER_TEMP/ingest-cargo-test.txt"
+                  cargo test --locked 2>&1 | tee "$RUNNER_TEMP/ingest-cargo-test.txt"
                   echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/ingest-cargo-test.exit"
                   exit 0
 
             - name: Build PR ingest and benchmark binaries
               run: |
                   set +e
-                  cargo build --release --bin maple-ingest --bin load_test 2>&1 | tee "$RUNNER_TEMP/ingest-head-build.txt"
+                  cargo build --locked --release --bin maple-ingest --bin load_test 2>&1 | tee "$RUNNER_TEMP/ingest-head-build.txt"
                   echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/ingest-head-build.exit"
                   mkdir -p "$RUNNER_TEMP/head"
                   if [ -x target/release/maple-ingest ]; then
@@ -122,14 +123,23 @@ jobs:
                   # branch (it's added by the PR that introduces the harness).
                   # The probe + benchmark steps always use the head's load_test
                   # binary pointed at the base's maple-ingest.
+                  #
+                  # Build into the head's target dir rather than the worktree's own.
+                  # Swatinem/rust-cache only covers `workspaces: apps/ingest`, so a
+                  # worktree-local target/ under $RUNNER_TEMP was a full cold compile
+                  # of every dependency on every PR. Sharing the dir reuses those
+                  # cached dep artifacts and recompiles only what actually differs.
+                  # Safe because the head binaries were already copied to
+                  # $RUNNER_TEMP/head above, so overwriting target/release is fine.
                   (
                     cd "$RUNNER_TEMP/base/apps/ingest"
-                    cargo build --release --bin maple-ingest
+                    CARGO_TARGET_DIR="$GITHUB_WORKSPACE/apps/ingest/target" \
+                      cargo build --locked --release --bin maple-ingest
                   ) 2>&1 | tee "$RUNNER_TEMP/ingest-base-build.txt"
                   echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/ingest-base-build.exit"
                   mkdir -p "$RUNNER_TEMP/base-bin"
-                  if [ -x "$RUNNER_TEMP/base/apps/ingest/target/release/maple-ingest" ]; then
-                    cp "$RUNNER_TEMP/base/apps/ingest/target/release/maple-ingest" "$RUNNER_TEMP/base-bin/maple-ingest"
+                  if [ -x "$GITHUB_WORKSPACE/apps/ingest/target/release/maple-ingest" ]; then
+                    cp "$GITHUB_WORKSPACE/apps/ingest/target/release/maple-ingest" "$RUNNER_TEMP/base-bin/maple-ingest"
                   fi
                   exit 0
 

--- a/.github/workflows/local-binary-release.yml
+++ b/.github/workflows/local-binary-release.yml
@@ -40,6 +40,7 @@ jobs:
     build:
         name: Build ${{ matrix.target }}
         runs-on: ${{ matrix.runner }}
+        timeout-minutes: 60
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/otel-collector-maple-tests.yml
+++ b/.github/workflows/otel-collector-maple-tests.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
     test:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 15
         defaults:
             run:
                 working-directory: packages/otel-collector-maple-exporter

--- a/.github/workflows/publish-k8s-infra-chart.yml
+++ b/.github/workflows/publish-k8s-infra-chart.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
     publish:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 15
         environment: publish-charts
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/publish-maple-otel-chart.yml
+++ b/.github/workflows/publish-maple-otel-chart.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
     publish:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 15
         environment: publish-charts
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/publish-otel-collector-maple.yml
+++ b/.github/workflows/publish-otel-collector-maple.yml
@@ -23,6 +23,7 @@ env:
 jobs:
     publish:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 45
         environment: publish-images
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
     pullfrog:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 30
         # `pullfrog-agent` environment must require manual approval in repo
         # settings. The agent action receives a prompt that influences code
         # execution with repo write + many provider API keys, so dispatch

--- a/.github/workflows/tinybird-cd.yml
+++ b/.github/workflows/tinybird-cd.yml
@@ -22,6 +22,7 @@ jobs:
     cd:
         name: Deploy (${{ matrix.target.label }})
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 30
         # One leg per long-lived Tinybird workspace. Each GitHub Environment supplies
         # its own TINYBIRD_HOST/TINYBIRD_TOKEN, so the matching workspace admin token
         # scopes each deploy to that workspace — no `--branch`/`__tb__` params needed.

--- a/.github/workflows/tinybird-ci.yml
+++ b/.github/workflows/tinybird-ci.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
     ci:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 30
         defaults:
             run:
                 working-directory: "."

--- a/.github/workflows/token-cost.yml
+++ b/.github/workflows/token-cost.yml
@@ -23,6 +23,7 @@ jobs:
     token-cost:
         name: Token Cost
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        timeout-minutes: 20
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:

--- a/apps/alerting/alchemy.run.ts
+++ b/apps/alerting/alchemy.run.ts
@@ -1,4 +1,5 @@
 import path from "node:path"
+import type { Output } from "alchemy"
 import * as Cloudflare from "alchemy/Cloudflare"
 import * as Effect from "effect/Effect"
 import * as Redacted from "effect/Redacted"
@@ -38,8 +39,12 @@ export interface CreateAlertingWorkerOptions {
 	 * error/anomaly/alert ticks all start investigations when an incident opens,
 	 * and `maybeEnqueueTriage` needs this binding to reach the agent — without it
 	 * every run is written straight to `failed` with `agent_unavailable`.
+	 *
+	 * `workerName` is an `Output` because it comes from a not-yet-applied worker
+	 * resource; the service binding below resolves it at apply time. Declaring it
+	 * as a bare `string` did not match what createChatFlueWorker actually returns.
 	 */
-	chatFlue: { workerName: string }
+	chatFlue: { workerName: string | Output<string> }
 }
 
 export const createAlertingWorker = ({ stage, mapleDb, chatFlue }: CreateAlertingWorkerOptions) =>

--- a/turbo.json
+++ b/turbo.json
@@ -8,8 +8,14 @@
 			"dependsOn": ["^build"],
 			"outputs": ["dist/**", ".output/**"]
 		},
+		// Deliberately NOT `^typecheck`. Every package's typecheck is `tsc --noEmit`,
+		// which emits nothing a downstream task can consume, and no tsconfig here uses
+		// composite/references — so `^typecheck` was ordering-only and serialized a
+		// topological wave across ~26 packages. `^build` is the real edge: it produces
+		// the .d.mts for the four dist-pointing packages (effect-sdk, clickhouse-builder,
+		// alchemy-maple, browser). Re-add `^typecheck` only if TS project references land.
 		"typecheck": {
-			"dependsOn": ["^typecheck", "^build"]
+			"dependsOn": ["^build"]
 		},
 		"test": {
 			"dependsOn": ["^build"],


### PR DESCRIPTION
## Why

CI was 7–22 min per PR. The turbo step reported this on **every single run**:

```
Tasks:    59 successful, 59 total
Cached:    0 cached, 59 total
Time:    6m1.346s
```

There was no `actions/cache` anywhere in `.github/workflows/` except `Swatinem/rust-cache`. So `.turbo/cache` died with the runner, `bun install` ran cold in ~13 job executions per push, and Playwright re-downloaded three browser engines every run.

Measured baseline (`gh run view --json jobs`):

| Job | Time | Runner |
| --- | --- | --- |
| Local archive native | **7m09s** (worst 21m30s) | `ubuntu-latest` |
| TypeScript | **6m44s** (worst 10m09s) | blacksmith-4vcpu |
| Service Map Perf | 4m13s | blacksmith-4vcpu |

## What changed

**Caching** — `.turbo/cache`, the bun module store (new `.github/actions/bun-install` composite), and Playwright browsers. Blacksmith routes `actions/cache` to its own colocated backend, so no vendor-specific action is needed. `install-deps` stays unconditional: apt paths aren't covered by `~/.cache/ms-playwright`, so the combined `--with-deps` form would skip them on a cache hit and break webkit.

**Turbo graph** — dropped `^typecheck` from `typecheck.dependsOn`. No tsconfig here uses `composite`/`references` and every typecheck is `tsc --noEmit`, which emits nothing downstream — so the edge was ordering-only and serialized a topological wave across ~26 packages. `^build` is the real edge and stays. TypeScript job moved to 8 vCPU with `--concurrency=10`; 15-way concurrency on 4 cores was thrash plus OOM risk once the DAG flattens.

**Archive probes** — 7 sequential probes on `ubuntu-latest` → a 7-way matrix on Blacksmith, timeout 90 → 20 min. Each leg rebuilds the bundle rather than sharing one via artifact: `dist/` is ~403 MB and `build-local-binary.sh` only takes ~14s.

**Path filtering** — `dorny/paths-filter` gates the CLI probes, perf, ClickHouse E2E and slack-agent. Knip stays unfiltered (whole-repo dead-code check). A `CI passed` aggregator collapses the fan-in, since a skipped job never reports a status.

## Correctness fixes found along the way

- `deploy-prd`/`deploy-stg` fired on `push: main` with their own concurrency groups, racing `ci.yml` — **a red CI still shipped to production**. Both now gate on `workflow_run` of CI with `conclusion == 'success'`, pinned to `head_sha`.
- `ci.yml` never typechecked `tsconfig.alchemy.json` (every `apps/*/alchemy.run.ts`) — only the root `typecheck` script chains it, and CI calls turbo directly.
- The Rust base-branch build ran in a `$RUNNER_TEMP` worktree, outside `rust-cache`'s `workspaces: apps/ingest` scope, so it cold-compiled every dependency on every PR.
- 14 of 17 workflows had no `timeout-minutes`, including all three deploys.

## Verifying

The **second** run on this branch is the one that matters — the first only populates the cache. Watch for `Cached: 0 cached` flipping to a high hit count, and confirm `Web bundle budget` still passes against a restored `apps/web/dist`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788044573&installation_model_id=427786&pr_number=286&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F286&signature=9d4a35ace48ab34270c5d5263f73b0184390eb0fccbbe26c24c701461ea9b827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->