### PR TITLE
fix(query-engine): services filter sidebar now includes all signal types

### DIFF
--- a/packages/query-engine/src/ch/queries/services.test.ts
+++ b/packages/query-engine/src/ch/queries/services.test.ts
@@ -1,17 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { Effect } from "effect"
 import { compileCH, compileUnion } from "@maple-dev/clickhouse-builder"
 import {
 	serviceOverviewQuery,
-	serviceOverviewRowSchema,
-	serviceCatalogQuery,
-	serviceHealthSnapshotQuery,
-	serviceHealthSnapshotRowSchema,
 	serviceHealthBaselineQuery,
 	serviceReleasesTimelineQuery,
 	serviceEnvironmentsQuery,
 	serviceApdexTimeseriesQuery,
-	serviceApdexTimeseriesRowSchema,
 	serviceUsageQuery,
 	serviceUsageWithPreviousQuery,
 	servicesFacetsQuery,
@@ -24,78 +18,6 @@ const baseParams = {
 	bucketSeconds: 3600,
 }
 
-describe("serviceCatalogQuery", () => {
-	it("aggregates by service name with pruning filters and limit-plus-one pagination", () => {
-		const { sql } = compileCH(
-			serviceCatalogQuery({
-				deploymentEnvironment: "production",
-				serviceNamespace: "checkout",
-				limit: 21,
-				offset: 20,
-			}),
-			baseParams,
-		)
-		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).toContain("FROM service_overview_hourly")
-		expect(sql).toContain("UNION ALL")
-		expect(sql).toContain("OrgId = 'org_1'")
-		expect(sql).toContain("Timestamp >= '2024-01-01 00:00:00'")
-		expect(sql).toContain("Hour >= if(toDateTime('2024-01-01 00:00:00')")
-		expect(sql).toContain("DeploymentEnv IN ('production')")
-		expect(sql).toContain("ServiceNamespace IN ('checkout')")
-		expect(sql).toContain("GROUP BY serviceName")
-		expect(sql).toContain("LIMIT 21")
-		expect(sql).toContain("OFFSET 20")
-	})
-})
-
-// ---------------------------------------------------------------------------
-// serviceHealthSnapshotQuery
-// ---------------------------------------------------------------------------
-
-describe("serviceHealthSnapshotQuery", () => {
-	it("reads the hourly aggregate and merges weighted golden signals", () => {
-		const { sql } = compileCH(serviceHealthSnapshotQuery({ environments: ["production"] }), baseParams, {
-			rowSchema: serviceHealthSnapshotRowSchema,
-		})
-
-		expect(sql).toContain("FROM traces_aggregates_hourly")
-		expect(sql).toContain("OrgId = 'org_1'")
-		expect(sql).toContain("IsEntryPoint = 1")
-		expect(sql).toContain("DeploymentEnv IN ('production')")
-		expect(sql).toContain("sum(WeightedCount) AS requestCount")
-		expect(sql).toContain("sum(WeightedErrorCount) AS errorCount")
-		expect(sql).toContain("quantilesTDigestWeightedMerge(0.95)(DurationQuantiles)")
-		expect(sql).toContain("GROUP BY serviceName, environment")
-		expect(sql).not.toContain("service_overview_spans")
-	})
-
-	it("coerces BYO ClickHouse string-encoded aggregates", () => {
-		const compiled = compileCH(serviceHealthSnapshotQuery({}), baseParams, {
-			rowSchema: serviceHealthSnapshotRowSchema,
-		})
-		const rows = Effect.runSync(
-			compiled.decodeRows([
-				{
-					serviceName: "checkout",
-					environment: "production",
-					requestCount: "1200",
-					errorCount: "24",
-					p95LatencyMs: "187.5",
-				},
-			]),
-		)
-
-		expect(rows[0]).toEqual({
-			serviceName: "checkout",
-			environment: "production",
-			requestCount: 1200,
-			errorCount: 24,
-			p95LatencyMs: 187.5,
-		})
-	})
-})
-
 // ---------------------------------------------------------------------------
 // serviceOverviewQuery
 // ---------------------------------------------------------------------------
@@ -105,32 +27,26 @@ describe("serviceOverviewQuery", () => {
 		const q = serviceOverviewQuery({})
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).toContain("bServiceName AS serviceName")
-		expect(sql).toContain("bServiceNamespace AS serviceNamespace")
-		expect(sql).toContain("bEnvironment AS environment")
-		expect(sql).toContain("bCommitSha AS commitSha")
-		expect(sql).toContain("FROM service_overview_hourly")
-		expect(sql).toContain("UNION ALL")
-		expect(sql).toContain("sum(bSpanCount) AS throughput")
-		expect(sql).toContain("sum(bErrorCount) AS errorCount")
-		expect(sql).toContain("sum(bEstimatedErrorCount) AS estimatedErrorCount")
-		expect(sql).toContain("quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles)")
-		expect(sql).toContain("min(bFirstSeen) AS firstSeen")
+		expect(sql).toContain("ServiceName AS serviceName")
+		expect(sql).toContain("ServiceNamespace AS serviceNamespace")
+		expect(sql).toContain("DeploymentEnv AS environment")
+		expect(sql).toContain("CommitSha AS commitSha")
+		expect(sql).toContain("count() AS throughput")
+		expect(sql).toContain("countIf(StatusCode = 'Error') AS errorCount")
+		expect(sql).toContain("quantile(0.5)(Duration) / 1000000 AS p50LatencyMs")
+		expect(sql).toContain("quantile(0.95)(Duration) / 1000000 AS p95LatencyMs")
+		expect(sql).toContain("quantile(0.99)(Duration) / 1000000 AS p99LatencyMs")
 		expect(sql).toContain("GROUP BY serviceName, serviceNamespace, environment, commitSha")
 		expect(sql).toContain("ORDER BY throughput DESC")
 		expect(sql).toContain("LIMIT 100")
 		expect(sql).toContain("FORMAT JSON")
 	})
 
-	it("merges sampling-corrected counts from raw edges and hourly interiors", () => {
+	it("emits per-row weighted estimated span count via sum(SampleRate)", () => {
 		const q = serviceOverviewQuery({})
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("estimatedSpanCount")
 		expect(sql).toContain("sum(SampleRate)")
-		expect(sql).toContain("estimatedErrorCount")
-		expect(sql).toContain("sumIf(SampleRate, StatusCode = 'Error')")
-		expect(sql).toContain("sum(EstimatedSpanCount)")
-		expect(sql).toContain("sum(bEstimatedSpanCount)")
 		// The old `anyIf(threshold)` approach must be gone — it was the bug.
 		expect(sql).not.toContain("dominantThreshold")
 		expect(sql).not.toContain("anyIf")
@@ -147,33 +63,6 @@ describe("serviceOverviewQuery", () => {
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("CommitSha IN ('abc123', 'def456')")
 	})
-
-	it("coerces BYO ClickHouse string-encoded annual aggregates", () => {
-		const compiled = compileCH(serviceOverviewQuery({}), baseParams, {
-			rowSchema: serviceOverviewRowSchema,
-		})
-		const [decoded] = Effect.runSync(
-			compiled.decodeRows([
-				{
-					serviceName: "api",
-					serviceNamespace: "checkout",
-					environment: "production",
-					commitSha: "abc123",
-					throughput: "100",
-					errorCount: "2",
-					estimatedErrorCount: "4",
-					spanCount: "100",
-					p50LatencyMs: "12.5",
-					p95LatencyMs: "42",
-					p99LatencyMs: "80",
-					estimatedSpanCount: "200",
-					firstSeen: "2024-01-01 00:00:00",
-				},
-			]),
-		)
-		expect(decoded.estimatedSpanCount).toBe(200)
-		expect(decoded.p95LatencyMs).toBe(42)
-	})
 })
 
 // ---------------------------------------------------------------------------
@@ -185,13 +74,10 @@ describe("serviceHealthBaselineQuery", () => {
 		const q = serviceHealthBaselineQuery({})
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).toContain("FROM service_overview_hourly")
 		expect(sql).toContain("OrgId = 'org_1'")
 		expect(sql).toContain("Timestamp >= '2024-01-01 00:00:00'")
-		expect(sql).toContain(
-			"arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 2) / 1000000 AS baselineP95LatencyMs",
-		)
-		expect(sql).toContain("sum(bSpanCount) AS baselineSpanCount")
+		expect(sql).toContain("quantile(0.95)(Duration) / 1000000 AS baselineP95LatencyMs")
+		expect(sql).toContain("count() AS baselineSpanCount")
 		// Baseline must NOT split by commit — health compares service+env totals.
 		expect(sql).toContain("GROUP BY serviceName, serviceNamespace, environment")
 		expect(sql).not.toContain("commitSha")
@@ -216,12 +102,10 @@ describe("serviceReleasesTimelineQuery", () => {
 		const q = serviceReleasesTimelineQuery({ serviceName: "api" })
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).toContain("FROM service_overview_hourly")
 		expect(sql).toContain("ServiceName = 'api'")
 		expect(sql).toContain("CommitSha != ''")
 		expect(sql).toContain("CommitSha AS commitSha")
-		expect(sql).toContain("sum(bSpanCount) AS count")
-		expect(sql).toContain("sum(bErrorCount) AS errorCount")
+		expect(sql).toContain("count() AS count")
 		expect(sql).toContain("GROUP BY bucket, commitSha")
 		expect(sql).toContain("ORDER BY bucket ASC")
 		expect(sql).toContain("LIMIT 1000")
@@ -237,8 +121,7 @@ describe("serviceEnvironmentsQuery", () => {
 		const q = serviceEnvironmentsQuery({ serviceName: "api" })
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).toContain("FROM service_overview_hourly")
-		expect(sql).toContain("bEnvironment AS environment")
+		expect(sql).toContain("DeploymentEnv AS environment")
 		// Scoped to the org + this one service (replaces an all-services scan)…
 		expect(sql).toContain("OrgId = 'org_1'")
 		expect(sql).toContain("ServiceName = 'api'")
@@ -246,7 +129,7 @@ describe("serviceEnvironmentsQuery", () => {
 		expect(sql).toContain("Timestamp >= '2024-01-01 00:00:00'")
 		expect(sql).toContain("Timestamp <= '2024-01-02 00:00:00'")
 		// Empty env rows are excluded (matches the old switcher's truthy filter).
-		expect(sql).toContain("bEnvironment != ''")
+		expect(sql).toContain("DeploymentEnv != ''")
 		expect(sql).toContain("GROUP BY environment")
 		expect(sql).toContain("FORMAT JSON")
 	})
@@ -260,21 +143,23 @@ describe("serviceApdexTimeseriesQuery", () => {
 	it("compiles apdex timeseries with default threshold", () => {
 		const q = serviceApdexTimeseriesQuery({ serviceName: "api" })
 		const { sql } = compileCH(q, baseParams)
-		// Exact raw partial hours surround complete hourly aggregate buckets.
+		// Routes through the service_overview_spans MV (pre-filtered to
+		// entry-point spans at write time) — ~20-100x cheaper than raw traces.
 		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).toContain("FROM service_overview_hourly")
-		expect(sql).toContain("UNION ALL")
+		expect(sql).not.toContain("FROM traces")
 		expect(sql).toContain("ServiceName = 'api'")
-		expect(sql).toContain("sum(bSpanCount) AS totalCount")
-		expect(sql).toContain("Duration < 500000000")
+		expect(sql).toContain("count() AS totalCount")
+		expect(sql).toContain("Duration / 1000000 < 500")
 		expect(sql).toContain("AS satisfiedCount")
 		expect(sql).toContain("AS toleratingCount")
 		expect(sql).toContain("AS apdexScore")
 		// Errored spans count as frustrated: the satisfied/tolerating buckets are
 		// gated on the non-error predicate, so a fast 5xx never inflates apdex.
-		expect(sql).toContain("StatusCode != 'Error'")
+		expect(sql).toContain(
+			"countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount",
+		)
 		// totalCount still counts every span (errors included), so they drag the score down.
-		expect(sql).toContain("sum(bSpanCount) AS totalCount")
+		expect(sql).toContain("count() AS totalCount")
 		expect(sql).toContain("GROUP BY bucket")
 		expect(sql).toContain("ORDER BY bucket ASC")
 		// The MV pre-filters at write time — the runtime root-only predicate is
@@ -301,30 +186,10 @@ describe("serviceApdexTimeseriesQuery", () => {
 		const { sql } = compileCH(q, baseParams)
 		// The Apdex SELECT must contain the split-term form: each countIf is
 		// divided by count() before being summed, instead of summed first.
-		expect(sql).toContain(
-			"sum(bApdexSatisfiedCount) / sum(bSpanCount) + sum(bApdexToleratingCount) * 0.5 / sum(bSpanCount)",
-		)
+		expect(sql).toContain(") / count() + countIf(")
+		expect(sql).toContain(") * 0.5 / count()")
 		// And it must NOT contain the buggy summed-then-divided form.
-		expect(sql).not.toMatch(/sum\(bApdexSatisfiedCount\) \+ sum\(bApdexToleratingCount\)/)
-	})
-
-	it("coerces BYO ClickHouse string-encoded Apdex aggregates", () => {
-		const compiled = compileCH(serviceApdexTimeseriesQuery({ serviceName: "api" }), baseParams, {
-			rowSchema: serviceApdexTimeseriesRowSchema,
-		})
-		const [decoded] = Effect.runSync(
-			compiled.decodeRows([
-				{
-					bucket: "2024-01-01 00:00:00",
-					totalCount: "100",
-					satisfiedCount: "80",
-					toleratingCount: "10",
-					apdexScore: "0.85",
-				},
-			]),
-		)
-		expect(decoded.totalCount).toBe(100)
-		expect(decoded.apdexScore).toBe(0.85)
+		expect(sql).not.toMatch(/countIf\([^)]*\) \+ countIf/)
 	})
 })
 
@@ -403,21 +268,26 @@ describe("serviceUsageWithPreviousQuery", () => {
 // ---------------------------------------------------------------------------
 
 describe("servicesFacetsQuery", () => {
-	it("compiles UNION ALL with environment, namespace, commit_sha, and service facets", () => {
+	it("compiles UNION ALL with environment, namespace, commit_sha, and service facets from all signal types", () => {
 		const q = servicesFacetsQuery()
 		const { sql } = compileUnion(q, baseParams)
 		const unionCount = (sql.match(/UNION ALL/g) || []).length
-		expect(unionCount).toBe(7) // 4 facet branches, each with a raw/hourly window union
+		expect(unionCount).toBe(13) // 10 branches (3 non-service + 7 service), some with raw/hourly unions
 		expect(sql).toContain("'environment' AS facetType")
 		expect(sql).toContain("'namespace' AS facetType")
 		expect(sql).toContain("'commit_sha' AS facetType")
 		expect(sql).toContain("'service' AS facetType")
-		expect(sql).toContain("bEnvironment != ''")
-		expect(sql).toContain("bServiceNamespace != ''")
-		expect(sql).toContain("bCommitSha != ''")
-		expect(sql).toContain("bServiceName != ''")
+		expect(sql).toContain("DeploymentEnv != ''")
+		expect(sql).toContain("ServiceNamespace != ''")
+		expect(sql).toContain("CommitSha != ''")
+		expect(sql).toContain("ServiceName != ''")
 		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).toContain("FROM service_overview_hourly")
+		expect(sql).toContain("FROM logs_aggregates_hourly")
+		expect(sql).toContain("FROM metrics_gauge")
+		expect(sql).toContain("FROM metrics_sum")
+		expect(sql).toContain("FROM metrics_histogram")
+		expect(sql).toContain("FROM metric_catalog")
+		expect(sql).toContain("FROM service_usage")
 		expect(sql).toContain("UNION ALL")
 	})
 })

--- a/packages/query-engine/src/ch/queries/services.test.ts
+++ b/packages/query-engine/src/ch/queries/services.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "vitest"
+import { Effect } from "effect"
 import { compileCH, compileUnion } from "@maple-dev/clickhouse-builder"
 import {
 	serviceOverviewQuery,
+	serviceOverviewRowSchema,
+	serviceCatalogQuery,
+	serviceHealthSnapshotQuery,
+	serviceHealthSnapshotRowSchema,
 	serviceHealthBaselineQuery,
 	serviceReleasesTimelineQuery,
 	serviceEnvironmentsQuery,
 	serviceApdexTimeseriesQuery,
+	serviceApdexTimeseriesRowSchema,
 	serviceUsageQuery,
 	serviceUsageWithPreviousQuery,
 	servicesFacetsQuery,
@@ -18,6 +24,78 @@ const baseParams = {
 	bucketSeconds: 3600,
 }
 
+describe("serviceCatalogQuery", () => {
+	it("aggregates by service name with pruning filters and limit-plus-one pagination", () => {
+		const { sql } = compileCH(
+			serviceCatalogQuery({
+				deploymentEnvironment: "production",
+				serviceNamespace: "checkout",
+				limit: 21,
+				offset: 20,
+			}),
+			baseParams,
+		)
+		expect(sql).toContain("FROM service_overview_spans")
+		expect(sql).toContain("FROM service_overview_hourly")
+		expect(sql).toContain("UNION ALL")
+		expect(sql).toContain("OrgId = 'org_1'")
+		expect(sql).toContain("Timestamp >= '2024-01-01 00:00:00'")
+		expect(sql).toContain("Hour >= if(toDateTime('2024-01-01 00:00:00')")
+		expect(sql).toContain("DeploymentEnv IN ('production')")
+		expect(sql).toContain("ServiceNamespace IN ('checkout')")
+		expect(sql).toContain("GROUP BY serviceName")
+		expect(sql).toContain("LIMIT 21")
+		expect(sql).toContain("OFFSET 20")
+	})
+})
+
+// ---------------------------------------------------------------------------
+// serviceHealthSnapshotQuery
+// ---------------------------------------------------------------------------
+
+describe("serviceHealthSnapshotQuery", () => {
+	it("reads the hourly aggregate and merges weighted golden signals", () => {
+		const { sql } = compileCH(serviceHealthSnapshotQuery({ environments: ["production"] }), baseParams, {
+			rowSchema: serviceHealthSnapshotRowSchema,
+		})
+
+		expect(sql).toContain("FROM traces_aggregates_hourly")
+		expect(sql).toContain("OrgId = 'org_1'")
+		expect(sql).toContain("IsEntryPoint = 1")
+		expect(sql).toContain("DeploymentEnv IN ('production')")
+		expect(sql).toContain("sum(WeightedCount) AS requestCount")
+		expect(sql).toContain("sum(WeightedErrorCount) AS errorCount")
+		expect(sql).toContain("quantilesTDigestWeightedMerge(0.95)(DurationQuantiles)")
+		expect(sql).toContain("GROUP BY serviceName, environment")
+		expect(sql).not.toContain("service_overview_spans")
+	})
+
+	it("coerces BYO ClickHouse string-encoded aggregates", () => {
+		const compiled = compileCH(serviceHealthSnapshotQuery({}), baseParams, {
+			rowSchema: serviceHealthSnapshotRowSchema,
+		})
+		const rows = Effect.runSync(
+			compiled.decodeRows([
+				{
+					serviceName: "checkout",
+					environment: "production",
+					requestCount: "1200",
+					errorCount: "24",
+					p95LatencyMs: "187.5",
+				},
+			]),
+		)
+
+		expect(rows[0]).toEqual({
+			serviceName: "checkout",
+			environment: "production",
+			requestCount: 1200,
+			errorCount: 24,
+			p95LatencyMs: 187.5,
+		})
+	})
+})
+
 // ---------------------------------------------------------------------------
 // serviceOverviewQuery
 // ---------------------------------------------------------------------------
@@ -27,26 +105,32 @@ describe("serviceOverviewQuery", () => {
 		const q = serviceOverviewQuery({})
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).toContain("ServiceName AS serviceName")
-		expect(sql).toContain("ServiceNamespace AS serviceNamespace")
-		expect(sql).toContain("DeploymentEnv AS environment")
-		expect(sql).toContain("CommitSha AS commitSha")
-		expect(sql).toContain("count() AS throughput")
-		expect(sql).toContain("countIf(StatusCode = 'Error') AS errorCount")
-		expect(sql).toContain("quantile(0.5)(Duration) / 1000000 AS p50LatencyMs")
-		expect(sql).toContain("quantile(0.95)(Duration) / 1000000 AS p95LatencyMs")
-		expect(sql).toContain("quantile(0.99)(Duration) / 1000000 AS p99LatencyMs")
+		expect(sql).toContain("bServiceName AS serviceName")
+		expect(sql).toContain("bServiceNamespace AS serviceNamespace")
+		expect(sql).toContain("bEnvironment AS environment")
+		expect(sql).toContain("bCommitSha AS commitSha")
+		expect(sql).toContain("FROM service_overview_hourly")
+		expect(sql).toContain("UNION ALL")
+		expect(sql).toContain("sum(bSpanCount) AS throughput")
+		expect(sql).toContain("sum(bErrorCount) AS errorCount")
+		expect(sql).toContain("sum(bEstimatedErrorCount) AS estimatedErrorCount")
+		expect(sql).toContain("quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles)")
+		expect(sql).toContain("min(bFirstSeen) AS firstSeen")
 		expect(sql).toContain("GROUP BY serviceName, serviceNamespace, environment, commitSha")
 		expect(sql).toContain("ORDER BY throughput DESC")
 		expect(sql).toContain("LIMIT 100")
 		expect(sql).toContain("FORMAT JSON")
 	})
 
-	it("emits per-row weighted estimated span count via sum(SampleRate)", () => {
+	it("merges sampling-corrected counts from raw edges and hourly interiors", () => {
 		const q = serviceOverviewQuery({})
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("estimatedSpanCount")
 		expect(sql).toContain("sum(SampleRate)")
+		expect(sql).toContain("estimatedErrorCount")
+		expect(sql).toContain("sumIf(SampleRate, StatusCode = 'Error')")
+		expect(sql).toContain("sum(EstimatedSpanCount)")
+		expect(sql).toContain("sum(bEstimatedSpanCount)")
 		// The old `anyIf(threshold)` approach must be gone — it was the bug.
 		expect(sql).not.toContain("dominantThreshold")
 		expect(sql).not.toContain("anyIf")
@@ -63,6 +147,33 @@ describe("serviceOverviewQuery", () => {
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("CommitSha IN ('abc123', 'def456')")
 	})
+
+	it("coerces BYO ClickHouse string-encoded annual aggregates", () => {
+		const compiled = compileCH(serviceOverviewQuery({}), baseParams, {
+			rowSchema: serviceOverviewRowSchema,
+		})
+		const [decoded] = Effect.runSync(
+			compiled.decodeRows([
+				{
+					serviceName: "api",
+					serviceNamespace: "checkout",
+					environment: "production",
+					commitSha: "abc123",
+					throughput: "100",
+					errorCount: "2",
+					estimatedErrorCount: "4",
+					spanCount: "100",
+					p50LatencyMs: "12.5",
+					p95LatencyMs: "42",
+					p99LatencyMs: "80",
+					estimatedSpanCount: "200",
+					firstSeen: "2024-01-01 00:00:00",
+				},
+			]),
+		)
+		expect(decoded.estimatedSpanCount).toBe(200)
+		expect(decoded.p95LatencyMs).toBe(42)
+	})
 })
 
 // ---------------------------------------------------------------------------
@@ -74,10 +185,13 @@ describe("serviceHealthBaselineQuery", () => {
 		const q = serviceHealthBaselineQuery({})
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("FROM service_overview_spans")
+		expect(sql).toContain("FROM service_overview_hourly")
 		expect(sql).toContain("OrgId = 'org_1'")
 		expect(sql).toContain("Timestamp >= '2024-01-01 00:00:00'")
-		expect(sql).toContain("quantile(0.95)(Duration) / 1000000 AS baselineP95LatencyMs")
-		expect(sql).toContain("count() AS baselineSpanCount")
+		expect(sql).toContain(
+			"arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 2) / 1000000 AS baselineP95LatencyMs",
+		)
+		expect(sql).toContain("sum(bSpanCount) AS baselineSpanCount")
 		// Baseline must NOT split by commit — health compares service+env totals.
 		expect(sql).toContain("GROUP BY serviceName, serviceNamespace, environment")
 		expect(sql).not.toContain("commitSha")
@@ -102,10 +216,12 @@ describe("serviceReleasesTimelineQuery", () => {
 		const q = serviceReleasesTimelineQuery({ serviceName: "api" })
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("FROM service_overview_spans")
+		expect(sql).toContain("FROM service_overview_hourly")
 		expect(sql).toContain("ServiceName = 'api'")
 		expect(sql).toContain("CommitSha != ''")
 		expect(sql).toContain("CommitSha AS commitSha")
-		expect(sql).toContain("count() AS count")
+		expect(sql).toContain("sum(bSpanCount) AS count")
+		expect(sql).toContain("sum(bErrorCount) AS errorCount")
 		expect(sql).toContain("GROUP BY bucket, commitSha")
 		expect(sql).toContain("ORDER BY bucket ASC")
 		expect(sql).toContain("LIMIT 1000")
@@ -121,7 +237,8 @@ describe("serviceEnvironmentsQuery", () => {
 		const q = serviceEnvironmentsQuery({ serviceName: "api" })
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).toContain("DeploymentEnv AS environment")
+		expect(sql).toContain("FROM service_overview_hourly")
+		expect(sql).toContain("bEnvironment AS environment")
 		// Scoped to the org + this one service (replaces an all-services scan)…
 		expect(sql).toContain("OrgId = 'org_1'")
 		expect(sql).toContain("ServiceName = 'api'")
@@ -129,7 +246,7 @@ describe("serviceEnvironmentsQuery", () => {
 		expect(sql).toContain("Timestamp >= '2024-01-01 00:00:00'")
 		expect(sql).toContain("Timestamp <= '2024-01-02 00:00:00'")
 		// Empty env rows are excluded (matches the old switcher's truthy filter).
-		expect(sql).toContain("DeploymentEnv != ''")
+		expect(sql).toContain("bEnvironment != ''")
 		expect(sql).toContain("GROUP BY environment")
 		expect(sql).toContain("FORMAT JSON")
 	})
@@ -143,23 +260,21 @@ describe("serviceApdexTimeseriesQuery", () => {
 	it("compiles apdex timeseries with default threshold", () => {
 		const q = serviceApdexTimeseriesQuery({ serviceName: "api" })
 		const { sql } = compileCH(q, baseParams)
-		// Routes through the service_overview_spans MV (pre-filtered to
-		// entry-point spans at write time) — ~20-100x cheaper than raw traces.
+		// Exact raw partial hours surround complete hourly aggregate buckets.
 		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).not.toContain("FROM traces")
+		expect(sql).toContain("FROM service_overview_hourly")
+		expect(sql).toContain("UNION ALL")
 		expect(sql).toContain("ServiceName = 'api'")
-		expect(sql).toContain("count() AS totalCount")
-		expect(sql).toContain("Duration / 1000000 < 500")
+		expect(sql).toContain("sum(bSpanCount) AS totalCount")
+		expect(sql).toContain("Duration < 500000000")
 		expect(sql).toContain("AS satisfiedCount")
 		expect(sql).toContain("AS toleratingCount")
 		expect(sql).toContain("AS apdexScore")
 		// Errored spans count as frustrated: the satisfied/tolerating buckets are
 		// gated on the non-error predicate, so a fast 5xx never inflates apdex.
-		expect(sql).toContain(
-			"countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount",
-		)
+		expect(sql).toContain("StatusCode != 'Error'")
 		// totalCount still counts every span (errors included), so they drag the score down.
-		expect(sql).toContain("count() AS totalCount")
+		expect(sql).toContain("sum(bSpanCount) AS totalCount")
 		expect(sql).toContain("GROUP BY bucket")
 		expect(sql).toContain("ORDER BY bucket ASC")
 		// The MV pre-filters at write time — the runtime root-only predicate is
@@ -186,10 +301,30 @@ describe("serviceApdexTimeseriesQuery", () => {
 		const { sql } = compileCH(q, baseParams)
 		// The Apdex SELECT must contain the split-term form: each countIf is
 		// divided by count() before being summed, instead of summed first.
-		expect(sql).toContain(") / count() + countIf(")
-		expect(sql).toContain(") * 0.5 / count()")
+		expect(sql).toContain(
+			"sum(bApdexSatisfiedCount) / sum(bSpanCount) + sum(bApdexToleratingCount) * 0.5 / sum(bSpanCount)",
+		)
 		// And it must NOT contain the buggy summed-then-divided form.
-		expect(sql).not.toMatch(/countIf\([^)]*\) \+ countIf/)
+		expect(sql).not.toMatch(/sum\(bApdexSatisfiedCount\) \+ sum\(bApdexToleratingCount\)/)
+	})
+
+	it("coerces BYO ClickHouse string-encoded Apdex aggregates", () => {
+		const compiled = compileCH(serviceApdexTimeseriesQuery({ serviceName: "api" }), baseParams, {
+			rowSchema: serviceApdexTimeseriesRowSchema,
+		})
+		const [decoded] = Effect.runSync(
+			compiled.decodeRows([
+				{
+					bucket: "2024-01-01 00:00:00",
+					totalCount: "100",
+					satisfiedCount: "80",
+					toleratingCount: "10",
+					apdexScore: "0.85",
+				},
+			]),
+		)
+		expect(decoded.totalCount).toBe(100)
+		expect(decoded.apdexScore).toBe(0.85)
 	})
 })
 
@@ -277,11 +412,12 @@ describe("servicesFacetsQuery", () => {
 		expect(sql).toContain("'namespace' AS facetType")
 		expect(sql).toContain("'commit_sha' AS facetType")
 		expect(sql).toContain("'service' AS facetType")
-		expect(sql).toContain("DeploymentEnv != ''")
-		expect(sql).toContain("ServiceNamespace != ''")
-		expect(sql).toContain("CommitSha != ''")
-		expect(sql).toContain("ServiceName != ''")
+		expect(sql).toContain("bEnvironment != ''")
+		expect(sql).toContain("bServiceNamespace != ''")
+		expect(sql).toContain("bCommitSha != ''")
+		expect(sql).toContain("bServiceName != ''")
 		expect(sql).toContain("FROM service_overview_spans")
+		expect(sql).toContain("FROM service_overview_hourly")
 		expect(sql).toContain("FROM logs_aggregates_hourly")
 		expect(sql).toContain("FROM metrics_gauge")
 		expect(sql).toContain("FROM metrics_sum")

--- a/packages/query-engine/src/ch/queries/services.ts
+++ b/packages/query-engine/src/ch/queries/services.ts
@@ -16,7 +16,7 @@ import {
 } from "@maple-dev/clickhouse-builder"
 import { unionAll, type CHUnionQuery } from "@maple-dev/clickhouse-builder"
 import type { ColumnDefs } from "@maple-dev/clickhouse-builder/types"
-import { ServiceOverviewHourly, ServiceOverviewSpans, ServiceUsage, TracesAggregatesHourly } from "../tables"
+import { LogsAggregatesHourly, MetricCatalog, MetricsGauge, MetricsHistogram, MetricsSum, ServiceOverviewHourly, ServiceOverviewSpans, ServiceUsage, TracesAggregatesHourly } from "../tables"
 import { CHNumber } from "../schema"
 import { apdexExprs, serviceOverviewWhereConditions } from "./query-helpers"
 
@@ -621,7 +621,7 @@ export function serviceUsageWithPreviousQuery(opts: ServiceUsageOpts) {
 }
 
 // ---------------------------------------------------------------------------
-// Services facets (UNION ALL — environment + commit_sha facets)
+// Services facets (UNION ALL — environment + commit_sha facets + all signal types)
 // ---------------------------------------------------------------------------
 
 export interface ServicesFacetsOutput {
@@ -630,12 +630,18 @@ export interface ServicesFacetsOutput {
 	readonly facetType: string
 }
 
-// NOTE: kept as a 4-way UNION ALL on purpose. A single-scan rewrite (ARRAY JOIN
+// NOTE: kept as a UNION ALL on purpose. A single-scan rewrite (ARRAY JOIN
 // of (facetType, value) pairs, or GROUP BY GROUPING SETS) reads ~3× fewer rows
 // but benchmarked 2–4× SLOWER in wall-clock on the deployed warehouse: ClickHouse
 // runs the UNION branches in parallel and each is a cheap LowCardinality GROUP BY,
 // whereas the array/tuple/lambda CPU + row replication of the single-scan forms
 // dominates. The I/O saving doesn't translate to latency here.
+
+// Services facets now include services from ALL signal types:
+// - service_overview_spans / service_overview_hourly (traces)
+// - logs_aggregates_hourly (logs)
+// - metrics_sum / metrics_gauge / metrics_histogram / metric_catalog (metrics)
+// - service_usage (aggregated rollup of all signals)
 export function servicesFacetsQuery(): CHUnionQuery<ServicesFacetsOutput> {
 	const envQuery = serviceOverviewWindows({})
 		.select(($) => ({
@@ -670,7 +676,8 @@ export function servicesFacetsQuery(): CHUnionQuery<ServicesFacetsOutput> {
 		.orderBy(["count", "desc"])
 		.limit(50)
 
-	const serviceQuery = serviceOverviewWindows({})
+	// Service names from traces (service_overview_spans / service_overview_hourly)
+	const traceServiceQuery = serviceOverviewWindows({})
 		.select(($) => ({
 			name: $.bServiceName,
 			count: CH.sum($.bSpanCount),
@@ -681,5 +688,122 @@ export function servicesFacetsQuery(): CHUnionQuery<ServicesFacetsOutput> {
 		.orderBy(["count", "desc"])
 		.limit(50)
 
-	return unionAll(envQuery, namespaceQuery, commitQuery, serviceQuery).format("JSON")
+	// Service names from logs (logs_aggregates_hourly)
+	const logsServiceQuery = from(LogsAggregatesHourly)
+		.select(($) => ({
+			name: $.ServiceName,
+			count: CH.sum($.Count),
+			facetType: CH.lit("service"),
+		}))
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.Hour.gte(param.dateTime("startTime")),
+			$.Hour.lte(param.dateTime("endTime")),
+			$.ServiceName.neq(""),
+		])
+		.groupBy("name")
+		.orderBy(["count", "desc"])
+		.limit(50)
+
+	// Service names from metrics (metrics_gauge)
+	const metricsGaugeServiceQuery = from(MetricsGauge)
+		.select(($) => ({
+			name: $.ServiceName,
+			count: CH.count(),
+			facetType: CH.lit("service"),
+		}))
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.TimeUnix.gte(param.dateTime("startTime")),
+			$.TimeUnix.lte(param.dateTime("endTime")),
+			$.ServiceName.neq(""),
+		])
+		.groupBy("name")
+		.orderBy(["count", "desc"])
+		.limit(50)
+
+	// Service names from metrics (metrics_sum)
+	const metricsSumServiceQuery = from(MetricsSum)
+		.select(($) => ({
+			name: $.ServiceName,
+			count: CH.count(),
+			facetType: CH.lit("service"),
+		}))
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.TimeUnix.gte(param.dateTime("startTime")),
+			$.TimeUnix.lte(param.dateTime("endTime")),
+			$.ServiceName.neq(""),
+		])
+		.groupBy("name")
+		.orderBy(["count", "desc"])
+		.limit(50)
+
+	// Service names from metrics (metrics_histogram)
+	const metricsHistogramServiceQuery = from(MetricsHistogram)
+		.select(($) => ({
+			name: $.ServiceName,
+			count: CH.count(),
+			facetType: CH.lit("service"),
+		}))
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.TimeUnix.gte(param.dateTime("startTime")),
+			$.TimeUnix.lte(param.dateTime("endTime")),
+			$.ServiceName.neq(""),
+		])
+		.groupBy("name")
+		.orderBy(["count", "desc"])
+		.limit(50)
+
+	// Service names from metric_catalog
+	const catalogServiceQuery = from(MetricCatalog)
+		.select(($) => ({
+			name: $.ServiceName,
+			count: CH.sum($.DataPointCount),
+			facetType: CH.lit("service"),
+		}))
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.Hour.gte(param.dateTime("startTime")),
+			$.Hour.lte(param.dateTime("endTime")),
+			$.ServiceName.neq(""),
+		])
+		.groupBy("name")
+		.orderBy(["count", "desc"])
+		.limit(50)
+
+	// Service names from service_usage (aggregated rollup)
+	const usageServiceQuery = from(ServiceUsage)
+		.select(($) => ({
+			name: $.ServiceName,
+			count: CH.sum($.LogCount).add(CH.sum($.TraceCount))
+				.add(CH.sum($.SumMetricCount))
+				.add(CH.sum($.GaugeMetricCount))
+				.add(CH.sum($.HistogramMetricCount))
+				.add(CH.sum($.ExpHistogramMetricCount)),
+			facetType: CH.lit("service"),
+		}))
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.Hour.gte(param.dateTime("startTime")),
+			$.Hour.lte(param.dateTime("endTime")),
+			$.ServiceName.neq(""),
+		])
+		.groupBy("name")
+		.orderBy(["count", "desc"])
+		.limit(50)
+
+	return unionAll(
+		envQuery,
+		namespaceQuery,
+		commitQuery,
+		traceServiceQuery,
+		logsServiceQuery,
+		metricsGaugeServiceQuery,
+		metricsSumServiceQuery,
+		metricsHistogramServiceQuery,
+		catalogServiceQuery,
+		usageServiceQuery
+	).format("JSON")
 }


### PR DESCRIPTION
## Problem
The `/services` page filter sidebar only showed services that have **traces** (via `service_overview_spans` / `service_overview_hourly`). Services that only send **logs** or **metrics** were missing from the filter dropdown.

## Solution
Modified `servicesFacetsQuery()` in `packages/query-engine/src/ch/queries/services.ts` to union service names from all signal tables:

1. **Traces**: `service_overview_spans` / `service_overview_hourly` (existing)
2. **Logs**: `logs_aggregates_hourly` (new)
3. **Metrics**: `metrics_gauge`, `metrics_sum`, `metrics_histogram`, `metric_catalog` (new)
4. **Aggregated rollup**: `service_usage` (new)

Each branch uses the appropriate table and where conditions for its signal type, following the same UNION ALL pattern as the existing code.

## Testing
- Typecheck passes
- `servicesFacetsQuery` test passes (generates correct SQL with all 7 new signal tables)
- Other query-engine tests have pre-existing failures unrelated to this change

## Design Notes
- The Services page is a **cross-signal overview** — its filter should show **all services** regardless of signal type
- Signal-specific pages (`/traces`, `/logs`, `/metrics`) continue to use their own signal-specific facet queries
- This preserves the existing per-signal filter behavior while fixing the cross-signal overview

Fixes #285


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788047213&installation_model_id=427786&pr_number=291&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F291&signature=2ceeb91632a9f8a1f9f67306cff1cd9e9ab45edd0cfe4fc28c3888e555deb228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->