### PR TITLE
chore: retire PlanetScale PR-preview branches and disable preview deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,9 +26,10 @@ CLICKHOUSE_PASSWORD=maple
 MAPLE_DB_URL=
 
 # Deployed stages (set in Infisical, not here): one PlanetScale Postgres connection
-# string for the stage's branch (direct port 5432). alchemy.run.ts parses it into
-# the Hyperdrive origin; the CI `drizzle-kit migrate` step and the import scripts
-# use it as-is. NB the connect-time database is `postgres` (the cluster default),
+# string for the stage's branch (direct port 5432), used by the CI `drizzle-kit
+# migrate` step and the import scripts. stg/prd bind their Hyperdrive by dashboard
+# config ID and never read this at deploy time; only dev stages have alchemy parse
+# it into a Hyperdrive origin. PR previews bind no database at all. NB the connect-time database is `postgres` (the cluster default),
 # NOT the PlanetScale resource name `maple` (that's only for `pscale` commands).
 # MAPLE_PG_URL=postgres://user:pass@host.pg.psdb.cloud:5432/postgres?sslmode=verify-full
 

--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -10,11 +10,18 @@ name: Cleanup Preview Orphans
 #     (e.g. #211/#214 closed with the pre-#215 skip-chain and orphaned).
 #   - A deploy landing after close (delayed event / re-run) can recreate the
 #     branch right after teardown deleted it (e.g. #180).
-# PS-DEV branches bill for time used, so orphans cost real money every hour.
-# The same failure modes leak Electric Cloud `pr-<n>` environments (each holds
-# a PlanetScale replication slot + a plan max-databases slot) and Tinybird
-# `pr_<n>` branches (they share compute with production), so all three
-# lifecycle scripts run their `sweep` subcommand here.
+# These failure modes leak Tinybird `pr_<n>` branches (they share compute with
+# production), Cloudflare workers/queues, and `maple-db-pr-*` Hyperdrive configs
+# (capped at 25 per account), so each lifecycle script runs its `sweep`
+# subcommand here.
+#
+# The PlanetScale and Electric sweeps are RESIDUAL as of 2026-08: PR previews no
+# longer provision a PlanetScale branch or an Electric source at all (see the
+# comment in deploy-pr-preview.yml and `resolveDatabaseMode` in
+# packages/infra/src/cloudflare/stage.ts). They stay as a safety net for anything
+# left over from before the cutover, and would come straight back into force if
+# per-PR databases are ever restored. The Hyperdrive sweep is now what reaps the
+# `maple-db-pr-*` configs those previews left behind.
 #
 # Caveat: sweep maps `pr-<n>` resource names to THIS repo's PR numbers
 # (GITHUB_REPOSITORY). If the PlanetScale database / Electric project /
@@ -23,7 +30,8 @@ name: Cleanup Preview Orphans
 
 on:
     schedule:
-        # Every 6 hours — orphaned PS-DEV branches bill continuously.
+        # Every 6 hours — orphaned Tinybird branches share production compute
+        # and orphaned Hyperdrive configs eat the 25-per-account cap.
         - cron: "17 */6 * * *"
     workflow_dispatch:
 
@@ -90,9 +98,9 @@ jobs:
               if: ${{ env.PLANETSCALE_SERVICE_TOKEN != '' }}
               uses: planetscale/setup-pscale-action@v1
 
-            # Mirrors the deploy workflow's gating: until the Infisical `dev`
-            # environment carries the PlanetScale service token, the sweep SKIPs
-            # cleanly instead of failing on every schedule tick.
+            # Residual net: previews no longer create `pr-<n>` branches, so this
+            # should find nothing. Gated on the service token, so it SKIPs cleanly
+            # rather than failing on every schedule tick when the token is absent.
             - name: Sweep orphaned PlanetScale PR branches
               if: ${{ env.PLANETSCALE_SERVICE_TOKEN != '' }}
               env:

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,11 +1,22 @@
 name: Deploy PR Preview (Cloudflare via Alchemy)
 
+# PREVIEW DEPLOYS ARE DISABLED (2026-08, cost). Only the `closed` event still
+# fires, so this workflow now does teardown ONLY: it tears down the stacks of
+# PRs that were deployed before the cutover and never deploys a new one. The
+# deploy-side steps below are kept intact and simply never run.
+#
+# To re-enable, restore the full trigger list:
+#     types: [opened, synchronize, reopened, closed]
+# Previews will then deploy without an application database — see the comment
+# further down and `resolveDatabaseMode` in packages/infra/src/cloudflare/stage.ts.
+#
+# While disabled, cleanup-preview-orphans.yml stays the backstop: its 6-hourly
+# sweeps reap any preview worker, queue, Tinybird branch or Hyperdrive config
+# whose PR closes without a teardown run (GitHub creates no `closed` run for a
+# PR that conflicts with its base branch).
 on:
     pull_request:
         types:
-            - opened
-            - synchronize
-            - reopened
             - closed
 
 concurrency:

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -89,99 +89,43 @@ jobs:
               if: ${{ github.event.action != 'closed' }}
               run: bun scripts/tinybird-pr-branch.ts up "$PR_NUMBER"
 
-            - name: Install PlanetScale CLI
-              if: ${{ env.PLANETSCALE_SERVICE_TOKEN != '' }}
-              uses: planetscale/setup-pscale-action@v1
-
-            # The PlanetScale + Alchemy steps below are gated on
-            # PLANETSCALE_SERVICE_TOKEN: until the `dev` Infisical environment carries the
-            # PlanetScale service token (+ PLANETSCALE_SERVICE_TOKEN_ID,
-            # PLANETSCALE_ORG), PR previews can't provision a Postgres branch, so
-            # they SKIP cleanly (the check stays green) rather than fail every PR.
-            # Adding the token activates per-PR preview deploys automatically.
-
-            # Ensure the ephemeral PlanetScale Postgres branch `pr-<n>` exists
-            # and is empty (created once per PR — ~9 min provision — then reset
-            # in SQL on later deploys), mint a credential, and export
-            # MAPLE_PG_URL to GITHUB_ENV so the migrate + Alchemy steps below
-            # bind to the branch.
-            - name: Create/refresh PlanetScale PR branch
-              if: ${{ github.event.action != 'closed' && env.PLANETSCALE_SERVICE_TOKEN != '' }}
-              # GITHUB_TOKEN lets the script refuse to provision when the PR is
-              # already closed — a delayed/re-run deploy after teardown would
-              # otherwise recreate the branch with nothing left to delete it.
-              env:
-                  GITHUB_TOKEN: ${{ github.token }}
-              run: bun scripts/planetscale-pr-branch.ts up "$PR_NUMBER"
-
-            # BEFORE migrate: installs default privileges granting PUBLIC on every
-            # table created from here on, so a new or rebuilt table can never land
-            # owner-only and leave a consumer with "permission denied for table …".
-            # Default privileges only apply to objects created after they are set,
-            # hence the ordering. See packages/db/scripts/ensure-privileges.ts.
-            - name: Ensure database privileges
-              if: ${{ github.event.action != 'closed' && env.PLANETSCALE_SERVICE_TOKEN != '' }}
-              run: DATABASE_URL="$MAPLE_PG_URL" bun run --cwd packages/db db:ensure-privileges
-
-            - name: Run database migrations
-              if: ${{ github.event.action != 'closed' && env.PLANETSCALE_SERVICE_TOKEN != '' }}
-              run: DATABASE_URL="$MAPLE_PG_URL" bun run --cwd packages/db db:migrate
-
-            # Reassign everything this run's ephemeral role created to `postgres`
-            # so the NEXT deploy's role (which inherits postgres) can drop it —
-            # pscale_api_* roles are not grantable to each other, so without this
-            # the in-place reset always fails on the prior run's objects and
-            # falls back to the ~9-minute delete → recreate path. See
-            # packages/db/scripts/normalize-preview-ownership.ts.
-            - name: Normalize preview branch ownership
-              if: ${{ github.event.action != 'closed' && env.PLANETSCALE_SERVICE_TOKEN != '' }}
-              run: DATABASE_URL="$MAPLE_PG_URL" bun run --cwd packages/db db:normalize-preview
-
-            # Create/refresh an Electric Cloud environment `pr-<n>` + a Postgres
-            # source pointed at this PR's PlanetScale branch (via the dedicated
-            # replication-role credential MAPLE_PG_ELECTRIC_URL), and
-            # export ELECTRIC_URL/ELECTRIC_SOURCE_ID/ELECTRIC_SECRET to GITHUB_ENV so
-            # the Alchemy deploy below binds the electric-sync worker to it. Runs
-            # after migrations so `0009_electric_publication` exists. Gated on
-            # ELECTRIC_API_TOKEN: until the `dev` Infisical environment carries the
-            # Electric CLI token (+ ELECTRIC_PROJECT_ID), previews SKIP cleanly —
-            # the electric-sync worker deploys unconfigured (503) and the web app
-            # stays on its effect-atom fetches. Adding the token activates per-PR
-            # sync automatically.
-            - name: Create/refresh Electric Cloud PR source
-              if: ${{ github.event.action != 'closed' && env.ELECTRIC_API_TOKEN != '' && env.PLANETSCALE_SERVICE_TOKEN != '' }}
-              run: bun scripts/electric-pr-branch.ts up "$PR_NUMBER"
+            # NO DATABASE STEP HERE, ON PURPOSE. PR previews used to provision an
+            # ephemeral PlanetScale branch `pr-<n>` (+ migrations + an Electric
+            # Cloud source pointed at it). PS-DEV branches bill for time used and
+            # every preview also burned one of the account's 25 Hyperdrive configs,
+            # so as of 2026-08 the `pr` stage deploys with NO application database:
+            # `resolveDatabaseMode` (packages/infra/src/cloudflare/stage.ts) returns
+            # "none", no MAPLE_DB binding is created, and DatabasePgLive fails per
+            # query — DB-backed routes 500 while the rest of the preview works.
+            #
+            # To restore per-PR databases: flip that resolver back to "managed" for
+            # `pr` and re-add the steps this comment replaced (PlanetScale CLI setup,
+            # `planetscale-pr-branch.ts up`, `db:ensure-privileges`, `db:migrate`,
+            # `db:normalize-preview`, `electric-pr-branch.ts up`, and the matching
+            # `planetscale-pr-branch.ts down` teardown). Every script is still in the
+            # repo, dormant.
 
             - name: Deploy PR preview stack with Alchemy
               id: deploy
-              if: ${{ github.event.action != 'closed' && env.PLANETSCALE_SERVICE_TOKEN != '' }}
+              if: ${{ github.event.action != 'closed' }}
               run: bun run alchemy:deploy:pr
 
             - name: Destroy PR preview stack with Alchemy
               id: destroy
-              if: ${{ github.event.action == 'closed' && env.PLANETSCALE_SERVICE_TOKEN != '' }}
-              # MAPLE_PG_URL is generated by the deploy run and does not survive
-              # into this separate close-event runner. Destroy only needs a valid
-              # URL so alchemy.run.ts can reconstruct the resource graph from
-              # state; it never connects to this placeholder origin.
-              env:
-                  MAPLE_PG_URL: postgres://preview-teardown:preview-teardown@127.0.0.1:5432/postgres
+              if: ${{ github.event.action == 'closed' }}
               run: bun run alchemy:destroy:pr
 
-            # After the stack (and its Hyperdrive config) is destroyed. PS-DEV
-            # branches bill for time used — this must run on every PR close.
             # `!cancelled()` keeps each teardown step running even when a sibling
             # teardown step fails — a failed `alchemy destroy` must not leave the
-            # PS/Electric/Tinybird branches behind (that skip-chain is how the
+            # Electric/Tinybird resources behind (that skip-chain is how the
             # pre-#215 orphan fleet accumulated).
-            - name: Remove PlanetScale PR branch
-              if: ${{ !cancelled() && github.event.action == 'closed' && env.PLANETSCALE_SERVICE_TOKEN != '' }}
-              run: bun scripts/planetscale-pr-branch.ts down "$PR_NUMBER"
 
             # Delete the Electric Cloud environment `pr-<n>` (its services are
             # deleted first — Electric refuses to delete an env holding
-            # services). Each source holds a PlanetScale replication slot and a
-            # plan max-databases slot, so teardown on close is mandatory.
+            # services). Residual since previews stopped creating sources: this
+            # only reaps environments left over from PRs opened before 2026-08,
+            # and is a no-op afterwards. Kept because each old source still holds
+            # a plan max-databases slot.
             - name: Remove Electric Cloud PR source
               if: ${{ !cancelled() && github.event.action == 'closed' && env.ELECTRIC_API_TOKEN != '' }}
               run: bun scripts/electric-pr-branch.ts down "$PR_NUMBER"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,12 @@ Workers via the Hyperdrive binding `MAPLE_DB`.
   `DatabasePgliteLive` (tests/local; `createTestDb()` in `apps/api/src/lib/test-pglite.ts`).
 - Migrations: `bun run --cwd packages/db db:generate`; CI applies them against the branch's DIRECT
   port 5432 (never a pooler) before `alchemy deploy`. PGlite applies them at layer build.
-- **PR previews have no application database** (since 2026-08 — PS-DEV branches billed
-  continuously and ate the Hyperdrive config cap). `resolveDatabaseMode` in
+- **PR preview deploys are disabled** (2026-08, cost). `deploy-pr-preview.yml` triggers on the
+  `closed` event only, so it tears down pre-cutover stacks and never deploys a new one; restore
+  `types: [opened, synchronize, reopened, closed]` to re-enable.
+- **PR previews have no application database** either (PS-DEV branches billed continuously and
+  ate the Hyperdrive config cap) — this is the state previews return to when re-enabled.
+  `resolveDatabaseMode` in
   `packages/infra/src/cloudflare/stage.ts` returns `"none"` for `pr`, so no `MAPLE_DB` is bound
   and `DatabasePgLive` fails every query with a `DatabaseError` — DB-backed routes 500, the rest
   of the preview works. To restore: return `"managed"` for `pr` and re-add the PlanetScale +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ const typedRows = compiled.castRows(rows)
 ## Application database (PlanetScale Postgres)
 
 Relational state (issues, alert rules, dashboards, org config, keys) is Drizzle/`pgTable` in
-`packages/db/src/schema/`, one PS branch per stage (`main`=prd, `stg`, `pr-<n>`), reached from
+`packages/db/src/schema/`, one PS branch per deployed stage (`main`=prd, `stg`), reached from
 Workers via the Hyperdrive binding `MAPLE_DB`.
 
 - App code keeps epoch-ms numbers and converts at the drizzle boundary (`new Date(ms)` writing,
@@ -71,8 +71,12 @@ Workers via the Hyperdrive binding `MAPLE_DB`.
   `DatabasePgliteLive` (tests/local; `createTestDb()` in `apps/api/src/lib/test-pglite.ts`).
 - Migrations: `bun run --cwd packages/db db:generate`; CI applies them against the branch's DIRECT
   port 5432 (never a pooler) before `alchemy deploy`. PGlite applies them at layer build.
-- PR previews: `scripts/planetscale-pr-branch.ts up|down <n>`; deleting the branch on PR close is
-  mandatory (billing + Hyperdrive config cap).
+- **PR previews have no application database** (since 2026-08 — PS-DEV branches billed
+  continuously and ate the Hyperdrive config cap). `resolveDatabaseMode` in
+  `packages/infra/src/cloudflare/stage.ts` returns `"none"` for `pr`, so no `MAPLE_DB` is bound
+  and `DatabasePgLive` fails every query with a `DatabaseError` — DB-backed routes 500, the rest
+  of the preview works. To restore: return `"managed"` for `pr` and re-add the PlanetScale +
+  Electric steps to `.github/workflows/deploy-pr-preview.yml` (the scripts are kept, dormant).
 - The ingest gateway resolves ingest keys from the same Postgres via PSBouncer (6432, no Hyperdrive).
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -110,10 +110,11 @@ single `Alchemy.Stack("maple", …)` whose program composes per-app factories:
 
 Stage grammar is `prd` / `stg` / `pr-<number>` / dev names, resolved via
 `@maple/infra/cloudflare` (`parseMapleStage`, `resolveMapleDomains`, `resolveWorkerName`,
-`resolveHyperdriveName`, `resolveHyperdriveRefId`). stg/prd bind the dashboard-managed
-Hyperdrive by config ID (`resolveHyperdriveRefId`) — origin credentials never touch a
-deploy and `MAPLE_PG_URL` is only needed for pr/dev stages, whose per-branch Hyperdrive
-alchemy manages itself.
+`resolveHyperdriveName`, `resolveHyperdriveRefId`, `resolveDatabaseMode`). stg/prd bind the
+dashboard-managed Hyperdrive by config ID (`resolveHyperdriveRefId`) — origin credentials
+never touch a deploy. `MAPLE_PG_URL` is only needed for dev stages, whose Hyperdrive alchemy
+manages itself. PR previews bind **no database at all** (`resolveDatabaseMode` → `"none"`):
+DB-backed routes 500, everything else in the preview works.
 
 Run locally:
 

--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -8,6 +8,7 @@ import type { MapleDomains, MapleStage } from "@maple/infra/cloudflare"
 import {
 	CLOUDFLARE_WORKER_PLACEMENT,
 	formatMapleStage,
+	resolveDatabaseMode,
 	resolveDeploymentEnvironment,
 	resolveHyperdriveName,
 	resolveHyperdriveRefId,
@@ -50,42 +51,49 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 		//   live only in the Cloudflare dashboard; deploys never see them and
 		//   MAPLE_PG_URL is not required.
 		//
-		// - pr/dev stages get an alchemy-MANAGED per-branch Hyperdrive whose origin
-		//   is pushed from MAPLE_PG_URL (a standard Postgres connection string,
-		//   direct port 5432) — the same env var the CI `drizzle-kit migrate` step
-		//   + import scripts use. Cloudflare Hyperdrive needs a STRUCTURED origin
-		//   (discrete host/user/…), not a URL, so we parse it here. Schema
-		//   migrations run in CI before deploy, never at boot.
+		// - dev stages get an alchemy-MANAGED Hyperdrive whose origin is pushed
+		//   from MAPLE_PG_URL (a standard Postgres connection string, direct port
+		//   5432) — the same env var the CI `drizzle-kit migrate` step + import
+		//   scripts use. Cloudflare Hyperdrive needs a STRUCTURED origin (discrete
+		//   host/user/…), not a URL, so we parse it here. Schema migrations run in
+		//   CI before deploy, never at boot.
+		//
+		// - pr previews get NO database binding at all (resolveDatabaseMode →
+		//   "none"): PlanetScale PR branches are no longer provisioned. The worker
+		//   still boots and serves — DatabasePgLive fails per query instead of
+		//   dying — so DB-backed routes 500 while everything else works.
+		const databaseMode = resolveDatabaseMode(stage)
 		const hyperdriveRefId = resolveHyperdriveRefId(stage)
-		const mapleDb = hyperdriveRefId
-			? undefined
-			: yield* Effect.gen(function* () {
-					const pgUrl = new URL(requireEnv("MAPLE_PG_URL"))
-					return yield* Cloudflare.Hyperdrive.Connection("maple-db", {
-						name: resolveHyperdriveName(stage),
-						origin: {
-							scheme: "postgres",
-							host: pgUrl.hostname,
-							port: Number(pgUrl.port || "5432"),
-							// Connect-time db (`postgres`, the PlanetScale cluster default),
-							// not the PS resource name.
-							database: pgUrl.pathname.replace(/^\//, "") || "postgres",
-							user: decodeURIComponent(pgUrl.username),
-							password: Redacted.make(decodeURIComponent(pgUrl.password)),
-						},
-						// Read-after-write everywhere (alert state CAS, dashboard versioning) —
-						// revisit caching once read paths that tolerate staleness are identified.
-						caching: { disabled: true },
-						dev: {
-							scheme: "postgres",
-							host: "localhost",
-							port: 5499,
-							database: "maple",
-							user: "maple",
-							password: Redacted.make("maple"),
-						},
+		const mapleDb =
+			databaseMode !== "managed"
+				? undefined
+				: yield* Effect.gen(function* () {
+						const pgUrl = new URL(requireEnv("MAPLE_PG_URL"))
+						return yield* Cloudflare.Hyperdrive.Connection("maple-db", {
+							name: resolveHyperdriveName(stage),
+							origin: {
+								scheme: "postgres",
+								host: pgUrl.hostname,
+								port: Number(pgUrl.port || "5432"),
+								// Connect-time db (`postgres`, the PlanetScale cluster default),
+								// not the PS resource name.
+								database: pgUrl.pathname.replace(/^\//, "") || "postgres",
+								user: decodeURIComponent(pgUrl.username),
+								password: Redacted.make(decodeURIComponent(pgUrl.password)),
+							},
+							// Read-after-write everywhere (alert state CAS, dashboard versioning) —
+							// revisit caching once read paths that tolerate staleness are identified.
+							caching: { disabled: true },
+							dev: {
+								scheme: "postgres",
+								host: "localhost",
+								port: 5499,
+								database: "maple",
+								user: "maple",
+								password: Redacted.make("maple"),
+							},
+						})
 					})
-				})
 
 		const mcpSessions = yield* Cloudflare.KV.Namespace("MCP_SESSIONS", {
 			title: resolveWorkerName("mcp-sessions", stage),

--- a/apps/api/src/lib/DatabasePgLive.ts
+++ b/apps/api/src/lib/DatabasePgLive.ts
@@ -1,7 +1,13 @@
 import { createMaplePgClient } from "@maple/db/client"
 import { Hyperdrive } from "@maple/effect-cloudflare/hyperdrive-connection"
 import { Effect, Layer } from "effect"
-import { Database, type DatabaseClient, type DatabaseShape, executeWithSpan } from "./DatabaseLive"
+import {
+	Database,
+	type DatabaseClient,
+	DatabaseError,
+	type DatabaseShape,
+	executeWithSpan,
+} from "./DatabaseLive"
 
 const MAPLE_DB = Hyperdrive("MAPLE_DB")
 
@@ -15,7 +21,21 @@ const makePgDatabase = Effect.gen(function* () {
 	const conn = yield* Hyperdrive.bind(MAPLE_DB)
 	const binding = yield* conn.raw
 	if (!binding) {
-		return yield* Effect.die(new Error("Missing worker Hyperdrive binding: MAPLE_DB"))
+		// Stages deployed without an application database (PR previews since
+		// 2026-08 — see resolveDatabaseMode in packages/infra). Dying here would
+		// abort construction of the ENTIRE isolate layer graph (layerPg is
+		// provideMerge'd into the handler in worker.ts), 504-ing every route
+		// including /health. Failing per `execute` keeps DB-free routes serving
+		// and turns DB-backed ones into ordinary 500s.
+		return Database.of({
+			execute: () =>
+				Effect.fail(
+					new DatabaseError({
+						message: "No application database on this stage (MAPLE_DB binding absent)",
+						cause: undefined,
+					}),
+				),
+		} satisfies DatabaseShape)
 	}
 
 	const connectionString = binding.connectionString

--- a/apps/electric-sync/alchemy.run.ts
+++ b/apps/electric-sync/alchemy.run.ts
@@ -58,9 +58,19 @@ export const createElectricSyncWorker = ({ stage, domains }: CreateElectricSyncW
 				...optionalSecret("CLERK_JWT_KEY"),
 				// ElectricSQL upstream: base URL (Electric Cloud in prod) + Cloud source
 				// credentials. The shape proxy 503s if URL is unset.
-				...optionalPlain("ELECTRIC_URL"),
-				...optionalPlain("ELECTRIC_SOURCE_ID"),
-				...optionalSecret("ELECTRIC_SECRET"),
+				//
+				// PR previews get none of the three on purpose: they no longer have a
+				// PlanetScale branch, so there is no per-PR Electric source to point at,
+				// and inheriting the shared `dev` credentials would proxy preview shapes
+				// against another stage's data. Absent ELECTRIC_URL → 503 → the web app
+				// falls back to its effect-atom fetches.
+				...(stage.kind === "pr"
+					? {}
+					: {
+							...optionalPlain("ELECTRIC_URL"),
+							...optionalPlain("ELECTRIC_SOURCE_ID"),
+							...optionalSecret("ELECTRIC_SECRET"),
+						}),
 				// Self-observability (OTLP export through the ingest gateway).
 				MAPLE_INGEST_KEY: Redacted.make(requireEnv("MAPLE_OTEL_INGEST_KEY")),
 				...optionalPlain("MAPLE_ENDPOINT"),

--- a/apps/landing/public/_headers
+++ b/apps/landing/public/_headers
@@ -1,0 +1,24 @@
+# Cloudflare Workers Assets header rules (copied verbatim into dist/).
+#
+# The markdown twins and llms.txt are served straight off the asset layer, so
+# their headers come from Cloudflare's extension sniffing rather than from the
+# Response our endpoints build — those are discarded when Astro writes the file
+# at build time. This is the only place their headers can be set.
+#
+# `text/markdown` is the correct type and what agents match on, but it is not a
+# type browsers are obliged to display: Chromium renders it, Safari and Firefox
+# treat an unfamiliar MIME as a download. `Content-Disposition: inline` is the
+# explicit "show this, don't save it" instruction. Resend sends the same header
+# on its own llms.txt.
+
+/*.md
+  Content-Disposition: inline
+  X-Content-Type-Options: nosniff
+
+/llms.txt
+  Content-Disposition: inline
+  X-Content-Type-Options: nosniff
+
+/llms-full.txt
+  Content-Disposition: inline
+  X-Content-Type-Options: nosniff

--- a/docs/electric-sync.md
+++ b/docs/electric-sync.md
@@ -164,9 +164,22 @@ a build-time constant, so a Vite restart is needed after changing it.
    With `ELECTRIC_URL` unset the proxy returns 503 and the synced lists fail to load.
 6. Validate initial per-org snapshot sizes before deploying a new synced table.
 
-## PR previews (per-PR Electric Cloud environment)
+## PR previews (no Electric source — dormant since 2026-08)
 
-PR previews provision an ephemeral Electric Cloud **environment** `pr-<n>` + a
+**PR previews no longer have an Electric source.** They stopped provisioning a
+PlanetScale branch (see `resolveDatabaseMode` in
+`packages/infra/src/cloudflare/stage.ts`), and with no Postgres to replicate from
+there is nothing for Electric to point at. `apps/electric-sync/alchemy.run.ts`
+therefore withholds `ELECTRIC_URL`/`ELECTRIC_SOURCE_ID`/`ELECTRIC_SECRET` on the
+`pr` stage — deliberately, so a preview can never inherit the shared `dev`
+credentials and proxy its shapes at another stage's data. The sync worker deploys
+unconfigured, returns 503, and the web app falls back to its effect-atom fetches.
+
+The `down`/`sweep` paths below still run: they reap environments left over from
+PRs opened before the cutover (each still holds a plan max-databases slot). The
+`up` path described here is dormant and documents the reverse path.
+
+The former lifecycle: an ephemeral Electric Cloud **environment** `pr-<n>` + a
 Postgres **source** per PR, mirroring the PlanetScale/Tinybird branch lifecycle.
 `scripts/electric-pr-branch.ts` (`up`/`down <pr-number>`, driven from
 `.github/workflows/deploy-pr-preview.yml`) uses `@electric-sql/cli`
@@ -183,8 +196,9 @@ the electric-sync worker by alchemy). On close it deletes the environment
 (cascades the source). Steps are gated on `ELECTRIC_API_TOKEN`, so previews stay
 green (and the worker 503s) until the token lands in Infisical.
 
-- The web build always reads through the sync path — provisioning the source is
-  what makes it work in previews.
+- The web build always reads through the sync path, so with no source provisioned
+  a preview's synced lists fall back to their effect-atom fetches. Provisioning
+  the source is what would make live sync work in previews again.
 - **Publication:** the migrate step runs `0009` (creates
   `electric_publication_default`) before the source is created. The script passes
   `--manual-table-publishing` by default (prod parity; Electric reads that

--- a/packages/db/scripts/normalize-preview-ownership.ts
+++ b/packages/db/scripts/normalize-preview-ownership.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env bun
 /**
+ * DORMANT since 2026-08 — PR previews no longer provision a PlanetScale branch
+ * (see `resolveDatabaseMode` in packages/infra/src/cloudflare/stage.ts). Kept
+ * intact as the reverse path; nothing calls it while `pr` maps to `"none"`.
+ *
  * Hand every object this deploy created on the PR-preview branch to `postgres`
  * — the step that makes the NEXT deploy's in-place reset possible.
  *

--- a/packages/db/scripts/reset-preview-branch.ts
+++ b/packages/db/scripts/reset-preview-branch.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env bun
 /**
+ * DORMANT since 2026-08 — PR previews no longer provision a PlanetScale branch
+ * (see `resolveDatabaseMode` in packages/infra/src/cloudflare/stage.ts). Kept
+ * intact as the reverse path; nothing calls it while `pr` maps to `"none"`.
+ *
  * In-place SQL reset of a PlanetScale PR-preview branch — the fast path of
  * `scripts/planetscale-pr-branch.ts up`.
  *

--- a/packages/infra/src/cloudflare/stage.ts
+++ b/packages/infra/src/cloudflare/stage.ts
@@ -127,12 +127,43 @@ export function resolveMapleDomains(stage: MapleStage): MapleDomains {
 	}
 }
 
+export type MapleDatabaseMode = "ref" | "managed" | "none"
+
+/**
+ * How a stage reaches the application database.
+ *
+ * - `"ref"` — bind a dashboard-managed Hyperdrive config by ID (stg/prd).
+ * - `"managed"` — alchemy creates a Hyperdrive whose origin is pushed from
+ *   `MAPLE_PG_URL` (dev stages, against the docker-compose Postgres).
+ * - `"none"` — no `MAPLE_DB` binding at all. `DatabasePgLive` then fails every
+ *   query with a `DatabaseError`, so DB-backed routes 500 while the rest of the
+ *   stack serves normally.
+ *
+ * PR previews are deliberately `"none"` (owner decision, 2026-08): the
+ * per-PR PlanetScale branches billed continuously for time used and consumed
+ * the account's Hyperdrive config cap. To reverse, return `"managed"` for `pr`
+ * and restore the PlanetScale/Electric steps in
+ * `.github/workflows/deploy-pr-preview.yml` (the scripts are kept, dormant).
+ */
+export function resolveDatabaseMode(stage: MapleStage): MapleDatabaseMode {
+	switch (stage.kind) {
+		case "prd":
+		case "stg":
+			return "ref"
+		case "pr":
+			return "none"
+		case "dev":
+			return "managed"
+	}
+}
+
 /**
  * Dashboard-managed Hyperdrive configs, bound by ID (v1's `HyperdriveRef`).
  * The origin/credentials are managed in the Cloudflare dashboard — deploys
- * never see or rewrite the database connection. Stages returning undefined
- * get an alchemy-managed per-branch Hyperdrive pushed from MAPLE_PG_URL.
- * Config IDs are not secrets.
+ * never see or rewrite the database connection. Stages returning undefined get
+ * an alchemy-managed Hyperdrive pushed from MAPLE_PG_URL, or no database at
+ * all — `resolveDatabaseMode` is the authority on which. Config IDs are not
+ * secrets.
  */
 export function resolveHyperdriveRefId(stage: MapleStage): string | undefined {
 	switch (stage.kind) {
@@ -168,9 +199,10 @@ export function resolveHyperdriveName(stage: MapleStage): string {
 
 /**
  * PlanetScale Postgres branch backing a stage. One database (`maple-api`)
- * with a fully-isolated branch per stage; pr branches are created/destroyed
- * by scripts/planetscale-pr-branch.ts. Dev stages have no managed branch —
- * local dev runs against the docker-compose Postgres.
+ * with a fully-isolated branch per stage. Dev stages have no managed branch —
+ * local dev runs against the docker-compose Postgres — and PR previews no
+ * longer provision one either (see `resolveDatabaseMode`), so the `pr` case
+ * here only documents the mapping the reverse path would restore.
  */
 export function resolvePlanetScaleBranch(stage: MapleStage): string | undefined {
 	switch (stage.kind) {

--- a/scripts/planetscale-pr-branch.ts
+++ b/scripts/planetscale-pr-branch.ts
@@ -3,6 +3,13 @@
  * Per-PR PlanetScale Postgres branch lifecycle for the PR-preview deploy.
  * Sibling of scripts/tinybird-pr-branch.ts with the same up/down contract.
  *
+ * ⚠️ `up`/`down` are DORMANT since 2026-08: PR previews deploy with no
+ * application database (`resolveDatabaseMode` → "none" for `pr`, see
+ * packages/infra/src/cloudflare/stage.ts), so the deploy workflow no longer
+ * calls them. Only `sweep` still runs on a schedule, as a residual safety net.
+ * Restoring per-PR databases means flipping that resolver and re-adding the
+ * steps described in the comment in .github/workflows/deploy-pr-preview.yml.
+ *
  *   bun scripts/planetscale-pr-branch.ts up    <pr-number>
  *   bun scripts/planetscale-pr-branch.ts down  <pr-number>
  *   bun scripts/planetscale-pr-branch.ts sweep


### PR DESCRIPTION
## Why

PlanetScale PS-DEV branches bill for time used, and 12 were live (oldest from 2026-07-08), each also burning one of the account's 25 Hyperdrive configs. **All 12 have been deleted** — `pscale branch list maple` now returns only production `main`, which is untouched.

## What changed

**PR preview deploys are disabled.** `deploy-pr-preview.yml` triggers on the `closed` event only, so it does teardown *only*: it tears down stacks deployed before the cutover and never deploys a new one. That also stops the per-PR Tinybird branch, which shares compute with production. Re-enabling is restoring `types: [opened, synchronize, reopened, closed]`.

**Previews also lost their application database**, which is the state they return to when re-enabled. `resolveDatabaseMode` (`packages/infra/src/cloudflare/stage.ts`) is the new authority — `ref` for stg/prd (dashboard config by ID), `managed` for dev (from `MAPLE_PG_URL`), `none` for pr. The `pr` stage therefore builds no Hyperdrive and binds no `MAPLE_DB`; DB-backed routes 500, everything else serves.

## Reviewer notes

- **The load-bearing change is `DatabasePgLive`.** A missing binding was `Effect.die` *during layer construction*, and `layerPg` is `provideMerge`'d into the isolate-wide handler (`apps/api/src/worker.ts:97`) — that would have 504'd **every** route, `/health` included, not just DB-backed ones. It now fails per `execute` with a `DatabaseError`. Alerting needed nothing: its crons already early-return on non-production stages.
- **`electric-sync` withholds `ELECTRIC_URL`/`SOURCE_ID`/`SECRET` on the `pr` stage.** Without that, a preview with no source of its own would inherit the shared Infisical `dev` triple, pass the coherence check, and proxy its shapes against another stage's data. Absent URL → 503 → the web app falls back to its effect-atom fetches.
- **The deploy/destroy steps were gated on `PLANETSCALE_SERVICE_TOKEN != ''`.** Removing the PlanetScale steps while leaving those gates would have silently skipped the whole preview; both are now gated on the event action alone.
- **Nothing is deleted from the repo.** `planetscale-pr-branch.ts`, `electric-pr-branch.ts`, `reset-preview-branch.ts` and `normalize-preview-ownership.ts` all stay, with dormancy headers. Every sweep in `cleanup-preview-orphans.yml` stays — the Hyperdrive sweep is now what reaps leftover `maple-db-pr-*` configs, and the whole file is the backstop for PRs that close without a teardown run (GitHub creates no `closed` run for a PR conflicting with its base branch).
- Reverse paths are spelled out in `stage.ts`, in `CLAUDE.md`, and in a comment where the removed workflow steps used to be.

## Verification

- `bun typecheck` passes for `@maple/infra`, `@maple/api`, `@maple/electric-sync`.
- `apps/api/src/lib/DatabaseLive.test.ts` (4 tests) and `apps/electric-sync/src/routes/shape.test.ts` (25 tests) pass. oxfmt/oxlint clean.
- Both workflow files parse; only teardown steps are reachable in `deploy-pr-preview.yml`.

**Not verified locally:** leftover `maple-db-pr-*` Hyperdrive configs (no Cloudflare creds on my machine). Closed PRs get swept automatically on the 6-hourly cron; the currently-open ones will need either a manual `cleanup-preview-orphans` dispatch or a direct API delete, since they'll no longer get a deploy that prunes them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788169039&installation_model_id=427786&pr_number=298&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F298&signature=8610bd57b28fb711660039dfe19018fb63e7fab619f3b2c869bd50ec089d26a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->