### PR TITLE
perf(query-engine): coalesce bucket cache fan-out into one warehouse query

### DIFF
--- a/packages/query-engine/src/caching/bucket-cache.test.ts
+++ b/packages/query-engine/src/caching/bucket-cache.test.ts
@@ -4,6 +4,7 @@ import { OrgId } from "@maple/domain"
 import type { TimeseriesPoint } from "../query-engine"
 import {
 	BucketCacheService,
+	coalesceMissingRanges,
 	findMissingRanges,
 	generateFingerprint,
 	mergeAndDeduplicateBuckets,
@@ -78,6 +79,77 @@ describe("findMissingRanges", () => {
 	it("handles unaligned end inside a gap", () => {
 		const missing = findMissingRanges([], 0, MIN + 15_000, MIN, FAR_FUTURE_FLUX)
 		expect(missing).toEqual([{ range: { startMs: 0, endMs: MIN + 15_000 }, cachable: true }])
+	})
+})
+
+describe("coalesceMissingRanges", () => {
+	it("returns nothing for a fully covered range", () => {
+		expect(coalesceMissingRanges([])).toEqual([])
+	})
+
+	it("passes a single range through unchanged", () => {
+		const missing = findMissingRanges([], 0, 10 * MIN, MIN, FAR_FUTURE_FLUX)
+		expect(coalesceMissingRanges(missing)).toEqual(missing)
+	})
+
+	it("collapses head + tail gaps into one query spanning the cached middle", () => {
+		const buckets = [bucket(2 * MIN, 3 * MIN), bucket(3 * MIN, 4 * MIN)]
+		const missing = findMissingRanges(buckets, 0, 6 * MIN, MIN, FAR_FUTURE_FLUX)
+		expect(missing).toHaveLength(2)
+		expect(coalesceMissingRanges(missing)).toEqual([
+			{ range: { startMs: 0, endMs: 6 * MIN }, cachable: true },
+		])
+	})
+
+	it("keeps the cachable range and the live tail separate", () => {
+		const buckets = [bucket(0, MIN), bucket(MIN, 2 * MIN)]
+		const flux = 3 * MIN
+		const missing = findMissingRanges(buckets, 0, 4 * MIN, MIN, flux)
+		expect(coalesceMissingRanges(missing)).toEqual([
+			{ range: { startMs: 2 * MIN, endMs: 3 * MIN }, cachable: true },
+			{ range: { startMs: 3 * MIN, endMs: 4 * MIN }, cachable: false },
+		])
+	})
+
+	it("never emits more than two ranges, however fragmented the gaps", () => {
+		// Alternating cached/uncached buckets across a long window — the shape
+		// that produced the ~2.9-queries-per-request fan-out in prod.
+		const buckets = Array.from({ length: 10 }, (_, i) =>
+			bucket(2 * i * MIN, (2 * i + 1) * MIN),
+		)
+		const flux = 15 * MIN
+		const missing = findMissingRanges(buckets, 0, 20 * MIN, MIN, flux)
+		expect(missing.length).toBeGreaterThan(2)
+
+		const coalesced = coalesceMissingRanges(missing)
+		expect(coalesced).toHaveLength(2)
+		expect(coalesced.filter((r) => r.cachable)).toHaveLength(1)
+		expect(coalesced.filter((r) => !r.cachable)).toHaveLength(1)
+	})
+
+	it("keeps every cachable range strictly below the flux boundary", () => {
+		const buckets = [bucket(0, MIN), bucket(5 * MIN, 6 * MIN)]
+		const flux = 7 * MIN
+		const missing = findMissingRanges(buckets, 0, 10 * MIN, MIN, flux)
+		for (const { range, cachable } of coalesceMissingRanges(missing)) {
+			if (cachable) expect(range.endMs).toBeLessThanOrEqual(flux)
+			else expect(range.startMs).toBeGreaterThanOrEqual(flux)
+		}
+	})
+
+	it("covers every original gap within the coalesced spans", () => {
+		const buckets = [bucket(MIN, 2 * MIN), bucket(4 * MIN, 5 * MIN), bucket(7 * MIN, 8 * MIN)]
+		const missing = findMissingRanges(buckets, 0, 10 * MIN, MIN, FAR_FUTURE_FLUX)
+		const coalesced = coalesceMissingRanges(missing)
+		for (const gap of missing) {
+			const covering = coalesced.find(
+				(span) =>
+					span.cachable === gap.cachable &&
+					span.range.startMs <= gap.range.startMs &&
+					span.range.endMs >= gap.range.endMs,
+			)
+			expect(covering).toBeDefined()
+		}
 	})
 })
 
@@ -243,6 +315,47 @@ describe("BucketCacheService.getOrComputeBuckets", () => {
 			assert.deepStrictEqual(computeCalls[1], { startMs: 3 * MIN, endMs: 4 * MIN })
 			assert.strictEqual(second.missingRangeCount, 1)
 			assert.strictEqual(second.points.length, 3)
+		}).pipe(Effect.provide(BucketLive), Effect.provide(makeConfig()))
+	})
+
+	it.live("issues one warehouse query when the cached buckets are fragmented", () => {
+		// Regression guard for the fan-out that made the cache net-negative in
+		// prod: a partially-cached window used to dispatch one query per gap, so
+		// warehouse load stayed flat no matter how much was cached.
+		const base = {
+			orgId,
+			query: { source: "traces", kind: "timeseries", fragmented: true },
+			bucketSeconds: 60,
+		}
+
+		const computeCalls: Array<{ startMs: number; endMs: number }> = []
+		const compute = ({ startMs, endMs }: { startMs: number; endMs: number }) => {
+			computeCalls.push({ startMs, endMs })
+			const out: TimeseriesPoint[] = []
+			for (let t = startMs; t < endMs; t += MIN) {
+				out.push(point(new Date(t).toISOString(), { v: t }))
+			}
+			return Effect.succeed(out)
+		}
+
+		return Effect.gen(function* () {
+			const svc = yield* BucketCacheService
+
+			// Warm two disjoint slices, leaving holes at [1m,2m) and [3m,6m).
+			yield* svc.getOrComputeBuckets({ ...base, startMs: 0, endMs: MIN }, compute)
+			yield* svc.getOrComputeBuckets({ ...base, startMs: 2 * MIN, endMs: 3 * MIN }, compute)
+			computeCalls.length = 0
+
+			const outcome = yield* svc.getOrComputeBuckets({ ...base, startMs: 0, endMs: 6 * MIN }, compute)
+
+			// Multiple gaps, but they collapse into a single warehouse query.
+			assert.isTrue(outcome.missingRangeCount > 1)
+			assert.strictEqual(outcome.warehouseQueryCount, 1)
+			assert.strictEqual(computeCalls.length, 1)
+			assert.deepStrictEqual(computeCalls[0], { startMs: MIN, endMs: 6 * MIN })
+
+			// Over-fetching the cached middle must not corrupt the result set.
+			assert.strictEqual(outcome.points.length, 6)
 		}).pipe(Effect.provide(BucketLive), Effect.provide(makeConfig()))
 	})
 

--- a/packages/query-engine/src/caching/bucket-cache.ts
+++ b/packages/query-engine/src/caching/bucket-cache.ts
@@ -197,6 +197,48 @@ export const findMissingRanges = (
 	return missing
 }
 
+/**
+ * Collapse a gap list into at most one range per cachability class, so a cache
+ * miss costs at most two warehouse queries instead of one per gap.
+ *
+ * Prod telemetry showed the per-gap fan-out averaging ~2.9 warehouse queries
+ * per request *regardless of cache coverage* — a request with 90% of its
+ * buckets cached issued as many queries as a cold one, so the cache paid its
+ * read cost and never collected the win. Coalescing is what makes coverage
+ * translate into avoided work.
+ *
+ * Safety: `findMissingRanges` splits every gap at the flux boundary, so all
+ * cachable gaps lie entirely below it and all non-cachable gaps entirely
+ * above. Taking `min(start)..max(end)` within a class therefore cannot drag a
+ * bucket across the boundary, and the "never write back the live tail" rule
+ * still holds.
+ *
+ * The coalesced range spans interior gaps that were already cached, so those
+ * buckets get refetched. That is intentional: one wider scan over a
+ * sort-key-aligned range beats N round trips, and the refetched buckets simply
+ * win the merge in `mergeAndDeduplicateBuckets` with equivalent data.
+ */
+export const coalesceMissingRanges = (
+	missing: ReadonlyArray<MissingRange>,
+): ReadonlyArray<MissingRange> => {
+	const spans = new Map<boolean, { startMs: number; endMs: number }>()
+	for (const { range, cachable } of missing) {
+		const span = spans.get(cachable)
+		if (span) {
+			span.startMs = Math.min(span.startMs, range.startMs)
+			span.endMs = Math.max(span.endMs, range.endMs)
+		} else {
+			spans.set(cachable, { startMs: range.startMs, endMs: range.endMs })
+		}
+	}
+	// Settled range before the live tail, so the write-back path sees the
+	// cachable result first.
+	return [true, false].flatMap((cachable) => {
+		const span = spans.get(cachable)
+		return span ? [{ range: { startMs: span.startMs, endMs: span.endMs }, cachable }] : []
+	})
+}
+
 // --- Bucket merging ------------------------------------------------------
 
 /**
@@ -510,10 +552,11 @@ export class BucketCacheService extends Context.Service<BucketCacheService, Buck
 						bucketMs,
 						fluxBoundaryMs,
 					)
-					const freshByRange = yield* Effect.forEach(missing, (item) => computeRange(item.range), {
+					const fillRanges = coalesceMissingRanges(missing)
+					const freshByRange = yield* Effect.forEach(fillRanges, (item) => computeRange(item.range), {
 						concurrency: fillConcurrency,
 					})
-					const rangeResults = missing.map((item, index) => ({
+					const rangeResults = fillRanges.map((item, index) => ({
 						item,
 						points: freshByRange[index]!,
 					}))
@@ -597,7 +640,7 @@ export class BucketCacheService extends Context.Service<BucketCacheService, Buck
 						bucketsHit,
 						bucketsMissed,
 						missingRangeCount: missing.length,
-						warehouseQueryCount: missing.length,
+						warehouseQueryCount: fillRanges.length,
 						segmentsHit: countStatus("hit"),
 						segmentsMissed: countStatus("miss"),
 						segmentsTimedOut: countStatus("timeout"),


### PR DESCRIPTION
## Why

A 7-day audit of prod cache telemetry (2026-07-25 → 08-01, `cache.*` span attributes) found the dashboard bucket cache is **net-negative today**: it pays the read cost, pays the fan-out cost, and never collects the win.

Warehouse queries per request stayed **flat at 2.7–2.9 across every coverage band**:

| coverage | n | p50 | p95 | avg warehouse queries |
|---|---:|---:|---:|---:|
| 0% | 476 | 519 ms | 4,030 ms | 2.71 |
| 1–49% | 33 | 410 ms | 2,191 ms | 2.73 |
| 50–89% | 75 | 414 ms | 2,201 ms | 2.89 |
| 90–100% | 218 | 194 ms | 2,152 ms | **2.90** |

A request with 90% of its buckets cached issued as many queries as a cold one. `warehouse_query_count == 0` on **0 of 802 requests** — it has never once served a request without hitting the warehouse. Median coverage was 0.

End to end this shows up as the bucket path being slower than the blob path it replaced:

| path | n | p50 | p95 | p99 |
|---|---:|---:|---:|---:|
| `legacyBlobCachedExecute` | 839 | 193 ms | 2,414 ms | 4,535 ms |
| `bucketCachedExecute` | 804 | **410 ms** | **3,794 ms** | **6,704 ms** |

This is the same fan-out documented in the `QueryEngineService.ts:97-105` post-mortem that caused `QE_EVAL_BUCKET_CACHE_ENABLED` to be defaulted `false` on 2026-06-01. That flag only covered `evaluate` — `QE_BUCKET_CACHE_ENABLED` stayed `true` for dashboard `execute`, where the same amplification has been live and unnoticed since.

## What changed

`findMissingRanges` emits one range per gap, and the fill step dispatched one warehouse query each. New `coalesceMissingRanges` collapses that list to `min(start)..max(end)` **per cachability class**, so a miss costs at most 2 queries — and exactly **1** when the requested range sits entirely behind the flux boundary, which is the case the cache exists to serve.

Also fixes `warehouseQueryCount` to report actual queries (`fillRanges.length`) rather than gap count. `missingRangeCount` still reports pre-coalesce gaps; the delta between the two is now the signal to watch.

## Reviewer notes

- **Why the flux-boundary invariant holds:** `findMissingRanges` already splits every gap at the boundary, so all cachable gaps lie strictly below it and all non-cachable ones strictly above. Taking min/max *within a class* cannot drag a bucket across it, so the "never write back the live tail" rule is preserved. There's a test asserting this directly.
- **The over-fetch is intentional.** The coalesced range spans interior gaps that were already cached, so those buckets get refetched. One wide scan over a sort-key-aligned range beats N round trips, and the refetched buckets simply win the merge in `mergeAndDeduplicateBuckets` with equivalent data.
- Read path, segment validation, and write-back skip-on-timeout are untouched — those measured fine (0 segment errors in 7 days).
- `QE_BUCKET_CACHE_FILL_CONCURRENCY` is kept as a backstop even though ≤2 ranges makes it moot.

## Testing

- `packages/query-engine/src/caching/` — 45 passing (8 new), incl. a service-level regression guard that fragments the cache and asserts `missingRangeCount > 1` while `warehouseQueryCount === 1`.
- `apps/api` `QueryEngineCache` + `QueryEngineEvaluateCache` — 35 passing.
- `packages/query-engine` typecheck clean.

Verified under test, **not in prod** — this is Worker-side code with no browser-observable surface. Post-deploy check on `BucketCacheService.readOrCompute`: `avg(cache.warehouse_query_count)` should drop to ≤1.2 with `countIf(warehouse_query_count = 0) > 0`, and `bucketCachedExecute` p50 should fall below `legacyBlobCachedExecute` p50.

## Out of scope (found in the same audit, not fixed here)

- **`qe-evaluate` has a 0.00% hit rate — 0 hits across 287,178 lookups in 7 days.** Alert eval runs a 60s cron against a 30s TTL, and the key snaps to 15s while the window slides 60s per tick, so it's unique by construction. Recommend deleting that cache rather than re-keying it.
- **`EDGE_CACHE_READ_TIMEOUT_MS` (250ms) fires on 27% of `org-clickhouse-config` reads** and 15% of `qe-direct`. Read p50 is 5–8ms everywhere, so 250ms isn't catching a slow tail — it *is* the tail, adding 250ms and then computing anyway.
- No alert on `cache.warehouse_query_count > 1`. That guardrail would have caught both regressions; hit rate hid them both.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788173971&installation_model_id=427786&pr_number=299&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F299&signature=31800ca8e23d8ca5bb1827fecd8f6c4f2a81fda0a518a9d860b35fa56e0b1ef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->