### PR TITLE
fix(api): name the widget and field in dashboard 400s instead of an empty body

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -36,7 +36,7 @@ import {
 import { V2SchemaErrorsLive } from "./routes/v2/error-envelope"
 import { HttpAuthLive, HttpAuthPublicLive } from "./routes/auth.http"
 import { HttpChatLive } from "./routes/chat.http"
-import { HttpDashboardsLive } from "./routes/dashboards.http"
+import { HttpDashboardSchemaErrorsLive, HttpDashboardsLive } from "./routes/dashboards.http"
 import { HttpDemoLive } from "./routes/demo.http"
 import { HttpDigestLive } from "./routes/digest.http"
 import { HttpIntegrationsLive, IntegrationsCallbackRouter } from "./routes/integrations.http"
@@ -308,6 +308,7 @@ const ApiRoutes = HttpApiBuilder.layer(MapleApi).pipe(
 	Layer.provide(Layer.mergeAll(HttpBillingLive, HttpBillingPublicLive)),
 	Layer.provide(HttpErrorsLive),
 	Layer.provide(HttpDashboardsLive),
+	Layer.provide(HttpDashboardSchemaErrorsLive),
 	Layer.provide(HttpDemoLive),
 	Layer.provide(HttpDigestLive),
 	Layer.provide(HttpIngestAttributeMappingsLive),

--- a/apps/api/src/routes/dashboards.http.test.ts
+++ b/apps/api/src/routes/dashboards.http.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it } from "@effect/vitest"
+import { ConfigProvider, Context, Effect, Layer } from "effect"
+import { HttpRouter } from "effect/unstable/http"
+import { HttpApi, HttpApiBuilder } from "effect/unstable/httpapi"
+import { CurrentTenant, DashboardsApiGroup } from "@maple/domain/http"
+import { Env } from "../lib/Env"
+import { cleanupTestDbs, createTestDb, type TestDb } from "../lib/test-pglite"
+import { DashboardPersistenceService } from "../services/DashboardPersistenceService"
+import { HttpDashboardSchemaErrorsLive, HttpDashboardsLive } from "./dashboards.http"
+
+const createdDbs: TestDb[] = []
+afterEach(() => cleanupTestDbs(createdDbs))
+
+/**
+ * Only the dashboards group, so the harness doesn't have to stand up every v1
+ * service. The api id must stay `"MapleApi"` — `HttpApiBuilder.group` keys its
+ * layer on `(apiId, groupIdentifier)`, so this is what lets the real
+ * `HttpDashboardsLive` satisfy it.
+ */
+class DashboardsOnlyApi extends HttpApi.make("MapleApi").add(DashboardsApiGroup) {}
+
+const TENANT = new CurrentTenant.TenantSchema({
+	orgId: "org_dashboards_schema_errors" as CurrentTenant.TenantSchema["orgId"],
+	userId: "user_dashboards_schema_errors" as CurrentTenant.TenantSchema["userId"],
+	roles: [],
+	authMode: "self_hosted",
+})
+
+const AuthorizationStubLayer = Layer.succeed(
+	CurrentTenant.Authorization,
+	CurrentTenant.Authorization.of({
+		bearer: (httpEffect) => Effect.provideService(httpEffect, CurrentTenant.Context, TENANT),
+	}),
+)
+
+const testConfig = () =>
+	ConfigProvider.layer(
+		ConfigProvider.fromUnknown({
+			PORT: "3480",
+			MCP_PORT: "3481",
+			TINYBIRD_HOST: "https://api.tinybird.co",
+			TINYBIRD_TOKEN: "test-token",
+			MAPLE_AUTH_MODE: "self_hosted",
+			MAPLE_ROOT_PASSWORD: "test-root-password",
+			MAPLE_DEFAULT_ORG_ID: "default",
+			MAPLE_INGEST_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 1).toString("base64"),
+			MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: "maple-test-lookup-secret",
+			INTERNAL_SERVICE_TOKEN: "test-internal-token",
+		}),
+	)
+
+const makeHarness = () => {
+	const testDb = createTestDb(createdDbs)
+	const envLive = Env.layer.pipe(Layer.provide(testConfig()))
+	const servicesLive = DashboardPersistenceService.layer.pipe(
+		Layer.provideMerge(Layer.mergeAll(envLive, testDb.layer)),
+	)
+
+	const routes = HttpApiBuilder.layer(DashboardsOnlyApi).pipe(
+		Layer.provide(HttpDashboardsLive),
+		Layer.provide(HttpDashboardSchemaErrorsLive),
+		Layer.provideMerge(AuthorizationStubLayer),
+		Layer.provideMerge(servicesLive),
+	)
+	const { handler, dispose } = HttpRouter.toWebHandler(routes, { disableLogger: true })
+
+	const request = async (method: string, path: string, body: unknown) => {
+		const response = await handler(
+			new Request(`http://maple.test${path}`, {
+				method,
+				headers: { authorization: "Bearer test-token", "content-type": "application/json" },
+				body: JSON.stringify(body),
+			}),
+			Context.empty() as never,
+		)
+		const text = await response.text()
+		return { status: response.status, body: text.length === 0 ? null : JSON.parse(text) }
+	}
+
+	return { request, dispose }
+}
+
+const widget = (id: string, overrides: Record<string, unknown> = {}) => ({
+	id,
+	visualization: "line",
+	dataSource: { endpoint: "traces_timeseries", params: {} },
+	display: { title: id, chartPresentation: { legend: "visible" } },
+	layout: { x: 0, y: 0, w: 6, h: 4 },
+	...overrides,
+})
+
+describe("v1 dashboards request-decode failures", () => {
+	it("answers a bad widget field with a 400 naming the widget id and the field path", async () => {
+		const harness = makeHarness()
+		try {
+			const response = await harness.request("PUT", "/api/dashboards/dash_abc", {
+				dashboard: {
+					id: "dash_abc",
+					name: "Operations",
+					timeRange: { type: "relative", value: "12h" },
+					widgets: [
+						widget("latency-p99"),
+						// `fillNulls` is `number | false`; `true` is the exact value that
+						// used to produce an empty 400 with no way to find it.
+						widget("error-rate", {
+							display: { title: "error-rate", chartPresentation: { fillNulls: true } },
+						}),
+					],
+					createdAt: "2026-08-02T00:00:00.000Z",
+					updatedAt: "2026-08-02T00:00:00.000Z",
+				},
+			})
+
+			expect(response.status).toBe(400)
+			expect(response.body).not.toBeNull()
+			expect(response.body._tag).toBe("@maple/http/errors/DashboardValidationError")
+			expect(response.body.message).toContain("payload is invalid")
+
+			const details: string[] = response.body.details
+			expect(details).toHaveLength(1)
+			const [detail] = details
+			// widget id, so a 14-widget document doesn't need bisecting...
+			expect(detail).toContain('widget "error-rate"')
+			// ...the JSON path down to the offending key...
+			expect(detail).toContain("dashboard.widgets[1].display.chartPresentation.fillNulls")
+			// ...and what was expected versus what arrived.
+			expect(detail).toContain("true")
+			expect(detail).toMatch(/Expected/)
+			// The widget that decoded cleanly is not mentioned.
+			expect(detail).not.toContain("latency-p99")
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	it("omits widget attribution for a field outside widgets[]", async () => {
+		const harness = makeHarness()
+		try {
+			const response = await harness.request("POST", "/api/dashboards", {
+				dashboard: {
+					name: 42,
+					timeRange: { type: "relative", value: "12h" },
+					widgets: [widget("cpu")],
+				},
+			})
+
+			expect(response.status).toBe(400)
+			// The runtime decoder stops at the first offending key, so a document
+			// with several bad fields surfaces them one request at a time.
+			const details: string[] = response.body.details
+			expect(details).toHaveLength(1)
+			expect(details[0]).toContain("dashboard.name")
+			expect(details[0]).not.toContain("widget")
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	it("attributes a bad widget layout field to its widget", async () => {
+		const harness = makeHarness()
+		try {
+			const response = await harness.request("POST", "/api/dashboards", {
+				dashboard: {
+					name: "Operations",
+					timeRange: { type: "relative", value: "12h" },
+					widgets: [widget("cpu", { layout: { x: 0, y: 0, w: "six", h: 4 } })],
+				},
+			})
+
+			expect(response.status).toBe(400)
+			const [detail] = response.body.details as string[]
+			expect(detail).toContain("dashboard.widgets[0].layout.w")
+			expect(detail).toContain('widget "cpu"')
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	it("still accepts a valid document", async () => {
+		const harness = makeHarness()
+		try {
+			const response = await harness.request("POST", "/api/dashboards", {
+				dashboard: {
+					name: "Operations",
+					timeRange: { type: "relative", value: "12h" },
+					widgets: [widget("cpu", { display: { chartPresentation: { fillNulls: false } } })],
+				},
+			})
+
+			expect(response.status).toBe(200)
+			expect(response.body.widgets).toHaveLength(1)
+		} finally {
+			await harness.dispose()
+		}
+	})
+})

--- a/apps/api/src/routes/dashboards.http.ts
+++ b/apps/api/src/routes/dashboards.http.ts
@@ -1,6 +1,7 @@
-import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { HttpApiBuilder, HttpApiMiddleware } from "effect/unstable/httpapi"
 import {
 	CurrentTenant,
+	DashboardSchemaErrors,
 	DashboardTemplateMetadata,
 	DashboardTemplateNotFoundError,
 	DashboardTemplatesListResponse,
@@ -10,10 +11,30 @@ import {
 	PortableDashboardDocument,
 } from "@maple/domain/http"
 import { Effect } from "effect"
+import { describeSchemaIssue, summarizeSchemaError } from "./schema-error-detail"
 import { DashboardPersistenceService } from "../services/DashboardPersistenceService"
 import { getTemplateById, listTemplateMetadata } from "../dashboard-templates"
 import type { TemplateParameterValues } from "../dashboard-templates"
 import { convertPersesDashboardToPortable } from "../services/perses-dashboard-import"
+
+/**
+ * Renders a dashboard request-decode failure as a `DashboardValidationError`
+ * whose `details` name the widget and field at fault, instead of the runtime's
+ * default empty 400 (see `./schema-error-detail`).
+ */
+export const HttpDashboardSchemaErrorsLive = HttpApiMiddleware.layerSchemaErrorTransform(
+	DashboardSchemaErrors,
+	(schemaError) =>
+		Effect.suspend(() => {
+			const details = describeSchemaIssue(schemaError.cause.issue)
+			return Effect.fail(
+				new DashboardValidationError({
+					message: summarizeSchemaError(schemaError.kind, details),
+					details: details.map(({ line }) => line),
+				}),
+			)
+		}),
+)
 
 export const HttpDashboardsLive = HttpApiBuilder.group(MapleApi, "dashboards", (handlers) =>
 	Effect.gen(function* () {

--- a/apps/api/src/routes/schema-error-detail.ts
+++ b/apps/api/src/routes/schema-error-detail.ts
@@ -1,0 +1,131 @@
+/**
+ * Turns an `HttpApiSchemaError` (the framework's request-decode failure) into
+ * human-readable, path-anchored lines.
+ *
+ * The runtime's own response for a decode failure is an empty 400 — no field,
+ * no value, no message — which leaves callers bisecting their payload widget by
+ * widget to find the one bad key. Every route that can reject a hand-authored
+ * document should render the issue tree instead.
+ *
+ * Each line reads `<json path> (widget "<id>"): Expected …, got …`, with the
+ * widget attribution present only when the path actually points inside a
+ * `widgets[]` array — resolved from the offending value itself, so it survives
+ * reordering and is stable across the v1/v2 key spellings.
+ */
+import { Option, SchemaIssue } from "effect"
+
+/** Which part of the request failed to decode; mirrors `HttpApiSchemaError.kind`. */
+export type SchemaErrorKind = "Params" | "Headers" | "Query" | "Body" | "Payload"
+
+/** Formats a path as `dashboard.widgets[3].display.fillNulls`. */
+export const formatIssuePath = (path: ReadonlyArray<PropertyKey>): string => {
+	let out = ""
+	for (const segment of path) {
+		if (typeof segment === "number") {
+			out += `[${segment}]`
+		} else if (typeof segment === "symbol") {
+			out += out === "" ? (segment.description ?? "<symbol>") : `.${segment.description ?? "<symbol>"}`
+		} else {
+			out += out === "" ? segment : `.${segment}`
+		}
+	}
+	return out
+}
+
+const readKey = (value: unknown, key: PropertyKey): unknown => {
+	if (typeof value !== "object" || value === null) return undefined
+	if (typeof key === "number") return Array.isArray(value) ? value[key] : undefined
+	return (value as Record<PropertyKey, unknown>)[key]
+}
+
+/**
+ * Resolves the `id` of the widget an issue path points into, by walking the
+ * decoded-from input down to the `widgets[i]` element. Returns undefined when
+ * the path is not inside a widget array or the element carries no string id
+ * (e.g. the id itself is the invalid field).
+ */
+export const widgetIdForPath = (root: unknown, path: ReadonlyArray<PropertyKey>): string | undefined => {
+	let cursor = root
+	let widgetId: string | undefined
+	for (let i = 0; i < path.length; i++) {
+		const segment = path[i]!
+		const next = readKey(cursor, segment)
+		if (segment === "widgets" && typeof path[i + 1] === "number") {
+			const widget = readKey(next, path[i + 1]!)
+			const id = readKey(widget, "id")
+			if (typeof id === "string") widgetId = id
+		}
+		cursor = next
+	}
+	return widgetId
+}
+
+const formatStandard = SchemaIssue.makeFormatterStandardSchemaV1()
+
+export interface SchemaIssueDetail {
+	/** Dotted/bracketed JSON path of the offending value, `""` at the root. */
+	readonly path: string
+	/** `id` of the enclosing widget, when the path points inside `widgets[]`. */
+	readonly widgetId: string | undefined
+	/** Expected-vs-received message(s) for this path, joined with `; `. */
+	readonly message: string
+	/** `path (widget "id"): message` — the string surfaced to API callers. */
+	readonly line: string
+}
+
+/** Hard cap so a wholesale-malformed document can't produce a megabyte of 400. */
+const MAX_DETAILS = 20
+
+/**
+ * Flattens a decode failure into one entry per offending path. Issues sharing a
+ * path (union branches, most commonly) are merged so a two-branch union reads as
+ * one problem rather than two.
+ */
+export const describeSchemaIssue = (issue: SchemaIssue.Issue): ReadonlyArray<SchemaIssueDetail> => {
+	const root = Option.getOrUndefined(SchemaIssue.getActual(issue))
+	const byPath = new Map<string, { path: ReadonlyArray<PropertyKey>; messages: Array<string> }>()
+
+	for (const entry of formatStandard(issue).issues) {
+		// Standard Schema allows either a bare key or a `{ key }` segment object.
+		const path = (entry.path ?? []).map((segment) =>
+			typeof segment === "object" && segment !== null ? segment.key : segment,
+		)
+		const key = formatIssuePath(path)
+		const existing = byPath.get(key)
+		if (existing === undefined) {
+			byPath.set(key, { path, messages: [entry.message] })
+		} else if (!existing.messages.includes(entry.message)) {
+			existing.messages.push(entry.message)
+		}
+	}
+
+	const details: Array<SchemaIssueDetail> = []
+	for (const [key, { path, messages }] of byPath) {
+		const widgetId = widgetIdForPath(root, path)
+		const message = messages.join("; ")
+		const location = key === "" ? "<root>" : key
+		const label = widgetId === undefined ? location : `${location} (widget "${widgetId}")`
+		details.push({ path: key, widgetId, message, line: `${label}: ${message}` })
+		if (details.length === MAX_DETAILS) break
+	}
+	return details
+}
+
+const KIND_LABEL: Record<SchemaErrorKind, string> = {
+	Params: "path parameters",
+	Headers: "headers",
+	Query: "query string",
+	Body: "body",
+	Payload: "payload",
+}
+
+/** `Request payload is invalid (2 problems).` — the summary line for the 400. */
+export const summarizeSchemaError = (
+	kind: SchemaErrorKind,
+	details: ReadonlyArray<SchemaIssueDetail>,
+): string => {
+	const label = KIND_LABEL[kind]
+	if (details.length === 0) return `Request ${label} is invalid.`
+	const count = details.length === 1 ? "1 problem" : `${details.length} problems`
+	return `Request ${label} is invalid (${count}).`
+}

--- a/apps/api/src/routes/v2/dashboards.http.test.ts
+++ b/apps/api/src/routes/v2/dashboards.http.test.ts
@@ -279,4 +279,35 @@ describe("v2 dashboards over HTTP", () => {
 
 		await harness.dispose()
 	})
+
+	it("points an invalid widget field at its widget id and full path", async () => {
+		const harness = makeHarness()
+		const key = await harness.bootstrapKey(["dashboards:write"])
+
+		const response = await harness.request("POST", "/v2/dashboards", key.secret, {
+			name: "Operations",
+			time_range: { type: "relative", value: "12h" },
+			widgets: [
+				{
+					id: "error-rate",
+					visualization: "line",
+					data_source: { endpoint: "traces_timeseries", params: {} },
+					// `fill_nulls` is `number | false`; `true` is not a member.
+					display: { title: "error-rate", chart_presentation: { fill_nulls: true } },
+					layout: { x: 0, y: 0, w: 6, h: 4 },
+				},
+			],
+		})
+
+		expect(response.status).toBe(400)
+		expect(response.body.error.type).toBe("invalid_request_error")
+		expect(response.body.error.code).toBe("parameter_invalid")
+		// `param` is the whole path, not just its first segment.
+		expect(response.body.error.param).toContain("widgets[0]")
+		expect(response.body.error.param).toContain("fill_nulls")
+		expect(response.body.error.message).toContain('widget "error-rate"')
+		expect(response.body.error.message).toContain("true")
+
+		await harness.dispose()
+	})
 })

--- a/apps/api/src/routes/v2/error-envelope.ts
+++ b/apps/api/src/routes/v2/error-envelope.ts
@@ -1,6 +1,7 @@
-import { Array as Arr, Effect, Layer, Option, Schema, SchemaIssue } from "effect"
+import { Effect, Layer, Schema } from "effect"
 import { HttpApiMiddleware } from "effect/unstable/httpapi"
 import { apiError, invalidRequest, V2SchemaErrors, V2UnexpectedErrors } from "@maple/domain/http/v2"
+import { describeSchemaIssue } from "../schema-error-detail"
 
 class V2RouteExecutionDefect extends Schema.TaggedErrorClass<V2RouteExecutionDefect>()(
 	"@maple/api/routes/v2/V2RouteExecutionDefect",
@@ -12,36 +13,41 @@ class V2RouteExecutionDefect extends Schema.TaggedErrorClass<V2RouteExecutionDef
 	},
 ) {}
 
-const formatSchemaIssue = SchemaIssue.makeFormatterStandardSchemaV1()
-
 /**
  * Request-decode failures (params/query/payload) under /v2 are rewritten into
  * the v2 error envelope — `{ "error": { "type": "invalid_request_error",
  * "code": "parameter_invalid", "message": … } }` — instead of the runtime's
  * default empty 400 (see docs/api-v2.md#errors).
+ *
+ * `param` carries the full JSON path (`widgets[3].display.fill_nulls`), not
+ * just its first segment, and the message names the enclosing widget when the
+ * path points inside a `widgets[]` array — the envelope holds one error, so a
+ * document with several bad fields reports the first and counts the rest.
  */
 const V2SchemaErrorTransformLive = HttpApiMiddleware.layerSchemaErrorTransform(
 	V2SchemaErrors,
 	(schemaError) =>
-		Effect.sync(() => formatSchemaIssue(schemaError.cause.issue)).pipe(
-			Effect.flatMap(({ issues }) => {
-				const issue = Arr.head(issues)
-				const firstPath = Option.flatMap(issue, ({ path }) =>
-					Option.flatMap(Option.fromNullishOr(path), Arr.head),
+		Effect.suspend(() => {
+			const details = describeSchemaIssue(schemaError.cause.issue)
+			const first = details[0]
+			if (first === undefined) {
+				return Effect.fail(
+					invalidRequest("parameter_invalid", `Invalid request ${schemaError.kind.toLowerCase()}.`),
 				)
-				const param = Option.getOrUndefined(
-					Option.filter(
-						firstPath,
-						(value) => typeof value === "string" || typeof value === "number",
-					).pipe(Option.map(String)),
-				)
-				const message = Option.getOrElse(
-					Option.map(issue, ({ message }) => message),
-					() => `Invalid request ${schemaError.kind.toLowerCase()}.`,
-				)
-				return Effect.fail(invalidRequest("parameter_invalid", message, param))
-			}),
-		),
+			}
+			const remaining = details.length - 1
+			const suffix =
+				remaining === 0
+					? ""
+					: ` (and ${remaining} other invalid ${remaining === 1 ? "field" : "fields"})`
+			return Effect.fail(
+				invalidRequest(
+					"parameter_invalid",
+					`${first.line}${suffix}`,
+					first.path === "" ? undefined : first.path,
+				),
+			)
+		}),
 )
 
 export const V2UnexpectedErrorsLive = Layer.succeed(

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -91,7 +91,7 @@ Every error response body is exactly:
 
 - `type` is closed: `invalid_request_error` (400), `authentication_error` (401), `permission_error` (403), `not_found_error` (404), `conflict_error` (409), `rate_limit_error` (429), `api_error` (5xx).
 - `code` is a stable machine-readable string (`api_key_not_found`, `alert_destination_in_use`, `api_key_lookup_unavailable`, `insufficient_scope`, `parameter_invalid`, …). Resource and dependency failures identify the affected resource and operation. Codes are append-only.
-- `param` names the offending parameter when applicable; `doc_url` may link to reference docs.
+- `param` names the offending parameter when applicable; `doc_url` may link to reference docs. On a request-decode failure it carries the full JSON path of the bad value (`widgets[3].display.chart_presentation.fill_nulls`), and for a path inside a `widgets[]` array the `message` also names the enclosing widget's `id`.
 - No internal tags or stack traces ever appear on the wire.
 - Expected internal failures use operation-specific tagged errors. Unexpected defects are logged with the group and operation, then returned as a sanitized `api_error` / `internal_error`; dependency messages are never copied to public 5xx responses.
 

--- a/packages/domain/src/http/dashboards.ts
+++ b/packages/domain/src/http/dashboards.ts
@@ -1,4 +1,4 @@
-import { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
+import { HttpApiEndpoint, HttpApiGroup, HttpApiMiddleware } from "effect/unstable/httpapi"
 import { Schema } from "effect"
 import {
 	DashboardId,
@@ -463,6 +463,21 @@ export class DashboardValidationError extends Schema.TaggedErrorClass<DashboardV
 	{ httpApiStatus: 400 },
 ) {}
 
+/**
+ * Rewrites request-decode failures on the dashboards group into a
+ * `DashboardValidationError` carrying the JSON path, the enclosing widget id
+ * and the expected-vs-received message for every offending field.
+ *
+ * Without it the runtime answers a schema failure with a bare empty 400, so the
+ * only way to find one bad key in a 14-widget document is to bisect it. The
+ * error class is already in every endpoint's error list, so attaching this
+ * widens no client contract.
+ */
+export class DashboardSchemaErrors extends HttpApiMiddleware.Service<DashboardSchemaErrors>()(
+	"DashboardSchemaErrors",
+	{ error: DashboardValidationError },
+) {}
+
 export class DashboardConcurrencyError extends Schema.TaggedErrorClass<DashboardConcurrencyError>()(
 	"@maple/http/errors/DashboardConcurrencyError",
 	{
@@ -682,4 +697,5 @@ export class DashboardsApiGroup extends HttpApiGroup.make("dashboards")
 		}),
 	)
 	.prefix("/api/dashboards")
-	.middleware(Authorization) {}
+	.middleware(Authorization)
+	.middleware(DashboardSchemaErrors) {}


### PR DESCRIPTION
## The problem

`POST`/`PUT /api/dashboards` rejected any invalid payload with HTTP 400 and a **completely empty response body** — no field path, no widget id, no message. Finding one bad key in a 14-widget document meant bisecting it widget by widget.

Reproduction: take a valid stored dashboard, set `widgets[i].display.chartPresentation.fillNulls = true` (the schema is `number | false`), `PUT` it back → `status 400, body: ""`.

## Root cause

Neither the error encoder dropping the payload nor the handler swallowing the failure. `HttpApiBuilder` wraps a decode failure in `HttpApiSchemaError` and `Effect.die`s it — deliberately bypassing the endpoint's declared error schema — and that class's `Respondable` impl is a hardcoded `HttpServerResponse.empty({ status: 400 })`. No option on `HttpApiBuilder.layer` or `toWebHandler` changes it; the only escape hatch is `HttpApiMiddleware.layerSchemaErrorTransform`.

## After

```json
{
  "_tag": "@maple/http/errors/DashboardValidationError",
  "message": "Request payload is invalid (1 problem).",
  "details": [
    "dashboard.widgets[1].display.chartPresentation.fillNulls (widget \"error-rate\"): Expected number | \"Infinity\" | \"-Infinity\" | \"NaN\" | false, got true"
  ]
}
```

## What changed

- **`apps/api/src/routes/schema-error-detail.ts`** (new) — shared renderer. Flattens the issue tree into `path (widget "id"): Expected …, got …`, resolving the widget id by walking the offending value down to `widgets[i]`, so attribution survives reordering and works for both key spellings. Capped at 20 details.
- **`packages/domain/src/http/dashboards.ts`** — new `DashboardSchemaErrors` middleware on the v1 group, erroring as the existing `DashboardValidationError`. That class is already in every endpoint's error list, so **no client contract widens**.
- **`apps/api/src/routes/dashboards.http.ts`** + **`app.ts`** — `HttpDashboardSchemaErrorsLive`, wired into `ApiRoutes`.
- **`apps/api/src/routes/v2/error-envelope.ts`** — v2 was already structured but reported only the *first path segment* as `param` (`"widgets"`). It now carries the full snake_case path and names the widget in the message. `docs/api-v2.md` updated to match.

## Tests

- `apps/api/src/routes/dashboards.http.test.ts` (new) — 4 end-to-end v1 cases through a real web handler: widget-field 400 carrying id + path, non-widget field with no widget attribution, widget layout field, valid document still 200.
- `apps/api/src/routes/v2/dashboards.http.test.ts` — one v2 case asserting `param` is the full path and the message names the widget.

The v1 harness builds an `HttpApi` containing only the dashboards group; the api id must stay `"MapleApi"` because `HttpApiBuilder.group` keys its layer on `(apiId, groupIdentifier)` — that's what lets the real `HttpDashboardsLive` satisfy it without standing up every v1 service.

Scoped run: `src/routes/dashboards.http.test.ts` + the whole `src/routes/v2` suite (108 tests) pass. `packages/domain` and `apps/api` typecheck clean in the touched files.

## Reviewer notes

- **The decoder aborts at the first offending key**, so a document with several bad fields surfaces them one request at a time. Multiple detail lines only appear from union branches at the same path.
- **Every other v1 group still returns the empty 400.** The formatter is group-agnostic — attaching it elsewhere is a two-line change when one bites.
- **Not done deliberately:** reusing the MCP `collectBlockingBuilderWarnings` pre-persist check on the HTTP path. It validates *query-builder semantics* (dropped filters, attribute-filter caps), not schema shape; making it a hard gate would start rejecting documents the web UI saves today. That's its own decision, not part of this fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788220978&installation_model_id=427786&pr_number=303&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F303&signature=d3e6a40921b4a22042df3098fbe7b255b01d1c9c245ea1ce07b4a47034457d54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->