### PR TITLE
feat(dashboards): let a widget pin its own time range

### DIFF
--- a/apps/api/src/mcp/lib/dashboard-mutations.ts
+++ b/apps/api/src/mcp/lib/dashboard-mutations.ts
@@ -5,6 +5,7 @@ import {
 	DashboardId,
 	DashboardWidgetSchema,
 	IsoDateTimeString,
+	TimeRangeSchema,
 	WidgetDataSourceSchema,
 	WidgetDisplayConfigSchema,
 	WidgetLayoutSchema,
@@ -27,6 +28,7 @@ const WidgetFromJson = Schema.fromJsonString(DashboardWidgetSchema)
 const DataSourceFromJson = Schema.fromJsonString(WidgetDataSourceSchema)
 const DisplayFromJson = Schema.fromJsonString(WidgetDisplayConfigSchema)
 const LayoutFromJson = Schema.fromJsonString(WidgetLayoutSchema)
+const TimeRangeFromJson = Schema.fromJsonString(TimeRangeSchema)
 
 const jsonDecodeError = (field: string, tool: string) => (error: unknown) =>
 	new McpQueryError({
@@ -53,6 +55,11 @@ export const decodeDisplayJson = (json: string, tool: string) =>
 export const decodeLayoutJson = (json: string, tool: string) =>
 	Schema.decodeUnknownEffect(LayoutFromJson)(json).pipe(
 		Effect.mapError(jsonDecodeError("layout_json", tool)),
+	)
+
+export const decodeTimeRangeJson = (json: string, tool: string) =>
+	Schema.decodeUnknownEffect(TimeRangeFromJson)(json).pipe(
+		Effect.mapError(jsonDecodeError("time_range_json", tool)),
 	)
 
 export const generateWidgetId = (): string => randomUUID()

--- a/apps/api/src/mcp/lib/inspect-widget.ts
+++ b/apps/api/src/mcp/lib/inspect-widget.ts
@@ -271,7 +271,8 @@ const metricExistsInCatalog = Effect.fn("metricExistsInCatalog")(function* (
 export interface InspectWidgetTimeRange {
 	startTime: string
 	endTime: string
-	source: "override" | "dashboard" | "fallback"
+	/** `widget` is the widget's own `timeRange` override; `override` is a caller-supplied window. */
+	source: "override" | "widget" | "dashboard" | "fallback"
 }
 
 /** Result of executing a raw_sql_chart widget's stored SQL during inspection. */
@@ -846,6 +847,17 @@ export const inspectWidgetsAfterMutation = Effect.fn("inspectWidgetsAfterMutatio
 					return { startTime: fallback.st, endTime: fallback.et, source: "fallback" as const }
 				})()
 
+		// A widget pinned to its own window must be validated against that window —
+		// inspecting a "last 30 minutes" tile over the board's 7 days would report
+		// on data the tile will never show.
+		const timeRangeFor = (widget: DashboardWidget): InspectWidgetTimeRange => {
+			if (!widget.timeRange) return timeRange
+			const widgetResolved = resolveDashboardTimeRange(widget.timeRange as DashboardTimeRangeInput)
+			return widgetResolved
+				? { startTime: widgetResolved.startTime, endTime: widgetResolved.endTime, source: "widget" }
+				: timeRange
+		}
+
 		const outcomes = yield* Effect.forEach(
 			toInspect,
 			(widget) =>
@@ -853,7 +865,7 @@ export const inspectWidgetsAfterMutation = Effect.fn("inspectWidgetsAfterMutatio
 					tenant,
 					dashboardName: dashboard.name,
 					widget,
-					timeRange,
+					timeRange: timeRangeFor(widget),
 				}),
 			{ concurrency: maxConcurrent },
 		)

--- a/apps/api/src/mcp/resources/instructions.ts
+++ b/apps/api/src/mcp/resources/instructions.ts
@@ -96,6 +96,9 @@ Valid aggregates: \`sum | first | count | avg | max | min\`. **No \`last\`.** Wi
 \`\`\`
 \`baseNames\` matches each hidden query's \`legend || name\`. Otherwise the auxiliary series render at full scale and skew percent-axis charts.
 
+### Per-widget time range (rare)
+A widget follows the dashboard's time range unless it carries its own optional top-level \`timeRange\`, in the dashboard's shape: \`{"type":"relative","value":"30m"}\` or \`{"type":"absolute","startTime":"...","endTime":"..."}\` (ISO 8601). Omit it for almost every widget — pin one only when the window is part of what the tile means ("active in the last 30 minutes" on a 7-day board). A relative override rebases against "now" on each refresh; the widget header labels the pinned range; dashboard variables still apply. \`add_dashboard_widget\` takes it as \`time_range_json\`; the widget-JSON tools take it inline — and since \`update_dashboard_widget\` replaces the whole widget, omitting \`timeRange\` there REMOVES an existing override.
+
 ### Batch rebuild
 \`replace_dashboard_widgets\` replaces a dashboard's ENTIRE widget list in one atomic, validated write — \`widgets_json\` is a JSON array of widget objects (same shape as \`widgets[]\` from \`get_dashboard\`); per-widget \`id\`/\`layout\` are optional (auto-generated/auto-placed). Every widget is validated before anything persists, so one bad widget aborts the whole batch. Prefer it over many incremental calls or a corruption-prone full \`dashboard_json\` replace.
 

--- a/apps/api/src/mcp/tools/add-dashboard-widget.ts
+++ b/apps/api/src/mcp/tools/add-dashboard-widget.ts
@@ -13,6 +13,7 @@ import {
 	decodeDataSourceJson,
 	decodeDisplayJson,
 	decodeLayoutJson,
+	decodeTimeRangeJson,
 	defaultSizeForVisualization,
 	findNextWidgetPosition,
 	generateWidgetId,
@@ -67,6 +68,9 @@ export function registerAddDashboardWidgetTool(server: McpToolRegistrar) {
 			widget_id: optionalStringParam(
 				"Optional stable id for the new widget. If omitted a UUID is generated.",
 			),
+			time_range_json: optionalStringParam(
+				'Optional JSON string pinning this widget to its own time range instead of the dashboard\'s: `{"type":"relative","value":"30m"}` or `{"type":"absolute","startTime":"...","endTime":"..."}` (ISO 8601). Omit it and the widget follows the dashboard range, which is what almost every widget should do — use it only when the tile genuinely means a different window (an "active in the last 30 minutes" stat on a 7-day board). The widget header labels the override so readers can see it.',
+			),
 		}),
 		Effect.fn("McpTool.addDashboardWidget")(function* ({
 			dashboard_id,
@@ -78,6 +82,7 @@ export function registerAddDashboardWidgetTool(server: McpToolRegistrar) {
 			display_json,
 			layout_json,
 			widget_id,
+			time_range_json,
 		}) {
 			if (!KNOWN_VISUALIZATIONS.includes(visualization)) {
 				return validationError(
@@ -129,6 +134,7 @@ export function registerAddDashboardWidgetTool(server: McpToolRegistrar) {
 			}
 
 			const explicitLayout = layout_json ? yield* decodeLayoutJson(layout_json, TOOL) : undefined
+			const timeRange = time_range_json ? yield* decodeTimeRangeJson(time_range_json, TOOL) : undefined
 
 			const newId = widget_id && widget_id.length > 0 ? widget_id : generateWidgetId()
 
@@ -157,6 +163,9 @@ export function registerAddDashboardWidgetTool(server: McpToolRegistrar) {
 						dataSource,
 						display,
 						layout,
+						// Absent unless asked for: the key must not exist at all, so the
+						// widget reads as "follows the dashboard range".
+						...(timeRange ? { timeRange } : {}),
 					}
 
 					return [...existingWidgets, widget]
@@ -186,6 +195,11 @@ export function registerAddDashboardWidgetTool(server: McpToolRegistrar) {
 				`Dashboard: ${dashboard.name} (${dashboard.id})`,
 				`Widget ID: ${newId}`,
 				`Visualization: ${visualization}`,
+				...(timeRange
+					? [
+							`Time range: pinned to ${timeRange.type === "relative" ? `last ${timeRange.value}` : `${timeRange.startTime} → ${timeRange.endTime}`} (not the dashboard's)`,
+						]
+					: []),
 				`Layout: x=${added?.layout.x ?? "?"} y=${added?.layout.y ?? "?"} w=${added?.layout.w ?? "?"} h=${added?.layout.h ?? "?"}`,
 				`Total widgets: ${dashboard.widgets.length}`,
 			]

--- a/apps/api/src/mcp/tools/get-dashboard.ts
+++ b/apps/api/src/mcp/tools/get-dashboard.ts
@@ -56,6 +56,10 @@ export function registerGetDashboardTool(server: McpToolRegistrar) {
 					dataSource: w.dataSource,
 					display: w.display,
 					layout: w.layout,
+					// Only present when the widget is pinned to its own window; the
+					// absence is meaningful ("follows the dashboard range"), so it must
+					// not become an explicit `undefined` on the way out.
+					...(w.timeRange ? { timeRange: w.timeRange } : {}),
 				})),
 				createdAt: dashboard.createdAt,
 				updatedAt: dashboard.updatedAt,

--- a/apps/api/src/mcp/tools/inspect-chart-data.ts
+++ b/apps/api/src/mcp/tools/inspect-chart-data.ts
@@ -246,12 +246,17 @@ export function registerInspectChartDataTool(server: McpToolRegistrar) {
 				const range = resolveTimeRange(start_time, end_time)
 				timeRange = { startTime: range.st, endTime: range.et, source: "override" }
 			} else {
-				const resolved = resolveDashboardTimeRange(dashboard.timeRange as DashboardTimeRangeInput)
+				// A widget pinned to its own window is inspected on that window —
+				// otherwise the rows returned here aren't the rows the tile renders.
+				const source = widget.timeRange ? ("widget" as const) : ("dashboard" as const)
+				const resolved = resolveDashboardTimeRange(
+					(widget.timeRange ?? dashboard.timeRange) as DashboardTimeRangeInput,
+				)
 				if (resolved) {
 					timeRange = {
 						startTime: resolved.startTime,
 						endTime: resolved.endTime,
-						source: "dashboard",
+						source,
 					}
 				} else {
 					const fallback = resolveTimeRange(undefined, undefined, 6)

--- a/apps/api/src/mcp/tools/replace-dashboard-widgets.ts
+++ b/apps/api/src/mcp/tools/replace-dashboard-widgets.ts
@@ -29,7 +29,7 @@ export function registerReplaceDashboardWidgetsTool(server: McpToolRegistrar) {
 				"ID of the dashboard whose widgets to replace (use list_dashboards to find IDs)",
 			),
 			widgets_json: requiredStringParam(
-				"JSON array of widget objects: [{ id?, visualization, dataSource, display, layout? }, ...]. `id` and `layout` are optional (auto-generated/auto-placed). This REPLACES the entire widget list.",
+				'JSON array of widget objects: [{ id?, visualization, dataSource, display, layout?, timeRange? }, ...]. `id` and `layout` are optional (auto-generated/auto-placed). `timeRange` pins one widget to its own window (`{"type":"relative","value":"30m"}` or `{"type":"absolute","startTime":"...","endTime":"..."}`); omit it and the widget follows the dashboard range, which is right for almost every widget. This REPLACES the entire widget list.',
 			),
 		}),
 		Effect.fn("McpTool.replaceDashboardWidgets")(function* ({ dashboard_id, widgets_json }) {

--- a/apps/api/src/mcp/tools/update-dashboard-widget.ts
+++ b/apps/api/src/mcp/tools/update-dashboard-widget.ts
@@ -23,7 +23,7 @@ export function registerUpdateDashboardWidgetTool(server: McpToolRegistrar) {
 				"ID of the widget to replace (use get_dashboard to see existing widget ids)",
 			),
 			widget_json: requiredStringParam(
-				"Full JSON for the replacement widget: { id, visualization, dataSource, display, layout }. Any `id` field inside this JSON is ignored in favor of widget_id.",
+				'Full JSON for the replacement widget: { id, visualization, dataSource, display, layout, timeRange? }. Any `id` field inside this JSON is ignored in favor of widget_id. `timeRange` pins the widget to its own window (`{"type":"relative","value":"30m"}` or `{"type":"absolute","startTime":"...","endTime":"..."}`); omitting it means "follow the dashboard\'s range", so leaving it out of an update REMOVES an existing override.',
 			),
 		}),
 		Effect.fn("McpTool.updateDashboardWidget")(function* ({ dashboard_id, widget_id, widget_json }) {

--- a/apps/api/src/routes/v2/dashboards.http.test.ts
+++ b/apps/api/src/routes/v2/dashboards.http.test.ts
@@ -182,6 +182,58 @@ describe("v2 dashboards over HTTP", () => {
 		await harness.dispose()
 	})
 
+	// A widget may pin its own window; the field is optional, snake_cased on the
+	// wire, and must survive a round-trip without leaking onto unpinned widgets.
+	it("round-trips a per-widget time range", async () => {
+		const harness = makeHarness()
+		const key = await harness.bootstrapKey(["dashboards:write"])
+
+		const widget = (id: string, timeRange?: unknown) => ({
+			id,
+			visualization: "stat",
+			data_source: { endpoint: "custom_query_builder_timeseries" },
+			display: { title: id },
+			layout: { x: 0, y: 0, w: 3, h: 3 },
+			...(timeRange !== undefined ? { time_range: timeRange } : {}),
+		})
+
+		const created = await harness.request("POST", "/v2/dashboards", key.secret, {
+			name: "Mixed ranges",
+			time_range: { type: "relative", value: "7d" },
+			widgets: [widget("pinned", { type: "relative", value: "30m" }), widget("follows")],
+		})
+		expect(created.status).toBe(200)
+		expect(created.body.widgets[0].time_range).toEqual({ type: "relative", value: "30m" })
+		expect("time_range" in created.body.widgets[1]).toBe(false)
+		expect("timeRange" in created.body.widgets[0]).toBe(false)
+
+		const id: string = created.body.id
+		const patched = await harness.request("PATCH", `/v2/dashboards/${id}`, key.secret, {
+			widgets: [
+				widget("pinned", {
+					type: "absolute",
+					start_time: "2026-07-15T00:00:00.000Z",
+					end_time: "2026-07-16T00:00:00.000Z",
+				}),
+			],
+		})
+		expect(patched.status).toBe(200)
+		expect(patched.body.widgets[0].time_range).toEqual({
+			type: "absolute",
+			start_time: "2026-07-15T00:00:00.000Z",
+			end_time: "2026-07-16T00:00:00.000Z",
+		})
+
+		// Re-sending the widget without the field is how an override is removed.
+		const cleared = await harness.request("PATCH", `/v2/dashboards/${id}`, key.secret, {
+			widgets: [widget("pinned")],
+		})
+		expect(cleared.status).toBe(200)
+		expect("time_range" in cleared.body.widgets[0]).toBe(false)
+
+		await harness.dispose()
+	})
+
 	it("enforces dashboard read/write scopes", async () => {
 		const harness = makeHarness()
 		const key = await harness.bootstrapKey(["dashboards:read"])

--- a/apps/api/src/routes/v2/dashboards.http.ts
+++ b/apps/api/src/routes/v2/dashboards.http.ts
@@ -95,6 +95,19 @@ const toInternalTimeRange = (
 				endTime: asIsoDateTime(range.endTime),
 			}
 
+/**
+ * A widget may pin its own window; its ISO strings need the same branding the
+ * dashboard-level range gets. Destructured rather than spread-and-overwrite so
+ * an unpinned widget arrives without the `optionalKey` at all.
+ */
+const toInternalWidgets = (
+	widgets: NonNullable<V2DashboardCreateParams["widgets"]>,
+): DashboardDocument["widgets"] =>
+	widgets.map((widget) => {
+		const { timeRange, ...rest } = widget
+		return timeRange ? { ...rest, timeRange: toInternalTimeRange(timeRange) } : rest
+	})
+
 const toPortable = (payload: V2DashboardCreateParams): PortableDashboardDocument =>
 	new PortableDashboardDocument({
 		name: payload.name,
@@ -106,7 +119,7 @@ const toPortable = (payload: V2DashboardCreateParams): PortableDashboardDocument
 			payload.timeRange === undefined
 				? { type: "relative", value: "12h" }
 				: toInternalTimeRange(payload.timeRange),
-		widgets: payload.widgets ?? [],
+		widgets: toInternalWidgets(payload.widgets ?? []),
 		...(payload.variables !== undefined ? { variables: payload.variables } : {}),
 		...(payload.refreshIntervalSeconds !== undefined && payload.refreshIntervalSeconds !== null
 			? { refreshIntervalSeconds: payload.refreshIntervalSeconds }
@@ -136,7 +149,7 @@ const applyUpdate = (
 		...(tags !== undefined ? { tags } : {}),
 		timeRange:
 			payload.timeRange === undefined ? current.timeRange : toInternalTimeRange(payload.timeRange),
-		widgets: payload.widgets ?? current.widgets,
+		widgets: payload.widgets ? toInternalWidgets(payload.widgets) : current.widgets,
 		...(variables !== undefined ? { variables } : {}),
 		...(refreshIntervalSeconds !== undefined ? { refreshIntervalSeconds } : {}),
 		createdAt: current.createdAt,

--- a/apps/web/src/atoms/dashboard-time-range-atoms.ts
+++ b/apps/web/src/atoms/dashboard-time-range-atoms.ts
@@ -8,7 +8,7 @@ type ResolvedTimeRange = { startTime: string; endTime: string }
 
 const DEFAULT_RELATIVE_FALLBACK = "1h"
 
-function resolveTimeRange(timeRange: TimeRange): ResolvedTimeRange | null {
+export function resolveTimeRange(timeRange: TimeRange): ResolvedTimeRange | null {
 	if (timeRange.type === "absolute") {
 		return { startTime: timeRange.startTime, endTime: timeRange.endTime }
 	}

--- a/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.tsx
+++ b/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.tsx
@@ -6,6 +6,7 @@ import "react-grid-layout/css/styles.css"
 import type { DashboardWidget } from "@/components/dashboard-builder/types"
 import { useDashboardActions } from "@/components/dashboard-builder/dashboard-actions-context"
 import { WidgetActionsProvider } from "@/components/dashboard-builder/widgets/widget-actions-context"
+import { WidgetTimeRangeProvider } from "@/components/dashboard-builder/widgets/widget-time-range-context"
 import { visualizationFor } from "@/components/dashboard-builder/widgets/types"
 import { useWidgetData } from "@/hooks/use-widget-data"
 
@@ -71,14 +72,16 @@ const WidgetRenderer = memo(function WidgetRenderer({ widget }: { widget: Dashbo
 
 	return (
 		<div ref={ref} className="h-full w-full">
-			<WidgetActionsProvider widget={widget} dataState={dataState}>
-				<Visualization
-					dataState={dataState}
-					display={widget.display}
-					mode={mode}
-					rowLimit={widget.dataSource.transform?.limit}
-				/>
-			</WidgetActionsProvider>
+			<WidgetTimeRangeProvider timeRange={widget.timeRange}>
+				<WidgetActionsProvider widget={widget} dataState={dataState}>
+					<Visualization
+						dataState={dataState}
+						display={widget.display}
+						mode={mode}
+						rowLimit={widget.dataSource.transform?.limit}
+					/>
+				</WidgetActionsProvider>
+			</WidgetTimeRangeProvider>
 		</div>
 	)
 })

--- a/apps/web/src/components/dashboard-builder/config/settings-fields.tsx
+++ b/apps/web/src/components/dashboard-builder/config/settings-fields.tsx
@@ -7,6 +7,9 @@ import { Textarea } from "@maple/ui/components/ui/textarea"
 import { cn } from "@maple/ui/utils"
 import { HEATMAP_COLOR_SCALES, type HeatmapColorScale } from "@maple/domain/http"
 import type { ValueUnit } from "@/components/dashboard-builder/types"
+import { TimeRangePicker } from "@/components/time-range-picker/time-range-picker"
+import { useDashboardTimeRange } from "@/components/dashboard-builder/dashboard-providers"
+import { resolveTimeRange } from "@/atoms/dashboard-time-range-atoms"
 import { WidgetBuilderForm } from "@/atoms/widget-query-builder-atoms"
 import { useAtom } from "@/lib/effect-atom"
 import { PANEL_TYPES, fromPanelType, toPanelType } from "@/lib/query-builder/panel-types"
@@ -586,6 +589,76 @@ function QueryOptions() {
 }
 
 /**
+ * Pins the widget to a window of its own instead of the dashboard's — the
+ * "Active in the last 30 minutes" tile on a board scoped to the last 7 days.
+ * Notes never query, so they don't offer it.
+ *
+ * A relative override ("30m") rebases against "now" on every dashboard refresh,
+ * exactly like the board's own relative range; an absolute one stays put.
+ */
+function WidgetTimeRange() {
+	const { state, set } = useSettings()
+	const {
+		state: { resolvedTimeRange: dashboardResolved },
+	} = useDashboardTimeRange()
+
+	if (state.visualization === "markdown") return null
+
+	const override = state.timeRange
+	const resolved = override ? resolveTimeRange(override) : null
+
+	return (
+		<Field label="Time range">
+			<div className="space-y-1.5">
+				<Segments
+					value={override ? "custom" : "dashboard"}
+					onSelect={(next) =>
+						set({
+							// Seed a new override from whatever the board is showing, so the
+							// tile doesn't jump to some unrelated window the moment you
+							// detach it.
+							timeRange:
+								next === "dashboard"
+									? null
+									: dashboardResolved
+										? {
+												type: "absolute",
+												startTime: dashboardResolved.startTime,
+												endTime: dashboardResolved.endTime,
+											}
+										: { type: "relative", value: "1h" },
+						})
+					}
+					options={[
+						{ value: "dashboard", label: "Dashboard" },
+						{ value: "custom", label: "Custom" },
+					]}
+				/>
+				{override && (
+					<TimeRangePicker
+						startTime={resolved?.startTime}
+						endTime={resolved?.endTime}
+						presetValue={override.type === "relative" ? override.value : undefined}
+						onChange={(range) => {
+							if (!range.startTime || !range.endTime) return
+							set({
+								timeRange: range.presetValue
+									? { type: "relative", value: range.presetValue }
+									: {
+											type: "absolute",
+											startTime: range.startTime,
+											endTime: range.endTime,
+										},
+							})
+						}}
+					/>
+				)}
+			</div>
+		</Field>
+	)
+}
+
+/**
  * The rail's field vocabulary. A panel type's `ConfigPanel` composes these; none
  * of them takes the widget state as a prop.
  */
@@ -593,6 +666,7 @@ export const WidgetSettings = {
 	Divider,
 	Name,
 	Description,
+	TimeRange: WidgetTimeRange,
 	TypePicker,
 	Stacked,
 	Curve,

--- a/apps/web/src/components/dashboard-builder/config/widget-query-builder-page.tsx
+++ b/apps/web/src/components/dashboard-builder/config/widget-query-builder-page.tsx
@@ -14,10 +14,12 @@ import {
 } from "@/components/dashboard-builder/config/raw-sql-editor-panel"
 import type {
 	DashboardWidget,
+	TimeRange,
 	VisualizationType,
 	WidgetDataSource,
 	WidgetDisplayConfig,
 } from "@/components/dashboard-builder/types"
+import { WidgetTimeRangeProvider } from "@/components/dashboard-builder/widgets/widget-time-range-context"
 import { TimeRangePicker } from "@/components/time-range-picker/time-range-picker"
 import { useDashboardTimeRange } from "@/components/dashboard-builder/dashboard-providers"
 import { useWidgetData } from "@/hooks/use-widget-data"
@@ -48,6 +50,8 @@ interface WidgetQueryBuilderPageProps {
 		visualization: VisualizationType
 		dataSource: WidgetDataSource
 		display: WidgetDisplayConfig
+		/** `undefined` clears any override: the widget follows the dashboard again. */
+		timeRange: TimeRange | undefined
 	}) => void
 }
 
@@ -58,7 +62,14 @@ const WidgetPreview = React.memo(function WidgetPreview({ widget }: { widget: Da
 	const { dataState } = useWidgetData(widget)
 	const Visualization = visualizationFor(widget.visualization)
 
-	return <Visualization dataState={dataState} display={widget.display} mode="view" />
+	// Same provider the canvas wraps a tile in, so the preview's secondary
+	// fetches and its "own time range" header badge behave as they will once
+	// saved.
+	return (
+		<WidgetTimeRangeProvider timeRange={widget.timeRange}>
+			<Visualization dataState={dataState} display={widget.display} mode="view" />
+		</WidgetTimeRangeProvider>
+	)
 })
 
 type SourceMode = "builder" | "rawSql"
@@ -165,9 +176,13 @@ export function WidgetQueryBuilderPage({
 	const [rawSqlPreviewDraft, setRawSqlPreviewDraft] = React.useState<RawSqlDraft>(initialRawSqlDraft)
 
 	const previewWidget = React.useMemo(() => {
+		// The override applies live from the editing state — it costs nothing to
+		// re-resolve and a pinned window you can't see until you save is a trap.
+		const timeRange = state.timeRange ?? undefined
 		if (mode === "rawSql") {
 			return {
 				...widget,
+				timeRange,
 				visualization: state.visualization,
 				dataSource: buildRawSqlDataSource(
 					widget,
@@ -193,6 +208,7 @@ export function WidgetQueryBuilderPage({
 		}
 		return {
 			...widget,
+			timeRange,
 			visualization: state.visualization,
 			dataSource: buildWidgetDataSource(widget, previewState, previewSeriesOptions),
 			display: buildWidgetDisplay(widget, previewState),
@@ -214,6 +230,7 @@ export function WidgetQueryBuilderPage({
 				visualization: state.visualization,
 				dataSource: buildRawSqlDataSource(widget, rawSqlDraft, state.visualization, state.chartId),
 				display: buildWidgetDisplay(widget, state),
+				timeRange: state.timeRange ?? undefined,
 			})
 			return
 		}
@@ -222,6 +239,7 @@ export function WidgetQueryBuilderPage({
 			visualization: state.visualization,
 			dataSource: buildWidgetDataSource(widget, state, seriesFieldOptions),
 			display: buildWidgetDisplay(widget, state),
+			timeRange: state.timeRange ?? undefined,
 		})
 	}
 

--- a/apps/web/src/components/dashboard-builder/config/widget-settings-bar.tsx
+++ b/apps/web/src/components/dashboard-builder/config/widget-settings-bar.tsx
@@ -26,6 +26,7 @@ export function WidgetSettingsBar({ sourceMode = "builder" }: { sourceMode?: "bu
 				</p>
 				<WidgetSettings.Name />
 				<WidgetSettings.Description />
+				<WidgetSettings.TimeRange />
 				<WidgetSettings.Divider />
 				<WidgetSettings.TypePicker />
 				<ConfigPanel />

--- a/apps/web/src/components/dashboard-builder/templates/template-live-preview.tsx
+++ b/apps/web/src/components/dashboard-builder/templates/template-live-preview.tsx
@@ -7,6 +7,7 @@ import { useMountEffect } from "@/hooks/use-mount-effect"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 import { DashboardTimeRangeWrapper } from "@/components/dashboard-builder/dashboard-providers"
 import { visualizationFor } from "@/components/dashboard-builder/widgets/types"
+import { WidgetTimeRangeProvider } from "@/components/dashboard-builder/widgets/widget-time-range-context"
 import type { DashboardWidget, TimeRange } from "@/components/dashboard-builder/types"
 import { useWidgetData } from "@/hooks/use-widget-data"
 import { CircleWarningIcon } from "@/components/icons"
@@ -94,7 +95,9 @@ const PreviewWidget = memo(function PreviewWidget({ widget }: { widget: Dashboar
 				height: heightFor(widget),
 			}}
 		>
-			<Visualization dataState={dataState} display={widget.display} mode="view" />
+			<WidgetTimeRangeProvider timeRange={widget.timeRange}>
+				<Visualization dataState={dataState} display={widget.display} mode="view" />
+			</WidgetTimeRangeProvider>
 		</div>
 	)
 })

--- a/apps/web/src/components/dashboard-builder/types.ts
+++ b/apps/web/src/components/dashboard-builder/types.ts
@@ -113,8 +113,17 @@ export type WidgetDataState =
 
 // --- Dashboard Widget ---
 
-export type DashboardWidget = Omit<DeepMutable<typeof DashboardWidgetSchema.Type>, "dataSource"> & {
+// `timeRange` is re-typed for the same reason `Dashboard["timeRange"]` is: the
+// schema brands its ISO strings, and every producer in the UI (the time-range
+// picker, the builder form) deals in plain strings. Branding happens once, at
+// the store's document boundary.
+export type DashboardWidget = Omit<
+	DeepMutable<typeof DashboardWidgetSchema.Type>,
+	"dataSource" | "timeRange"
+> & {
 	dataSource: WidgetDataSource
+	/** Absent means the widget follows the dashboard's range. */
+	timeRange?: TimeRange
 }
 
 // --- Dashboard Variables ---

--- a/apps/web/src/components/dashboard-builder/widgets/widget-shell.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/widget-shell.tsx
@@ -9,6 +9,7 @@ import {
 	DotsVerticalIcon,
 	ChatBubbleSparkleIcon,
 	BellIcon,
+	ClockIcon,
 } from "@/components/icons"
 
 import { Card, CardContent, CardHeader, CardTitle, CardAction } from "@maple/ui/components/ui/card"
@@ -23,6 +24,10 @@ import {
 import type { WidgetMode, WidgetDataState } from "@/components/dashboard-builder/types"
 import { useWidgetActions } from "@/components/dashboard-builder/widgets/widget-actions-context"
 import { useDashboardVariablesOptional } from "@/components/dashboard-builder/dashboard-variables-context"
+import {
+	useWidgetTimeRangeOverride,
+	widgetTimeRangeLabel,
+} from "@/components/dashboard-builder/widgets/widget-time-range-context"
 import { interpolateDisplayText } from "@/lib/dashboard-variables/interpolate"
 
 interface WidgetShellProps {
@@ -65,6 +70,12 @@ export function WidgetShell({
 	const variablesContext = useDashboardVariablesOptional()
 	const displayTitle = variablesContext ? interpolateDisplayText(title, variablesContext.values) : title
 
+	// A tile pinned to its own window says so in the header. Without the label a
+	// reader has no way to tell that one card on a 7-day board is showing the
+	// last 30 minutes.
+	const timeRangeOverride = useWidgetTimeRangeOverride()
+	const timeRangeLabel = timeRangeOverride ? widgetTimeRangeLabel(timeRangeOverride) : null
+
 	return (
 		<Card className="h-full flex flex-col">
 			<CardHeader className="py-2.5">
@@ -77,6 +88,15 @@ export function WidgetShell({
 					<CardTitle className="min-w-0 truncate text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 						{displayTitle}
 					</CardTitle>
+					{timeRangeLabel && (
+						<span
+							className="flex shrink-0 items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+							title={`This widget uses its own time range (${timeRangeLabel}) instead of the dashboard's`}
+						>
+							<ClockIcon size={10} />
+							{timeRangeLabel}
+						</span>
+					)}
 					{headerValue != null && (
 						<div className="ml-auto shrink-0 font-mono font-semibold text-xs tabular-nums">
 							{headerValue}

--- a/apps/web/src/components/dashboard-builder/widgets/widget-time-range-context.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/widget-time-range-context.tsx
@@ -1,0 +1,34 @@
+import { createContext, use, type ReactNode } from "react"
+
+import type { TimeRange } from "@/components/dashboard-builder/types"
+import { formatTimeRangeDisplay, presetLabel } from "@/lib/time-utils"
+
+/** How an override reads in the widget header and in the settings rail. */
+export function widgetTimeRangeLabel(timeRange: TimeRange): string {
+	return timeRange.type === "relative"
+		? presetLabel(timeRange.value)
+		: formatTimeRangeDisplay(timeRange.startTime, timeRange.endTime)
+}
+
+const WidgetTimeRangeContext = createContext<TimeRange | null>(null)
+
+/**
+ * The time range a single widget is pinned to, or `null` when it follows the
+ * dashboard's. Read by `useWidgetDataSource` (so a tile's secondary fetches —
+ * a stat's sparkline — query the same window as its headline value) and by
+ * `WidgetShell` (which labels the override in the card header, so a reader can
+ * tell the tile isn't on the board's range).
+ */
+export function useWidgetTimeRangeOverride(): TimeRange | null {
+	return use(WidgetTimeRangeContext)
+}
+
+export function WidgetTimeRangeProvider({
+	timeRange,
+	children,
+}: {
+	timeRange: TimeRange | undefined
+	children: ReactNode
+}) {
+	return <WidgetTimeRangeContext value={timeRange ?? null}>{children}</WidgetTimeRangeContext>
+}

--- a/apps/web/src/hooks/use-dashboard-store.ts
+++ b/apps/web/src/hooks/use-dashboard-store.ts
@@ -140,6 +140,26 @@ const v2DashboardToDashboard = (value: V2DashboardMutation): Dashboard => ({
 	updatedAt: value.updatedAt,
 })
 
+// The one place plain UI time ranges become the schema's branded ISO strings.
+const toDocumentTimeRange = (timeRange: TimeRange) =>
+	timeRange.type === "absolute"
+		? {
+				type: "absolute" as const,
+				startTime: asIsoDateTimeString(timeRange.startTime),
+				endTime: asIsoDateTimeString(timeRange.endTime),
+			}
+		: timeRange
+
+/** Widgets pinned to their own range carry ISO strings that need the same branding. */
+const toDocumentWidgets = (widgets: Dashboard["widgets"]): DashboardDocument["widgets"] =>
+	widgets.map((widget) => {
+		// Destructured rather than spread-and-overwrite: `timeRange` is `optionalKey`
+		// on the document, so an unpinned widget has to reach it without the key at
+		// all — a present `undefined` fails the encode.
+		const { timeRange, ...rest } = widget
+		return timeRange ? { ...rest, timeRange: toDocumentTimeRange(timeRange) } : rest
+	})
+
 function toDashboardDocument(dashboard: Dashboard): DashboardDocument {
 	// `description`/`tags`/`variables` are `Schema.optionalKey` on `DashboardDocument`;
 	// the Schema.Class constructor rejects a present `undefined`. The web `Dashboard`
@@ -155,14 +175,8 @@ function toDashboardDocument(dashboard: Dashboard): DashboardDocument {
 		...(tags !== undefined && { tags }),
 		...(variables !== undefined && { variables }),
 		...(refreshIntervalSeconds !== undefined && { refreshIntervalSeconds }),
-		timeRange:
-			dashboard.timeRange.type === "absolute"
-				? {
-						type: "absolute",
-						startTime: asIsoDateTimeString(dashboard.timeRange.startTime),
-						endTime: asIsoDateTimeString(dashboard.timeRange.endTime),
-					}
-				: dashboard.timeRange,
+		widgets: toDocumentWidgets(dashboard.widgets),
+		timeRange: toDocumentTimeRange(dashboard.timeRange),
 	})
 }
 
@@ -181,15 +195,8 @@ function toPortableDashboardDocument(dashboard: PortableDashboard): PortableDash
 		...(tags !== undefined && { tags: [...tags] }),
 		...(variables !== undefined && { variables: jsonClone(variables) }),
 		...(refreshIntervalSeconds !== undefined && { refreshIntervalSeconds }),
-		widgets: jsonClone(dashboard.widgets),
-		timeRange:
-			dashboard.timeRange.type === "absolute"
-				? {
-						type: "absolute",
-						startTime: asIsoDateTimeString(dashboard.timeRange.startTime),
-						endTime: asIsoDateTimeString(dashboard.timeRange.endTime),
-					}
-				: dashboard.timeRange,
+		widgets: toDocumentWidgets(jsonClone(dashboard.widgets)),
+		timeRange: toDocumentTimeRange(dashboard.timeRange),
 	})
 }
 
@@ -395,13 +402,21 @@ function makeWidgetMutators(deps: {
 	const updateWidget = (
 		dashboardId: string,
 		widgetId: string,
-		updates: Partial<Pick<DashboardWidget, "visualization" | "dataSource" | "display" | "layout">>,
+		updates: Partial<
+			Pick<DashboardWidget, "visualization" | "dataSource" | "display" | "layout" | "timeRange">
+		>,
 	) => {
 		return mutateDashboard(dashboardId, (dashboard) => ({
 			...dashboard,
-			widgets: dashboard.widgets.map((widget) =>
-				widget.id === widgetId ? { ...widget, ...updates } : widget,
-			),
+			widgets: dashboard.widgets.map((widget) => {
+				if (widget.id !== widgetId) return widget
+				const next = { ...widget, ...updates }
+				// `timeRange: undefined` means "follow the dashboard again". The key
+				// has to go, not sit there holding `undefined` — the widget schema
+				// declares it `optionalKey`, which won't encode an explicit undefined.
+				if (next.timeRange === undefined) delete next.timeRange
+				return next
+			}),
 			updatedAt: new Date().toISOString(),
 		}))
 	}

--- a/apps/web/src/hooks/use-widget-data.ts
+++ b/apps/web/src/hooks/use-widget-data.ts
@@ -4,9 +4,11 @@ import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { Effect, Schedule, Schema } from "effect"
 import { useDashboardTimeRange } from "@/components/dashboard-builder/dashboard-providers"
 import { useDashboardVariablesOptional } from "@/components/dashboard-builder/dashboard-variables-context"
+import { useWidgetTimeRangeOverride } from "@/components/dashboard-builder/widgets/widget-time-range-context"
+import { resolveTimeRange } from "@/atoms/dashboard-time-range-atoms"
 import { getServerFunction } from "@/components/dashboard-builder/data-source-registry"
 import { hasUnresolvedVariableRefs, interpolateWidgetParams } from "@/lib/dashboard-variables/interpolate"
-import type { DashboardWidget, WidgetDataSource } from "@/components/dashboard-builder/types"
+import type { DashboardWidget, TimeRange, WidgetDataSource } from "@/components/dashboard-builder/types"
 
 /**
  * The structural shape a data source must satisfy to be fetched. Both the
@@ -347,10 +349,31 @@ export function useWidgetDataSource(
 	 * visibility (lazy-load) so off-screen tiles don't fire queries on mount.
 	 */
 	enabled = true,
+	/**
+	 * Pins this fetch to a window of its own instead of the dashboard's. Callers
+	 * that already hold the widget pass `widget.timeRange`; nested fetches inside
+	 * a widget (a stat's sparkline) inherit it from context instead.
+	 */
+	timeRangeOverride?: TimeRange,
 ) {
 	const {
-		state: { resolvedTimeRange },
+		state: { resolvedTimeRange: dashboardTimeRange },
 	} = useDashboardTimeRange()
+	const contextOverride = useWidgetTimeRangeOverride()
+	const override = timeRangeOverride ?? contextOverride ?? undefined
+	const overrideKey = override ? encodeKey(override) : null
+
+	const resolvedTimeRange = useMemo(
+		() => (override ? resolveTimeRange(override) : dashboardTimeRange),
+		// Keyed on the serialized override, not its identity: the dashboard object
+		// is rebuilt on every optimistic write, and re-resolving an unchanged
+		// override would hand every pinned tile fresh params and refetch it.
+		// `dashboardTimeRange` stays in the deps so a manual reload or auto-refresh
+		// (which gives it a new identity) rebases a relative override against "now"
+		// as well.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[overrideKey, dashboardTimeRange],
+	)
 	const variablesContext = useDashboardVariablesOptional()
 
 	const isStatic = dataSource?.endpoint === "markdown_static"
@@ -361,7 +384,9 @@ export function useWidgetDataSource(
 		: isStatic
 			? null
 			: !resolvedTimeRange
-				? "Unable to resolve dashboard time range"
+				? override
+					? "Unable to resolve this widget's time range"
+					: "Unable to resolve dashboard time range"
 				: !hasServerFn
 					? `Unknown data source endpoint: ${dataSource.endpoint}`
 					: null
@@ -451,7 +476,7 @@ export function useWidgetDataSource(
 }
 
 export function useWidgetData(widget: DashboardWidget, enabled = true) {
-	return useWidgetDataSource(widget.dataSource, enabled)
+	return useWidgetDataSource(widget.dataSource, enabled, widget.timeRange)
 }
 
 export const __testables = {

--- a/apps/web/src/lib/query-builder/widget-builder-shared.ts
+++ b/apps/web/src/lib/query-builder/widget-builder-shared.ts
@@ -9,7 +9,12 @@ import {
 	type QueryBuilderQueryDraft,
 } from "@/lib/query-builder/model"
 import type { ListColumnDraft, ListDataSource } from "@/components/dashboard-builder/config/list-config-panel"
-import type { ValueUnit, VisualizationType, WidgetDataSource } from "@/components/dashboard-builder/types"
+import type {
+	TimeRange,
+	ValueUnit,
+	VisualizationType,
+	WidgetDataSource,
+} from "@/components/dashboard-builder/types"
 import type { LegendPosition } from "@/components/dashboard-builder/config/settings-fields"
 import type { HeatmapColorScale, HeatmapScaleType } from "@maple/domain/http"
 import {
@@ -34,6 +39,11 @@ export interface QueryBuilderWidgetState {
 	visualization: VisualizationType
 	title: string
 	description: string
+	/**
+	 * The widget's own time range, or `null` to follow the dashboard's — the
+	 * default, and what every widget carried before overrides existed.
+	 */
+	timeRange: TimeRange | null
 	chartId: string
 	stacked: boolean
 	curveType: "linear" | "monotone"

--- a/apps/web/src/lib/query-builder/widget-builder-utils.test.ts
+++ b/apps/web/src/lib/query-builder/widget-builder-utils.test.ts
@@ -30,6 +30,7 @@ function makeState(): QueryBuilderWidgetState {
 		visualization: "chart",
 		title: "",
 		description: "",
+		timeRange: null,
 		chartId: "query-builder-line",
 		stacked: false,
 		curveType: "linear",

--- a/apps/web/src/lib/query-builder/widget-builder-utils.ts
+++ b/apps/web/src/lib/query-builder/widget-builder-utils.ts
@@ -92,6 +92,7 @@ export function toInitialState(widget: DashboardWidget): QueryBuilderWidgetState
 		visualization: normalized.visualization,
 		title: widget.display.title ?? "",
 		description: widget.display.description ?? "",
+		timeRange: widget.timeRange ?? null,
 		chartId: normalized.chartId ?? "query-builder-line",
 		stacked: widget.display.stacked ?? false,
 		curveType: widget.display.curveType ?? "linear",

--- a/apps/web/src/lib/query-builder/widget-type-cycle.test.ts
+++ b/apps/web/src/lib/query-builder/widget-type-cycle.test.ts
@@ -53,6 +53,7 @@ function makeState(overrides: Partial<QueryBuilderWidgetState> = {}): QueryBuild
 		visualization: "chart",
 		title: "",
 		description: "",
+		timeRange: null,
 		chartId: "query-builder-line",
 		stacked: false,
 		curveType: "linear",

--- a/apps/web/src/routes/dashboards/$dashboardId_.widgets.$widgetId.tsx
+++ b/apps/web/src/routes/dashboards/$dashboardId_.widgets.$widgetId.tsx
@@ -58,6 +58,7 @@ function WidgetConfigurePage() {
 		visualization: VisualizationType
 		dataSource: WidgetDataSource
 		display: WidgetDisplayConfig
+		timeRange: TimeRange | undefined
 	}) => {
 		if (readOnly || isSaving) return
 		setIsSaving(true)

--- a/packages/domain/src/http/dashboards.ts
+++ b/packages/domain/src/http/dashboards.ts
@@ -13,7 +13,7 @@ import {
 import { Authorization } from "./current-tenant"
 import { HEATMAP_COLOR_SCALES, HEATMAP_SCALE_TYPES } from "./widget-types"
 
-const TimeRangeSchema = Schema.Union([
+export const TimeRangeSchema = Schema.Union([
 	Schema.Struct({
 		type: Schema.Literal("relative"),
 		value: Schema.String,
@@ -24,6 +24,7 @@ const TimeRangeSchema = Schema.Union([
 		endTime: IsoDateTimeString,
 	}),
 ])
+export type TimeRange = typeof TimeRangeSchema.Type
 
 const UnknownRecord = Schema.Record(Schema.String, Schema.Unknown)
 const StringRecord = Schema.Record(Schema.String, Schema.String)
@@ -220,6 +221,14 @@ export const DashboardWidgetSchema = Schema.Struct({
 	dataSource: WidgetDataSourceSchema,
 	display: WidgetDisplayConfigSchema,
 	layout: WidgetLayoutSchema,
+	// Per-widget time range. Absent (the common case) means "follow the
+	// dashboard's range" — the tile re-queries whenever the board's picker moves.
+	// When set, the tile is pinned to its own window regardless of the board's,
+	// which is how a "last 30 minutes" health stat lives on a 7-day board. The
+	// override only replaces the time window: dashboard variables still
+	// interpolate normally, and the board's auto-refresh still rebases a relative
+	// override against "now".
+	timeRange: Schema.optionalKey(TimeRangeSchema),
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/domain/src/http/v2/dashboards.ts
+++ b/packages/domain/src/http/v2/dashboards.ts
@@ -264,7 +264,10 @@ export const V2DashboardWidget = Schema.Struct({
 	dataSource: V2WidgetDataSource,
 	display: V2WidgetDisplay,
 	layout: V2WidgetLayout,
-}).pipe(Schema.encodeKeys({ dataSource: "data_source" }))
+	// Optional per-widget window. Omit it — the overwhelmingly common case — and
+	// the widget follows the dashboard's `time_range`.
+	timeRange: optional(V2TimeRange),
+}).pipe(Schema.encodeKeys({ dataSource: "data_source", timeRange: "time_range" }))
 
 const V2DashboardVariableSource = Schema.Union([
 	Schema.Struct({ kind: Schema.Literal("facet"), facet: DashboardQueryVariableFacet }),

--- a/packages/domain/src/mcp-structured-types.ts
+++ b/packages/domain/src/mcp-structured-types.ts
@@ -623,7 +623,7 @@ export interface WidgetInspectionSummary {
 	timeRange?: {
 		startTime: string
 		endTime: string
-		source: "override" | "dashboard" | "fallback"
+		source: "override" | "widget" | "dashboard" | "fallback"
 	}
 }
 
@@ -640,7 +640,7 @@ export interface InspectChartDataData {
 	timeRange: {
 		startTime: string
 		endTime: string
-		source: "override" | "dashboard" | "fallback"
+		source: "override" | "widget" | "dashboard" | "fallback"
 	}
 	queries: InspectChartQueryResult[]
 	verdict: InspectChartVerdict

--- a/skills/maple-dashboard-widgets/SKILL.md
+++ b/skills/maple-dashboard-widgets/SKILL.md
@@ -138,6 +138,41 @@ Valid `aggregate` values: `"sum" | "first" | "count" | "avg" | "max" | "min"`. *
 
 `display.thresholds` color the arc (the highest threshold ≤ the value wins) and place tick marks. `gauge.min`/`max` default to `0`/`100`. Arc color falls back to `var(--chart-1)` when no threshold matches.
 
+## Per-widget time range (`timeRange`)
+
+Widgets follow the dashboard's time range unless they carry their own `timeRange` — an optional
+top-level field on the widget, beside `display` and `layout`, in the same shape as the dashboard's:
+
+```json
+{
+  "id": "w0",
+  "visualization": "stat",
+  "timeRange": { "type": "relative", "value": "30m" },
+  "dataSource": { ... },
+  "display": { "title": "Active trains", "unit": "number" },
+  "layout": { "x": 0, "y": 0, "w": 3, "h": 3 }
+}
+```
+
+Absolute form: `{ "type": "absolute", "startTime": "2026-08-01T00:00:00Z", "endTime": "2026-08-02T00:00:00Z" }`.
+Relative `value` is the usual shorthand (`30m`, `6h`, `7d`, `2w`, `3mo`).
+
+- **Omit it for almost every widget.** The whole point of a dashboard time picker is that the
+  board moves as one; a pinned tile is for cases where the window is part of what the tile
+  *means* — "active in the last 30 minutes" on a board scoped to the last 7 days, or a 24h
+  trend sitting beside a 7d comparison.
+- A relative override rebases against "now" on every dashboard refresh, exactly like the board's
+  own relative range. An absolute override never moves.
+- The widget header renders a small clock label with the pinned range, so a reader can see the
+  tile isn't on the board's range.
+- Dashboard **variables** still apply normally — the override replaces the time window only.
+- `update_dashboard_widget` replaces the whole widget: **leaving `timeRange` out of the JSON
+  removes an existing override.** Re-send it to keep it.
+- `add_dashboard_widget` takes it as the separate `time_range_json` parameter (the widget-JSON
+  tools take it inline).
+- `inspect_chart_data` and the auto-validation summary evaluate a pinned widget on *its* window
+  and report `source: "widget"` in the time range they used.
+
 ## Threshold lines on time-series charts
 
 `display.thresholds` also works on `chart` widgets — each entry draws a dashed horizontal `ReferenceLine` across line/area/bar charts, with an optional `label`. Reuse it to mark SLO/alert boundaries.
@@ -222,4 +257,6 @@ incremental `add_dashboard_widget` calls and the corruption-prone full `dashboar
 - [ ] `display.unit` is set (and matches the aggregation — `duration_ms`, `percent`, etc.).
 - [ ] Stat widgets include `dataSource.transform.reduceToValue`.
 - [ ] Formula charts with hidden queries include `dataSource.transform.hideSeries.baseNames`.
+- [ ] No `timeRange` on the widget unless the tile genuinely means a different window than the
+      board — and if you're updating a pinned widget, the `timeRange` is still in the JSON.
 - [ ] After submitting, read the auto-validation summary; verify `suspicious`/`broken` widgets with `inspect_chart_data` or by loading the dashboard.


### PR DESCRIPTION
## What

A dashboard widget can now carry an optional `timeRange` of its own. Absent — the case for essentially every existing widget — means "follow the dashboard's range", so every stored dashboard stays valid and unchanged.

## Why

`timeRange` only existed at the document level, so a board scoped to 7 days could not carry an "active in the last 30 minutes" tile. This is table stakes for ops dashboards and a common Grafana pattern; it surfaced while rebuilding a reference dashboard where an "Active Trains (30m)" stat simply could not be reproduced.

## What changed

**Schema**
- `DashboardWidgetSchema` gains `timeRange: Schema.optionalKey(TimeRangeSchema)` (`packages/domain/src/http/dashboards.ts`).
- `V2DashboardWidget` mirrors it as `time_range` (`packages/domain/src/http/v2/dashboards.ts`).

**Web**
- `useWidgetDataSource` resolves the effective range in one place, taking an explicit override or falling back to a new `WidgetTimeRangeProvider` context — so a stat's sparkline queries the same window as its headline value.
- The memo is keyed on the *serialized* override, with the dashboard's resolved range still in the deps. An optimistic dashboard rewrite (new object identity, same range) can't refetch every pinned tile, but a manual reload or auto-refresh still rebases a relative override against "now".
- `WidgetShell` renders a clock chip with the pinned range beside the title — without that affordance the feature is a footgun.
- Panel Options grows a "Time range" field (Dashboard / Custom + the standard picker), seeded from whatever the board currently shows so detaching doesn't jump. Hidden for markdown notes. The builder preview applies it live.
- The UI keeps plain ISO strings; the store brands them once at the document boundary (`toDocumentWidgets`), matching how the dashboard-level range was already handled.

**API / MCP**
- `add_dashboard_widget` takes `time_range_json`; `update_dashboard_widget` and `replace_dashboard_widgets` accept it inline via the schema (descriptions now warn that omitting it on an update *removes* an existing override).
- `get_dashboard` emits the field only when set.
- Validation and `inspect_chart_data` evaluate a pinned widget on **its** window and report `source: "widget"` — otherwise the rows they report are not the rows the tile renders.

**Docs** — new sections in `skills/maple-dashboard-widgets/SKILL.md` and the `maple://instructions` resource, both leading with "omit it for almost every widget".

## Design notes for reviewers

- **Variables**: the override replaces the time window only. Variable option lists stay board-scoped — a pinned tile silently narrowing everyone's dropdowns would be worse.
- **Refresh interval**: needs nothing special. A refresh gives the resolved dashboard range a new identity, which re-resolves relative overrides against "now" and leaves absolute ones alone.
- **Removal semantics**: `optionalKey` won't encode a present `undefined`, so the key is deleted rather than set — in the web store's `updateWidget`, in `toDocumentWidgets`, and in the v2 route's `toInternalWidgets`.

## Testing

- New round-trip test in `apps/api/src/routes/v2/dashboards.http.test.ts`: relative → absolute → cleared, and unpinned widgets carry no `time_range`.
- Scoped vitest green: `dashboards.http`, `mutating`, `dashboard-concurrency`, `v2-contract`, `openapi`, plus the five touched web suites (66 tests).
- `typecheck` clean for every touched file across `@maple/api`, `@maple/web`, `@maple/domain`.

**Not verified in a browser.** The settings field and the header chip haven't been exercised against a running stack — worth a look at `/dashboards/<id>/widgets/<widgetId>` before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788221189&installation_model_id=427786&pr_number=304&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F304&signature=0bb9e44b4f4b821e889757d890d42b5f36d4e489a1a8e8be94f4611238443fd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->