### PR TITLE
fix(web): bound the Electric collection load so dashboards can't spin forever

### DIFF
--- a/apps/web/src/components/common/sync-unavailable.tsx
+++ b/apps/web/src/components/common/sync-unavailable.tsx
@@ -1,0 +1,73 @@
+import { Button } from "@maple/ui/components/ui/button"
+import {
+	Empty,
+	EmptyContent,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle,
+} from "@maple/ui/components/ui/empty"
+
+import { CircleWarningIcon } from "@/components/icons"
+
+/**
+ * The terminal state of an ElectricSQL-backed page: the shape stream could not
+ * be established and has stopped retrying.
+ *
+ * It always carries a retry action. Both recovery budgets (the collection
+ * factory's backoff and the org-collections heal) are bounded on purpose, so
+ * once they are spent nothing in the app will try again — without a button the
+ * only way forward is a page reload, which is exactly the dead end this replaces.
+ */
+export function SyncUnavailable({
+	title,
+	description,
+	onRetry,
+}: {
+	title: string
+	description: string
+	onRetry: () => void
+}) {
+	return (
+		<Empty className="py-12">
+			<EmptyHeader>
+				<EmptyMedia variant="icon">
+					<CircleWarningIcon size={18} />
+				</EmptyMedia>
+				<EmptyTitle>{title}</EmptyTitle>
+				<EmptyDescription>{description}</EmptyDescription>
+			</EmptyHeader>
+			<EmptyContent>
+				<Button size="sm" variant="outline" onClick={onRetry}>
+					Try again
+				</Button>
+			</EmptyContent>
+		</Empty>
+	)
+}
+
+/**
+ * The banner for a page reading a plain-HTTP snapshot because live sync is down:
+ * the rows are real but frozen, and writes are disabled. Distinct from
+ * {@link SyncUnavailable} — there is data on screen, so this must inform without
+ * taking the page over.
+ */
+export function SyncDegradedBanner({ onRetry }: { onRetry: () => void }) {
+	return (
+		<div className="mb-3 flex items-start gap-2 rounded-md border border-border bg-muted/40 p-2.5 text-xs text-muted-foreground">
+			<CircleWarningIcon size={14} className="mt-0.5 shrink-0" />
+			<span className="flex-1">
+				Live sync is unavailable, so this is a snapshot loaded over HTTP — it won’t update on its own
+				and editing is disabled.
+			</span>
+			<Button
+				size="sm"
+				variant="ghost"
+				onClick={onRetry}
+				className="-my-1 h-6 shrink-0 px-2 text-xs hover:text-foreground"
+			>
+				Retry sync
+			</Button>
+		</div>
+	)
+}

--- a/apps/web/src/hooks/use-alerts-list.ts
+++ b/apps/web/src/hooks/use-alerts-list.ts
@@ -12,6 +12,7 @@ import {
 	rowToAlertIncidentDocument,
 	rowToAlertRuleDocument,
 } from "@/lib/collections/alerts"
+import { useCollectionLoadFailed } from "@/lib/collections/collection-load"
 import {
 	getOrgCollections,
 	useActiveOrgId,
@@ -44,6 +45,16 @@ export interface AlertDestinationsListHook {
 
 const noop = () => {}
 
+/**
+ * The failure every one of these hooks reports when its shape stream never
+ * arrives. A live query has no bounded load of its own, so without this an
+ * unreachable sync endpoint keeps `isLoading` true forever and the alerts pages
+ * render skeletons that never resolve.
+ */
+const SYNC_UNAVAILABLE: ListError = {
+	message: "Live sync is unavailable, so alerts couldn’t be loaded. Reload to try again.",
+}
+
 export function useAlertRulesList(): AlertRulesListHook {
 	const orgKey = useActiveOrgId() ?? "pending"
 	const generation = useCollectionsGeneration()
@@ -66,12 +77,16 @@ export function useAlertRulesList(): AlertRulesListHook {
 	)
 	const { data: stateRows } = useLiveQuery((q) => q.from({ s: statesCollection }), [statesCollection])
 
+	const pending = rulesLoading && (ruleRows?.length ?? 0) === 0
+	const syncFailed = useCollectionLoadFailed(rulesCollection.id, pending)
+
 	const result = useMemo<Result.Result<AlertRulesListResponse, ListError>>(() => {
-		if (rulesLoading && (ruleRows?.length ?? 0) === 0) return Result.initial(true)
+		if (syncFailed) return Result.fail(SYNC_UNAVAILABLE)
+		if (pending) return Result.initial(true)
 		const statesByRuleId = buildRuleStatesByRuleId(stateRows ?? [])
 		const rules = (ruleRows ?? []).map((row) => rowToAlertRuleDocument(row, statesByRuleId))
 		return Result.success(new AlertRulesListResponse({ rules }))
-	}, [ruleRows, stateRows, rulesLoading])
+	}, [ruleRows, stateRows, pending, syncFailed])
 
 	return { result, refresh: noop }
 }
@@ -90,11 +105,15 @@ export function useAlertIncidentsList(): AlertIncidentsListHook {
 		[collection],
 	)
 
+	const pending = isLoading && (rows?.length ?? 0) === 0
+	const syncFailed = useCollectionLoadFailed(collection.id, pending)
+
 	const result = useMemo<Result.Result<AlertIncidentsListResponse, ListError>>(() => {
-		if (isLoading && (rows?.length ?? 0) === 0) return Result.initial(true)
+		if (syncFailed) return Result.fail(SYNC_UNAVAILABLE)
+		if (pending) return Result.initial(true)
 		const incidents = (rows ?? []).map(rowToAlertIncidentDocument)
 		return Result.success(new AlertIncidentsListResponse({ incidents }))
-	}, [rows, isLoading])
+	}, [rows, pending, syncFailed])
 
 	return { result, refresh: noop }
 }
@@ -114,11 +133,15 @@ export function useAlertDestinationsList(): AlertDestinationsListHook {
 		[collection],
 	)
 
+	const pending = isLoading && (rows?.length ?? 0) === 0
+	const syncFailed = useCollectionLoadFailed(collection.id, pending)
+
 	const result = useMemo<Result.Result<AlertDestinationsListResponse, ListError>>(() => {
-		if (isLoading && (rows?.length ?? 0) === 0) return Result.initial(true)
+		if (syncFailed) return Result.fail(SYNC_UNAVAILABLE)
+		if (pending) return Result.initial(true)
 		const destinations = (rows ?? []).map(rowToAlertDestinationDocument)
 		return Result.success(new AlertDestinationsListResponse({ destinations }))
-	}, [rows, isLoading])
+	}, [rows, pending, syncFailed])
 
 	return { result, refresh: noop }
 }

--- a/apps/web/src/hooks/use-api-keys.ts
+++ b/apps/web/src/hooks/use-api-keys.ts
@@ -4,6 +4,7 @@ import { useLiveQuery } from "@tanstack/react-db"
 import { Effect } from "effect"
 import { useCallback, useMemo } from "react"
 import { rowToV2ApiKey } from "@/lib/collections/api-keys"
+import { useCollectionLoadFailed } from "@/lib/collections/collection-load"
 import {
 	getOrgCollections,
 	useActiveOrgId,
@@ -46,7 +47,11 @@ export function useApiKeysList(): {
 		[collection],
 	)
 	const keys = useMemo(() => (rows ?? []).map(rowToV2ApiKey), [rows])
-	return { keys, isLoading: isLoading && keys.length === 0, isError }
+	const pending = isLoading && keys.length === 0
+	// A live query never times out on its own; without this a dead sync endpoint
+	// leaves the API-keys settings page on a skeleton indefinitely.
+	const syncFailed = useCollectionLoadFailed(collection.id, pending)
+	return { keys, isLoading: pending && !syncFailed, isError: isError || syncFailed }
 }
 
 /**

--- a/apps/web/src/hooks/use-dashboard-store.ts
+++ b/apps/web/src/hooks/use-dashboard-store.ts
@@ -13,10 +13,13 @@ import type { DashboardRefreshIntervalSeconds } from "@maple/domain/http"
 import type { V2DashboardMutation } from "@maple/domain/http/v2"
 import { useLiveQuery } from "@tanstack/react-db"
 import { runMapleApiV2 } from "@/lib/collections/api-runner"
-import { rowToDashboard } from "@/lib/collections/dashboards"
+import { rowToDashboard, v2DashboardToDashboard } from "@/lib/collections/dashboards"
+import { useCollectionLoadFailed } from "@/lib/collections/collection-load"
+import { useDashboardsFallback } from "@/lib/collections/dashboards-fallback"
 import {
 	getOrgCollections,
 	handleCollectionStuck,
+	retryOrgCollections,
 	useActiveOrgId,
 	useCollectionsGeneration,
 } from "@/lib/collections/org-collections"
@@ -124,21 +127,6 @@ function isConcurrencyConflict(failure: Exit.Exit<unknown, unknown>): boolean {
 		onSome: (error) => error instanceof DashboardConcurrencyError,
 	})
 }
-
-const v2DashboardToDashboard = (value: V2DashboardMutation): Dashboard => ({
-	id: value.id,
-	name: value.name,
-	...(value.description !== null ? { description: value.description } : {}),
-	tags: [...value.tags],
-	timeRange: value.timeRange,
-	widgets: [...value.widgets] as Dashboard["widgets"],
-	variables: [...value.variables] as Dashboard["variables"],
-	...(value.refreshIntervalSeconds !== null
-		? { refreshIntervalSeconds: value.refreshIntervalSeconds }
-		: {}),
-	createdAt: value.createdAt,
-	updatedAt: value.updatedAt,
-})
 
 function toDashboardDocument(dashboard: Dashboard): DashboardDocument {
 	// `description`/`tags`/`variables` are `Schema.optionalKey` on `DashboardDocument`;
@@ -484,11 +472,26 @@ export function useDashboardMutationSync() {
 	return { prepareForMutation, reconcileTxid }
 }
 
+/** What {@link useDashboardsRead} hands its consumers. */
+export interface DashboardsRead {
+	readonly dashboards: ReadonlyArray<Dashboard>
+	readonly isLoading: boolean
+	readonly isError: boolean
+	/**
+	 * True when `dashboards` is the plain-HTTP snapshot rather than live sync:
+	 * the rows are correct as of the fetch but will not update, so editing
+	 * affordances should be treated as unavailable.
+	 */
+	readonly degraded: boolean
+	/** Recreates the shape streams with a fresh budget — the retry affordance. */
+	readonly retry: () => void
+}
+
 // The read half of the ElectricSQL-backed dashboard store: a live query over
 // the org's synced collection, mapped to the web `Dashboard` shape. Global
 // chrome (sidebar, command palette) uses this directly — it needs the list but
 // none of the mutators.
-export function useDashboardsRead() {
+export function useDashboardsRead(): DashboardsRead {
 	const collection = useDashboardsCollection()
 
 	const {
@@ -497,14 +500,35 @@ export function useDashboardsRead() {
 		isError,
 	} = useLiveQuery((q) => q.from({ d: collection }).orderBy(({ d }) => d.updated_at, "desc"), [collection])
 
-	const dashboards = useMemo(
+	const synced = useMemo(
 		() => (rows ?? []).map(rowToDashboard).filter((d): d is Dashboard => d !== null),
 		[rows],
 	)
 
-	const isLoading = liveLoading && dashboards.length === 0
+	const stillLoading = liveLoading && synced.length === 0
 
-	return { dashboards, isLoading, isError }
+	// The bounded load a live query has no notion of. Without it an unreachable
+	// sync endpoint keeps `liveLoading` true forever and every consumer of this
+	// hook renders a skeleton that never resolves.
+	const syncFailed = useCollectionLoadFailed(collection.id, stillLoading)
+	const fallback = useDashboardsFallback(syncFailed)
+
+	// Live rows always win. The HTTP snapshot only stands in while sync is down,
+	// and once it has loaded it keeps standing in across heal attempts rather than
+	// blinking back to a skeleton every time a retry re-enters `loading`.
+	const degraded = synced.length === 0 && fallback.status === "ready"
+	// `idle` counts as pending for one commit: `useSyncExternalStore` fires the
+	// fetch from `subscribe`, i.e. after the render that first saw the failure.
+	const fallbackPending = fallback.status === "loading" || (syncFailed && fallback.status === "idle")
+	const failed = isError || fallback.status === "failed" || (syncFailed && !fallbackPending)
+
+	return {
+		dashboards: degraded ? fallback.dashboards : synced,
+		isLoading: !degraded && !failed && (stillLoading || fallbackPending),
+		isError: failed && !degraded,
+		degraded,
+		retry: retryOrgCollections,
+	}
 }
 
 // The write half: create/import/delete plus the per-dashboard widget mutators,
@@ -700,5 +724,9 @@ export function useDashboardMutations() {
 // dashboard detail route, the widget route, the toolbar). `persistenceErrorAtom`
 // is module-level shared state, so the split halves stay coherent.
 export function useDashboardStore() {
-	return { ...useDashboardsRead(), ...useDashboardMutations() }
+	const read = useDashboardsRead()
+	const mutations = useDashboardMutations()
+	// A degraded (HTTP-snapshot) read has no live sync to reconcile a write
+	// against, so editing stays off until the shape stream is back.
+	return { ...read, ...mutations, readOnly: read.degraded || mutations.readOnly }
 }

--- a/apps/web/src/lib/collections/collection-load.ts
+++ b/apps/web/src/lib/collections/collection-load.ts
@@ -1,0 +1,119 @@
+/**
+ * A bounded load for the collections consumed through `useLiveQuery` hooks.
+ *
+ * The unitflow model path gets this from `Db.fromCollectionByKey`'s stuck
+ * watchdog (`orgCollectionStuckOptions`), but a live query has no such guard: an
+ * unreachable sync endpoint leaves the collection in `loading` and every hook
+ * reports `isLoading: true` forever, so the page renders a skeleton that never
+ * resolves and nothing is logged.
+ *
+ * The watchdog lives OUTSIDE React, keyed by collection id, for two reasons:
+ * several components watch the same collection (sidebar, command palette and the
+ * dashboard page all read `dashboards`) and should share one timer and one
+ * verdict; and the timeout is a property of the sync stream, not of whoever
+ * happens to be mounted. Components subscribe via `useSyncExternalStore`, so
+ * arming and disarming ride React's own subscribe/cleanup rather than an effect.
+ */
+
+import { useCallback, useSyncExternalStore } from "react"
+
+import {
+	handleCollectionStuck,
+	isCollectionSyncFailed,
+	subscribeCollectionsGeneration,
+	subscribeSyncFailure,
+} from "./org-collections"
+
+/**
+ * How long a collection may sit in `loading` with nothing to show before we call
+ * it failed. Matches `orgCollectionStuckOptions.stuckTimeoutMs` so both paths
+ * give up at the same moment — a user on /dashboards and one on /alerts see the
+ * error after the same wait.
+ */
+export const COLLECTION_LOAD_TIMEOUT_MS = 30_000
+
+const timedOut = new Set<string>()
+const listeners = new Map<string, Set<() => void>>()
+
+const notify = (collectionId: string): void => {
+	for (const listener of listeners.get(collectionId) ?? []) listener()
+}
+
+const addListener = (collectionId: string, listener: () => void): (() => void) => {
+	let set = listeners.get(collectionId)
+	if (!set) {
+		set = new Set()
+		listeners.set(collectionId, set)
+	}
+	set.add(listener)
+	return () => {
+		set.delete(listener)
+		if (set.size === 0) listeners.delete(collectionId)
+	}
+}
+
+// A generation bump means every collection was just recreated with a fresh
+// stream (and reuses its `<shape>:<orgId>` id), so a previous verdict no longer
+// describes anything live — clear it and let the new stream have its full window.
+//
+// Registered on first use rather than at import: a module that reaches into the
+// collections registry the moment it is imported is a trap for any consumer that
+// mocks that registry, and nothing here matters until something is watching.
+let watchingGenerations = false
+const watchGenerations = (): void => {
+	if (watchingGenerations) return
+	watchingGenerations = true
+	subscribeCollectionsGeneration(() => {
+		if (timedOut.size === 0) return
+		const cleared = [...timedOut]
+		timedOut.clear()
+		for (const collectionId of cleared) notify(collectionId)
+	})
+}
+
+/**
+ * Whether this collection has failed to load: either its stream gave up for good
+ * (`collection:sync-failed`) or it sat in `loading` past
+ * {@link COLLECTION_LOAD_TIMEOUT_MS} while `isLoading` stayed true.
+ *
+ * Passing `isLoading: false` disarms the watchdog, so a collection that is simply
+ * empty (a real, successful, zero-row sync) is never reported as failed.
+ */
+export const useCollectionLoadFailed = (collectionId: string, isLoading: boolean): boolean => {
+	const subscribe = useCallback(
+		(onStoreChange: () => void) => {
+			watchGenerations()
+			const removeListener = addListener(collectionId, onStoreChange)
+			const removeSyncFailure = subscribeSyncFailure(onStoreChange)
+			// Nothing to wait for once loaded, and no point re-arming after a verdict.
+			if (!isLoading || timedOut.has(collectionId)) {
+				return () => {
+					removeListener()
+					removeSyncFailure()
+				}
+			}
+			const timer = setTimeout(() => {
+				timedOut.add(collectionId)
+				// Same recovery the model path uses: a bounded, spaced recreate of the
+				// org collections, so a merely wedged stream still gets a fresh one.
+				handleCollectionStuck()
+				notify(collectionId)
+			}, COLLECTION_LOAD_TIMEOUT_MS)
+			return () => {
+				clearTimeout(timer)
+				removeListener()
+				removeSyncFailure()
+			}
+		},
+		[collectionId, isLoading],
+	)
+
+	// Derived on every read (both sources are plain sets) — `subscribe` above is
+	// what tells React when either of them may have changed.
+	const getSnapshot = useCallback(
+		() => timedOut.has(collectionId) || isCollectionSyncFailed(collectionId),
+		[collectionId],
+	)
+
+	return useSyncExternalStore(subscribe, getSnapshot, () => false)
+}

--- a/apps/web/src/lib/collections/dashboards-fallback.ts
+++ b/apps/web/src/lib/collections/dashboards-fallback.ts
@@ -1,0 +1,171 @@
+/**
+ * The read-only escape hatch for a dead dashboards shape stream.
+ *
+ * Dashboards are not latency-critical to sync — the list is read far more often
+ * than it is written, and `GET /v2/dashboards` returns the same rows Electric
+ * would have streamed. So when the shape stream gives up (unreachable sync
+ * endpoint, misconfigured `VITE_ELECTRIC_SYNC_URL`, a proxy eating the
+ * long-poll), fetching the list over plain HTTP beats showing an error page for
+ * data that is sitting right there.
+ *
+ * The snapshot is deliberately a SNAPSHOT: no live updates, and callers surface
+ * it as degraded/read-only rather than pretending sync is healthy.
+ *
+ * One module-level store, not a per-consumer fetch: /dashboards mounts both the
+ * list model and (through the sidebar) the `useDashboardsRead` hook, and a
+ * failing stream must not turn into two identical HTTP reads.
+ */
+
+import { Registry, Store } from "@maple/unitflow"
+import * as Effect from "effect/Effect"
+import * as Queue from "effect/Queue"
+import * as Stream from "effect/Stream"
+import { useCallback, useSyncExternalStore } from "react"
+
+import type { Dashboard } from "@/components/dashboard-builder/types"
+import { mapleRuntime } from "@/lib/registry"
+import { subscribeActiveOrgId } from "@/lib/services/common/auth-headers"
+import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { v2DashboardToDashboard } from "./dashboards"
+import { subscribeCollectionsGeneration } from "./org-collections"
+
+/** The v2 list endpoint's per-page ceiling (`LIST_LIMIT_MAX`). */
+const PAGE_SIZE = 100
+
+// A backstop, not a real limit: 20 pages is 2000 dashboards, far past any real
+// org. It exists so a server that kept answering `has_more: true` could never
+// spin this loop forever — the exact failure mode this module is here to fix.
+const MAX_PAGES = 20
+
+/**
+ * Walks the cursor-paginated list endpoint into the web {@link Dashboard} shape.
+ * Ordering (most recently updated first) comes from the endpoint and is
+ * preserved across pages, matching what the Electric-backed list renders.
+ */
+const fetchDashboardsOverHttp = Effect.gen(function* () {
+	const client = yield* MapleApiV2AtomClient
+	const dashboards: Array<Dashboard> = []
+	let cursor: string | undefined
+
+	for (let page = 0; page < MAX_PAGES; page++) {
+		const response = yield* client.dashboards.list({
+			query: cursor === undefined ? { limit: PAGE_SIZE } : { limit: PAGE_SIZE, cursor },
+		})
+		for (const dashboard of response.data) dashboards.push(v2DashboardToDashboard(dashboard))
+		if (!response.has_more || response.next_cursor === null) break
+		cursor = response.next_cursor
+	}
+
+	return dashboards as ReadonlyArray<Dashboard>
+})
+
+export type DashboardsFallbackState =
+	| { readonly status: "idle" }
+	| { readonly status: "loading" }
+	| { readonly status: "ready"; readonly dashboards: ReadonlyArray<Dashboard> }
+	| { readonly status: "failed" }
+
+let state: DashboardsFallbackState = { status: "idle" }
+const listeners = new Set<() => void>()
+
+const setState = (next: DashboardsFallbackState): void => {
+	state = next
+	for (const listener of listeners) listener()
+}
+
+export const getDashboardsFallback = (): DashboardsFallbackState => state
+
+export const subscribeDashboardsFallback = (listener: () => void): (() => void) => {
+	listeners.add(listener)
+	return () => listeners.delete(listener)
+}
+
+/**
+ * Loads the HTTP snapshot once. Idempotent: repeated calls while loading, after
+ * a successful load, or after a failed one are no-ops, so the 30s stuck verdict
+ * re-firing across heal attempts can't stack up requests.
+ *
+ * The snapshot is deliberately NOT invalidated when the collections are
+ * recreated — a heal that fails again would otherwise blank the list the user is
+ * reading every 30 seconds. It IS invalidated on an org switch, where the cached
+ * rows belong to the wrong tenant.
+ */
+export const requestDashboardsFallback = (): void => {
+	watchInvalidation()
+	if (state.status !== "idle") return
+	setState({ status: "loading" })
+	mapleRuntime.runFork(
+		fetchDashboardsOverHttp.pipe(
+			Effect.tap((dashboards) => Effect.sync(() => setState({ status: "ready", dashboards }))),
+			Effect.tapError((cause) =>
+				Effect.logError("Dashboards HTTP fallback failed; sync and fallback are both down").pipe(
+					Effect.annotateLogs({ cause }),
+				),
+			),
+			Effect.catchCause(() => Effect.sync(() => setState({ status: "failed" }))),
+		),
+	)
+}
+
+// Registered on first request rather than at import: nothing here is worth
+// invalidating until a snapshot exists, and a module that reaches into the auth
+// and collections registries the moment it is imported is a trap for consumers
+// that mock them.
+let watchingInvalidation = false
+const watchInvalidation = (): void => {
+	if (watchingInvalidation) return
+	watchingInvalidation = true
+	// An org switch makes a cached snapshot flatly wrong — it belongs to the
+	// previous tenant.
+	subscribeActiveOrgId(() => {
+		if (state.status !== "idle") setState({ status: "idle" })
+	})
+	// A recreate (heal or user retry) is a fresh chance for the HTTP read too, but
+	// only a FAILED snapshot is discarded: dropping a good one would blank the
+	// list a user is reading every time a heal attempt cycles.
+	subscribeCollectionsGeneration(() => {
+		if (state.status === "failed") setState({ status: "idle" })
+	})
+}
+
+/**
+ * React binding. `enabled` gates the fetch, not the subscription: components
+ * pass the collection's failure verdict, and the request fires the moment it
+ * flips true.
+ */
+export const useDashboardsFallback = (enabled: boolean): DashboardsFallbackState => {
+	const subscribe = useCallback(
+		(onStoreChange: () => void) => {
+			if (enabled) requestDashboardsFallback()
+			listeners.add(onStoreChange)
+			return () => {
+				listeners.delete(onStoreChange)
+			}
+		},
+		[enabled],
+	)
+	return useSyncExternalStore(subscribe, getDashboardsFallback, () => state)
+}
+
+/** unitflow binding — the same single store, as a model-scoped read-only Store. */
+export const makeDashboardsFallbackStore: Effect.Effect<
+	Store.Store<DashboardsFallbackState>,
+	never,
+	Registry
+> = Effect.gen(function* () {
+	const store = Store.make<DashboardsFallbackState>(getDashboardsFallback())
+	yield* Registry.run(
+		Stream.callback<DashboardsFallbackState>((queue) =>
+			Effect.acquireRelease(
+				Effect.sync(() => {
+					const push = () => Queue.offerUnsafe(queue, getDashboardsFallback())
+					const unsubscribe = subscribeDashboardsFallback(push)
+					push()
+					return unsubscribe
+				}),
+				(unsubscribe) => Effect.sync(unsubscribe),
+			),
+		).pipe(Stream.mapEffect((next) => Store.set(store, next))),
+	)
+	return store
+})

--- a/apps/web/src/lib/collections/dashboards.ts
+++ b/apps/web/src/lib/collections/dashboards.ts
@@ -1,5 +1,5 @@
 import { DashboardDocument, DashboardId } from "@maple/domain/http"
-import type { V2DashboardUpdateParams } from "@maple/domain/http/v2"
+import type { V2Dashboard, V2DashboardUpdateParams } from "@maple/domain/http/v2"
 import { Effect, Schema } from "effect"
 import type { Dashboard } from "@/components/dashboard-builder/types"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
@@ -79,6 +79,27 @@ export const rowToDashboard = (row: DashboardRow): Dashboard | null => {
 		return null
 	}
 }
+
+/**
+ * Widens a v2 API dashboard into the mutable web {@link Dashboard} shape. The
+ * `V2DashboardMutation` returned by writes is structurally a `V2Dashboard` plus
+ * an optional `txid`, so both wire shapes go through this one converter — the
+ * write path (create/import) and the HTTP list fallback.
+ */
+export const v2DashboardToDashboard = (value: V2Dashboard): Dashboard => ({
+	id: value.id,
+	name: value.name,
+	...(value.description !== null ? { description: value.description } : {}),
+	tags: [...value.tags],
+	timeRange: value.timeRange,
+	widgets: [...value.widgets] as Dashboard["widgets"],
+	variables: [...value.variables] as Dashboard["variables"],
+	...(value.refreshIntervalSeconds !== null
+		? { refreshIntervalSeconds: value.refreshIntervalSeconds }
+		: {}),
+	createdAt: value.createdAt,
+	updatedAt: value.updatedAt,
+})
 
 /**
  * Builds the v2 PATCH payload from a row's optimistic `payload_json`. The stored

--- a/apps/web/src/lib/collections/org-collections.test.ts
+++ b/apps/web/src/lib/collections/org-collections.test.ts
@@ -238,6 +238,64 @@ describe("org-collections bounded self-heal", () => {
 		expect(mod.getCollectionsGeneration()).toBe(start + 1)
 	})
 
+	it("marks a terminally stopped stream, and clears the mark when it is recreated", async () => {
+		const { mod } = await freshModule()
+		const failed = new CustomEvent("collection:sync-failed", {
+			detail: { collectionId: "dashboards:org_a" },
+		})
+
+		mod.handleCollectionSyncFailed(failed)
+		expect(mod.isCollectionSyncFailed("dashboards:org_a")).toBe(true)
+		expect(mod.isCollectionSyncFailed("alert_rules:org_a")).toBe(false)
+
+		// The rebuilt collection reuses the same id, so a stale mark would make a
+		// brand-new stream look dead before its first fetch.
+		mod.recreateOrgCollections()
+		expect(mod.isCollectionSyncFailed("dashboards:org_a")).toBe(false)
+	})
+
+	it("retryOrgCollections recreates even after the heal budget is spent", async () => {
+		const { mod } = await freshModule()
+
+		for (let i = 0; i < 12; i++) {
+			mod.handleSchemaError()
+			vi.advanceTimersByTime(6_000)
+		}
+		const exhausted = mod.getCollectionsGeneration()
+
+		// The user-facing retry is the only way out of a spent budget — without it
+		// a page reload is the only recovery.
+		mod.retryOrgCollections()
+		expect(mod.getCollectionsGeneration()).toBe(exhausted + 1)
+
+		// And the budget is refreshed, so automatic recovery works again.
+		mod.handleCollectionStuck()
+		vi.advanceTimersByTime(6_000)
+		expect(mod.getCollectionsGeneration()).toBe(exhausted + 2)
+	})
+
+	it("notifies subscribers when a stream fails and when the mark clears", async () => {
+		const { mod } = await freshModule()
+		const listener = vi.fn()
+		const unsubscribe = mod.subscribeSyncFailure(listener)
+
+		mod.handleCollectionSyncFailed(
+			new CustomEvent("collection:sync-failed", { detail: { collectionId: "dashboards:org_a" } }),
+		)
+		expect(listener).toHaveBeenCalledTimes(1)
+
+		// A repeat event for the same collection is not a state change.
+		mod.handleCollectionSyncFailed(
+			new CustomEvent("collection:sync-failed", { detail: { collectionId: "dashboards:org_a" } }),
+		)
+		expect(listener).toHaveBeenCalledTimes(1)
+
+		mod.recreateOrgCollections()
+		expect(listener).toHaveBeenCalledTimes(2)
+
+		unsubscribe()
+	})
+
 	it("resets the heal budget on a genuine org switch", async () => {
 		const { mod } = await freshModule()
 

--- a/apps/web/src/lib/collections/org-collections.ts
+++ b/apps/web/src/lib/collections/org-collections.ts
@@ -1,3 +1,4 @@
+import { COLLECTION_SYNC_FAILED_EVENT } from "@maple/effect-db/electric"
 import { Effect } from "effect"
 import { useSyncExternalStore } from "react"
 import { mapleRuntime } from "@/lib/registry"
@@ -63,8 +64,69 @@ export const recreateOrgCollections = (): void => {
 	generation += 1
 	const previous = current
 	current = null
+	// The rebuilt collections reuse their `<shape>:<org>` ids, so a stale failure
+	// mark would make a freshly minted stream look dead before it has fetched once.
+	clearSyncFailures()
 	if (previous) scheduleOrgCollectionsCleanup(previous)
 	for (const listener of generationListeners) listener()
+}
+
+// ---------------------------------------------------------------------------
+// Terminal sync failures
+// ---------------------------------------------------------------------------
+//
+// `collection:sync-failed` (from @maple/effect-db) means a shape stream spent its
+// whole backoff budget and STOPPED — nothing will refetch it until the collection
+// is recreated. That is the difference between "still loading" and "will never
+// load", and without it a dead sync endpoint is indistinguishable from a slow one:
+// the collection sits in `loading` and the page renders a skeleton forever.
+//
+// Consumers read `isCollectionSyncFailed(collection.id)` to render a real error
+// immediately, and call `retryOrgCollections()` for the retry affordance.
+
+const failedCollectionIds = new Set<string>()
+const syncFailureListeners = new Set<() => void>()
+
+const notifySyncFailure = (): void => {
+	for (const listener of syncFailureListeners) listener()
+}
+
+const clearSyncFailures = (): void => {
+	if (failedCollectionIds.size === 0) return
+	failedCollectionIds.clear()
+	notifySyncFailure()
+}
+
+export const subscribeSyncFailure = (listener: () => void): (() => void) => {
+	syncFailureListeners.add(listener)
+	return () => syncFailureListeners.delete(listener)
+}
+
+/** Whether this collection's stream gave up for good (id is `<shape>:<orgId>`). */
+export const isCollectionSyncFailed = (collectionId: string): boolean => failedCollectionIds.has(collectionId)
+
+/** Records a terminally stopped stream. Exported for tests. */
+export const handleCollectionSyncFailed = (event: Event): void => {
+	const collectionId = (event as CustomEvent<{ collectionId?: string }>).detail?.collectionId
+	if (collectionId === undefined || failedCollectionIds.has(collectionId)) return
+	failedCollectionIds.add(collectionId)
+	mapleRuntime.runFork(
+		Effect.logError(
+			"Electric shape stream stopped retrying; collection will not load until retried",
+		).pipe(Effect.annotateLogs({ collectionId })),
+	)
+	notifySyncFailure()
+}
+
+/**
+ * The user-facing retry: clears the bounded heal budget and every failure mark,
+ * then recreates the collections so each shape stream starts over with a full
+ * backoff budget. This is the ONLY way out once both budgets are spent — short of
+ * a page reload, which is what users otherwise resort to.
+ */
+export const retryOrgCollections = (): void => {
+	resetSchemaHealBudget()
+	recreateOrgCollections()
 }
 
 // ---------------------------------------------------------------------------
@@ -273,6 +335,7 @@ export const getOrgCollections = (orgId: string): OrgCollections => {
 if (typeof window !== "undefined") {
 	window.addEventListener("collection:schema-error", handleSchemaError)
 	window.addEventListener("collection:auth-error", handleCollectionAuthError)
+	window.addEventListener(COLLECTION_SYNC_FAILED_EVENT, handleCollectionSyncFailed)
 }
 
 /** Reactive active-org id (null when signed out / org-less). Mode-agnostic — both Clerk and self-hosted auth publish via setActiveOrgId. */

--- a/apps/web/src/lib/models/alerts-overview-model.ts
+++ b/apps/web/src/lib/models/alerts-overview-model.ts
@@ -31,7 +31,12 @@ import {
 	rowToAlertRuleDocument,
 } from "@/lib/collections/alerts"
 import { getOrgCollections } from "@/lib/collections/org-collections"
-import { collectionFailureMessage, makeOrgCollectionsKey, orgIdOf } from "@/lib/models/org-collections-key"
+import {
+	collectionFailureMessage,
+	makeOrgCollectionsKey,
+	orgCollectionStuckOptions,
+	orgIdOf,
+} from "@/lib/models/org-collections-key"
 import { v2DeliveryToDocument } from "@/lib/alerts/form-utils"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 
@@ -218,17 +223,23 @@ export class AlertsOverviewModel extends Model.Service<AlertsOverviewModel>()("m
 	make: () =>
 		Effect.gen(function* () {
 			const orgKey = yield* makeOrgCollectionsKey
+			// `orgCollectionStuckOptions` on every one: without a bounded load an
+			// unreachable sync endpoint parks each store in `loading` and the hub
+			// renders skeletons forever instead of its error state.
 			const rules = yield* Db.fromCollectionByKey(
 				orgKey,
 				(key) => getOrgCollections(orgIdOf(key)).alertRules,
+				orgCollectionStuckOptions,
 			)
 			const states = yield* Db.fromCollectionByKey(
 				orgKey,
 				(key) => getOrgCollections(orgIdOf(key)).alertRuleStates,
+				orgCollectionStuckOptions,
 			)
 			const incidents = yield* Db.fromCollectionByKey(
 				orgKey,
 				(key) => getOrgCollections(orgIdOf(key)).alertIncidents,
+				orgCollectionStuckOptions,
 			)
 
 			// Delivery events stay a capped HTTP read (no Electric shape) — refetched

--- a/apps/web/src/lib/models/dashboards-list-model.test.ts
+++ b/apps/web/src/lib/models/dashboards-list-model.test.ts
@@ -1,6 +1,9 @@
+import { CollectionError } from "@maple/unitflow/db"
+import type * as Db from "@maple/unitflow/db"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import { describe, expect, it } from "vitest"
 import type { DashboardRow } from "@/lib/collections/dashboards"
-import { deriveDashboardsList } from "./dashboards-list-model"
+import { buildList, deriveDashboardsList } from "./dashboards-list-model"
 
 const ISO_OLD = "2026-01-01T00:00:00.000Z"
 const ISO_MID = "2026-03-01T00:00:00.000Z"
@@ -86,6 +89,56 @@ describe("deriveDashboardsList", () => {
 			id: "w1",
 			visualization: "timeseries",
 			layout: { x: 0, y: 0, w: 4, h: 5 },
+		})
+	})
+})
+
+describe("buildList", () => {
+	const rowsInitial: Db.CollectionState<DashboardRow> = AsyncResult.initial(true)
+	const rowsFailed: Db.CollectionState<DashboardRow> = AsyncResult.fail(
+		new CollectionError({ reason: "load-timeout", message: "Collection timed out while loading" }),
+	)
+	const rowsReady = (rows: ReadonlyArray<DashboardRow>): Db.CollectionState<DashboardRow> =>
+		AsyncResult.success(rows)
+
+	const fallbackDashboards = deriveDashboardsList([makeRow("dash-http", ISO_NEW)])
+
+	it("renders synced rows and never reaches for the fallback", () => {
+		const list = buildList(rowsReady([makeRow("dash-live", ISO_NEW)]), {
+			status: "ready",
+			dashboards: fallbackDashboards,
+		})
+		expect(list).toMatchObject({ phase: "ready", degraded: false })
+		expect(list.phase === "ready" && list.dashboards.map((d) => d.id)).toEqual(["dash-live"])
+	})
+
+	it("stays on the skeleton for the tick between the failure and its fallback request", () => {
+		expect(buildList(rowsFailed, { status: "idle" })).toEqual({ phase: "loading" })
+		expect(buildList(rowsFailed, { status: "loading" })).toEqual({ phase: "loading" })
+	})
+
+	it("serves the HTTP snapshot, flagged degraded, once sync has failed", () => {
+		const list = buildList(rowsFailed, { status: "ready", dashboards: fallbackDashboards })
+		expect(list).toMatchObject({ phase: "ready", degraded: true })
+		expect(list.phase === "ready" && list.dashboards.map((d) => d.id)).toEqual(["dash-http"])
+	})
+
+	it("keeps serving the snapshot while a heal attempt re-enters loading", () => {
+		// The recreate puts the rows store back to `initial`; blinking the list away
+		// every 30s while heal attempts cycle would be worse than a frozen list.
+		const list = buildList(rowsInitial, { status: "ready", dashboards: fallbackDashboards })
+		expect(list).toMatchObject({ phase: "ready", degraded: true })
+	})
+
+	it("errors only when sync and the HTTP fallback are both down", () => {
+		expect(buildList(rowsFailed, { status: "failed" })).toMatchObject({ phase: "error" })
+	})
+
+	it("reports a genuinely empty org as ready, not degraded", () => {
+		expect(buildList(rowsReady([]), { status: "idle" })).toEqual({
+			phase: "ready",
+			dashboards: [],
+			degraded: false,
 		})
 	})
 })

--- a/apps/web/src/lib/models/dashboards-list-model.ts
+++ b/apps/web/src/lib/models/dashboards-list-model.ts
@@ -11,20 +11,36 @@
  * subscription of their own.
  */
 
-import { Model, Store } from "@maple/unitflow"
+import { Model, Registry, Store } from "@maple/unitflow"
 import * as Db from "@maple/unitflow/db"
 import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 
 import type { Dashboard } from "@/components/dashboard-builder/types"
 import { type DashboardRow, rowToDashboard } from "@/lib/collections/dashboards"
+import {
+	type DashboardsFallbackState,
+	makeDashboardsFallbackStore,
+	requestDashboardsFallback,
+} from "@/lib/collections/dashboards-fallback"
 import { getOrgCollections } from "@/lib/collections/org-collections"
-import { collectionFailureMessage, makeOrgCollectionsKey, orgIdOf } from "@/lib/models/org-collections-key"
+import {
+	collectionFailureMessage,
+	makeOrgCollectionsKey,
+	orgCollectionStuckOptions,
+	orgIdOf,
+} from "@/lib/models/org-collections-key"
 
 /** The fully derived list — everything the route renders when ready. */
 export interface DashboardsListReady {
 	readonly phase: "ready"
 	readonly dashboards: ReadonlyArray<Dashboard>
+	/**
+	 * True when the rows came from the plain-HTTP fallback rather than the shape
+	 * stream: correct as of the fetch, but frozen, and writes are unavailable.
+	 */
+	readonly degraded: boolean
 }
 
 /** The derived list, in the phases the route renders distinctly. */
@@ -48,16 +64,39 @@ export const deriveDashboardsList = (rows: ReadonlyArray<DashboardRow>): Readonl
 		.filter((dashboard): dashboard is Dashboard => dashboard !== null)
 }
 
-/** Row-level combine body: phase handling, then {@link deriveDashboardsList}. */
-const buildList = (rows: Db.CollectionState<DashboardRow>): DashboardsListData => {
+/**
+ * Row-level combine body: phase handling, then {@link deriveDashboardsList}.
+ *
+ * Synced rows always win. The HTTP fallback only stands in once the shape stream
+ * has failed, and once it has loaded it keeps standing in across heal attempts
+ * (each of which re-enters `loading`) so the list a user is reading doesn't blink
+ * back to a skeleton every 30 seconds.
+ *
+ * Exported for tests — the phase table is where the fallback's edge cases live.
+ */
+export const buildList = (
+	rows: Db.CollectionState<DashboardRow>,
+	fallback: DashboardsFallbackState,
+): DashboardsListData => {
+	if (AsyncResult.isSuccess(rows) && rows.value.length > 0) {
+		return { phase: "ready", dashboards: deriveDashboardsList(rows.value), degraded: false }
+	}
+	if (fallback.status === "ready") {
+		return { phase: "ready", dashboards: fallback.dashboards, degraded: true }
+	}
 	const message = collectionFailureMessage(rows)
+	// `idle` with a failed collection is the single tick between the failure and
+	// the fallback request it triggers — reporting an error there would flash one.
+	if (fallback.status === "loading" || (message !== null && fallback.status === "idle")) {
+		return { phase: "loading" }
+	}
 	if (message !== null) {
 		return { phase: "error", message }
 	}
 	if (!AsyncResult.isSuccess(rows)) {
 		return { phase: "loading" }
 	}
-	return { phase: "ready", dashboards: deriveDashboardsList(rows.value) }
+	return { phase: "ready", dashboards: deriveDashboardsList(rows.value), degraded: false }
 }
 
 export class DashboardsListModel extends Model.Service<DashboardsListModel>()("maple/dashboards/list")({
@@ -72,9 +111,25 @@ export class DashboardsListModel extends Model.Service<DashboardsListModel>()("m
 			const rows = yield* Db.fromCollectionByKey(
 				orgKey,
 				(key) => getOrgCollections(orgIdOf(key)).dashboards,
+				// Without this the page has no bounded load at all: an unreachable
+				// sync endpoint leaves the collection in `loading` and the route
+				// renders its skeleton forever.
+				orgCollectionStuckOptions,
 			)
 
-			const list = rows.pipe(Store.map(buildList))
+			const fallback = yield* makeDashboardsFallbackStore
+			// The moment live sync gives up, read the same rows over plain HTTP.
+			// Dashboards aren't latency-critical to sync, so a frozen-but-correct
+			// list beats an error page for data the API serves happily.
+			yield* Registry.run(
+				Store.stream(rows).pipe(
+					Stream.mapEffect((state) =>
+						AsyncResult.isFailure(state) ? Effect.sync(requestDashboardsFallback) : Effect.void,
+					),
+				),
+			)
+
+			const list = Store.combine([rows, fallback], buildList)
 
 			return {
 				inputs: {},

--- a/apps/web/src/routes/dashboards/$dashboardId.tsx
+++ b/apps/web/src/routes/dashboards/$dashboardId.tsx
@@ -27,6 +27,7 @@ import type { WidgetMode } from "@/components/dashboard-builder/types"
 import { useDashboardStore } from "@/hooks/use-dashboard-store"
 import { DashboardHistoryPanel, PreviewedCanvas } from "@/components/dashboard-builder/history"
 import { DashboardViewSkeleton } from "@/components/dashboard-builder/loading-skeletons"
+import { SyncDegradedBanner, SyncUnavailable } from "@/components/common/sync-unavailable"
 import { historyPanelOpenAtom, previewedVersionAtom } from "@/atoms/dashboard-history-atoms"
 import { useDashboardVersions } from "@/components/dashboard-builder/history/use-dashboard-history"
 import { Result } from "@/lib/effect-atom"
@@ -86,6 +87,9 @@ function DashboardViewPage() {
 	const {
 		dashboards,
 		isLoading,
+		isError,
+		degraded,
+		retry,
 		readOnly,
 		persistenceError,
 		updateDashboard,
@@ -152,6 +156,28 @@ function DashboardViewPage() {
 						<DashboardLayout.Content>
 							<DashboardLayout.Scroll>
 								<DashboardViewSkeleton />
+							</DashboardLayout.Scroll>
+						</DashboardLayout.Content>
+					</DashboardLayout.Body>
+				</DashboardLayout.Root>
+			)
+		}
+		// A dead sync stream must not masquerade as a missing dashboard: the row may
+		// exist and simply never have arrived.
+		if (isError) {
+			return (
+				<DashboardLayout.Root>
+					<DashboardLayout.Breadcrumbs
+						items={[{ label: "Dashboards", href: "/dashboards" }, { label: "Unavailable" }]}
+					/>
+					<DashboardLayout.Body>
+						<DashboardLayout.Content>
+							<DashboardLayout.Scroll>
+								<SyncUnavailable
+									title="Couldn’t load this dashboard"
+									description="The sync stream isn’t reachable, so the dashboard couldn’t be read. Nothing has been lost — this is a read problem."
+									onRetry={retry}
+								/>
 							</DashboardLayout.Scroll>
 						</DashboardLayout.Content>
 					</DashboardLayout.Body>
@@ -245,6 +271,7 @@ function DashboardViewPage() {
 										</DashboardLayout.Header>
 									</DashboardLayout.Sticky>
 									<DashboardLayout.Scroll>
+										{degraded && <SyncDegradedBanner onRetry={retry} />}
 										{persistenceError && (
 											<div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
 												{persistenceError}. Dashboard editing is temporarily disabled.

--- a/apps/web/src/routes/dashboards/index.tsx
+++ b/apps/web/src/routes/dashboards/index.tsx
@@ -5,12 +5,12 @@ import { toast } from "sonner"
 
 import { Unitflow, View } from "@maple/unitflow/react"
 import { Button } from "@maple/ui/components/ui/button"
-import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@maple/ui/components/ui/empty"
 import { formatRelativeTimeOrDate } from "@maple/ui/time-format"
 
 import { DashboardList, type DashboardScope } from "@/components/dashboard-builder/list/dashboard-list"
 import { headerSummary } from "@/components/dashboard-builder/list/dashboard-summary"
 import { DashboardListSkeleton } from "@/components/dashboard-builder/loading-skeletons"
+import { SyncDegradedBanner, SyncUnavailable } from "@/components/common/sync-unavailable"
 import {
 	downloadPortableDashboard,
 	isPersesDashboardJson,
@@ -23,6 +23,7 @@ import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { isDashboardSortOption, type DashboardSortOption } from "@/atoms/dashboard-preferences-atoms"
 import { useDashboardPreferences } from "@/hooks/use-dashboard-preferences"
 import { useDashboardMutations } from "@/hooks/use-dashboard-store"
+import { retryOrgCollections } from "@/lib/collections/org-collections"
 import { DashboardsListModel } from "@/lib/models/dashboards-list-model"
 import { unitflowRuntime } from "@/lib/models/runtime"
 
@@ -284,17 +285,11 @@ function PageShell({
 
 function ListLoadError() {
 	return (
-		<Empty className="py-12">
-			<EmptyHeader>
-				<EmptyMedia variant="icon">
-					<CircleWarningIcon size={18} />
-				</EmptyMedia>
-				<EmptyTitle>Couldn’t load dashboards</EmptyTitle>
-				<EmptyDescription>
-					The sync stream dropped. Your dashboards are safe — this is a read problem.
-				</EmptyDescription>
-			</EmptyHeader>
-		</Empty>
+		<SyncUnavailable
+			title="Couldn’t load dashboards"
+			description="The sync stream dropped and the list couldn’t be read over HTTP either. Your dashboards are safe — this is a read problem."
+			onRetry={retryOrgCollections}
+		/>
 	)
 }
 
@@ -321,7 +316,12 @@ const ModelPage = View.make(
 				actions={props.actions}
 				persistenceError={props.persistenceError}
 			>
-				<DashboardList dashboards={list.dashboards} {...props.list} />
+				{list.degraded && <SyncDegradedBanner onRetry={retryOrgCollections} />}
+				<DashboardList
+					dashboards={list.dashboards}
+					{...props.list}
+					readOnly={props.list.readOnly || list.degraded}
+				/>
 			</PageShell>
 		)
 	},

--- a/packages/effect-db/src/electric/collection.ts
+++ b/packages/effect-db/src/electric/collection.ts
@@ -20,13 +20,23 @@ export type { CollectionStatus } from "@tanstack/db"
 type OnErrorHandler = NonNullable<ShapeStreamOptions<unknown>["onError"]>
 
 /**
- * Default backoff configuration
+ * Default backoff configuration.
+ *
+ * `maxRetries` is deliberately FINITE. An unreachable sync endpoint (down,
+ * misconfigured `VITE_ELECTRIC_SYNC_URL`, corporate proxy) fails every shape
+ * fetch, and an unlimited budget turns that into a request loop that never ends
+ * and never tells anyone: the collection stays in `loading`, so the page renders
+ * a skeleton forever while the browser keeps dialling. Ten attempts spans
+ * ~1s+2s+4s+8s+16s+30s×4 ≈ 2.5 minutes of real recovery time — long enough to
+ * ride out a redeploy or a laptop waking from sleep — after which the stream
+ * stops and `collection:sync-failed` hands the app a definitive failure it can
+ * render (and offer a retry for) instead of an infinite spinner.
  */
 const DEFAULT_BACKOFF_CONFIG: Required<BackoffConfig> = {
 	initialDelayMs: 1000,
 	maxDelayMs: 30000,
 	multiplier: 2,
-	maxRetries: Number.POSITIVE_INFINITY,
+	maxRetries: 10,
 	jitter: true,
 	resetTimeoutMs: 60000,
 }
@@ -35,6 +45,15 @@ const DEFAULT_BACKOFF_CONFIG: Required<BackoffConfig> = {
  * Custom event name for collection error state changes
  */
 export const COLLECTION_ERROR_STATE_CHANGED_EVENT = "collection:error-state-changed"
+
+/**
+ * Custom event name announcing that a shape stream has stopped retrying for
+ * good — its backoff budget is spent and nothing further will be fetched until
+ * the collection is recreated. Unlike {@link COLLECTION_ERROR_STATE_CHANGED_EVENT}
+ * (fired on every transient error) this is terminal, so the app can render a real
+ * error state with a retry affordance instead of a skeleton that never resolves.
+ */
+export const COLLECTION_SYNC_FAILED_EVENT = "collection:sync-failed"
 
 /**
  * Dispatch an event when collection error state changes
@@ -46,6 +65,13 @@ function dispatchErrorStateChanged(collectionId: string | undefined, isError: bo
 				detail: { collectionId, isError },
 			}),
 		)
+	}
+}
+
+/** Announces a terminally stopped stream (see {@link COLLECTION_SYNC_FAILED_EVENT}). */
+function dispatchSyncFailed(collectionId: string | undefined): void {
+	if (typeof window !== "undefined") {
+		window.dispatchEvent(new CustomEvent(COLLECTION_SYNC_FAILED_EVENT, { detail: { collectionId } }))
 	}
 }
 
@@ -156,6 +182,9 @@ function createBackoffOnError(
 				retryCount,
 				cause: error,
 			})
+			// Terminal: nothing will refetch this shape until the collection is
+			// recreated, so tell the app rather than leaving it on a skeleton.
+			dispatchSyncFailed(collectionId)
 			// Return undefined to stop syncing
 			return
 		}

--- a/packages/effect-db/src/electric/index.ts
+++ b/packages/effect-db/src/electric/index.ts
@@ -4,6 +4,7 @@ export type { Txid } from "@tanstack/electric-db-collection"
 // Core collection creation
 export {
 	COLLECTION_ERROR_STATE_CHANGED_EVENT,
+	COLLECTION_SYNC_FAILED_EVENT,
 	type CollectionStatus,
 	createEffectCollection,
 	type EffectCollection,

--- a/packages/effect-db/src/electric/types.ts
+++ b/packages/effect-db/src/electric/types.ts
@@ -71,8 +71,11 @@ export interface BackoffConfig {
 	multiplier?: number
 
 	/**
-	 * Maximum number of retries before giving up. Set to Infinity for unlimited retries.
-	 * @default Infinity
+	 * Maximum number of retries before giving up, after which the stream stops and
+	 * `collection:sync-failed` fires. Set to Infinity for unlimited retries — but
+	 * only where an infinite spinner is an acceptable outcome, since a stopped
+	 * stream is the only thing that turns "still loading" into "failed".
+	 * @default 10
 	 */
 	maxRetries?: number
 
@@ -181,7 +184,7 @@ export interface EffectElectricCollectionConfig<
 	 *
 	 * Set to `false` to disable backoff entirely.
 	 *
-	 * @default { initialDelayMs: 1000, maxDelayMs: 30000, multiplier: 2, maxRetries: Infinity, jitter: true }
+	 * @default { initialDelayMs: 1000, maxDelayMs: 30000, multiplier: 2, maxRetries: 10, jitter: true }
 	 */
 	backoff?: BackoffConfig | false
 }


### PR DESCRIPTION
## The bug

With the Electric sync endpoint unreachable, `/dashboards` renders "Loading dashboards" and `/dashboards/$id` renders "Loading dashboard" **forever** — no error state, no timeout, no retry ceiling, nothing in the console. Meanwhile `GET /v2/dashboards` returns all 52 dashboards in 56ms. The data is perfectly reachable; the app just never asks for it, and never admits it gave up.

Any user whose sync endpoint is down, misconfigured, or blocked by a corporate proxy sees a permanently loading page. A reload doesn't help.

## Why it happened — three independent gaps

1. **The stuck watchdog was dead code.** `orgCollectionStuckOptions` (30s `stuckTimeoutMs` + `onStuck`) exists in `org-collections-key.ts` but had **zero call sites** — every `Db.fromCollectionByKey` call passed no options, so it was never armed for *any* collection.
2. **The hook path had no bounded load at all.** `useLiveQuery` has no notion of a timeout, so the dashboard detail page, sidebar, command palette, alerts hooks and API-keys page all reported `isLoading: true` indefinitely.
3. **`maxRetries` was `Infinity`.** The stream was dialled forever and nothing ever transitioned to a failed state — "still loading" and "will never load" were indistinguishable.

## What changed

**Bounded load (everywhere)**
- Wired `orgCollectionStuckOptions` into `dashboards-list-model.ts` and all three collections in `alerts-overview-model.ts`.
- New `lib/collections/collection-load.ts`: `useCollectionLoadFailed(collectionId, isLoading)` for the live-query path. The watchdog lives outside React keyed by collection id, so the sidebar, palette and page share one timer and one verdict; it arms via `useSyncExternalStore`'s subscribe (no effect), disarms when loading ends, and clears on a generation bump. Same 30s window as the model path, so both give up at the same moment.

**Retry ceiling**
- `DEFAULT_BACKOFF_CONFIG.maxRetries` → `10` (~1+2+4+8+16+30×4 ≈ 2.5 min of real recovery — enough to ride out a redeploy or a laptop waking from sleep).
- On exhaustion the stream stops and dispatches a terminal `collection:sync-failed` event. `org-collections.ts` records it per collection id and logs it once.
- New `retryOrgCollections()` resets the heal budget *and* recreates the streams. It is the only escape once both budgets are spent, and it backs the "Try again" affordance on every new error state.

**HTTP fallback**
- `lib/collections/dashboards-fallback.ts` walks `GET /v2/dashboards` into `Dashboard[]` behind one single-flight module store, consumed by both the model (unitflow `Store` bridge) and the hook (`useSyncExternalStore`) — a failing stream produces one request, not two.
- Live rows always win. The snapshot renders read-only behind a `SyncDegradedBanner`, survives heal attempts (so the list doesn't blink back to a skeleton every 30s), and is discarded on an org switch — or on a recreate if it had failed.

**Honest error states**
- New `components/common/sync-unavailable.tsx` (`SyncUnavailable` + `SyncDegradedBanner`), reusing the existing `Empty` primitives so it matches the list page's current error design.
- The detail route gained an explicit error branch. Previously a dead stream fell through to **"Dashboard not found"** — which is a lie: the row exists and simply never arrived.

**Other collections (item 4 of the report)**
- Alerts (rules / incidents / destinations) and API keys had the identical failure mode; all now surface a real failure instead of an eternal skeleton. Issues are **not** Electric-backed and are unaffected.

## Reviewer notes

- `useDashboardStore` now forces `readOnly` when the read is degraded — an HTTP snapshot has no live sync to reconcile a write against.
- `v2DashboardToDashboard` moved from `use-dashboard-store.ts` into `lib/collections/dashboards.ts` so the fallback can reuse it without a circular import.
- Both new modules register their registry subscriptions on first use rather than at import. An import-time reach into the collections/auth registries is a trap for any consumer that mocks them (it broke `use-api-keys.test.tsx` the first time round).
- `buildList` is now exported — the phase table is where the fallback's edge cases live, and it is unit-tested directly.

## Testing

- `apps/web` and `packages/effect-db` typecheck clean.
- 52 scoped tests pass, including new coverage for: the terminal-failure registry (mark, clear-on-recreate, subscriber notification, no double-notify), `retryOrgCollections` escaping a spent heal budget, and the full `buildList` phase table (fallback pending → degraded → both-down error → genuinely-empty org).

**Not browser-verified.** Exercising this end to end needs web + api + electric-sync running together, which was out of scope for the hour it was written in. Worth a manual pass before merge: run `maple-web-verify` with no `VITE_ELECTRIC_SYNC_URL` to confirm the 30s error state, the degraded banner and the retry button, then the healthy path with `maple-web-verify-electric`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788221192&installation_model_id=427786&pr_number=305&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F305&signature=fbe95e8ea42d4f80e239fa2e82617844b3f6fedf87aae450e91cda2910f2039b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->