### PR TITLE
fix(dashboards): pie table legend, breakdown Other bucket, gauge label collision, trailing partial bucket

### DIFF
--- a/apps/web/src/api/warehouse/query-builder-breakdown.ts
+++ b/apps/web/src/api/warehouse/query-builder-breakdown.ts
@@ -23,6 +23,13 @@ const QueryBuilderBreakdownInputSchema = Schema.Struct({
 	startTime: dateTimeString,
 	endTime: dateTimeString,
 	queries: Schema.mutable(Schema.Array(QueryBuilderQueryDraftSchema)),
+	/**
+	 * Rows to fetch per query when the author set no explicit limit add-on.
+	 * A panel that collapses its long tail into an "Other" bucket asks for more
+	 * rows than it draws, so that bucket is a real sum rather than absent; one
+	 * that plots every row it receives omits this and keeps the warehouse default.
+	 */
+	defaultLimit: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
 })
 
 export type QueryBuilderBreakdownInput = Schema.Schema.Type<typeof QueryBuilderBreakdownInputSchema>
@@ -39,8 +46,9 @@ const executeBreakdownQuery = Effect.fn("QueryEngine.executeBreakdownQuery")(fun
 	startTime: string,
 	endTime: string,
 	query: QueryBuilderBreakdownInput["queries"][number],
+	defaultLimit: number | undefined,
 ) {
-	const built = buildBreakdownQuerySpec(query)
+	const built = buildBreakdownQuerySpec(query, { defaultLimit })
 
 	if (!built.query) {
 		return {
@@ -180,7 +188,7 @@ const getQueryBuilderBreakdownEffect = Effect.fn("QueryEngine.getQueryBuilderBre
 
 	const results = yield* Effect.forEach(
 		enabledQueries,
-		(query) => executeBreakdownQuery(input.startTime, input.endTime, query),
+		(query) => executeBreakdownQuery(input.startTime, input.endTime, query, input.defaultLimit),
 		{ concurrency: enabledQueries.length },
 	)
 

--- a/apps/web/src/components/dashboard-builder/config/settings-fields.tsx
+++ b/apps/web/src/components/dashboard-builder/config/settings-fields.tsx
@@ -333,7 +333,12 @@ function Unit({ label = "Unit" }: { label?: string }) {
 	)
 }
 
-function Legend() {
+/**
+ * `seriesStats` is the Min/Max/Mean/Last table, which only time-series legends
+ * render — a categorical legend (pie) has one value per row and nothing to
+ * reduce over time, so those panels pass `seriesStats={false}`.
+ */
+function Legend({ seriesStats = true }: { seriesStats?: boolean }) {
 	const { state, set } = useSettings()
 	return (
 		<Field label="Legend">
@@ -346,23 +351,25 @@ function Legend() {
 					{ value: "hidden", label: "Hidden" },
 				]}
 			/>
-			<div className="pt-0.5">
-				<CheckboxRow
-					id="qb-series-stats"
-					label="Show Min/Max/Mean/Last stats"
-					checked={state.seriesStatsEnabled}
-					onChange={(checked) =>
-						// Stats live inside the legend, so enabling them with the legend
-						// hidden would have no visible effect — turn the legend on
-						// (bottom) in the same change.
-						set(
-							checked && state.legendPosition === "hidden"
-								? { seriesStatsEnabled: true, legendPosition: "bottom" }
-								: { seriesStatsEnabled: checked },
-						)
-					}
-				/>
-			</div>
+			{seriesStats && (
+				<div className="pt-0.5">
+					<CheckboxRow
+						id="qb-series-stats"
+						label="Show Min/Max/Mean/Last stats"
+						checked={state.seriesStatsEnabled}
+						onChange={(checked) =>
+							// Stats live inside the legend, so enabling them with the legend
+							// hidden would have no visible effect — turn the legend on
+							// (bottom) in the same change.
+							set(
+								checked && state.legendPosition === "hidden"
+									? { seriesStatsEnabled: true, legendPosition: "bottom" }
+									: { seriesStatsEnabled: checked },
+							)
+						}
+					/>
+				</div>
+			)}
 		</Field>
 	)
 }

--- a/apps/web/src/components/dashboard-builder/widgets/gauge-widget.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/gauge-widget.tsx
@@ -16,13 +16,27 @@ const CY = 118
 const R_OUTER = 88
 const R_INNER = 58
 const R_RIM = 93
-const R_LABEL = 106
+const R_LABEL = 104
+const R_TICK_INNER = 89
+const R_TICK_OUTER = 96
 const START_ANGLE = 135
 const SWEEP = 270
 const SEGMENT_COUNT = 56
 const RIM_SEGMENT_COUNT = 96
 const GAP_RATIO = 0.32
 const VALUE_Y = 108
+/**
+ * Minimum arc separation between two rim *labels*, in degrees.
+ *
+ * Labels are horizontal and centred on their tick, so the binding case is two
+ * of them side by side near the bottom of the arc: at R_LABEL a 9px-font value
+ * like "100.0%" is ~27px wide, which is ~15° of arc. Anything closer overlaps.
+ *
+ * Thresholds bunched against a bound (0/95/99/100 on a 0–100 gauge — the whole
+ * top 5% of the range lands within 13° of the max) therefore keep their tick and
+ * drop their text, rather than stacking three unreadable numbers on each other.
+ */
+const MIN_LABEL_GAP_DEG = 16
 
 // Perceptual green → yellow → orange → red ramp swept along the arc.
 const RAMP: ReadonlyArray<readonly [number, number, number, number]> = [
@@ -107,22 +121,35 @@ export const GaugeWidget = memo(function GaugeWidget({ dataState, display, mode 
 		}
 	})
 
-	// Rim labels: the range bounds plus each in-range threshold value, rotated
-	// to sit tangent to the arc.
+	// Rim ticks: every in-range bound and threshold gets one, so a threshold whose
+	// text can't fit still reads as a marked position on the arc.
 	const seen = new Set<number>()
-	const labels = [min, ...(display.thresholds ?? []).map((threshold) => threshold.value), max]
-		.filter((labelValue) => {
-			if (labelValue < min || labelValue > max || seen.has(labelValue)) return false
-			seen.add(labelValue)
+	const angleFor = (tickValue: number) => START_ANGLE + ((tickValue - min) / span) * SWEEP
+	const ticks = [min, max, ...(display.thresholds ?? []).map((threshold) => threshold.value)]
+		// Bounds first so that when a threshold crowds one of them it is the
+		// threshold that loses its label — the range endpoints anchor the scale.
+		.filter((tickValue) => {
+			if (tickValue < min || tickValue > max || seen.has(tickValue)) return false
+			seen.add(tickValue)
 			return true
 		})
-		.sort((a, b) => a - b)
-		.map((labelValue) => {
-			const angle = START_ANGLE + ((labelValue - min) / span) * SWEEP
-			const point = polar(R_LABEL, angle)
-			let rotation = (angle + 90) % 360
-			if (rotation > 90 && rotation < 270) rotation -= 180
-			return { value: labelValue, x: point.x, y: point.y, rotation }
+		.map((tickValue) => ({ value: tickValue, angle: angleFor(tickValue) }))
+
+	// Label only the ticks that clear MIN_LABEL_GAP_DEG from every already-placed
+	// label. Horizontal, centred on the tick — the previous tangent rotation made
+	// crowded end-of-arc labels illegible even before they collided.
+	const placedAngles: number[] = []
+	const labels = ticks
+		.filter((tick) => {
+			if (placedAngles.some((angle) => Math.abs(angle - tick.angle) < MIN_LABEL_GAP_DEG)) {
+				return false
+			}
+			placedAngles.push(tick.angle)
+			return true
+		})
+		.map((tick) => {
+			const point = polar(R_LABEL, tick.angle)
+			return { value: tick.value, x: point.x, y: point.y }
 		})
 
 	return (
@@ -134,7 +161,10 @@ export const GaugeWidget = memo(function GaugeWidget({ dataState, display, mode 
 			loadingSkeleton={<ChartSkeleton variant="gauge" />}
 		>
 			<svg
-				viewBox="0 0 240 212"
+				// Padded 16px either side of the 240-wide dial so a wide horizontal
+				// label at the arc's extremes ("1,000ms") isn't clipped by the
+				// viewport. CX stays the box's horizontal centre.
+				viewBox="-16 0 272 212"
 				preserveAspectRatio="xMidYMid meet"
 				className="h-full w-full"
 				role="img"
@@ -186,7 +216,26 @@ export const GaugeWidget = memo(function GaugeWidget({ dataState, display, mode 
 					/>
 				))}
 
-				{/* Range + threshold labels, tangent to the rim. */}
+				{/* Range + threshold ticks across the rim. */}
+				{ticks.map((tick) => {
+					const inner = polar(R_TICK_INNER, tick.angle)
+					const outer = polar(R_TICK_OUTER, tick.angle)
+					return (
+						<line
+							key={`tick-${tick.value}`}
+							x1={inner.x}
+							y1={inner.y}
+							x2={outer.x}
+							y2={outer.y}
+							stroke="var(--muted-foreground)"
+							strokeOpacity={0.55}
+							strokeWidth={1.4}
+							strokeLinecap="round"
+						/>
+					)
+				})}
+
+				{/* Range + threshold labels, horizontal, centred on their tick. */}
 				{labels.map((label) => (
 					<text
 						key={label.value}
@@ -194,7 +243,6 @@ export const GaugeWidget = memo(function GaugeWidget({ dataState, display, mode 
 						y={label.y}
 						textAnchor="middle"
 						dominantBaseline="central"
-						transform={`rotate(${label.rotation} ${label.x} ${label.y})`}
 						className="fill-muted-foreground"
 						style={{ fontSize: 9 }}
 					>

--- a/apps/web/src/components/dashboard-builder/widgets/types/breakdown.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/types/breakdown.tsx
@@ -18,6 +18,7 @@ import {
 	extendDisplay,
 	type WidgetTypeDefinition,
 } from "@/components/dashboard-builder/widgets/widget-type-registry"
+import { BREAKDOWN_TAIL_LIMIT } from "@/lib/query-builder/model"
 import type { BuildDataSourceContext } from "@/lib/query-builder/widget-builder-shared"
 import {
 	hasActiveGroupBy,
@@ -37,7 +38,13 @@ import { chartPresetPreview } from "@/components/dashboard-builder/widgets/types
 // (`meta.requiresGroupBy`) and enforced before Apply.
 // ---------------------------------------------------------------------------
 
-const breakdownDataSource = ({ sharedTransform, visibleQueries }: BuildDataSourceContext) =>
+const breakdownDataSource = (
+	{ sharedTransform, visibleQueries }: BuildDataSourceContext,
+	// Only the pie collapses its long tail into an "Other" slice, so only the pie
+	// asks for rows past what it draws. Funnel/heatmap/histogram plot every row
+	// they receive — handing them 50 turns a 10-stage funnel into a truncated list.
+	options?: { defaultLimit?: number },
+) =>
 	({
 		endpoint: "custom_query_builder_breakdown",
 		// Deliberately NOT forwarding `state.formulas`. A formula is a timeseries
@@ -46,7 +53,10 @@ const breakdownDataSource = ({ sharedTransform, visibleQueries }: BuildDataSourc
 		// accepts only startTime/endTime/queries — smuggling formulas through the
 		// params to preserve them across a reopen fails the request decode and
 		// leaves the widget stuck on its loading skeleton.
-		params: { queries: visibleQueries },
+		params: {
+			queries: visibleQueries,
+			...(options?.defaultLimit ? { defaultLimit: options.defaultLimit } : {}),
+		},
 		transform: sharedTransform,
 	}) satisfies WidgetDataSource
 
@@ -55,10 +65,18 @@ export const pieWidgetType: WidgetTypeDefinition = {
 	icon: CirclePercentageIcon,
 	Renderer: PieWidget,
 	queryEditor: "builder",
-	ConfigPanel: () => <WidgetSettings.QueryOptions />,
+	// "Right" renders the sorted Value/% table — the standard reading of a
+	// composition breakdown, and the reason the legend is configurable here at all.
+	ConfigPanel: () => (
+		<>
+			<WidgetSettings.Divider />
+			<WidgetSettings.Legend seriesStats={false} />
+			<WidgetSettings.QueryOptions />
+		</>
+	),
 	presets: piePresets,
 	PresetPreview: chartPresetPreview("query-builder-pie"),
-	buildDataSource: breakdownDataSource,
+	buildDataSource: (ctx) => breakdownDataSource(ctx, { defaultLimit: BREAKDOWN_TAIL_LIMIT }),
 	buildDisplay: ({ base }) => base,
 }
 

--- a/apps/web/src/components/widget-lab/scenarios.ts
+++ b/apps/web/src/components/widget-lab/scenarios.ts
@@ -224,6 +224,34 @@ export const gaugeScenarios: WidgetScenario[] = [
 		},
 	},
 	{
+		// The SLO shape: thresholds crowded into the top few percent of the range,
+		// so 95/99/100 all land within ~13° of the arc's end. Only the bounds get
+		// labels; 95 and 99 keep their ticks.
+		label: "Crowded thresholds (SLO)",
+		dataState: ready(99.4),
+		display: {
+			title: "Today's health",
+			unit: "percent_100",
+			gauge: { min: 0, max: 100 },
+			thresholds: [
+				{ value: 0, color: "var(--color-red-500)" },
+				{ value: 95, color: "var(--color-amber-500)" },
+				{ value: 99, color: "var(--color-emerald-500)" },
+			],
+		},
+	},
+	{
+		// Widest labels the dial can produce — checks nothing clips at the arc ends.
+		label: "Wide labels at the arc ends",
+		dataState: ready(720),
+		display: {
+			title: "p99 latency",
+			unit: "duration_ms",
+			gauge: { min: 0, max: 1000 },
+			thresholds: [{ value: 250, color: "var(--color-amber-500)" }],
+		},
+	},
+	{
 		label: "Loading",
 		dataState: loadingState,
 		display: { title: "Error rate", unit: "percent", gauge: { min: 0, max: 10 } },
@@ -508,7 +536,66 @@ const singlePointSeries: Record<string, unknown>[] = [
 	{ bucket: "2026-01-01T00:00:00Z", "demo-api": 42, "demo-worker": 17 },
 ]
 
+/**
+ * A healthy series whose final bucket is the current, still-filling interval.
+ *
+ * Buckets are anchored to wall-clock "now" because that is how the widget
+ * actually detects the in-progress bucket — `query-builder-timeseries` sends no
+ * `partial` flag, so `markIncompleteSegments` falls back to comparing each
+ * bucket's end against the clock. A fixed 2026-01-01 timestamp is entirely in
+ * the past and would exercise nothing.
+ */
+function makeTrailingBucketSeries(lastBucket: { api: number; worker: number } | null) {
+	const hour = 3_600_000
+	const currentBucketStart = Math.floor(Date.now() / hour) * hour
+	return Array.from({ length: 13 }, (_, i) => {
+		const isCurrent = i === 12
+		return {
+			bucket: new Date(currentBucketStart - (12 - i) * hour).toISOString(),
+			"demo-api": isCurrent ? (lastBucket?.api ?? 0) : 900 + Math.round(180 * Math.sin(i / 2)),
+			"demo-worker": isCurrent
+				? (lastBucket?.worker ?? 0)
+				: 420 + Math.round(90 * Math.cos(i / 3)),
+		}
+	})
+}
+
+/** The current bucket came back with nothing — drawn as-is it cliffs to zero. */
+const trailingEmptyBucketSeries: Record<string, unknown>[] = makeTrailingBucketSeries(null)
+
+/** Same shape, but the current bucket did report — it stays, dashed. */
+const trailingPartialBucketSeries: Record<string, unknown>[] = makeTrailingBucketSeries({
+	api: 240,
+	worker: 110,
+})
+
 export const stressScenarios: ChartScenario[] = [
+	{
+		label: "Area — trailing empty bucket (no cliff)",
+		chartId: "query-builder-area",
+		chartName: "Area",
+		category: "area",
+		dataState: ready(trailingEmptyBucketSeries),
+		display: {
+			title: "Span throughput (current bucket empty)",
+			chartId: "query-builder-area",
+			unit: "number",
+			chartPresentation: { legend: "visible", seriesStats: false },
+		},
+	},
+	{
+		label: "Area — trailing partial bucket (dashed)",
+		chartId: "query-builder-area",
+		chartName: "Area",
+		category: "area",
+		dataState: ready(trailingPartialBucketSeries),
+		display: {
+			title: "Span throughput (current bucket reporting)",
+			chartId: "query-builder-area",
+			unit: "number",
+			chartPresentation: { legend: "visible", seriesStats: false },
+		},
+	},
 	{
 		label: "Line — 25 series (compact legend)",
 		chartId: "query-builder-line",
@@ -1046,6 +1133,24 @@ export const pieScenarios: WidgetScenario[] = [
 		display: {
 			title: "Traffic by service",
 			pie: { donut: true, showLabels: true, showPercent: true },
+		},
+	},
+	{
+		label: "Table legend (Value + %)",
+		dataState: ready(pieMany),
+		display: {
+			title: "Traffic by service",
+			chartPresentation: { legend: "right" },
+			pie: {},
+		},
+	},
+	{
+		label: "Table legend — long tail (+N others)",
+		dataState: ready(makePieSlices(50)),
+		display: {
+			title: "Traffic by service (50 groups)",
+			chartPresentation: { legend: "right" },
+			pie: { donut: true },
 		},
 	},
 	{

--- a/apps/web/src/lib/query-builder/widget-builder-utils.test.ts
+++ b/apps/web/src/lib/query-builder/widget-builder-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { createFormulaDraft, createQueryDraft } from "@/lib/query-builder/model"
+import { BREAKDOWN_TAIL_LIMIT, createFormulaDraft, createQueryDraft } from "@/lib/query-builder/model"
 import {
 	buildWidgetDataSource,
 	buildWidgetDisplay,
@@ -221,17 +221,38 @@ describe("funnel/heatmap endpoint routing (MAP-49)", () => {
 	})
 
 	it("sends breakdown params the endpoint schema accepts, and nothing more", () => {
-		// QueryBuilderBreakdownInputSchema accepts only startTime/endTime/queries.
-		// An extra key (formulas, comparison, debug) fails the request decode and
-		// leaves the widget stuck on its loading skeleton, so this is a contract
-		// test, not a style preference.
+		// QueryBuilderBreakdownInputSchema accepts only startTime/endTime/queries
+		// and the optional defaultLimit. An extra key (formulas, comparison, debug)
+		// fails the request decode and leaves the widget stuck on its loading
+		// skeleton, so this is a contract test, not a style preference.
 		const state = {
 			...makeState(),
 			visualization: "pie" as const,
 			formulas: [createFormulaDraft(0, ["A", "B"])],
 		}
 		const dataSource = buildWidgetDataSource(makeWidget(), state, ["A", "B"])
-		expect(Object.keys(dataSource.params ?? {})).toEqual(["queries"])
+		expect(Object.keys(dataSource.params ?? {})).toEqual(["queries", "defaultLimit"])
+	})
+
+	it("asks for the long tail on a pie, and only on a pie", () => {
+		// The pie is the only breakdown panel that collapses its tail into "Other",
+		// so it is the only one that fetches past what it draws. Handing 50 rows to
+		// a funnel turns a 10-stage funnel into a truncated list.
+		const pie = buildWidgetDataSource(
+			makeWidget(),
+			{ ...makeState(), visualization: "pie" as const },
+			["A", "B"],
+		)
+		expect(pie.params?.defaultLimit).toBe(BREAKDOWN_TAIL_LIMIT)
+
+		for (const visualization of ["funnel", "heatmap", "histogram"] as const) {
+			const dataSource = buildWidgetDataSource(
+				makeWidget(),
+				{ ...makeState(), visualization },
+				["A", "B"],
+			)
+			expect(dataSource.params?.defaultLimit).toBeUndefined()
+		}
 	})
 })
 

--- a/apps/web/src/lib/query-builder/widget-builder-utils.ts
+++ b/apps/web/src/lib/query-builder/widget-builder-utils.ts
@@ -79,6 +79,11 @@ export function toInitialState(widget: DashboardWidget): QueryBuilderWidgetState
 
 	const chartPresentation = widget.display.chartPresentation
 	const legendRaw = chartPresentation?.legend
+	// A pie with no legend is a ring of anonymous colours, so it falls back to the
+	// side table (matching `PieWidget`'s own render default) instead of the
+	// hidden-by-default every time-series chart wants. Only the *absent* case
+	// differs — an explicit persisted legend always wins.
+	const legendFallback: LegendPosition = panelType === "pie" ? "right" : "hidden"
 	const legendPosition: LegendPosition =
 		legendRaw === "hidden"
 			? "hidden"
@@ -86,7 +91,7 @@ export function toInitialState(widget: DashboardWidget): QueryBuilderWidgetState
 				? "right"
 				: legendRaw === "visible"
 					? "bottom"
-					: "hidden"
+					: legendFallback
 
 	const shared: QueryBuilderWidgetState = {
 		visualization: normalized.visualization,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -46,6 +46,10 @@ const PUBLIC_PATHS = new Set([
 	"/sign-in",
 	"/sign-up",
 	"/org-required",
+	// Fixture-only dev surfaces. They render `scenarios.ts` / generated data and
+	// never touch a warehouse or the app database, so gating them on a session
+	// only made the widget gallery unreachable without a running API.
+	"/widget-lab",
 	"/service-map-bench",
 	"/service-detail-bench",
 	"/infra-bench",

--- a/packages/query-engine/src/query-builder/model.ts
+++ b/packages/query-engine/src/query-builder/model.ts
@@ -1058,7 +1058,27 @@ export function buildTimeseriesQuerySpec(query: QueryBuilderQueryDraftPayload): 
 	}
 }
 
-export function buildBreakdownQuerySpec(query: QueryBuilderQueryDraftPayload): BuildSpecResult {
+/**
+ * Rows to fetch for a breakdown that collapses its long tail into an "Other"
+ * bucket, when the author set no explicit limit.
+ *
+ * The warehouse default is 10, which is also roughly what a pie can *draw* — so
+ * the chart received exactly the rows it wanted to show and had no idea a tail
+ * existed. Its "Other" bucket therefore never fired and the panel silently
+ * claimed the top 10 was everything.
+ *
+ * `LIMIT` only bounds the rows returned, not the scan: the GROUP BY has already
+ * aggregated every group, so 50 rows costs the same query as 10. Fetching past
+ * what we render is what makes "Other" a real number and lets the legend say how
+ * many categories it stands for. Panels that plot every row they receive
+ * (funnel, heatmap) keep the warehouse default instead.
+ */
+export const BREAKDOWN_TAIL_LIMIT = 50
+
+export function buildBreakdownQuerySpec(
+	query: QueryBuilderQueryDraftPayload,
+	options?: { defaultLimit?: number },
+): BuildSpecResult {
 	const timeseriesResult = buildTimeseriesQuerySpec(query)
 	if (!timeseriesResult.query) return timeseriesResult
 
@@ -1080,7 +1100,7 @@ export function buildBreakdownQuerySpec(query: QueryBuilderQueryDraftPayload): B
 	const limit =
 		parsedLimit && Number.isFinite(parsedLimit) && parsedLimit > 0 && parsedLimit <= 100
 			? parsedLimit
-			: undefined
+			: options?.defaultLimit
 
 	return {
 		query: {

--- a/packages/ui/src/components/charts/_shared/bucket-series.ts
+++ b/packages/ui/src/components/charts/_shared/bucket-series.ts
@@ -20,6 +20,12 @@ export const MAX_BAR_SERIES = 12
 export interface CategoricalRow {
 	name: string
 	value: number
+	/**
+	 * How many source categories this row stands for. Only set on the aggregated
+	 * `"Other"` row, so a legend can say *how much* it is hiding ("Other · 39
+	 * groups") instead of leaving the reader to assume the chart is everything.
+	 */
+	collapsedCount?: number
 }
 
 /**
@@ -39,7 +45,7 @@ export function bucketCategorical(
 	const head = sorted.slice(0, max - 1)
 	const tail = sorted.slice(max - 1)
 	const otherValue = tail.reduce((sum, r) => sum + r.value, 0)
-	return [...head, { name: OTHER_LABEL, value: otherValue }]
+	return [...head, { name: OTHER_LABEL, value: otherValue, collapsedCount: tail.length }]
 }
 
 export interface BucketedTimeseries<Row> {

--- a/packages/ui/src/components/charts/pie/query-builder-pie-chart.tsx
+++ b/packages/ui/src/components/charts/pie/query-builder-pie-chart.tsx
@@ -5,12 +5,15 @@ import { cn } from "../../../lib/utils"
 import { formatNumber, formatValueByUnit } from "../../../lib/format"
 import { pieSampleData } from "../_shared/sample-data"
 import { resolveSeriesColors } from "../../../lib/semantic-series-colors"
-import { bucketCategorical, MAX_CATEGORICAL, OTHER_COLOR, OTHER_LABEL } from "../_shared/bucket-series"
+import {
+	bucketCategorical,
+	type CategoricalRow,
+	MAX_CATEGORICAL,
+	OTHER_COLOR,
+	OTHER_LABEL,
+} from "../_shared/bucket-series"
 
-interface Row {
-	name: string
-	value: number
-}
+type Row = CategoricalRow
 
 interface Slice extends Row {
 	pct: number
@@ -114,6 +117,19 @@ const LEGEND_ROW_H = 18
 const LEGEND_MAX_ROWS = 2
 const PIE_PAD = 4
 const PIE_MIN_SIZE = 48
+// Tabular legend: a share of the card, bounded so the pie never starves and the
+// name column never runs away. Below TABLE_MIN_PIE_W of remaining width there
+// is no pie worth drawing, so that layout falls back to the bottom chips.
+//
+// The minimum is set by the columns, not by taste: swatch + gaps + padding +
+// the Value and Percent columns come to TABLE_FIXED_W, and anything narrower
+// than that leaves the flex-1 name column at zero width — a legend of coloured
+// squares and numbers with no labels, which is worse than the chips it replaced.
+const TABLE_LEGEND_RATIO = 0.46
+const TABLE_FIXED_W = 116
+const TABLE_LEGEND_MIN_W = TABLE_FIXED_W + 52
+const TABLE_LEGEND_MAX_W = 240
+const TABLE_MIN_PIE_W = 120
 // Slices below this percentage do not get an in-slice label — the wedge is
 // too narrow to host text without overflowing onto its neighbours.
 const LABEL_MIN_PCT = 0.06
@@ -175,25 +191,38 @@ export function QueryBuilderPieChart({ data, className, legend, tooltip, unit, p
 		return () => ro.disconnect()
 	}, [])
 
+	// A composition breakdown is read as a ranked table, not as a colour-matching
+	// exercise: `legend: "right"` puts the slices in a sorted Value/% table beside
+	// the pie. "visible" keeps the compact bottom chips for cards too narrow to
+	// host a table. Below TABLE_MIN_PIE_W of leftover width the table would starve
+	// the pie, so it degrades to chips rather than rendering both badly.
+	const showLegend = legend !== "hidden"
+	const tableLegendW = clamp(
+		Math.round(size.w * TABLE_LEGEND_RATIO),
+		TABLE_LEGEND_MIN_W,
+		TABLE_LEGEND_MAX_W,
+	)
+	const tableLegend = showLegend && legend === "right" && size.w - tableLegendW >= TABLE_MIN_PIE_W
+
 	// Measure legend after render. We allow up to LEGEND_MAX_ROWS rows of
 	// wrapped chips, then clip excess (the tooltip still shows the full name).
-	const showLegend = legend !== "hidden"
+	const chipLegend = showLegend && !tableLegend
 	const legendRef = React.useRef<HTMLDivElement | null>(null)
 	const [legendH, setLegendH] = React.useState(() => (showLegend ? LEGEND_ROW_H : 0))
 	React.useLayoutEffect(() => {
-		if (!showLegend || !legendRef.current) {
+		if (!chipLegend || !legendRef.current) {
 			if (legendH !== 0) setLegendH(0)
 			return
 		}
 		const h = legendRef.current.scrollHeight
 		const capped = Math.min(h, LEGEND_ROW_H * LEGEND_MAX_ROWS + 2)
 		if (capped !== legendH) setLegendH(capped)
-	}, [showLegend, slices.length, size.w])
+	}, [chipLegend, slices.length, size.w])
 
 	const [hover, setHover] = React.useState<number | null>(null)
 
-	const pieAreaW = size.w
-	const pieAreaH = size.h - (showLegend ? legendH + LEGEND_GAP : 0)
+	const pieAreaW = tableLegend ? size.w - tableLegendW : size.w
+	const pieAreaH = size.h - (chipLegend ? legendH + LEGEND_GAP : 0)
 	const pieSize = Math.max(PIE_MIN_SIZE, Math.min(pieAreaW, pieAreaH) - PIE_PAD * 2)
 	const cx = pieAreaW / 2
 	const cy = Math.max(pieSize / 2 + PIE_PAD, pieAreaH / 2)
@@ -365,6 +394,11 @@ export function QueryBuilderPieChart({ data, className, legend, tooltip, unit, p
 							style={{ backgroundColor: slices[hover].color }}
 						/>
 						<span>{slices[hover].name}</span>
+						{slices[hover].collapsedCount ? (
+							<span className="font-normal text-muted-foreground">
+								({slices[hover].collapsedCount} categories)
+							</span>
+						) : null}
 					</div>
 					<div className="mt-0.5 tabular-nums text-muted-foreground">
 						<span className="text-foreground/90">{fmtValue(slices[hover].value, unit)}</span>
@@ -374,8 +408,70 @@ export function QueryBuilderPieChart({ data, className, legend, tooltip, unit, p
 				</div>
 			)}
 
+			{/* Tabular legend — sorted largest-first, with Value and % columns. */}
+			{tableLegend && (
+				<div
+					className="absolute right-0 top-0 bottom-0 flex flex-col overflow-hidden"
+					style={{ width: tableLegendW }}
+				>
+					{/* Column widths here must match the rows below and TABLE_FIXED_W. */}
+					<div className="flex items-center gap-1.5 border-b border-border/60 px-1 pb-1 text-[10px] uppercase tracking-[0.04em] text-muted-foreground/70">
+						<span className="size-2.5 shrink-0" />
+						<span className="min-w-0 flex-1">Name</span>
+						<span className="w-12 shrink-0 text-right">Value</span>
+						<span className="w-8 shrink-0 text-right">%</span>
+					</div>
+					<div className="min-h-0 flex-1 overflow-y-auto">
+						{slices.map((s, i) => {
+							const isHover = hover === i
+							const collapsed = s.collapsedCount
+							return (
+								<button
+									key={s.name}
+									type="button"
+									title={
+										collapsed
+											? `${s.name} — ${collapsed} smaller categories · ${fmtValue(s.value, unit)} (${(s.pct * 100).toFixed(1)}%)`
+											: `${s.name} · ${fmtValue(s.value, unit)} (${(s.pct * 100).toFixed(1)}%)`
+									}
+									onPointerEnter={() => setHover(i)}
+									onFocus={() => setHover(i)}
+									className={cn(
+										"flex w-full items-center gap-1.5 rounded-[3px] px-1 py-[3px] text-left text-[11px] tabular-nums transition-colors",
+										isHover
+											? "bg-muted/50 text-foreground"
+											: hover !== null
+												? "text-muted-foreground/60"
+												: "text-muted-foreground",
+									)}
+								>
+									<span
+										className="size-2.5 shrink-0 rounded-[2px]"
+										style={{ backgroundColor: s.color }}
+									/>
+									<span className="min-w-0 flex-1 truncate">
+										{s.name}
+										{collapsed ? (
+											<span className="pl-1 text-muted-foreground/60">
+												+{collapsed}
+											</span>
+										) : null}
+									</span>
+									<span className="w-12 shrink-0 truncate text-right text-foreground/85">
+										{fmtValue(s.value, unit)}
+									</span>
+									<span className="w-8 shrink-0 text-right">
+										{(s.pct * 100).toFixed(s.pct >= 0.1 ? 0 : 1)}
+									</span>
+								</button>
+							)
+						})}
+					</div>
+				</div>
+			)}
+
 			{/* Legend — bottom, wrapping, capped at LEGEND_MAX_ROWS rows. */}
-			{showLegend && (
+			{chipLegend && (
 				<div
 					ref={legendRef}
 					className="absolute left-0 right-0 bottom-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 overflow-hidden px-2"
@@ -405,6 +501,11 @@ export function QueryBuilderPieChart({ data, className, legend, tooltip, unit, p
 									style={{ backgroundColor: s.color }}
 								/>
 								<span className="truncate">{s.name}</span>
+								{s.collapsedCount ? (
+									<span className="shrink-0 text-muted-foreground/60">
+										+{s.collapsedCount}
+									</span>
+								) : null}
 							</button>
 						)
 					})}

--- a/packages/ui/src/lib/__tests__/incomplete-buckets.test.ts
+++ b/packages/ui/src/lib/__tests__/incomplete-buckets.test.ts
@@ -144,6 +144,57 @@ describe("markIncompleteSegments", () => {
 		expect(result.data[2].throughput_incomplete).toBe(5)
 	})
 
+	it("drops an empty trailing incomplete bucket instead of drawing a cliff to zero", () => {
+		const now = Date.now()
+		const data = [
+			makeRow(hoursAgo(3, now), { throughput: 10 }),
+			makeRow(hoursAgo(2, now), { throughput: 20 }),
+			makeRow(hoursAgo(1, now), { throughput: 30 }),
+			// The current, still-filling bucket — queried before any data landed.
+			makeRow(hoursAgo(0, now), { throughput: 0 }),
+		]
+
+		const result = markIncompleteSegments(data, ["throughput"], { now })
+
+		expect(result.data).toHaveLength(3)
+		expect(result.data[2].throughput).toBe(30)
+		// Nothing incomplete survives, so no dashed segment is drawn at all.
+		expect(result.hasIncomplete).toBe(false)
+		expect(result.incompleteKeys).toEqual([])
+	})
+
+	it("keeps a trailing incomplete bucket that reported real data", () => {
+		const now = Date.now()
+		const data = [
+			makeRow(hoursAgo(2, now), { throughput: 10 }),
+			makeRow(hoursAgo(1, now), { throughput: 20 }),
+			makeRow(hoursAgo(0, now), { throughput: 7 }),
+		]
+
+		const result = markIncompleteSegments(data, ["throughput"], { now })
+
+		expect(result.data).toHaveLength(3)
+		expect(result.hasIncomplete).toBe(true)
+		expect(result.data[2].throughput).toBeNull()
+		expect(result.data[2].throughput_incomplete).toBe(7)
+	})
+
+	it("trims only the empty tail when several incomplete buckets follow", () => {
+		const data: Array<Record<string, unknown>> = [
+			{ bucket: "2020-01-01T00:00:00Z", v: 10 },
+			{ bucket: "2020-01-01T00:05:00Z", v: 8, partial: true },
+			{ bucket: "2020-01-01T00:10:00Z", v: 0, partial: true },
+			{ bucket: "2020-01-01T00:15:00Z", v: null, partial: true },
+		]
+
+		const result = markIncompleteSegments(data, ["v"], { now: Date.now() })
+
+		expect(result.data).toHaveLength(2)
+		expect(result.hasIncomplete).toBe(true)
+		expect(result.data[1].v).toBeNull()
+		expect(result.data[1].v_incomplete).toBe(8)
+	})
+
 	it("handles multiple value keys", () => {
 		const now = Date.now()
 		const data = [

--- a/packages/ui/src/lib/incomplete-buckets.ts
+++ b/packages/ui/src/lib/incomplete-buckets.ts
@@ -60,10 +60,38 @@ export function markIncompleteSegments<T extends Record<string, unknown>>(
 		return { data, hasIncomplete: false, incompleteKeys: [] }
 	}
 
+	// Drop trailing incomplete buckets that carry nothing.
+	//
+	// The current interval is usually queried before any of its data has landed,
+	// so it comes back empty (or zero-filled by the merge step). Plotting it draws
+	// a line falling off a cliff to zero at the right edge, which reads as an
+	// outage that isn't happening — and `fillNulls: 0` produces the same picture,
+	// so there is no presentation setting that fixes it. A bucket we have no
+	// reading for is not a reading of zero: end the series at the last bucket that
+	// actually reported. Incomplete buckets with real (partial) data are kept and
+	// still render dashed.
+	const isEmptyRow = (row: T): boolean =>
+		valueKeys.every((key) => {
+			const value = row[key]
+			return value === null || value === undefined || value === 0
+		})
+
+	let end = data.length
+	while (end > firstIncompleteIdx && end > 1 && isEmptyRow(data[end - 1])) {
+		end--
+	}
+
+	const trimmed = end === data.length ? data : data.slice(0, end)
+	if (end <= firstIncompleteIdx) {
+		// Every incomplete bucket was empty — the series simply ends at the last
+		// complete one, with no dashed segment to draw.
+		return { data: trimmed, hasIncomplete: false, incompleteKeys: [] }
+	}
+
 	const incompleteKeys = valueKeys.map((k) => `${k}_incomplete`)
 	const bridgeIdx = firstIncompleteIdx - 1
 
-	const result = data.map((row, i) => {
+	const result = trimmed.map((row, i) => {
 		const next = { ...row } as Record<string, unknown>
 
 		if (i < firstIncompleteIdx) {


### PR DESCRIPTION
Four independent rendering defects found while rebuilding a dense Grafana dashboard with the Maple builder ("Rail Ops Clone — Builder Fidelity Test", dashboard `5d14373b-1253-42f3-82a3-c7f5f52bc28d`). Each fix stands alone.

All four are reproducible in `/widget-lab`, which gains scenarios for each.

## 1. Pie/donut had no tabular legend

`chartPresentation.legend: "right"` rendered the same flat wrapped row of colour chips as `"visible"`, which for a 10-slice pie is much harder to read than a sorted table. It now draws a **sorted Name / Value / % table beside the pie** — the standard reading of a composition breakdown.

No new display key: `"right"` was already in the schema and `PieWidget` already defaulted to it, so the option existed and simply wasn't implemented.

Two supporting gaps this surfaced:

- The pie panel had **no legend control at all** (`ConfigPanel` was just `<QueryOptions />`), so `display.pie` and the legend were only settable via MCP or raw JSON.
- `toInitialState` defaulted an unset legend to `"hidden"` for every panel type, so opening a pie in the builder and saving would have silently turned its legend off. Pie now falls back to `"right"`, matching `PieWidget`'s own render default. Only the *absent* case changed — an explicit persisted legend always wins.

`WidgetSettings.Legend` takes a `seriesStats` prop so the pie can drop the Min/Max/Mean/Last checkbox, which has nothing to reduce over on a categorical legend.

The table degrades to bottom chips below ~288px of card width. That threshold is derived, not taste: the swatch, gaps, padding and the Value/Percent columns come to a fixed 116px, and anything narrower leaves the `flex-1` name column at zero width — a legend of coloured squares and numbers with no labels, which is worse than the chips it replaced. I shipped that bug on the first pass and caught it in the browser.

## 2. Breakdowns silently capped at top 10

`tracesBreakdownQuery` capped at `opts.limit ?? 10`, which is also roughly what a pie can *draw*. The chart therefore received exactly the rows it wanted to show and had no idea a tail existed — its `bucketCategorical` "Other" bucket never fired, and the panel silently claimed the top 10 was everything.

Pie breakdowns now request 50 rows via a new optional `defaultLimit` on the breakdown endpoint. `LIMIT` bounds the rows returned, not the scan — the `GROUP BY` has already aggregated every group, so 50 rows costs the same query as 10. Fetching past what we render is what makes "Other" a real number.

`bucketCategorical` now reports `collapsedCount`, and the legend renders `Other +39` with the full count in the tooltip. On the 50-group fixture that tail is **41% of total volume** that was previously invisible.

Scoped to pie deliberately — funnel/heatmap/histogram plot every row they receive, and handing a funnel 50 rows turns a 10-stage funnel into a truncated list.

Pie *presets* are untouched: they set `limit: "10"` explicitly with the limit add-on visible in the query editor, so that is an author's choice on screen, not the silent default this fixes.

## 3. Gauge threshold labels collided at the arc ends

With `thresholds: [0, 95, 99]` on a `0–100` gauge, the top 5% of the range lands within ~13° of the arc's end, stacking three rotated numbers on top of each other.

- Labels are **horizontal and centred on their tick**. The tangent rotation made crowded end-of-arc labels illegible even before they collided.
- A label is **dropped when it lands within 16° of an already-placed one**. Bounds are placed first, so a crowded threshold loses its text rather than the range endpoint. 16° is the arc width of a `100.0%` label at the label radius.
- **Every in-range threshold keeps a rim tick** regardless, so a threshold whose text can't fit still reads as a marked position.
- viewBox padded to `-16 0 272 212` so a wide label at the arc's extremes (`250.0ms` on a `duration_ms` gauge) isn't clipped by the viewport.

Verified on `0/95/99/100`: 4 ticks, 2 labels, nothing overlapping.

## 4. A trailing partial bucket drew a cliff to zero

A time-series whose last bucket is the current, incomplete interval came back empty and rendered a line plunging to zero at the right edge, reading as a real outage. `chartPresentation.fillNulls: 0` produces the identical picture, so there was no presentation setting that fixed it.

`markIncompleteSegments` now drops trailing incomplete buckets whose values are all null/zero. **A bucket we have no reading for is not a reading of zero** — the series ends at the last bucket that actually reported. Incomplete buckets carrying real partial data are kept and still render dashed; both cases sit side by side in the Stress section of the lab.

This lands in the shared helper, so every chart using it (query-builder line/area, latency, throughput, apdex, error-rate) is covered.

## Reviewer notes

- **`/widget-lab` added to `PUBLIC_PATHS`.** It renders `scenarios.ts` fixtures and touches no warehouse or app database — same class as the `*-bench` routes already listed there — but was gated behind a session, which made the widget gallery unreachable without a running API, including for verifying these fixes. Easy to drop if you'd rather it stay gated.
- `OwnedDisplayKey` needed no change: the pie legend rides on the existing `chartPresentation` key rather than introducing a new top-level display key.

## Verification

Browser-verified every fix in `/widget-lab`; no console errors.

| Scope | Result |
| --- | --- |
| `packages/ui` (charts + incomplete-buckets) | 23 passed |
| `apps/web` (query-builder, dashboard-builder, breakdown) | 193 passed |
| `packages/query-engine` (query-builder) | 24 passed |
| `tsc --noEmit` on all three packages | clean |

Full suite and repo-wide typecheck not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788221313&installation_model_id=427786&pr_number=307&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F307&signature=5633b21e6a815827300568b2d234153653167f2ec9ff652c13fa911cffb37bf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->