### PR TITLE
fix(query-engine): one definition and one population for traces `count`

### DIFF
--- a/packages/query-engine/src/ch/ch.test.ts
+++ b/packages/query-engine/src/ch/ch.test.ts
@@ -221,10 +221,11 @@ describe("tracesTimeseriesQuery", () => {
 		const q = tracesTimeseriesQuery({ metric: "count", needsSampling: false })
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("SELECT")
-		// With no span-level filters/groupBy, routes to the MV.
-		expect(sql).toContain("FROM service_overview_spans")
+		// Without rootOnly the query means "all spans", which the entry-point-only
+		// MV cannot answer — it reads raw traces.
+		expect(sql).toContain("FROM traces")
 		expect(sql).toContain("OrgId = 'org_123'")
-		expect(sql).toContain("count() AS count")
+		expect(sql).toContain("sum(SampleRate) AS count")
 		expect(sql).toContain("INTERVAL 3600 SECOND")
 		expect(sql).toContain("GROUP BY bucket, groupName")
 		expect(sql).toContain("ORDER BY bucket ASC, groupName ASC")
@@ -267,10 +268,10 @@ describe("tracesTimeseriesQuery", () => {
 		expect(sql).toContain("quantile(0.99)(Duration) / 1000000 AS p99Duration")
 	})
 
-	it("builds error_rate timeseries", () => {
+	it("builds error_rate timeseries weighted on both sides of the ratio", () => {
 		const q = tracesTimeseriesQuery({ metric: "error_rate", needsSampling: false })
 		const { sql } = compileCH(q, baseParams)
-		expect(sql).toContain("countIf(StatusCode = 'Error') / count(), 0) AS errorRate")
+		expect(sql).toContain("sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate")
 	})
 
 	it("emits sum(SampleRate) when needsSampling is true", () => {
@@ -348,14 +349,25 @@ describe("tracesTimeseriesQuery", () => {
 		expect(sql).toContain("UNION ALL")
 		expect(sql).toContain("Timestamp < if(toDateTime('2024-01-01 00:00:00')")
 		expect(sql).toContain("Hour < toStartOfHour(toDateTime('2024-01-02 00:00:00'))")
-		expect(sql).toContain("sum(bEstimatedSpanCount) AS estimatedSpanCount")
+		// Weighted estimate, with a raw-count fallback for buckets written before
+		// `EstimatedSpanCount` existed. `count` reports the same expression.
+		expect(sql).toContain(
+			"if(sum(bEstimatedSpanCount) > 0, sum(bEstimatedSpanCount), sum(bCount)) AS count",
+		)
+		expect(sql).toContain(
+			"if(sum(bEstimatedSpanCount) > 0, sum(bEstimatedSpanCount), sum(bCount)) AS estimatedSpanCount",
+		)
 		expect(sql).toContain("quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles)")
 	})
 
-	it("routes default (no filters) to service_overview_spans_mv", () => {
-		const q = tracesTimeseriesQuery({ metric: "count", needsSampling: false })
-		const { sql } = compileCH(q, baseParams)
-		expect(sql).toContain("FROM service_overview_spans")
+	// `service_overview_spans` stores only entry-point spans (Server/Consumer OR
+	// root). Routing an all-spans query there silently swaps the population, which
+	// is how one dashboard showed two answers to the same question.
+	it("keeps non-rootOnly queries off service_overview_spans_mv", () => {
+		const q = tracesTimeseriesQuery({ metric: "count", needsSampling: false, bucketSeconds: 300 })
+		const { sql } = compileCH(q, { ...baseParams, bucketSeconds: 300 })
+		expect(sql).not.toContain("FROM service_overview_spans")
+		expect(sql).toContain("FROM traces")
 	})
 
 	it("routes eligible hourly trace timeseries to traces_aggregates_hourly", () => {
@@ -368,7 +380,13 @@ describe("tracesTimeseriesQuery", () => {
 		})
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("FROM traces_aggregates_hourly")
-		expect(sql).toContain("quantilesTDigestWeightedMerge(0.5, 0.95, 0.99)(DurationQuantiles)")
+		// Whole-hour interior state is re-emitted for the union, then merged once
+		// in the outer query alongside the raw partial-hour edges.
+		expect(sql).toContain("quantilesTDigestWeightedMergeState(0.5, 0.95, 0.99)(DurationQuantiles)")
+		expect(sql).toContain(
+			"quantilesTDigestWeightedState(0.5, 0.95, 0.99)(Duration, toUInt32(greatest(SampleRate, 1.0)))",
+		)
+		expect(sql).toContain("quantilesTDigestWeightedMerge(0.5, 0.95, 0.99)(bDurationQuantiles)")
 		expect(sql).toContain("IsEntryPoint = 1")
 		expect(sql).not.toContain("FROM service_overview_spans")
 	})
@@ -453,15 +471,15 @@ describe("tracesTimeseriesQuery", () => {
 		expect(sql).toContain("StatusCode = 'Error'")
 	})
 
-	it("filters by environments (MV path uses pre-extracted DeploymentEnv)", () => {
+	it("filters by environments (raw path reads the ResourceAttributes map)", () => {
 		const q = tracesTimeseriesQuery({
 			metric: "count",
 			needsSampling: false,
 			environments: ["production", "staging"],
 		})
 		const { sql } = compileCH(q, baseParams)
-		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).toContain("DeploymentEnv IN ('production', 'staging')")
+		expect(sql).toContain("FROM traces")
+		expect(sql).toContain("ResourceAttributes['deployment.environment'] IN ('production', 'staging')")
 	})
 
 	it("filters by environments with rootOnly (MV path uses pre-extracted DeploymentEnv)", () => {
@@ -602,10 +620,10 @@ describe("tracesBreakdownQuery", () => {
 		const q = tracesBreakdownQuery({ metric: "count", groupBy: "service" })
 		const { sql } = compileCH(q, baseParams)
 		expect(sql).toContain("SELECT")
-		expect(sql).toContain("FROM service_overview_spans")
-		expect(sql).not.toContain("FROM traces")
+		expect(sql).toContain("FROM traces")
+		expect(sql).not.toContain("FROM service_overview_spans")
 		expect(sql).toContain("ServiceName AS name")
-		expect(sql).toContain("count() AS count")
+		expect(sql).toContain("sum(SampleRate) AS count")
 		expect(sql).toContain("GROUP BY name")
 		expect(sql).toContain("ORDER BY count DESC")
 		expect(sql).toContain("LIMIT 10")
@@ -623,8 +641,15 @@ describe("tracesBreakdownQuery", () => {
 	it("groups by status_code", () => {
 		const q = tracesBreakdownQuery({ metric: "count", groupBy: "status_code" })
 		const { sql } = compileCH(q, baseParams)
-		expect(sql).toContain("FROM service_overview_spans")
+		expect(sql).toContain("FROM traces")
 		expect(sql).toContain("StatusCode AS name")
+	})
+
+	it("routes rootOnly breakdowns to service_overview_spans_mv", () => {
+		const q = tracesBreakdownQuery({ metric: "count", groupBy: "service", rootOnly: true })
+		const { sql } = compileCH(q, baseParams)
+		expect(sql).toContain("FROM service_overview_spans")
+		expect(sql).toContain("sum(SampleRate) AS count")
 	})
 
 	it("groups by http_method", () => {
@@ -682,7 +707,7 @@ describe("tracesBreakdownQuery", () => {
 			errorsOnly: true,
 		})
 		const { sql } = compileCH(q, baseParams)
-		expect(sql).toContain("FROM service_overview_spans")
+		expect(sql).toContain("FROM traces")
 		expect(sql).toContain("ServiceName = 'api'")
 		expect(sql).toContain("StatusCode = 'Error'")
 	})
@@ -691,6 +716,7 @@ describe("tracesBreakdownQuery", () => {
 		const q = tracesBreakdownQuery({
 			metric: "count",
 			groupBy: "service",
+			rootOnly: true,
 			environments: ["prod"],
 		})
 		const { sql } = compileCH(q, baseParams)

--- a/packages/query-engine/src/ch/queries/count-semantics.test.ts
+++ b/packages/query-engine/src/ch/queries/count-semantics.test.ts
@@ -1,0 +1,291 @@
+// ---------------------------------------------------------------------------
+// Count-scale invariants for traces queries.
+//
+// A single dashboard must never show two answers to "how many spans?". Two
+// things have to hold for that:
+//
+//   1. DEFINITION — every route that emits a `count` column emits the same
+//      sample-weighted estimate (`sum(SampleRate)` on row-level tables,
+//      `sum(WeightedCount)` on the hourly rollup), never a raw row count.
+//   2. POPULATION — the rows being counted are the same set regardless of which
+//      table a route picks or which dimension the caller grouped by. In
+//      practice that means `service_overview_spans` (entry-point spans only) is
+//      reachable only from a `rootOnly` query.
+//
+// Breaking either produced the bug this file exists to prevent: a "Spans" stat
+// reading 5.5B directly above a status donut totalling 26.6M.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "vitest"
+import { compileCH } from "@maple-dev/clickhouse-builder"
+import { tracesBreakdownQuery, tracesTimeseriesQuery } from "./traces"
+import type { TracesBaseWhereOpts } from "./query-helpers"
+
+const baseParams = {
+	orgId: "org_123",
+	startTime: "2024-01-01 00:00:00",
+	endTime: "2024-01-02 00:00:00",
+	bucketSeconds: 3600,
+}
+
+/** The SELECT expression aliased as `count`, e.g. `sum(SampleRate)`. */
+function countExpr(sql: string): string {
+	// Scan by line rather than by regex over the whole string: the expression can
+	// itself contain commas (`if(sum(a) > 0, sum(a), sum(b))`).
+	const line = sql.split("\n").find((l) => / AS count\b/.test(l))
+	if (!line) throw new Error(`no count column in:\n${sql}`)
+	return line.slice(0, line.indexOf(" AS count")).trim()
+}
+
+function sourceTable(sql: string): string {
+	const tables = [...sql.matchAll(/FROM (\w+)/g)].map((m) => m[1])
+	// Union/CTE shapes read several tables; the invariant cares about the set.
+	return [...new Set(tables)].sort().join("+")
+}
+
+/** Every count expression must weight by SampleRate, on either table shape. */
+function expectWeighted(sql: string) {
+	const expr = countExpr(sql)
+	expect(
+		expr.includes("SampleRate") || expr.includes("WeightedCount") || expr.includes("Estimated"),
+		`count expression "${expr}" is not sample-weighted`,
+	).toBe(true)
+	expect(expr).not.toBe("count()")
+}
+
+// Each entry pins one routing branch of `tracesTimeseriesQuery`, so a new
+// branch that forgets to weight its count fails here rather than in prod.
+const TIMESERIES_ROUTES: ReadonlyArray<{
+	name: string
+	table: string
+	opts: Parameters<typeof tracesTimeseriesQuery>[0]
+}> = [
+	{
+		name: "raw traces",
+		table: "traces",
+		opts: { metric: "count", needsSampling: false, groupBy: ["http_method"], bucketSeconds: 3600 },
+	},
+	{
+		name: "service_overview_spans MV",
+		table: "service_overview_spans",
+		opts: { metric: "count", needsSampling: false, rootOnly: true, bucketSeconds: 300 },
+	},
+	{
+		// Raw partial-hour edges unioned with the whole-hour rollup interior.
+		name: "traces_aggregates_hourly rollup",
+		table: "traces+traces_aggregates_hourly",
+		opts: { metric: "count", needsSampling: false, groupBy: ["service"], bucketSeconds: 3600 },
+	},
+	{
+		name: "annual service_overview_hourly union",
+		table: "service_overview_hourly+service_overview_spans",
+		opts: {
+			metric: "count",
+			needsSampling: true,
+			allMetrics: true,
+			rootOnly: true,
+			bucketSeconds: 3600,
+		},
+	},
+]
+
+describe("traces count is sample-weighted on every route", () => {
+	for (const route of TIMESERIES_ROUTES) {
+		it(`weights count on the ${route.name} timeseries path`, () => {
+			const { sql } = compileCH(tracesTimeseriesQuery(route.opts), baseParams)
+			expect(sourceTable(sql)).toBe(route.table)
+			expectWeighted(sql)
+		})
+	}
+
+	// Alerting's `minimumSampleCount` is a confidence guard, so it reads
+	// `spanCount` (rows observed), never the extrapolated `count`. Row-level
+	// tables must therefore keep both columns distinct.
+	it("keeps an unweighted spanCount alongside the weighted count", () => {
+		for (const opts of [
+			{ metric: "count", needsSampling: false, groupBy: ["http_method"], bucketSeconds: 300 },
+			{ metric: "count", needsSampling: false, rootOnly: true, bucketSeconds: 300 },
+		] as const) {
+			const { sql } = compileCH(tracesTimeseriesQuery(opts), { ...baseParams, bucketSeconds: 300 })
+			expect(sql).toContain("count() AS spanCount")
+			expect(countExpr(sql)).toBe("sum(SampleRate)")
+		}
+	})
+
+	it("weights count on the raw breakdown path", () => {
+		const { sql } = compileCH(tracesBreakdownQuery({ metric: "count", groupBy: "span_name" }), {
+			orgId: "org_123",
+			startTime: baseParams.startTime,
+			endTime: baseParams.endTime,
+		})
+		expect(sourceTable(sql)).toBe("traces")
+		expectWeighted(sql)
+	})
+
+	it("weights count on the MV breakdown path", () => {
+		const { sql } = compileCH(
+			tracesBreakdownQuery({ metric: "count", groupBy: "service", rootOnly: true }),
+			{ orgId: "org_123", startTime: baseParams.startTime, endTime: baseParams.endTime },
+		)
+		expect(sourceTable(sql)).toBe("service_overview_spans")
+		expectWeighted(sql)
+	})
+})
+
+// The dimensions the query builder offers for traces. Grouping is a projection
+// of the same rows — it must never change how many spans exist.
+const BREAKDOWN_DIMENSIONS = [
+	{ groupBy: "service" },
+	{ groupBy: "span_name" },
+	{ groupBy: "status_code" },
+	{ groupBy: "http_method" },
+	{ groupBy: "attribute", groupByAttributeKey: "rpc.service" },
+] as const
+
+describe("a breakdown totals the same regardless of the dimension", () => {
+	for (const filters of [{}, { rootOnly: true }, { serviceName: "api" }] as TracesBaseWhereOpts[]) {
+		const label = Object.keys(filters).length ? Object.keys(filters).join("+") : "no filters"
+
+		it(`uses one count definition and one population across dimensions (${label})`, () => {
+			const compiled = BREAKDOWN_DIMENSIONS.map(
+				(dim) =>
+					compileCH(tracesBreakdownQuery({ metric: "count", ...dim, ...filters }), {
+						orgId: "org_123",
+						startTime: baseParams.startTime,
+						endTime: baseParams.endTime,
+					}).sql,
+			)
+
+			const exprs = new Set(compiled.map(countExpr))
+			expect([...exprs]).toEqual(["sum(SampleRate)"])
+
+			// Table may differ (the MV can serve some dimensions and not others),
+			// but the entry-point-only MV is reachable only when the query asked
+			// for entry points — so the counted population is identical either way.
+			for (const sql of compiled) {
+				if (sql.includes("FROM service_overview_spans")) {
+					expect(filters.rootOnly).toBe(true)
+				}
+			}
+		})
+	}
+})
+
+describe("timeseries and breakdown agree for the same query", () => {
+	// Same window, same filters, same dimension: summing the timeseries buckets
+	// must reproduce the breakdown total. Both sides therefore have to count the
+	// same rows with the same expression.
+	const cases: ReadonlyArray<{ groupBy: string; opts: TracesBaseWhereOpts }> = [
+		{ groupBy: "service", opts: {} },
+		{ groupBy: "status_code", opts: {} },
+		{ groupBy: "span_name", opts: { serviceName: "api" } },
+		{ groupBy: "http_method", opts: { rootOnly: true } },
+	]
+
+	const breakdownSql = (groupBy: string, opts: TracesBaseWhereOpts) =>
+		compileCH(tracesBreakdownQuery({ metric: "count", groupBy, ...opts }), {
+			orgId: "org_123",
+			startTime: baseParams.startTime,
+			endTime: baseParams.endTime,
+		}).sql
+
+	const timeseriesSql = (groupBy: string, opts: TracesBaseWhereOpts, bucketSeconds: number) =>
+		compileCH(
+			tracesTimeseriesQuery({
+				metric: "count",
+				needsSampling: false,
+				groupBy: [groupBy],
+				bucketSeconds,
+				...opts,
+			}),
+			{ ...baseParams, bucketSeconds },
+		).sql
+
+	// Sub-hour buckets keep the timeseries on a row-level table, so both sides
+	// compile to literally the same count over literally the same table.
+	for (const { groupBy, opts } of cases) {
+		it(`matches definition and population for groupBy=${groupBy} (5m buckets)`, () => {
+			const ts = timeseriesSql(groupBy, opts, 300)
+			const bd = breakdownSql(groupBy, opts)
+
+			expect(countExpr(ts)).toBe(countExpr(bd))
+			expect(sourceTable(ts)).toBe(sourceTable(bd))
+		})
+	}
+
+	// At >= 1h an eligible timeseries reads the hourly rollup. It stays comparable
+	// because the rollup covers only whole hours and raw `traces` covers the two
+	// partial edge hours — the halves tile the requested window exactly. Reading
+	// the rollup alone (`Hour BETWEEN startTime AND endTime`) dropped the partial
+	// head hour and took the trailing hour whole, which put an hourly chart up to
+	// an hour of traffic below the breakdown of the same window.
+	for (const { groupBy, opts } of cases) {
+		it(`matches definition and window for groupBy=${groupBy} (1h buckets)`, () => {
+			const ts = timeseriesSql(groupBy, opts, 3600)
+			const bd = breakdownSql(groupBy, opts)
+
+			// Dimensions the rollup cannot serve stay entirely row-level.
+			if (!ts.includes("FROM traces_aggregates_hourly")) {
+				expect(countExpr(ts)).toBe(countExpr(bd))
+				expect(sourceTable(ts)).toBe(sourceTable(bd))
+				return
+			}
+
+			// Both union branches weight, and the outer query just sums the partials.
+			expect(ts).toContain("sum(SampleRate) AS bWeightedCount")
+			expect(ts).toContain("sum(WeightedCount) AS bWeightedCount")
+			expect(countExpr(ts)).toBe("sum(bWeightedCount)")
+
+			// The edges cover [start, firstFullHour) ∪ [endHour, end] and the interior
+			// covers [firstFullHour, endHour) — no gap, no double count.
+			const firstFullHour =
+				"if(toDateTime('2024-01-01 00:00:00') = toStartOfHour(toDateTime('2024-01-01 00:00:00')), " +
+				"toStartOfHour(toDateTime('2024-01-01 00:00:00')), " +
+				"toStartOfHour(toDateTime('2024-01-01 00:00:00')) + INTERVAL 1 HOUR)"
+			const endHour = "toStartOfHour(toDateTime('2024-01-02 00:00:00'))"
+			expect(ts).toContain(`(Timestamp < ${firstFullHour} OR Timestamp >= ${endHour})`)
+			expect(ts).toContain(`Hour >= ${firstFullHour}`)
+			expect(ts).toContain(`Hour < ${endHour}`)
+			// The inclusive-end rollup bound is the bug; it must not come back.
+			expect(ts).not.toContain("Hour <=")
+		})
+	}
+
+	// A UNION branch mismatch here is a hard ClickHouse error on a path shared by
+	// dashboards and alert evaluation, so pin the two columns whose natural types
+	// disagree: `count()` is UInt64, `sum(WeightedCount)` is Float64, and
+	// ClickHouse refuses to find a supertype for that pair.
+	it("keeps union branch column types compatible", () => {
+		const sql = timeseriesSql("service", {}, 3600)
+		expect(sql).toContain("toFloat64(count()) AS bSpanCount")
+		expect(sql).toContain("sum(WeightedCount) AS bSpanCount")
+		expect(sql).not.toContain("count() AS bSpanCount\n")
+	})
+
+	// Quantile state must be the same aggregate type on both branches: the raw
+	// side builds it, the rollup side re-emits its stored state via -MergeState.
+	it("emits matching quantile aggregate states across the union", () => {
+		const sql = compileCH(
+			tracesTimeseriesQuery({
+				metric: "p95_duration",
+				needsSampling: false,
+				groupBy: ["service"],
+				bucketSeconds: 3600,
+			}),
+			baseParams,
+		).sql
+		expect(sql).toContain(
+			"quantilesTDigestWeightedState(0.5, 0.95, 0.99)(Duration, toUInt32(greatest(SampleRate, 1.0)))",
+		)
+		expect(sql).toContain("quantilesTDigestWeightedMergeState(0.5, 0.95, 0.99)(DurationQuantiles)")
+		expect(sql).toContain("quantilesTDigestWeightedMerge(0.5, 0.95, 0.99)(bDurationQuantiles)")
+	})
+
+	// No t-digest work when the metric doesn't need it — but the placeholder has
+	// to be the same type on both branches, or the union stops compiling.
+	it("skips quantile state on both branches when the metric needs none", () => {
+		const sql = timeseriesSql("service", {}, 3600)
+		expect(sql).not.toContain("quantilesTDigest")
+		expect([...sql.matchAll(/'' AS bDurationQuantiles/g)]).toHaveLength(2)
+	})
+})

--- a/packages/query-engine/src/ch/queries/query-helpers.ts
+++ b/packages/query-engine/src/ch/queries/query-helpers.ts
@@ -305,6 +305,14 @@ export function tracesBaseWhereConditions(
 
 /** Returns true iff the opts + groupBy can be served by service_overview_spans_mv. */
 export function canUseServiceOverviewMv(opts: TracesBaseWhereOpts, groupBy?: readonly string[]): boolean {
+	// The MV is *lossy*: it stores only entry-point spans (Server/Consumer OR
+	// root). That set is equivalent to the raw table only when the query itself
+	// asks for entry points via `rootOnly`. Routing a non-rootOnly query here
+	// silently swaps the population — the query says "all spans" and gets
+	// "entry spans", which is how one dashboard could show a breakdown by
+	// service (MV-routed, entry spans) next to a breakdown by span name
+	// (raw-routed, all spans) with a 20x gap between their totals.
+	if (!opts.rootOnly) return false
 	// The MV has no SpanName column, so neither spelling of the span-name filter
 	// can be served from it.
 	if (opts.spanName || opts.spanNames?.length) return false
@@ -322,7 +330,8 @@ export function canUseServiceOverviewMv(opts: TracesBaseWhereOpts, groupBy?: rea
 /**
  * Build the WHERE conditions for queries against service_overview_spans.
  * Mirrors the subset of tracesBaseWhereConditions that the MV can serve.
- * `rootOnly` is a no-op here: the MV already pre-filters to entry-point spans.
+ * `rootOnly` is a no-op here: the MV already pre-filters to entry-point spans,
+ * and `canUseServiceOverviewMv` only routes rootOnly queries to it.
  */
 export function serviceOverviewWhereConditions(
 	$: ColumnAccessor<typeof ServiceOverviewSpans.columns>,
@@ -418,18 +427,26 @@ export function canUseTracesAggregatesMv(
 	return true
 }
 
-/** Build WHERE conditions for queries against traces_aggregates_hourly. */
+/**
+ * Build WHERE conditions for queries against traces_aggregates_hourly.
+ *
+ * `hourBounds` overrides the default `[startTime, endTime]` window with raw SQL
+ * expressions. Callers that union this MV with raw partial-hour edges pass the
+ * whole-hour interior (`[firstFullHour, endHour)`) so the two halves tile the
+ * requested window exactly instead of overlapping or leaving a gap.
+ */
 export function tracesAggregatesWhereConditions(
 	$: ColumnAccessor<typeof TracesAggregatesHourly.columns>,
 	opts: TracesBaseWhereOpts,
+	hourBounds?: { readonly gte: string; readonly lt: string },
 ): Array<CH.Condition | undefined> {
 	const mm = opts.matchModes
 	const services = inclusionValues(opts.serviceName, opts.serviceNames)
 	const spanNames = inclusionValues(opts.spanName, opts.spanNames)
 	const conditions: Array<CH.Condition | undefined> = [
 		$.OrgId.eq(param.string("orgId")),
-		$.Hour.gte(param.dateTime("startTime")),
-		$.Hour.lte(param.dateTime("endTime")),
+		hourBounds ? $.Hour.gte(CH.rawExpr<string>(hourBounds.gte)) : $.Hour.gte(param.dateTime("startTime")),
+		hourBounds ? $.Hour.lt(CH.rawExpr<string>(hourBounds.lt)) : $.Hour.lte(param.dateTime("endTime")),
 		CH.when(services, (v: readonly string[]) =>
 			mm?.serviceName === "contains" && v.length === 1
 				? CH.positionCaseInsensitive($.ServiceName, CH.lit(v[0]!)).gt(0)

--- a/packages/query-engine/src/ch/queries/traces.ts
+++ b/packages/query-engine/src/ch/queries/traces.ts
@@ -27,6 +27,8 @@ import {
 	buildProjectedMapExpr,
 	canUseServiceOverviewMv,
 	canUseTracesAggregatesMv,
+	inclusionCondition,
+	inclusionValues,
 	serviceOverviewWhereConditions,
 	tracesAggregatesWhereConditions,
 	tracesBaseWhereConditions,
@@ -35,6 +37,26 @@ import {
 
 // ---------------------------------------------------------------------------
 // Metric SELECT expressions
+//
+// COUNT SEMANTICS — read this before touching `count`.
+//
+// `count` is the **sample-weighted estimate of how many spans actually
+// happened**, never the number of rows we happened to store: every row
+// contributes its `SampleRate` (a multiplier >= 1.0, DEFAULT 1.0 for unsampled
+// spans — see `SAMPLE_RATE_EXPR` in @maple/domain's datasources).
+//
+// This is forced, not chosen. `traces_aggregates_hourly` — which serves every
+// hourly+ trace timeseries — only stores `WeightedCount`; the raw row count is
+// not recoverable from it. A "stored rows" definition would therefore be
+// unimplementable on the rollup routes, whereas the weighted one is
+// implementable everywhere (raw `traces` and `service_overview_spans` both
+// carry `SampleRate`). It is also the definition the rest of the product
+// already uses for throughput: `resolveThroughput` in the web app prefers
+// `estimatedSpanCount` over `count`, and the service map / service overview /
+// service operations queries all report `sum(SampleRate)`.
+//
+// Consequence: the number is sampling-config-independent. Turning head sampling
+// on must not make a dashboard's "spans" number drop.
 // ---------------------------------------------------------------------------
 
 /**
@@ -68,21 +90,40 @@ function metricSelectExprs(
 				apdexScore: CH.lit(0),
 			}
 
+	// Per-span weighted sum: each row contributes `SampleRate` (>= 1.0). Matches
+	// `sum(WeightedCount)` on `traces_aggregates_hourly`, so both routes answer
+	// the same question. See the COUNT SEMANTICS note above.
+	const weightedCount = CH.sum($.SampleRate)
+
 	return {
-		count: CH.count(),
+		count: weightedCount,
+		// Rows actually observed, unweighted. Not a user-facing metric — it is the
+		// statistical-confidence input behind an alert rule's `minimumSampleCount`,
+		// which must not be inflated by extrapolation.
+		spanCount: CH.count(),
 		avgDuration: needs.has("avg_duration") ? CH.avg($.Duration).div(1000000) : CH.lit(0),
 		p50Duration: needs.has("quantiles") ? CH.quantile(0.5)($.Duration).div(1000000) : CH.lit(0),
 		p95Duration: needs.has("quantiles") ? CH.quantile(0.95)($.Duration).div(1000000) : CH.lit(0),
 		p99Duration: needs.has("quantiles") ? CH.quantile(0.99)($.Duration).div(1000000) : CH.lit(0),
+		// Weighted on both sides of the ratio, matching
+		// `sum(WeightedErrorCount) / sum(WeightedCount)` on the hourly rollup.
+		// Leaving the numerator raw while `count` is weighted would make
+		// `count * errorRate` disagree with any error count on the same widget.
 		errorRate: needs.has("error_rate")
-			? CH.if_(CH.count().gt(0), CH.countIf($.StatusCode.eq("Error")).div(CH.count()), CH.lit(0))
+			? CH.if_(
+					weightedCount.gt(0),
+					CH.sumIf($.SampleRate, $.StatusCode.eq("Error")).div(weightedCount),
+					CH.lit(0),
+				)
 			: CH.lit(0),
+		// Apdex intentionally stays on raw `count()` (inside `apdexExprs`): it is a
+		// self-consistent ratio of raw satisfied/tolerating/total, and the hourly
+		// rollup carries no weighted apdex buckets to match against anyway.
 		...apdex,
-		// Per-span weighted sum: each row contributes `SampleRate` (>= 1.0).
-		// Replaces the old `sampledSpanCount * dominantWeight + unsampledSpanCount`
-		// approximation, which mis-estimated buckets with mixed sampling rates
-		// because `anyIf` picked one arbitrary threshold and applied it to all.
-		estimatedSpanCount: needsSampling ? CH.sum($.SampleRate) : CH.lit(0),
+		// Retained as a distinct output column because `@maple/domain`'s series
+		// keys and the web app's `resolveThroughput` still read it; it is now by
+		// construction equal to `count` whenever it is emitted.
+		estimatedSpanCount: needsSampling ? weightedCount : CH.lit(0),
 	}
 }
 
@@ -282,7 +323,10 @@ export interface TracesTimeseriesOpts extends TracesQueryOpts {
 export interface TracesTimeseriesOutput {
 	readonly bucket: string
 	readonly groupName: string
+	/** Sample-weighted estimate of spans that happened. See COUNT SEMANTICS. */
 	readonly count: number
+	/** Raw rows observed. Confidence input for alerting, not a display metric. */
+	readonly spanCount: number
 	readonly avgDuration: number
 	readonly p50Duration: number
 	readonly p95Duration: number
@@ -301,6 +345,7 @@ const TRACES_TS_COLUMNS: ColumnDefs = {
 	bucket: T.string,
 	groupName: T.string,
 	count: T.float64,
+	spanCount: T.float64,
 	avgDuration: T.float64,
 	p50Duration: T.float64,
 	p95Duration: T.float64,
@@ -392,29 +437,41 @@ export function tracesTimeseriesQuery(
 
 		const annual = fromUnion(unionAll(rawEdges, hourlyInterior), "service_metric_windows")
 			.select(($) => {
-				const total = CH.sum($.bCount)
+				// `rawTotal` is the stored-row count; it stays the apdex denominator
+				// because the satisfied/tolerating numerators are raw counts too.
+				const rawTotal = CH.sum($.bCount)
+				// `service_overview_hourly.EstimatedSpanCount` post-dates the table, so
+				// buckets written before it carry 0 — fall back to the raw count rather
+				// than reporting a hole. Mirrors `resolveThroughput` in the web app.
+				const weightedTotal = CH.rawExpr<number>(
+					"if(sum(bEstimatedSpanCount) > 0, sum(bEstimatedSpanCount), sum(bCount))",
+				)
 				const satisfied = CH.sum($.bSatisfiedCount)
 				const tolerating = CH.sum($.bToleratingCount)
 				const quantiles = "quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles)"
 				return {
 					bucket: $.bucket,
 					groupName: CH.lit("all"),
-					count: total,
+					count: weightedTotal,
+					spanCount: rawTotal,
 					avgDuration: CH.rawExpr<number>(
 						"if(sum(bCount) > 0, sum(bDurationSum) / sum(bCount) / 1000000, 0)",
 					),
 					p50Duration: CH.rawExpr<number>(`arrayElement(${quantiles}, 1) / 1000000`),
 					p95Duration: CH.rawExpr<number>(`arrayElement(${quantiles}, 2) / 1000000`),
 					p99Duration: CH.rawExpr<number>(`arrayElement(${quantiles}, 3) / 1000000`),
+					// Raw ratio: `service_overview_hourly` stores no weighted error count.
+					// Unbiased as long as errored and non-errored spans share a sampling
+					// rate, which head sampling (trace-level) guarantees.
 					errorRate: CH.rawExpr<number>("if(sum(bCount) > 0, sum(bErrorCount) / sum(bCount), 0)"),
 					satisfiedCount: satisfied,
 					toleratingCount: tolerating,
 					apdexScore: CH.if_(
-						total.gt(0),
-						CH.round_(satisfied.div(total).add(tolerating.mul(0.5).div(total)), 4),
+						rawTotal.gt(0),
+						CH.round_(satisfied.div(rawTotal).add(tolerating.mul(0.5).div(rawTotal)), 4),
 						CH.lit(0),
 					),
-					estimatedSpanCount: CH.sum($.bEstimatedSpanCount),
+					estimatedSpanCount: weightedTotal,
 				}
 			})
 			.groupBy("bucket", "groupName")
@@ -432,30 +489,106 @@ export function tracesTimeseriesQuery(
 		canUseTracesAggregatesMv(opts, opts.groupBy, opts.bucketSeconds)
 	) {
 		const needs = new Set(METRIC_NEEDS[opts.metric])
-		const weightedCount = CH.rawExpr<number>("sum(WeightedCount)")
-		const weightedQuantiles = "quantilesTDigestWeightedMerge(0.5, 0.95, 0.99)(DurationQuantiles)"
-		const aggregates = from(TracesAggregatesHourly)
+		const wantsQuantiles = needs.has("quantiles")
+
+		// The MV is keyed on whole hours, but dashboard ranges are relative
+		// ("now - 24h") and practically never land on an hour boundary. Reading it
+		// with `Hour BETWEEN startTime AND endTime` drops the partial head hour
+		// entirely and takes the trailing hour whole, so an hourly chart silently
+		// under-reported a row-level breakdown of the identical window by up to an
+		// hour of traffic. Instead: raw `traces` covers the two partial edge hours,
+		// the MV covers the whole-hour interior, and the two tile the window
+		// exactly. Same shape as the annual service-overview branch above.
+		const startHour = "toStartOfHour(toDateTime(__PARAM_startTime__))"
+		const endHour = "toStartOfHour(toDateTime(__PARAM_endTime__))"
+		const firstFullHour = `if(toDateTime(__PARAM_startTime__) = ${startHour}, ${startHour}, ${startHour} + INTERVAL 1 HOUR)`
+
+		// The union's branches must agree on aggregate-state types, so the raw side
+		// emits `quantilesTDigestWeightedState(…)(Duration, toUInt32(…))` to match
+		// the MV column's `AggregateFunction(quantilesTDigestWeighted(...), UInt64,
+		// UInt32)`, and the MV side re-emits state via `-MergeState`. When the
+		// metric needs no quantiles both branches emit `''` instead — still the
+		// same type on both sides, and no t-digest work.
+		const rawQuantileState = wantsQuantiles
+			? "quantilesTDigestWeightedState(0.5, 0.95, 0.99)(Duration, toUInt32(greatest(SampleRate, 1.0)))"
+			: "''"
+		const mvQuantileState = wantsQuantiles
+			? "quantilesTDigestWeightedMergeState(0.5, 0.95, 0.99)(DurationQuantiles)"
+			: "''"
+
+		const spanNames = inclusionValues(opts.spanName, opts.spanNames)
+		const rawEdges = from(Traces)
+			.select(($) => ({
+				bucket: CH.toStartOfInterval($.Timestamp, param.int("bucketSeconds")),
+				groupName: buildGroupNameExpr($, opts.groupBy, undefined),
+				bWeightedCount: CH.sum($.SampleRate),
+				// `toFloat64` is load-bearing: the MV side of this column is
+				// `sum(WeightedCount)` (Float64), and ClickHouse refuses a UNION of
+				// UInt64 with Float64 outright ("there is no supertype ... because
+				// some of them are integers and some are floating point").
+				bSpanCount: CH.rawExpr<number>("toFloat64(count())"),
+				bWeightedDurationSum: CH.sum(CH.rawExpr<number>("toFloat64(Duration) * SampleRate")),
+				bWeightedErrorCount: CH.sumIf($.SampleRate, $.StatusCode.eq("Error")),
+				bDurationQuantiles: CH.rawExpr<string>(rawQuantileState),
+			}))
+			.where(($) => [
+				// Span-name matching is narrowed to the MV's spelling: the raw table
+				// also matches the *display* name ("GET /api/users"), which
+				// `traces_aggregates_hourly` cannot store. Leaving that OR in would
+				// make the edge hours select rows the interior hours could not,
+				// which is the same class of bug this union exists to close.
+				...tracesBaseWhereConditions($, { ...opts, spanName: undefined, spanNames: undefined }),
+				CH.when(spanNames, (v: readonly string[]) =>
+					opts.matchModes?.spanName === "contains" && v.length === 1
+						? CH.positionCaseInsensitive($.SpanName, CH.lit(v[0]!)).gt(0)
+						: inclusionCondition($.SpanName, v),
+				),
+				CH.rawCond(`(Timestamp < ${firstFullHour} OR Timestamp >= ${endHour})`),
+			])
+			.groupBy("bucket", "groupName")
+
+		const hourlyInterior = from(TracesAggregatesHourly)
 			.select(($) => ({
 				bucket: CH.toStartOfInterval($.Hour, param.int("bucketSeconds")),
 				groupName: buildAggregatesGroupNameExpr($, opts.groupBy),
+				bWeightedCount: CH.sum($.WeightedCount),
+				// The MV stores no raw row count, so the weighted value stands in for
+				// it on interior hours. An hourly alert rule routed here therefore
+				// evaluates `minimumSampleCount` against a partly-estimated sample
+				// count; sub-hour rules stay on row-level tables and get the true one.
+				bSpanCount: CH.sum($.WeightedCount),
+				bWeightedDurationSum: CH.sum($.WeightedDurationSum),
+				bWeightedErrorCount: CH.sum($.WeightedErrorCount),
+				bDurationQuantiles: CH.rawExpr<string>(mvQuantileState),
+			}))
+			.where(($) => tracesAggregatesWhereConditions($, opts, { gte: firstFullHour, lt: endHour }))
+			.groupBy("bucket", "groupName")
+
+		const weightedCount = CH.rawExpr<number>("sum(bWeightedCount)")
+		const weightedQuantiles = "quantilesTDigestWeightedMerge(0.5, 0.95, 0.99)(bDurationQuantiles)"
+		const aggregates = fromUnion(unionAll(rawEdges, hourlyInterior), "traces_metric_windows")
+			.select(($) => ({
+				bucket: $.bucket,
+				groupName: $.groupName,
 				count: weightedCount,
+				spanCount: CH.sum($.bSpanCount),
 				avgDuration: needs.has("avg_duration")
 					? CH.rawExpr<number>(
-							"if(sum(WeightedCount) > 0, sum(WeightedDurationSum) / sum(WeightedCount) / 1000000, 0)",
+							"if(sum(bWeightedCount) > 0, sum(bWeightedDurationSum) / sum(bWeightedCount) / 1000000, 0)",
 						)
 					: CH.lit(0),
-				p50Duration: needs.has("quantiles")
+				p50Duration: wantsQuantiles
 					? CH.rawExpr<number>(`arrayElement(${weightedQuantiles}, 1) / 1000000`)
 					: CH.lit(0),
-				p95Duration: needs.has("quantiles")
+				p95Duration: wantsQuantiles
 					? CH.rawExpr<number>(`arrayElement(${weightedQuantiles}, 2) / 1000000`)
 					: CH.lit(0),
-				p99Duration: needs.has("quantiles")
+				p99Duration: wantsQuantiles
 					? CH.rawExpr<number>(`arrayElement(${weightedQuantiles}, 3) / 1000000`)
 					: CH.lit(0),
 				errorRate: needs.has("error_rate")
 					? CH.rawExpr<number>(
-							"if(sum(WeightedCount) > 0, sum(WeightedErrorCount) / sum(WeightedCount), 0)",
+							"if(sum(bWeightedCount) > 0, sum(bWeightedErrorCount) / sum(bWeightedCount), 0)",
 						)
 					: CH.lit(0),
 				satisfiedCount: CH.lit(0),
@@ -463,7 +596,6 @@ export function tracesTimeseriesQuery(
 				apdexScore: CH.lit(0),
 				estimatedSpanCount: opts.needsSampling ? weightedCount : CH.lit(0),
 			}))
-			.where(($) => tracesAggregatesWhereConditions($, opts))
 			.groupBy("bucket", "groupName")
 			.orderBy(["bucket", "asc"], ["groupName", "asc"])
 		return finalizeTimeseries(aggregates, TRACES_TS_COLUMNS, "count", opts) as unknown as CHQuery<
@@ -528,7 +660,9 @@ export interface TracesBreakdownOpts extends TracesQueryOpts {
 
 export interface TracesBreakdownOutput {
 	readonly name: string
+	/** Sample-weighted estimate of spans that happened. See COUNT SEMANTICS. */
 	readonly count: number
+	readonly spanCount: number
 	readonly avgDuration: number
 	readonly p50Duration: number
 	readonly p95Duration: number

--- a/packages/query-engine/src/runtime/query-engine.ts
+++ b/packages/query-engine/src/runtime/query-engine.ts
@@ -2015,7 +2015,11 @@ export const computeAlertBuckets = Effect.fnUntraced(function* <T extends QueryT
 			"tracesAlertEval",
 		)
 		for (const row of rows) {
-			const sampleCount = Number(row.count ?? 0)
+			// `count` is a sample-weighted estimate; `minimumSampleCount` is a
+			// confidence guard and must see rows actually observed. They differ only
+			// under sampling, and only the hourly rollup (which stores no raw count)
+			// falls back to the estimate.
+			const sampleCount = Number(row.spanCount ?? row.count ?? 0)
 			const value = sampleCount > 0 ? tracesAggregateValueForMetric(query.metric, row) : null
 			obs.push({
 				bucket: normalizeBucket(row.bucket),


### PR DESCRIPTION
## The bug

Dashboard `5d14373b-1253-42f3-82a3-c7f5f52bc28d` showed a **"Spans" stat of 5.5B directly above a "Span Status" donut whose centre total read 26.6M** — two answers to the same question, side by side. Breakdowns also disagreed *with each other*: `service.name` and `status.code` totalled ~26M while `span.name` and `http.method` were on a ~550M scale.

## Root cause — three independent defects, not one

**1. Definition.** `metricSelectExprs` in `traces.ts` emitted raw `count()`, but the `traces_aggregates_hourly` branch emitted `sum(WeightedCount)`. Which one you got depended on whether the query was rollup-eligible (bucket ≥ 1h, no attr filters). That's the 5.28B vs 26.5M leg.

**2. Population.** `canUseServiceOverviewMv` routed *any* eligible query to `service_overview_spans` — a MV that stores **entry-point spans only** (`SpanKind IN ('Server','Consumer') OR ParentSpanId = ''`). A query with no `root_only` filter means "all spans" and silently got entry spans. Dimensions the MV can't serve (`span.name`, `http.method`) fell through to raw `traces` and counted everything. So the **groupBy dimension was changing the row population**, not just the weighting — that's the 26M vs 552M leg.

**3. Window.** The rollup route read `Hour BETWEEN startTime AND endTime`. Dashboard ranges are relative ("now − 24h") and practically never hour-aligned, so the partial head hour was dropped entirely and the trailing hour taken whole — **measured 15% low on a 3h window**, ~4% on 24h.

## Which scale is correct

**Sample-weighted — `count` is an estimate of how many spans happened, not how many rows we stored.**

Forced, not a taste call: `traces_aggregates_hourly` stores only `WeightedCount`, so a "stored rows" definition is unimplementable on the route that serves every hourly+ timeseries, while the weighted one is implementable everywhere. It's also already the product's definition of throughput — `resolveThroughput` in the web app prefers `estimatedSpanCount` over `count`, and the service map / service overview / service operations queries all report `sum(SampleRate)`. And it has the property you want: **turning head sampling on must not make a dashboard's span count drop.**

## The fix

- `count` = `sum(SampleRate)` on row-level tables, matching `sum(WeightedCount)` on the rollup. `errorRate` weighted on both sides of the ratio to match. Apdex deliberately left on raw counts — it's a self-consistent ratio and the rollup has no weighted apdex buckets to match against.
- `canUseServiceOverviewMv` returns false unless `rootOnly`. The entry-point MV is reachable only from a query that asked for entry points.
- The rollup branch is now a union: raw `traces` covers `[start, firstFullHour) ∪ [endHour, end]`, the MV covers `[firstFullHour, endHour)`. Same shape as the annual service-overview branch directly above it.

Two things that weren't obvious going in:

- **Span-name matching in the union.** Raw `traces` also matches the *display* name (`GET /api/users`) via an OR the MV can't reproduce — it stores only the raw `SpanName`. Left alone, the edge hours would select rows the interior hours couldn't, which is the same class of bug the union exists to close. The raw edge is built with the MV's narrower predicate.
- **`minimumSampleCount`.** Weighting `count` would have silently gutted alert rules' confidence guard — at 10× sampling, a rule requiring 100 samples would pass on 10 real spans. New unweighted `spanCount` column carries the observed row count and the alert lowering reads it. Only the rollup route, which stores no raw count, falls back to the estimate.

## Verification against the live workspace

Unit tests compile SQL; they can't catch a ClickHouse type error on a path shared by dashboards *and* alert evaluation. So the compiled SQL was run through the Tinybird MCP — and the first attempt **failed**:

```
NO_COMMON_TYPE: There is no supertype for types Float64, UInt64 because some of them
are integers and some are floating point
```

Raw `count()` is UInt64, `sum(WeightedCount)` is Float64. Fixed with `toFloat64(count())`. After that:

| Check | Result |
|---|---|
| Aggregate-state union analyzes (bogus OrgId, zero rows) | passes |
| Full compiled SQL, real org, 3h non-aligned window | 16 sane per-service/per-hour buckets |
| **edges + interior vs raw baseline** (single atomic query) | **752,813 == 752,813** |
| old rollup-only route, same window | 639,453 — **15% low** |
| p95: union vs raw baseline | 7.659 ms vs 7.634 ms (0.33%, t-digest error) |

## Tests

New `count-semantics.test.ts` pins both invariants: every routing branch weights its count; row-level routes keep `spanCount` unweighted; a breakdown uses one count definition across all five dimensions and only reaches the entry-point MV when `rootOnly`; timeseries and breakdown agree at 5m buckets (same expression, same table) and at 1h buckets (both union branches weight, and the halves tile the window — including `expect(ts).not.toContain("Hour <=")` so the inclusive-end bound can't come back). Three more cover the union mechanics: branch column types, matching quantile states, and `''` on both branches when no quantiles are needed.

Updated 9 tests in `ch.test.ts` that encoded the old behaviour — e.g. *"routes default (no filters) to service_overview_spans_mv"* **was** the bug.

`bun run --cwd packages/query-engine vitest run src/ch/ch.test.ts src/ch/queries/count-semantics.test.ts src/ch/queries/traces.test.ts src/runtime src/query-builder src/ch/queries/services.test.ts src/ch/queries/series-cap.test.ts` → 261 passing. Typecheck clean on the touched files.

## Reviewer notes — saved dashboards will change

- **Sampled orgs: numbers go up.** Any traces `count`/`error_rate` widget on a raw route now reports weighted volume. Unsampled orgs see no change (`SampleRate` is 1.0).
- **Non-`root_only` widgets change population.** Widgets grouped by service/status that were quietly showing entry spans now show all spans — a large jump, and the one that makes the dashboard internally consistent.
- **Hourly charts read higher** by up to an hour of traffic. That's recovered data, not inflation — the head hour was being dropped.
- **Alerts:** count-threshold rules on traces now compare against weighted values, and hourly rules on eligible queries were evaluating a short window and will now see complete ones. Rules with `minimumSampleCount` keep the raw guard except on the rollup route.
- **Perf:** non-`root_only` sub-hour timeseries drop off the MV onto raw `traces`. Correctness over speed — the old number was wrong. Hourly+ queries still hit the rollup for the interior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788221561&installation_model_id=427786&pr_number=308&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F308&signature=749373a8819058f91ffd98bb826bfa98011a6f1200dac55577a4f072178e25af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->