### PR TITLE
refactor(ui): unify clipboard copy into @maple/ui

### DIFF
--- a/apps/landing/src/lib/copy-to-clipboard.ts
+++ b/apps/landing/src/lib/copy-to-clipboard.ts
@@ -1,43 +1,17 @@
 /**
- * Shared copy-to-clipboard wiring for the landing site's install snippets.
+ * Copy-to-clipboard *binding* for the landing site's install snippets.
  *
  * The landing site is Astro with no React islands, so it can't use
  * `@maple/ui`'s `CopyButton` — but it should still behave the same way: the
  * button says it copies, so it copies; the label reverts after a beat; and a
- * blocked clipboard says so rather than silently claiming success.
+ * blocked clipboard says so rather than silently claiming success. Only the DOM
+ * binding is local; the write itself is `@maple/ui`'s, so the insecure-origin
+ * fallback has one implementation across the product and the marketing site.
  */
 
+import { writeClipboardText } from "@maple/ui/lib/clipboard"
+
 const RESET_MS = 1600
-
-/** Writes `text`, falling back to a hidden textarea on insecure origins. */
-export async function writeToClipboard(text: string): Promise<boolean> {
-	if (!text) return false
-
-	try {
-		if (navigator.clipboard?.writeText) {
-			await navigator.clipboard.writeText(text)
-			return true
-		}
-	} catch {
-		// fall through to the legacy path
-	}
-
-	const area = document.createElement("textarea")
-	area.value = text
-	area.setAttribute("readonly", "")
-	area.style.position = "fixed"
-	area.style.opacity = "0"
-	document.body.appendChild(area)
-	area.select()
-	let ok = false
-	try {
-		ok = document.execCommand("copy")
-	} catch {
-		ok = false
-	}
-	document.body.removeChild(area)
-	return ok
-}
 
 export interface CopyButtonOptions {
 	/** Container holding `[data-copy]` elements. Defaults to the whole document. */
@@ -88,7 +62,7 @@ export function bindCopyButtons({
 		let timer: ReturnType<typeof setTimeout> | undefined
 
 		button.addEventListener("click", async () => {
-			const ok = await writeToClipboard(text)
+			const ok = await writeClipboardText(text)
 			label.textContent = ok ? copiedLabel : errorLabel
 			button.classList.toggle(doneClass, ok)
 

--- a/apps/local-ui/src/components/connect-button.tsx
+++ b/apps/local-ui/src/components/connect-button.tsx
@@ -60,7 +60,7 @@ function ConnectPanel() {
 				<span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
 					Quick start
 				</span>
-				<CopyableField label="" value={`OTEL_EXPORTER_OTLP_ENDPOINT=${LOCAL_OTLP_ENDPOINT}`} />
+				<CopyableField label="" copyLabel="Command" value={`OTEL_EXPORTER_OTLP_ENDPOINT=${LOCAL_OTLP_ENDPOINT}`} />
 				<p className="text-xs text-muted-foreground">
 					Recording browser sessions? Point{" "}
 					<code className="rounded bg-muted px-1">@maple-dev/browser</code> at the same endpoint.

--- a/apps/local-ui/src/components/view-states.tsx
+++ b/apps/local-ui/src/components/view-states.tsx
@@ -136,7 +136,7 @@ function InstallCommands() {
 			</TabsList>
 			{INSTALL_METHODS.map((method) => (
 				<TabsContent key={method.id} value={method.id} className="mt-0">
-					<CopyableField label="" value={method.command} />
+					<CopyableField label="" copyLabel="Command" value={method.command} />
 				</TabsContent>
 			))}
 		</Tabs>

--- a/apps/web/src/components/chat/chat-transcript.test.tsx
+++ b/apps/web/src/components/chat/chat-transcript.test.tsx
@@ -126,16 +126,20 @@ describe("ChatTranscript", () => {
 			/>,
 		)
 
-		expect(screen.queryAllByLabelText("Copy message")).toHaveLength(1)
-		expect(screen.queryAllByLabelText("Copy link to message")).toHaveLength(1)
+		// `CopyButton` composes its accessible name as `Copy ${label}`, and the
+		// shared convention is a capitalized label ("Session ID", "API key", …) —
+		// so these read "Copy Message" / "Copy Link to message" since the
+		// one-CopyButton refactor replaced the hand-rolled buttons here.
+		expect(screen.queryAllByLabelText("Copy Message")).toHaveLength(1)
+		expect(screen.queryAllByLabelText("Copy Link to message")).toHaveLength(1)
 		expect(document.querySelectorAll('[data-slot="message-footer"]')).toHaveLength(1)
 	})
 
 	it("omits the permalink action when the thread isn't shareable", () => {
 		render(<ChatTranscript {...baseProps} messages={[message("m1", "assistant", "hello")]} />)
 
-		expect(screen.queryByLabelText("Copy message")).toBeTruthy()
-		expect(screen.queryByLabelText("Copy link to message")).toBeNull()
+		expect(screen.queryByLabelText("Copy Message")).toBeTruthy()
+		expect(screen.queryByLabelText("Copy Link to message")).toBeNull()
 	})
 
 	it("marks a read-only shared thread with a separator row", () => {

--- a/apps/web/src/components/chat/message-actions.tsx
+++ b/apps/web/src/components/chat/message-actions.tsx
@@ -1,5 +1,6 @@
 import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import type { UIMessage } from "@/components/ai-elements/types"
+import { LinkIcon } from "@/components/icons"
 
 /** The visible text of a message, with tool calls and markers left out. */
 export function messageText(message: UIMessage): string {
@@ -30,7 +31,13 @@ export function MessageActions({ message, permalink }: MessageActionsProps) {
 		<div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover/message:opacity-100 focus-within:opacity-100">
 			{text ? <CopyButton value={text} label="Message" size="icon-sm" toast={false} /> : null}
 			{permalink ? (
-				<CopyButton value={permalink} label="Link to message" glyph="link" size="icon-sm" toast={false} />
+				<CopyButton
+					value={permalink}
+					label="Link to message"
+					idleIcon={LinkIcon}
+					size="icon-sm"
+					toast={false}
+				/>
 			) : null}
 		</div>
 	)

--- a/apps/web/src/components/header/connect-button.tsx
+++ b/apps/web/src/components/header/connect-button.tsx
@@ -68,7 +68,7 @@ function ConnectPanel() {
 				<span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
 					Fastest path · Claude Code
 				</span>
-				<CopyableField value={ONBOARD_SKILL_COMMAND} />
+				<CopyableField value={ONBOARD_SKILL_COMMAND} copyLabel="Command" />
 				<p className="text-xs text-muted-foreground">
 					The <code className="rounded bg-muted px-1">maple-onboard</code> skill installs
 					OpenTelemetry and wires traces, logs, and metrics end-to-end.

--- a/apps/web/src/components/logs/log-meta-strip.tsx
+++ b/apps/web/src/components/logs/log-meta-strip.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router"
-import { ClockIcon, ExternalLinkIcon, PulseIcon } from "@/components/icons"
+import { ClockIcon, ExternalLinkIcon, LinkIcon, PulseIcon } from "@/components/icons"
 
 import { CopyableValue } from "@/components/attributes"
 import { CopyButton } from "@maple/ui/components/ui/copy-button"
@@ -69,7 +69,7 @@ export function LogMetaStrip({ log, timeZone, showOpenFullPage = true }: LogMeta
 				<CopyButton
 					value={() => `${window.location.origin}/logs/${encodeLogKey(log)}`}
 					label="Shareable link"
-					glyph="link"
+					idleIcon={LinkIcon}
 					iconSize={13}
 					tooltip
 				/>

--- a/apps/web/src/components/metrics/metric-graduation-actions.tsx
+++ b/apps/web/src/components/metrics/metric-graduation-actions.tsx
@@ -10,7 +10,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@maple/ui/components/ui/dialog"
-import { BellIcon, GridSquareCirclePlusIcon } from "@/components/icons"
+import { BellIcon, GridSquareCirclePlusIcon, LinkIcon } from "@/components/icons"
 import { useDashboardStore } from "@/hooks/use-dashboard-store"
 import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import { encodeAlertChartToSearchParam } from "@/lib/alerts/widget-chart-param"
@@ -65,7 +65,7 @@ export function MetricGraduationActions({ draft }: MetricGraduationActionsProps)
 				value={() => window.location.href}
 				label="Link"
 				idleLabel="Copy link"
-				glyph="link"
+				idleIcon={LinkIcon}
 				toast={false}
 				variant="outline"
 			/>

--- a/apps/web/src/components/replays/session-detail-parts.tsx
+++ b/apps/web/src/components/replays/session-detail-parts.tsx
@@ -3,9 +3,6 @@ import { motion, useReducedMotion } from "motion/react"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { GlobeIcon, ClockIcon } from "@/components/icons"
 import { CopyButton } from "@maple/ui/components/ui/copy-button"
-
-// Re-exported so the replay panels keep importing their copy control from here.
-export { CopyButton }
 import { formatRelativeFrom } from "@maple/ui/time-format"
 import { formatSessionDuration, gradientFor, hostFromUrl } from "./replay-format"
 import { parseChTimestampMs } from "./replay-timeline"

--- a/apps/web/src/components/replays/session-events-panel.tsx
+++ b/apps/web/src/components/replays/session-events-panel.tsx
@@ -6,6 +6,7 @@ import {
 	getSessionTranscriptResultAtom,
 	getSessionTraceSummariesResultAtom,
 } from "@/lib/services/atoms/warehouse-query-atoms"
+import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { HttpSpanLabel } from "@maple/ui/components/traces/http-span-label"
 import { parseAttributes } from "@maple/ui/lib/span-tree"
@@ -15,7 +16,6 @@ import { formatClock, formatSessionDuration, type ReplayPartitionWindow } from "
 import { useReplayPlayer } from "./replay-player-context"
 import { parseChTimestampMs } from "./replay-timeline"
 import type { SessionTraceSummary } from "./replay-editor-timeline"
-import { CopyButton } from "./session-detail-parts"
 
 export type EventRow = {
 	readonly timestamp: string

--- a/apps/web/src/components/traces/trace-id-badge.tsx
+++ b/apps/web/src/components/traces/trace-id-badge.tsx
@@ -1,7 +1,7 @@
 import type { VariantProps } from "class-variance-authority"
 import type { badgeVariants } from "@maple/ui/components/ui/badge"
+import { CopyableBadge } from "@maple/ui/components/ui/copyable-badge"
 import { cn } from "@maple/ui/utils"
-import { CopyableBadge } from "@/components/common/copyable-badge"
 import { IdBadgeIcon } from "@/components/icons"
 
 interface TraceIdBadgeProps {

--- a/apps/web/src/components/widget-lab/widget-lab.tsx
+++ b/apps/web/src/components/widget-lab/widget-lab.tsx
@@ -4,6 +4,7 @@ import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import { CopyableValue } from "@maple/ui/components/attributes"
 
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { LinkIcon } from "@/components/icons"
 import { ToggleGroup, ToggleGroupItem } from "@maple/ui/components/ui/toggle-group"
 import type { WidgetMode } from "@/components/dashboard-builder/types"
 
@@ -112,7 +113,7 @@ function CopyScenarios() {
 		},
 		{
 			label: "link glyph",
-			node: <CopyButton value="https://maple.dev" label="Link" glyph="link" tooltip />,
+			node: <CopyButton value="https://maple.dev" label="Link" idleIcon={LinkIcon} tooltip />,
 		},
 		{
 			label: "with label / outline",

--- a/bun.lock
+++ b/bun.lock
@@ -656,7 +656,6 @@
         "clsx": "catalog:ui",
         "effect": "catalog:effect",
         "embla-carousel-react": "^8.6.0",
-        "motion": "^12.40.0",
         "react-day-picker": "^10.0.1",
         "react-resizable-panels": "^4.9.0",
         "recharts": "catalog:ui",
@@ -664,9 +663,15 @@
         "tailwind-merge": "catalog:tailwind",
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "catalog:react",
         "@types/react-dom": "catalog:react",
+        "jsdom": "^29.1.1",
+        "react": "catalog:react",
+        "react-dom": "catalog:react",
         "typescript": "catalog:tooling",
+        "vite": "catalog:",
         "vitest": "catalog:",
       },
       "peerDependencies": {
@@ -2699,7 +2704,7 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
@@ -4205,7 +4210,7 @@
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
-    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
 
@@ -4219,7 +4224,7 @@
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
-    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
@@ -4699,7 +4704,7 @@
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
-    "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serialize-error": ["serialize-error@2.1.0", "", {}, "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw=="],
 
@@ -5361,6 +5366,8 @@
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
+    "@expo/cli/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
     "@expo/cli/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@expo/cli/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
@@ -5368,6 +5375,8 @@
     "@expo/cli/ora": ["ora@3.4.0", "", { "dependencies": { "chalk": "^2.4.2", "cli-cursor": "^2.1.0", "cli-spinners": "^2.0.0", "log-symbols": "^2.2.0", "strip-ansi": "^5.2.0", "wcwidth": "^1.0.1" } }, "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg=="],
 
     "@expo/cli/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
+
+    "@expo/cli/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
     "@expo/cli/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -5729,6 +5738,8 @@
 
     "@solana/web3.js/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
+    "@solana/web3.js/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
@@ -5776,8 +5787,6 @@
     "@types/sax/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
     "@wallet-standard/errors/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
-
-    "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "agents/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -5873,6 +5882,8 @@
 
     "engine.io/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
+    "engine.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
     "engine.io/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "engine.io/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
@@ -5893,17 +5904,11 @@
 
     "expo-router/semver": ["semver@7.6.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
 
-    "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "express/send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "h3/cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
@@ -5989,8 +5994,6 @@
 
     "metro/@babel/traverse": ["@babel/traverse@7.29.8", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.8", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.8", "@babel/template": "^7.29.7", "@babel/types": "^7.29.8", "debug": "^4.3.1" } }, "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg=="],
 
-    "metro/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
     "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
@@ -6034,8 +6037,6 @@
     "mongodb-connection-string-url/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
-    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
@@ -6127,21 +6128,13 @@
 
     "seek-bzip/commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
 
-    "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
-
-    "send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
-
-    "send/range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
-
-    "serve-static/send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
     "sha.js/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "simple-plist/bplist-parser": ["bplist-parser@0.3.1", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA=="],
 
     "sitemap/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
+
+    "socket.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "socket.io-adapter/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
@@ -6331,6 +6324,10 @@
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
+    "@expo/cli/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "@expo/cli/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
     "@expo/cli/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@expo/cli/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -6346,6 +6343,14 @@
     "@expo/cli/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "@expo/cli/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "@expo/cli/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "@expo/cli/send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "@expo/cli/send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "@expo/cli/send/range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "@expo/cli/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -6605,6 +6610,8 @@
 
     "@react-native/dev-middleware/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
+    "@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+
     "@react-navigation/core/query-string/decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
     "@react-navigation/core/query-string/filter-obj": ["filter-obj@1.1.0", "", {}, "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="],
@@ -6674,6 +6681,8 @@
     "@solana/transactions/@solana/errors/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "@solana/wallet-standard-wallet-adapter-base/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
+
+    "@solana/web3.js/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 
@@ -6752,8 +6761,6 @@
     "@types/jsonwebtoken/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@types/sax/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "agents/@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.17", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ=="],
 
@@ -6959,6 +6966,10 @@
 
     "engine.io/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "engine.io/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "engine.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
     "expo-modules-autolinking/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "expo-modules-autolinking/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -6972,8 +6983,6 @@
     "expo/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "expo/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
-    "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -7024,8 +7033,6 @@
     "metro-source-map/@babel/traverse/@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
 
     "metro-transform-plugins/@babel/traverse/@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
-
-    "metro/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
@@ -7086,10 +7093,6 @@
     "mongodb-connection-string-url/whatwg-url/webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
     "next/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
-
-    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
-    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "octokit/@octokit/core/@octokit/auth-token": ["@octokit/auth-token@4.0.0", "", {}, "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="],
 
@@ -7201,9 +7204,11 @@
 
     "run-jxa/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
-    "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
     "sitemap/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "socket.io/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "socket.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "terminal-link/ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
@@ -7523,6 +7528,8 @@
 
     "@babel/highlight/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
+    "@expo/cli/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "@expo/cli/ora/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
     "@expo/cli/ora/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
@@ -7532,6 +7539,8 @@
     "@expo/cli/ora/cli-cursor/restore-cursor": ["restore-cursor@2.0.0", "", { "dependencies": { "onetime": "^2.0.0", "signal-exit": "^3.0.2" } }, "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q=="],
 
     "@expo/cli/ora/strip-ansi/ansi-regex": ["ansi-regex@4.1.1", "", {}, "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="],
+
+    "@expo/cli/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "@expo/cli/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -7597,9 +7606,23 @@
 
     "@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
+    "@react-native/community-cli-plugin/@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+
+    "@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "@react-native/dev-middleware/serve-static/send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "@react-native/dev-middleware/serve-static/send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "@react-native/dev-middleware/serve-static/send/range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
     "@solana/codecs/@solana/codecs-core/@solana/errors/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "@solana/codecs/@solana/codecs-numbers/@solana/errors/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
+
+    "@solana/web3.js/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "@solana/web3.js/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "ast-kit/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 
@@ -7657,6 +7680,8 @@
 
     "astro/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "engine.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "ink-confirm-input/ink-text-input/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "ink-confirm-input/ink-text-input/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -7708,6 +7733,8 @@
     "react-native/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
+
+    "socket.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
@@ -7789,6 +7816,16 @@
 
     "@react-native/codegen/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "@react-native/community-cli-plugin/@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "@react-native/community-cli-plugin/@react-native/dev-middleware/serve-static/send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "@react-native/community-cli-plugin/@react-native/dev-middleware/serve-static/send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "@react-native/community-cli-plugin/@react-native/dev-middleware/serve-static/send/range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
     "metro/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "qrcode/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -7816,5 +7853,7 @@
     "@react-native/babel-plugin-codegen/@react-native/codegen/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@react-native/babel-plugin-codegen/@react-native/codegen/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@react-native/community-cli-plugin/@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,7 +27,6 @@
 		"clsx": "catalog:ui",
 		"effect": "catalog:effect",
 		"embla-carousel-react": "^8.6.0",
-		"motion": "^12.40.0",
 		"react-day-picker": "^10.0.1",
 		"react-resizable-panels": "^4.9.0",
 		"recharts": "catalog:ui",
@@ -35,9 +34,15 @@
 		"tailwind-merge": "catalog:tailwind"
 	},
 	"devDependencies": {
+		"@testing-library/dom": "^10.4.1",
+		"@testing-library/react": "^16.3.2",
 		"@types/react": "catalog:react",
 		"@types/react-dom": "catalog:react",
+		"jsdom": "^29.1.1",
+		"react": "catalog:react",
+		"react-dom": "catalog:react",
 		"typescript": "catalog:tooling",
+		"vite": "catalog:",
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {

--- a/packages/ui/src/components/ui/copy-button.test.tsx
+++ b/packages/ui/src/components/ui/copy-button.test.tsx
@@ -1,0 +1,56 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { copyTooltipText, CopyButton } from "./copy-button"
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+let writeText: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+	writeText = vi.fn().mockResolvedValue(undefined)
+	Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } })
+})
+
+afterEach(() => {
+	cleanup()
+	vi.restoreAllMocks()
+})
+
+describe("CopyButton", () => {
+	it("renders a labelled button whose status region is empty at rest", () => {
+		render(<CopyButton value="maple" label="Trace ID" />)
+
+		expect(screen.getByRole("button", { name: "Copy Trace ID" })).toBeDefined()
+		expect(screen.getByRole("status").textContent).toBe("")
+	})
+
+	it("writes the value on click and announces the result", async () => {
+		render(<CopyButton value={() => "maple"} label="Trace ID" />)
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "Copy Trace ID" }))
+		})
+
+		expect(writeText).toHaveBeenCalledWith("maple")
+		expect(screen.getByRole("status").textContent).toBe("Copied")
+	})
+})
+
+// The wording is shared with `CopyableBadge`; pin it here so a change in one
+// component can't quietly diverge from the other.
+describe("copyTooltipText", () => {
+	it("names the thing being copied while idle", () => {
+		expect(copyTooltipText("idle", "trace ID")).toBe("Copy trace ID")
+	})
+
+	it("reports success and failure", () => {
+		expect(copyTooltipText("copied", "trace ID")).toBe("Copied")
+		expect(copyTooltipText("error", "trace ID")).toBe("Failed to copy")
+	})
+
+	it("lets a callsite override the outcome wording", () => {
+		expect(copyTooltipText("copied", "link", { copiedLabel: "Link copied" })).toBe("Link copied")
+		expect(copyTooltipText("error", "link", { errorLabel: "Nope" })).toBe("Nope")
+	})
+})

--- a/packages/ui/src/components/ui/copy-button.tsx
+++ b/packages/ui/src/components/ui/copy-button.tsx
@@ -1,18 +1,12 @@
 "use client"
 
 import * as React from "react"
-import { motion, useReducedMotion } from "motion/react"
 
 import { useCopy, type CopyStatus, type UseCopyOptions } from "../../hooks/use-copy"
 import { cn } from "../../lib/utils"
-import { CopyIcon, LinkIcon } from "../icons"
+import { CopyIcon, type IconComponent } from "../icons"
 import { Button, type ButtonProps } from "./button"
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./tooltip"
-
-const EASE = [0.23, 1, 0.32, 1] as const
-const CROSSFADE = { damping: 34, mass: 0.8, stiffness: 260, type: "spring" } as const
-const DRAW = { duration: 0.26, ease: EASE } as const
-const INSTANT = { duration: 0 } as const
 
 /**
  * The house icon set is dotted-outline, so only the check is drawable — it's the
@@ -30,14 +24,88 @@ const CHECK_PATH = "M4.5 12.5L9.5 17.5L19.5 6.5"
  */
 const FULL_STRENGTH = "opacity-100"
 
-export type CopyGlyph = "copy" | "link"
+/**
+ * All three glyph layers stay mounted and the active one is picked purely in
+ * CSS, off a `data-copy-status` attribute on the nearest `group/copy`. This is a
+ * per-row affordance on detail surfaces — one per expanded JSON blob, per log
+ * attribute chip, per key row — and it sits idle essentially all the time, so it
+ * deliberately costs nothing per instance: no animation library, no
+ * `prefers-reduced-motion` subscription, no work at all until the status flips.
+ *
+ * The timings are what the springs used to land on. The old crossfade spring was
+ * overdamped (ζ≈1.18), which reads as a decel curve, so it maps onto a 240ms
+ * ease-out; the draw keeps its original 260ms.
+ */
+const EASE = "ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none"
+
+/** One grid cell, faded and scaled back until its status is the active one. */
+const LAYER = cn(
+	"col-start-1 row-start-1 flex items-center justify-center",
+	"scale-[0.92] opacity-0 transition-[opacity,scale] duration-[240ms]",
+	EASE,
+)
+
+/**
+ * Spelled out per status rather than interpolated — Tailwind only emits classes
+ * that appear literally in the source.
+ */
+const LAYER_ACTIVE: Record<CopyStatus, string> = {
+	copied: "group-data-[copy-status=copied]/copy:scale-100 group-data-[copy-status=copied]/copy:opacity-100",
+	error: "group-data-[copy-status=error]/copy:scale-100 group-data-[copy-status=error]/copy:opacity-100",
+	idle: "group-data-[copy-status=idle]/copy:scale-100 group-data-[copy-status=idle]/copy:opacity-100",
+}
+
+/**
+ * `pathLength="1"` renormalises the check to a unit length, so the dash pair is
+ * a literal `1` rather than a measured one and the draw is a plain
+ * `stroke-dashoffset: 1 → 0` — no JS ever touches the path.
+ */
+const CHECK_DRAW = cn(
+	"[stroke-dasharray:1] [stroke-dashoffset:1] transition-[stroke-dashoffset] duration-[260ms]",
+	"group-data-[copy-status=copied]/copy:[stroke-dashoffset:0]",
+	EASE,
+)
+
+/** Same crossfade as the glyph, plus the blur/rise the label has always had. */
+const LABEL_LAYER = cn(
+	"col-start-1 row-start-1 whitespace-nowrap",
+	"translate-y-[3px] opacity-0 blur-[3px] transition-[opacity,filter,translate] duration-[240ms]",
+	EASE,
+)
+
+const LABEL_ACTIVE: Record<CopyStatus, string> = {
+	copied: "group-data-[copy-status=copied]/copy:translate-y-0 group-data-[copy-status=copied]/copy:opacity-100 group-data-[copy-status=copied]/copy:blur-[0px]",
+	error: "group-data-[copy-status=error]/copy:translate-y-0 group-data-[copy-status=error]/copy:opacity-100 group-data-[copy-status=error]/copy:blur-[0px]",
+	idle: "group-data-[copy-status=idle]/copy:translate-y-0 group-data-[copy-status=idle]/copy:opacity-100 group-data-[copy-status=idle]/copy:blur-[0px]",
+}
+
+export interface CopyTooltipLabels {
+	copiedLabel?: string
+	errorLabel?: string
+}
+
+/**
+ * The wording every copy tooltip shares. Lives here rather than inline in each
+ * component so `CopyButton` and `CopyableBadge` can't drift on it.
+ */
+export function copyTooltipText(
+	status: CopyStatus,
+	label: string,
+	{ copiedLabel = "Copied", errorLabel = "Failed to copy" }: CopyTooltipLabels = {},
+): string {
+	if (status === "copied") return copiedLabel
+	if (status === "error") return errorLabel
+	return `Copy ${label}`
+}
 
 export interface CopyIndicatorProps {
 	status: CopyStatus
 	/** Rendered size in px. Matches the `size` prop on the icon components. */
 	size?: number
-	/** Which icon represents the resting state — `link` for share-a-URL affordances. */
-	glyph?: CopyGlyph
+	/** Icon for the resting state — pass `LinkIcon` for share-a-URL affordances,
+	 * or whatever else the callsite is copying. Only the idle glyph is the
+	 * callsite's to pick; the success check and failure X are fixed. */
+	idleIcon?: IconComponent
 	className?: string
 }
 
@@ -47,42 +115,28 @@ export interface CopyIndicatorProps {
  * states never reflows the row.
  *
  * Exported on its own for surfaces that can't use `CopyButton` — dropdown menu
- * items, chips, and anything already wrapped in its own trigger.
+ * items, chips, and anything already wrapped in its own trigger. Standalone it
+ * carries its own `group/copy`, so it animates whether or not a `CopyButton` is
+ * above it.
  */
 export function CopyIndicator({
 	status,
 	size = 14,
-	glyph = "copy",
+	idleIcon: Idle = CopyIcon,
 	className,
 }: CopyIndicatorProps): React.ReactElement {
-	const reduced = useReducedMotion()
-	const fade = reduced ? INSTANT : CROSSFADE
-	const draw = reduced ? INSTANT : DRAW
-
-	const Idle = glyph === "link" ? LinkIcon : CopyIcon
-	const layer = "col-start-1 row-start-1 flex items-center justify-center"
-
 	return (
 		<span
 			aria-hidden="true"
-			className={cn("grid shrink-0", className)}
+			data-copy-status={status}
+			className={cn("group/copy grid shrink-0", className)}
 			style={{ height: size, width: size }}
 		>
-			<motion.span
-				className={layer}
-				initial={false}
-				animate={{ opacity: status === "idle" ? 1 : 0, scale: status === "idle" ? 1 : 0.92 }}
-				transition={fade}
-			>
+			<span className={cn(LAYER, LAYER_ACTIVE.idle)}>
 				<Idle size={size} />
-			</motion.span>
+			</span>
 
-			<motion.span
-				className={cn(layer, "text-severity-info")}
-				initial={false}
-				animate={{ opacity: status === "copied" ? 1 : 0, scale: status === "copied" ? 1 : 0.92 }}
-				transition={fade}
-			>
+			<span className={cn(LAYER, LAYER_ACTIVE.copied, "text-severity-info")}>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					viewBox="0 0 24 24"
@@ -92,24 +146,18 @@ export function CopyIndicator({
 					aria-hidden="true"
 					className={FULL_STRENGTH}
 				>
-					<motion.path
+					<path
 						d={CHECK_PATH}
+						pathLength={1}
 						stroke="currentColor"
 						strokeWidth="2"
 						strokeLinecap="square"
-						initial={false}
-						animate={{ pathLength: status === "copied" ? 1 : 0 }}
-						transition={draw}
+						className={CHECK_DRAW}
 					/>
 				</svg>
-			</motion.span>
+			</span>
 
-			<motion.span
-				className={cn(layer, "text-destructive-foreground")}
-				initial={false}
-				animate={{ opacity: status === "error" ? 1 : 0, scale: status === "error" ? 1 : 0.92 }}
-				transition={fade}
-			>
+			<span className={cn(LAYER, LAYER_ACTIVE.error, "text-destructive-foreground")}>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					viewBox="0 0 24 24"
@@ -122,7 +170,7 @@ export function CopyIndicator({
 					<path d="M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="square" />
 					<path d="M18 6L6 18" stroke="currentColor" strokeWidth="2" strokeLinecap="square" />
 				</svg>
-			</motion.span>
+			</span>
 		</span>
 	)
 }
@@ -130,68 +178,45 @@ export function CopyIndicator({
 /**
  * Label that crossfades between the three states. Every string is stacked in
  * the same grid cell, so the button is sized to the longest one up front and
- * never jumps width mid-animation.
+ * never jumps width mid-animation. Reads the status off the `group/copy` its
+ * `CopyButton` puts on the button element.
  */
-function CopyLabel({
-	status,
-	labels,
-}: {
-	status: CopyStatus
-	labels: ReadonlyArray<readonly [CopyStatus, string]>
-}): React.ReactElement {
-	const reduced = useReducedMotion()
-	const fade = reduced ? INSTANT : CROSSFADE
-
+function CopyLabel({ labels }: { labels: ReadonlyArray<readonly [CopyStatus, string]> }): React.ReactElement {
 	return (
 		<span aria-hidden="true" className="relative grid">
 			{labels.map(([key, text]) => (
-				<motion.span
-					key={key}
-					initial={false}
-					animate={
-						key === status
-							? { filter: "blur(0px)", opacity: 1, y: 0 }
-							: { filter: "blur(3px)", opacity: 0, y: 3 }
-					}
-					transition={fade}
-					className="col-start-1 row-start-1 whitespace-nowrap"
-				>
+				<span key={key} className={cn(LABEL_LAYER, LABEL_ACTIVE[key])}>
 					{text}
-				</motion.span>
+				</span>
 			))}
 		</span>
 	)
 }
 
 export interface CopyButtonProps
-	extends Omit<ButtonProps, "children" | "onCopy" | "onError" | "value">,
+	extends
+		Omit<ButtonProps, "children" | "onCopy" | "onError" | "value">,
 		Pick<UseCopyOptions, "timeout" | "toast" | "successMessage" | "onCopy" | "onError"> {
 	/** What lands on the clipboard. Pass a thunk when building it is expensive. */
 	value: string | (() => string)
 	/** Human name for the thing being copied — drives `aria-label` and toasts. */
 	label: string
-	/** Text shown next to the glyph while resting. Implies `showLabel`. */
+	/** Text shown next to the glyph while resting. Passing it is what turns the
+	 * animated text label on; glyph-only is the default. */
 	idleLabel?: string
 	copiedLabel?: string
 	errorLabel?: string
-	/** Render the animated text label beside the glyph. */
-	showLabel?: boolean
 	/** Wrap in a tooltip whose text follows the copy status. */
 	tooltip?: boolean
 	/** Sonner feedback; on by default. See `useCopy`. */
 	toast?: boolean
 	/** Glyph size in px. Defaults to 14 to match the icon buttons it replaces. */
 	iconSize?: number
-	glyph?: CopyGlyph
+	/** Resting glyph. Defaults to the copy icon; pass `LinkIcon` (or any icon)
+	 * when the thing being copied reads as something else. */
+	idleIcon?: IconComponent
 }
 
-/**
- * The one copy affordance. Built on `Button`, so every variant, size, pressed
- * state, focus ring, and the `render` polymorphism come along unchanged —
- * motion is scoped to the glyph. Toasts by default; the drawn check is the
- * immediate, in-place confirmation on top of that. Pass `toast={false}` only
- * where a toast per click would pile up.
- */
 /** Resolve a lazy `value` without letting a throwing resolver (a circular
  * `JSON.stringify`, say) escape as an uncaught click handler error. */
 function resolveValue(value: string | (() => string)): string | null {
@@ -203,16 +228,22 @@ function resolveValue(value: string | (() => string)): string | null {
 	}
 }
 
+/**
+ * The one copy affordance. Built on `Button`, so every variant, size, pressed
+ * state, focus ring, and the `render` polymorphism come along unchanged —
+ * motion is scoped to the glyph. Toasts by default; the drawn check is the
+ * immediate, in-place confirmation on top of that. Pass `toast={false}` only
+ * where a toast per click would pile up.
+ */
 export function CopyButton({
 	value,
 	label,
 	idleLabel,
 	copiedLabel = "Copied",
 	errorLabel = "Failed to copy",
-	showLabel,
 	tooltip,
 	iconSize = 14,
-	glyph = "copy",
+	idleIcon,
 	timeout,
 	toast,
 	successMessage,
@@ -225,7 +256,7 @@ export function CopyButton({
 	...props
 }: CopyButtonProps): React.ReactElement {
 	const { copy, status } = useCopy({ label, onCopy, onError, successMessage, timeout, toast })
-	const withLabel = showLabel ?? idleLabel !== undefined
+	const withLabel = idleLabel !== undefined
 	const resolvedSize = size ?? (withLabel ? "sm" : "icon-xs")
 
 	const button = (
@@ -233,7 +264,8 @@ export function CopyButton({
 			aria-label={`Copy ${label}`}
 			variant={variant}
 			size={resolvedSize}
-			className={cn("text-muted-foreground hover:text-foreground", className)}
+			data-copy-status={status}
+			className={cn("group/copy text-muted-foreground hover:text-foreground", className)}
 			onClick={(event) => {
 				onClick?.(event)
 				if (event.defaultPrevented) return
@@ -241,12 +273,11 @@ export function CopyButton({
 			}}
 			{...props}
 		>
-			<CopyIndicator status={status} size={iconSize} glyph={glyph} />
+			<CopyIndicator status={status} size={iconSize} idleIcon={idleIcon} />
 			{withLabel && (
 				<CopyLabel
-					status={status}
 					labels={[
-						["idle", idleLabel ?? label],
+						["idle", idleLabel],
 						["copied", copiedLabel],
 						["error", errorLabel],
 					]}
@@ -263,9 +294,7 @@ export function CopyButton({
 	return (
 		<Tooltip>
 			<TooltipTrigger render={button} />
-			<TooltipPopup>
-				{status === "copied" ? copiedLabel : status === "error" ? errorLabel : `Copy ${label}`}
-			</TooltipPopup>
+			<TooltipPopup>{copyTooltipText(status, label, { copiedLabel, errorLabel })}</TooltipPopup>
 		</Tooltip>
 	)
 }

--- a/packages/ui/src/components/ui/copyable-badge.tsx
+++ b/packages/ui/src/components/ui/copyable-badge.tsx
@@ -1,12 +1,16 @@
+"use client"
+
 import type { ReactNode } from "react"
 
 import type { VariantProps } from "class-variance-authority"
-import { badgeVariants } from "@maple/ui/components/ui/badge"
-import { Tooltip, TooltipPopup, TooltipTrigger } from "@maple/ui/components/ui/tooltip"
-import { useCopy } from "@maple/ui/hooks/use-copy"
-import { cn } from "@maple/ui/utils"
 
-interface CopyableBadgeProps {
+import { useCopy } from "../../hooks/use-copy"
+import { cn } from "../../lib/utils"
+import { badgeVariants } from "./badge"
+import { copyTooltipText } from "./copy-button"
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./tooltip"
+
+export interface CopyableBadgeProps {
 	/** The full value written to the clipboard (may differ from the displayed children). */
 	value: string
 	/** What the badge displays — defaults to the value. */
@@ -40,13 +44,7 @@ export function CopyableBadge({
 			>
 				{children ?? value}
 			</TooltipTrigger>
-			<TooltipPopup>
-				{status === "copied"
-					? "Copied!"
-					: status === "error"
-						? "Copy failed"
-						: `Click to copy ${label}`}
-			</TooltipPopup>
+			<TooltipPopup>{copyTooltipText(status, label)}</TooltipPopup>
 		</Tooltip>
 	)
 }

--- a/packages/ui/src/components/ui/copyable-field.tsx
+++ b/packages/ui/src/components/ui/copyable-field.tsx
@@ -21,8 +21,12 @@ export function maskKey(key: string): string {
 
 export interface CopyableFieldProps {
 	value: string
-	/** Optional caption rendered above the field. */
+	/** Optional caption rendered above the field. Also names the value in the
+	 * copy toast unless `copyLabel` overrides it. */
 	label?: string
+	/** Name for the copied thing when the field carries no caption (or when the
+	 * caption doesn't read as a noun in "<name> copied"). */
+	copyLabel?: string
 	/** Mask the value behind a reveal toggle (for secrets). */
 	masked?: boolean
 }
@@ -32,7 +36,12 @@ export interface CopyableFieldProps {
  * implementation shared by the Connect popover, ingestion settings, the
  * dashboard setup checklist, and the local UI's disconnected state.
  */
-export function CopyableField({ value, label, masked }: CopyableFieldProps): React.ReactElement {
+export function CopyableField({
+	value,
+	label,
+	copyLabel,
+	masked,
+}: CopyableFieldProps): React.ReactElement {
 	const [isVisible, setIsVisible] = React.useState(false)
 
 	return (
@@ -55,7 +64,7 @@ export function CopyableField({ value, label, masked }: CopyableFieldProps): Rea
 					)}
 					<CopyButton
 						value={value}
-						label={label || "Command"}
+						label={copyLabel || label || "Value"}
 						render={<InputGroupButton />}
 					/>
 				</InputGroupAddon>

--- a/packages/ui/src/hooks/use-copy.test.tsx
+++ b/packages/ui/src/hooks/use-copy.test.tsx
@@ -1,13 +1,7 @@
-// @vitest-environment jsdom
-
-// `useCopy` lives in `@maple/ui`, but that package's vitest suite is pure-logic
-// with no DOM renderer. apps/web already has jsdom + @testing-library wired, so
-// the hook's behavior is covered from here.
-
 import { act, cleanup, render } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { toast } from "sonner"
-import { useCopy, type CopyAPI, type UseCopyOptions } from "@maple/ui/hooks/use-copy"
+import { useCopy, type CopyAPI, type UseCopyOptions } from "./use-copy"
 
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
 
@@ -21,7 +15,12 @@ function Probe({ options, onReady }: { options?: UseCopyOptions; onReady: (api: 
 function mount(options?: UseCopyOptions) {
 	let latest!: CopyAPI
 	const view = render(<Probe options={options} onReady={(api) => (latest = api)} />)
-	return { get api() { return latest }, view }
+	return {
+		get api() {
+			return latest
+		},
+		view,
+	}
 }
 
 let writeText: ReturnType<typeof vi.fn>
@@ -75,6 +74,24 @@ describe("useCopy", () => {
 		expect(probe.api.status).toBe("error")
 		expect(probe.api.copied).toBe(false)
 		expect(onError).toHaveBeenCalledOnce()
+	})
+
+	it("succeeds through the execCommand fallback when the clipboard API rejects", async () => {
+		// The path that only ever runs on insecure origins and embedded contexts —
+		// i.e. never in a developer's browser, so it needs a test more than the
+		// happy path does.
+		const onCopy = vi.fn()
+		writeText.mockRejectedValue(new Error("denied"))
+		Object.defineProperty(document, "execCommand", { configurable: true, value: () => true })
+		const probe = mount({ label: "Trace ID", onCopy })
+
+		await act(async () => {
+			expect(await probe.api.copy("maple")).toBe(true)
+		})
+		expect(probe.api.status).toBe("copied")
+		expect(onCopy).toHaveBeenCalledWith("maple")
+		expect(toast.success).toHaveBeenCalledWith("Trace ID copied")
+		expect(toast.error).not.toHaveBeenCalled()
 	})
 
 	it("treats an empty value as an error rather than a silent success", async () => {

--- a/packages/ui/src/hooks/use-copy.tsx
+++ b/packages/ui/src/hooks/use-copy.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { toast as sonner } from "sonner"
 
+import { writeClipboardFallback } from "../lib/clipboard"
 import { useClipboard } from "./use-clipboard"
 
 export type CopyStatus = "idle" | "copied" | "error"
@@ -38,42 +39,6 @@ export interface CopyAPI {
 }
 
 /**
- * Last-resort clipboard write for insecure origins and embedded contexts where
- * `navigator.clipboard` is missing or rejects. Restores the user's selection so
- * copying doesn't visibly steal the caret.
- */
-function writeFallback(text: string): boolean {
-	if (typeof document === "undefined") return false
-
-	const area = document.createElement("textarea")
-	area.value = text
-	area.setAttribute("readonly", "")
-	area.style.position = "fixed"
-	area.style.top = "0"
-	area.style.left = "0"
-	area.style.opacity = "0"
-	document.body.appendChild(area)
-
-	const selection = document.getSelection()
-	const previous = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null
-
-	area.select()
-	let ok = false
-	try {
-		ok = document.execCommand("copy")
-	} catch {
-		ok = false
-	}
-
-	document.body.removeChild(area)
-	if (selection && previous) {
-		selection.removeAllRanges()
-		selection.addRange(previous)
-	}
-	return ok
-}
-
-/**
  * The one copy-to-clipboard hook. Writes through the platform `ClipboardAPI`
  * (so a `ClipboardProvider` override still applies), falls back to
  * `document.execCommand` when that rejects, and exposes an `idle | copied |
@@ -92,24 +57,26 @@ export function useCopy({
 }: UseCopyOptions = {}): CopyAPI {
 	const clipboard = useClipboard()
 	const [status, setStatus] = React.useState<CopyStatus>("idle")
-	// Bumped on every copy so a re-click during the hold restarts the timer.
-	const [ticket, setTicket] = React.useState(0)
 
+	// Restarted on every copy so a re-click during the hold extends the window
+	// rather than letting the first timer snap the status back early.
+	const timer = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 	const mounted = React.useRef(true)
 	React.useEffect(() => {
 		mounted.current = true
 		return () => {
 			mounted.current = false
+			clearTimeout(timer.current)
 		}
 	}, [])
 
 	// Kept in refs so `copy` stays referentially stable across renders.
-	const latest = React.useRef({ clipboard, label, onCopy, onError, successMessage, toast })
-	latest.current = { clipboard, label, onCopy, onError, successMessage, toast }
+	const latest = React.useRef({ clipboard, label, onCopy, onError, successMessage, timeout, toast })
+	latest.current = { clipboard, label, onCopy, onError, successMessage, timeout, toast }
 
 	const reset = React.useCallback(() => {
+		clearTimeout(timer.current)
 		setStatus("idle")
-		setTicket(0)
 	}, [])
 
 	const copy = React.useCallback(async (text: string | null | undefined): Promise<boolean> => {
@@ -119,6 +86,7 @@ export function useCopy({
 			onCopy: copied,
 			onError: failed,
 			successMessage: message,
+			timeout: hold,
 			toast: notify,
 		} = latest.current
 
@@ -134,7 +102,7 @@ export function useCopy({
 			} catch (error) {
 				reason = error
 				try {
-					ok = writeFallback(text)
+					ok = writeClipboardFallback(text)
 				} catch {
 					ok = false
 				}
@@ -152,16 +120,13 @@ export function useCopy({
 		if (!mounted.current) return ok
 
 		setStatus(ok ? "copied" : "error")
-		setTicket((t) => t + 1)
+		clearTimeout(timer.current)
+		timer.current = setTimeout(() => {
+			if (mounted.current) setStatus("idle")
+		}, hold)
 
 		return ok
 	}, [])
-
-	React.useEffect(() => {
-		if (ticket === 0 || status === "idle") return
-		const id = setTimeout(() => setStatus("idle"), timeout)
-		return () => clearTimeout(id)
-	}, [ticket, status, timeout])
 
 	return { copied: status === "copied", copy, reset, status }
 }

--- a/packages/ui/src/lib/clipboard.test.ts
+++ b/packages/ui/src/lib/clipboard.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { writeClipboardFallback, writeClipboardText } from "./clipboard"
+
+let execCommand: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+	execCommand = vi.fn(() => true)
+	Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand })
+})
+
+afterEach(() => {
+	vi.restoreAllMocks()
+	Reflect.deleteProperty(navigator, "clipboard")
+})
+
+describe("writeClipboardFallback", () => {
+	it("copies through a textarea and leaves no node behind", () => {
+		const before = document.body.childNodes.length
+		let seen: HTMLTextAreaElement | undefined
+		execCommand.mockImplementation(() => {
+			// The element only exists for the duration of the call — capture it now
+			// or the assertions below have nothing to check.
+			seen = document.body.querySelector("textarea") ?? undefined
+			return true
+		})
+
+		expect(writeClipboardFallback("maple")).toBe(true)
+		expect(seen?.value).toBe("maple")
+		expect(seen?.getAttribute("readonly")).toBe("")
+		expect(document.body.childNodes.length).toBe(before)
+		expect(document.body.querySelector("textarea")).toBeNull()
+	})
+
+	it("restores the user's selection instead of stealing the caret", () => {
+		const paragraph = document.createElement("p")
+		paragraph.textContent = "selected text"
+		document.body.appendChild(paragraph)
+		const range = document.createRange()
+		range.selectNodeContents(paragraph)
+		const selection = document.getSelection()!
+		selection.removeAllRanges()
+		selection.addRange(range)
+
+		writeClipboardFallback("maple")
+
+		expect(selection.rangeCount).toBe(1)
+		expect(selection.getRangeAt(0).startContainer).toBe(paragraph)
+		paragraph.remove()
+	})
+
+	it("reports failure and still removes the textarea when execCommand throws", () => {
+		execCommand.mockImplementation(() => {
+			throw new Error("blocked")
+		})
+
+		expect(writeClipboardFallback("maple")).toBe(false)
+		expect(document.body.querySelector("textarea")).toBeNull()
+	})
+})
+
+describe("writeClipboardText", () => {
+	it("prefers navigator.clipboard when it resolves", async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined)
+		Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } })
+
+		expect(await writeClipboardText("maple")).toBe(true)
+		expect(writeText).toHaveBeenCalledWith("maple")
+		expect(execCommand).not.toHaveBeenCalled()
+	})
+
+	it("falls back when the clipboard API rejects", async () => {
+		const writeText = vi.fn().mockRejectedValue(new Error("denied"))
+		Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } })
+
+		expect(await writeClipboardText("maple")).toBe(true)
+		expect(execCommand).toHaveBeenCalledWith("copy")
+	})
+
+	it("falls back when the clipboard API is missing (insecure origin)", async () => {
+		expect(await writeClipboardText("maple")).toBe(true)
+		expect(execCommand).toHaveBeenCalledWith("copy")
+	})
+
+	it("refuses an empty value without touching the clipboard", async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined)
+		Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } })
+
+		expect(await writeClipboardText("")).toBe(false)
+		expect(writeText).not.toHaveBeenCalled()
+		expect(execCommand).not.toHaveBeenCalled()
+	})
+})

--- a/packages/ui/src/lib/clipboard.ts
+++ b/packages/ui/src/lib/clipboard.ts
@@ -1,0 +1,62 @@
+/**
+ * Framework-free clipboard writes. Lives outside the React hook so the non-React
+ * surfaces (the Astro landing site) share one implementation of the fiddly
+ * insecure-origin fallback instead of keeping their own copy of it.
+ */
+
+/**
+ * Last-resort clipboard write for insecure origins and embedded contexts where
+ * `navigator.clipboard` is missing or rejects. Restores the user's selection so
+ * copying doesn't visibly steal the caret.
+ */
+export function writeClipboardFallback(text: string): boolean {
+	if (typeof document === "undefined") return false
+
+	const area = document.createElement("textarea")
+	area.value = text
+	area.setAttribute("readonly", "")
+	area.style.position = "fixed"
+	area.style.top = "0"
+	area.style.left = "0"
+	area.style.opacity = "0"
+	document.body.appendChild(area)
+
+	const selection = document.getSelection()
+	const previous = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null
+
+	area.select()
+	let ok = false
+	try {
+		ok = document.execCommand("copy")
+	} catch {
+		ok = false
+	}
+
+	document.body.removeChild(area)
+	if (selection && previous) {
+		selection.removeAllRanges()
+		selection.addRange(previous)
+	}
+	return ok
+}
+
+/**
+ * Write `text` through `navigator.clipboard`, falling back to the hidden
+ * textarea when the API is missing or rejects. React callers should prefer
+ * `useCopy`, which routes through the platform `ClipboardAPI` first so a
+ * `ClipboardProvider` override still applies.
+ */
+export async function writeClipboardText(text: string): Promise<boolean> {
+	if (!text) return false
+
+	try {
+		if (navigator.clipboard?.writeText) {
+			await navigator.clipboard.writeText(text)
+			return true
+		}
+	} catch {
+		// fall through to the legacy path
+	}
+
+	return writeClipboardFallback(text)
+}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config"
+
+// The package is mostly pure logic, but hooks and components live here too and
+// their behavior tests used to be exiled to apps/web for want of a renderer.
+// jsdom is the default environment so a `.test.tsx` next to a component just
+// works; the pure-logic suites don't care either way.
+export default defineConfig({
+	test: {
+		environment: "jsdom",
+		include: ["src/**/*.test.{ts,tsx}"],
+	},
+})


### PR DESCRIPTION
Split out of #301. Moves the clipboard primitives into `@maple/ui` so `web`, `local-ui` and
`landing` share one implementation, and drops the `motion/react` dependency from the package.

## What moves

- New `packages/ui/src/lib/clipboard.ts` — the low-level write with its fallback path, extracted so
  non-React callers (`apps/landing`) can use it without a hook.
- `apps/web/src/components/common/copyable-badge.tsx` → `packages/ui/src/components/ui/`.
- `apps/web/src/hooks/use-copy.test.tsx` → `packages/ui/src/hooks/` (the hook itself already lived
  in `packages/ui`; only the test was stranded).
- New `packages/ui/vitest.config.ts` (jsdom) so these components are tested where they live. That's
  what the `@testing-library/*` / `jsdom` / `vite` devDeps are for.

## Breaking prop changes (why this lands atomically)

- `CopyButtonProps.glyph: "copy" | "link"` → `idleIcon?: IconComponent`. All four callers are
  updated here — `message-actions`, `log-meta-strip`, `metric-graduation-actions`, `widget-lab`.
- `CopyButton`'s animation is now CSS (`group-data-[copy-status=…]`) instead of `motion.span`.
  That made `motion` dead in `packages/ui`, so it's removed from the manifest.
- `CopyableField`'s default `copyLabel` flips `"Command"` → `"Value"`, hence the three
  connect-button call sites passing `copyLabel="Command"` explicitly.
- `chat-transcript.test.tsx` expectations change `"Copy message"` → `"Copy Message"`: the
  hand-rolled buttons are gone and `CopyButton` derives `aria-label` from the label.

## Notes for review

`packages/ui/src/hooks/use-clipboard.tsx` (`ClipboardProvider`) intentionally survives alongside the
new `lib/clipboard.ts`. They're layered, not duplicated — `useCopy` prefers the provider when one is
mounted and falls back to the direct write otherwise.

The `bun.lock` delta beyond the `packages/ui` block (`accepts`, `send`, `negotiator`, `node-fetch`
re-hoisting) is pre-existing drift: `main`'s lockfile is stale against bun 1.3.14, so any
`bun install` reproduces it.

## Verification

- `bun run --cwd packages/ui test` — 200 passed (17 files, including the three new/moved ones)
- `bun run --cwd apps/web test -- src/components/chat/chat-transcript.test.tsx` — 15 passed
- `bun run --cwd packages/ui typecheck`, `bun run --cwd apps/web typecheck` — clean
