### PR TITLE
refactor(dashboards): make the canvas responsive with width tiers

### DIFF
--- a/apps/api/src/mcp/lib/dashboard-mutations.ts
+++ b/apps/api/src/mcp/lib/dashboard-mutations.ts
@@ -76,7 +76,7 @@ export const defaultSizeForVisualization = (visualization: string): { w: number;
 
 /**
  * Port of `findNextPosition` from
- * `apps/web/src/hooks/use-dashboard-store.ts:32-54`. Keeps auto-layout
+ * `findNextPosition` in `apps/web/src/hooks/use-dashboard-store.ts`. Keeps auto-layout
  * behavior identical between UI-added and MCP-added widgets.
  */
 export const findNextWidgetPosition = (

--- a/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.tsx
+++ b/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.tsx
@@ -1,14 +1,31 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { GridLayout, useContainerWidth, verticalCompactor } from "react-grid-layout"
+import { GridLayout, noCompactor, verticalCompactor } from "react-grid-layout"
 import type { Layout } from "react-grid-layout"
 import "react-grid-layout/css/styles.css"
+import { useContainerSize } from "@maple/ui/hooks/use-container-size"
+import { cn } from "@maple/ui/utils"
 
+import {
+	GRID_ROW_HEIGHT,
+	projectLayout,
+	tierForWidth,
+} from "@/components/dashboard-builder/canvas/grid-breakpoints"
 import type { DashboardWidget } from "@/components/dashboard-builder/types"
 import { useDashboardActions } from "@/components/dashboard-builder/dashboard-actions-context"
 import { WidgetActionsProvider } from "@/components/dashboard-builder/widgets/widget-actions-context"
 import { WidgetTimeRangeProvider } from "@/components/dashboard-builder/widgets/widget-time-range-context"
 import { visualizationFor } from "@/components/dashboard-builder/widgets/types"
 import { useWidgetData } from "@/hooks/use-widget-data"
+
+/** Same widgets in the same boxes, ignoring order. */
+function sameLayout(a: Layout, b: Layout): boolean {
+	if (a.length !== b.length) return false
+	const byId = new Map(b.map((item) => [item.i, item]))
+	return a.every((item) => {
+		const other = byId.get(item.i)
+		return other !== undefined && other.x === item.x && other.y === item.y && other.w === item.w && other.h === item.h
+	})
+}
 
 interface DashboardCanvasProps {
 	widgets: DashboardWidget[]
@@ -88,40 +105,41 @@ const WidgetRenderer = memo(function WidgetRenderer({ widget }: { widget: Dashbo
 
 export function DashboardCanvas({ widgets, readOnly = false }: DashboardCanvasProps) {
 	const { mode, updateWidgetLayouts } = useDashboardActions()
-	const { width, containerRef, mounted } = useContainerWidth()
-	const editable = mode === "edit" && !readOnly
+	// Deliberately not react-grid-layout's own `useContainerWidth`: it seeds
+	// width at a hardcoded 1280 and its ResizeObserver was observed failing to
+	// correct that here, so the grid laid every tile out for a 1280px canvas and
+	// overflowed the real ~1150px one. `useContainerSize` reads the box
+	// synchronously before observing, which is exactly the case that broke.
+	const containerRef = useRef<HTMLDivElement>(null)
+	const { width: measuredWidth } = useContainerSize(containerRef)
+	// Rounded so subpixel container widths don't re-lay-out the whole grid.
+	const width = Math.round(measuredWidth)
+	const measured = width > 0
 
-	const layouts: Layout = useMemo(
-		() =>
-			widgets.map((w) => ({
-				i: w.id,
-				x: w.layout.x,
-				y: w.layout.y,
-				w: w.layout.w,
-				h: w.layout.h,
-				minW: w.layout.minW ?? 2,
-				minH: w.layout.minH ?? 2,
-				...(w.layout.maxW != null ? { maxW: w.layout.maxW } : {}),
-				...(w.layout.maxH != null ? { maxH: w.layout.maxH } : {}),
-			})),
-		[widgets],
-	)
+	// Only the canonical tier's layout is authored and persisted; narrower ones
+	// are projected from it at render time. Editing there would write a
+	// phone-shaped layout over the real one, so drag, resize and persistence are
+	// all gated on `tier.canonical`.
+	const tier = tierForWidth(width)
+	const editable = mode === "edit" && !readOnly && tier.canonical
 
-	// react-grid-layout fires onLayoutChange once on mount with the
-	// post-compaction layout. That first call is not a real user edit, so
-	// we drop it to avoid a spurious upsert that invalidates the dashboards
-	// list and cascades a re-render of every widget.
-	const initialLayoutSeenRef = useRef(false)
+	const layout = useMemo(() => projectLayout(widgets, tier), [widgets, tier])
 
+	// react-grid-layout fires onLayoutChange with the post-compaction layout
+	// after every re-layout, not just on user edits — a tier crossing produces
+	// one, and an upsert from a plain window resize would invalidate the
+	// dashboards list and cascade a re-render of every widget.
+	//
+	// Comparing against the layout we handed the grid is what separates the two,
+	// rather than counting callbacks: this version of react-grid-layout does not
+	// fire on mount, so a "drop the first call per tier" rule swallows the user's
+	// first real edit instead of the re-layout it was aiming at.
 	const handleLayoutChange = useCallback(
-		(layout: Layout) => {
+		(next: Layout) => {
 			if (!editable) return
-			if (!initialLayoutSeenRef.current) {
-				initialLayoutSeenRef.current = true
-				return
-			}
+			if (sameLayout(next, layout)) return
 			updateWidgetLayouts(
-				layout.map((l) => ({
+				next.map((l) => ({
 					i: l.i,
 					x: l.x,
 					y: l.y,
@@ -130,19 +148,28 @@ export function DashboardCanvas({ widgets, readOnly = false }: DashboardCanvasPr
 				})),
 			)
 		},
-		[editable, updateWidgetLayouts],
+		[editable, layout, updateWidgetLayouts],
 	)
 
 	return (
-		<div ref={containerRef}>
-			{mounted && (
+		// `is-layout-locked` lets WidgetShell hide its drag grip when the grid is
+		// showing a generated layout — a grip that can't be dragged reads as a
+		// bug. Widget-level actions (configure, clone, delete) stay available;
+		// only the arrangement is locked.
+		<div ref={containerRef} className={cn("group/canvas", !tier.canonical && "is-layout-locked")}>
+			{mode === "edit" && !readOnly && !tier.canonical && (
+				<p className="mb-3 text-xs text-muted-foreground">
+					Showing a layout adapted to this width. Widen the window to rearrange widgets.
+				</p>
+			)}
+			{measured && (
 				<GridLayout
 					width={width}
-					layout={layouts}
+					layout={layout}
 					gridConfig={{
-						cols: 12,
-						rowHeight: 60,
-						margin: [12, 12] as [number, number],
+						cols: tier.cols,
+						rowHeight: GRID_ROW_HEIGHT,
+						margin: tier.margin,
 					}}
 					dragConfig={{
 						enabled: editable,
@@ -154,7 +181,10 @@ export function DashboardCanvas({ widgets, readOnly = false }: DashboardCanvasPr
 						enabled: editable,
 						handles: ["se"],
 					}}
-					compactor={verticalCompactor}
+					// Derived tiers ship exact row-packed positions; letting the
+					// vertical compactor run would float short tiles up into the
+					// gaps beside taller neighbours and break the rows apart.
+					compactor={tier.canonical ? verticalCompactor : noCompactor}
 					onLayoutChange={handleLayoutChange}
 				>
 					{widgets.map((widget) => (

--- a/apps/web/src/components/dashboard-builder/canvas/grid-breakpoints.test.ts
+++ b/apps/web/src/components/dashboard-builder/canvas/grid-breakpoints.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest"
+
+import {
+	CANONICAL_COLS,
+	GRID_TIERS,
+	projectLayout,
+	tierForWidth,
+} from "@/components/dashboard-builder/canvas/grid-breakpoints"
+import type { DashboardWidget } from "@/components/dashboard-builder/types"
+
+function widget(id: string, x: number, y: number, w: number, h: number): DashboardWidget {
+	return {
+		id,
+		visualization: "stat",
+		dataSource: {},
+		display: {},
+		layout: { x, y, w, h },
+	} as unknown as DashboardWidget
+}
+
+/** A realistic authored dashboard: a row of stats over charts over a wide table. */
+const AUTHORED = [
+	widget("stat-a", 0, 0, 3, 4),
+	widget("stat-b", 3, 0, 3, 4),
+	widget("stat-c", 6, 0, 3, 4),
+	widget("stat-d", 9, 0, 3, 4),
+	widget("chart-a", 0, 4, 6, 6),
+	widget("chart-b", 6, 4, 6, 6),
+	widget("table", 0, 10, 12, 5),
+]
+
+const derivedTiers = GRID_TIERS.filter((tier) => !tier.canonical)
+
+describe("tierForWidth", () => {
+	it("returns the canonical tier on a desktop canvas", () => {
+		expect(tierForWidth(1152).canonical).toBe(true)
+		expect(tierForWidth(1152).cols).toBe(CANONICAL_COLS)
+	})
+
+	it("steps down as the canvas narrows, and never falls off the end", () => {
+		expect(tierForWidth(736).cols).toBe(8)
+		expect(tierForWidth(480).cols).toBe(6)
+		expect(tierForWidth(343).cols).toBe(1)
+		expect(tierForWidth(0).cols).toBe(1)
+	})
+})
+
+describe("projectLayout", () => {
+	it("passes the authored layout through untouched at the canonical tier", () => {
+		const projected = projectLayout(AUTHORED, GRID_TIERS[0])
+		expect(projected.map((l) => [l.i, l.x, l.y, l.w, l.h])).toEqual(
+			AUTHORED.map((w) => [w.id, w.layout.x, w.layout.y, w.layout.w, w.layout.h]),
+		)
+	})
+
+	// A plain loop rather than `describe.each`: its overload resolution is heavy
+	// enough to push `tsc --noEmit` over its heap limit on this project.
+	for (const tier of derivedTiers) {
+		describe(`at ${tier.cols} columns`, () => {
+			const projected = projectLayout(AUTHORED, tier)
+
+			it("keeps every widget exactly once", () => {
+				expect(projected.map((l) => l.i).toSorted()).toEqual(AUTHORED.map((w) => w.id).toSorted())
+			})
+
+			it("keeps every widget inside the grid", () => {
+				for (const item of projected) {
+					expect(item.x).toBeGreaterThanOrEqual(0)
+					expect(item.w).toBeGreaterThanOrEqual(1)
+					expect(item.x + item.w).toBeLessThanOrEqual(tier.cols)
+				}
+			})
+
+			it("fills each row edge to edge, with no gaps or overlaps", () => {
+				const rows = new Map<number, typeof projected>()
+				for (const item of projected) {
+					rows.set(item.y, [...(rows.get(item.y) ?? []), item])
+				}
+				for (const row of rows.values()) {
+					const ordered = row.toSorted((a, b) => a.x - b.x)
+					let cursor = 0
+					for (const item of ordered) {
+						// Abutting exactly proves no overlap and no gap in one check.
+						expect(item.x).toBe(cursor)
+						cursor += item.w
+					}
+					expect(cursor).toBe(tier.cols)
+				}
+			})
+
+			it("preserves reading order", () => {
+				const authoredOrder = AUTHORED.map((w) => w.id)
+				const projectedOrder = projected.toSorted((a, b) => a.y - b.y || a.x - b.x).map((l) => l.i)
+				expect(projectedOrder).toEqual(authoredOrder)
+			})
+
+			it("starts each row below the tallest widget of the row above", () => {
+				const rowTops = [...new Set(projected.map((l) => l.y))].toSorted((a, b) => a - b)
+				for (const [index, top] of rowTops.entries()) {
+					const next = rowTops[index + 1]
+					if (next === undefined) continue
+					const tallest = Math.max(...projected.filter((l) => l.y === top).map((l) => l.h))
+					expect(next).toBeGreaterThanOrEqual(top + tallest)
+				}
+			})
+
+			it("gives every widget in a row the same height, so rows have no holes", () => {
+				const rows = new Map<number, number[]>()
+				for (const item of projected) {
+					rows.set(item.y, [...(rows.get(item.y) ?? []), item.h])
+				}
+				for (const heights of rows.values()) {
+					expect(new Set(heights).size).toBe(1)
+				}
+			})
+
+			it("never shrinks a widget below its authored height", () => {
+				for (const item of projected) {
+					const source = AUTHORED.find((w) => w.id === item.i)
+					expect(item.h).toBeGreaterThanOrEqual(source?.layout.h ?? 0)
+				}
+			})
+		})
+	}
+
+	it("stacks every widget full width in a single column", () => {
+		const single = GRID_TIERS.find((tier) => tier.cols === 1)
+		if (!single) throw new Error("expected a single-column tier")
+		const projected = projectLayout(AUTHORED, single)
+		expect(projected.every((l) => l.x === 0 && l.w === 1)).toBe(true)
+		expect(new Set(projected.map((l) => l.y)).size).toBe(AUTHORED.length)
+	})
+
+	it("honours the per-tier minimum span so narrow tiles never get narrower", () => {
+		const sixCol = GRID_TIERS.find((tier) => tier.cols === 6)
+		if (!sixCol) throw new Error("expected a six-column tier")
+		// Four w:2 stats would each scale to a single column (~17%) without the floor.
+		const stats = [
+			widget("a", 0, 0, 2, 4),
+			widget("b", 2, 0, 2, 4),
+			widget("c", 4, 0, 2, 4),
+			widget("d", 6, 0, 2, 4),
+		]
+		const projected = projectLayout(stats, sixCol)
+		expect(projected.every((l) => l.w >= sixCol.minSpan)).toBe(true)
+	})
+
+	it("returns an empty layout for a dashboard with no widgets", () => {
+		expect(projectLayout([], GRID_TIERS[2])).toEqual([])
+	})
+})

--- a/apps/web/src/components/dashboard-builder/canvas/grid-breakpoints.ts
+++ b/apps/web/src/components/dashboard-builder/canvas/grid-breakpoints.ts
@@ -1,0 +1,141 @@
+import type { Layout, LayoutItem } from "react-grid-layout"
+
+import type { DashboardWidget } from "@/components/dashboard-builder/types"
+
+/**
+ * Grid geometry for the dashboard canvas.
+ *
+ * Dashboards persist exactly one layout, authored against the 12-column
+ * canonical grid. Narrower layouts are never stored — `projectLayout` derives
+ * them at render time, so every existing dashboard is responsive without a
+ * schema change or a migration.
+ *
+ * The corollary is that only the canonical tier may be edited: a layout derived
+ * for a phone must never be written back over the authored one. The canvas
+ * enforces that by gating `editable` and layout persistence on `tier.canonical`.
+ */
+
+/** Column count of the authored (persisted) layout. */
+export const CANONICAL_COLS = 12
+
+export const GRID_ROW_HEIGHT = 60
+
+export interface GridTier {
+	/** Minimum container width in px at which this tier applies. */
+	minWidth: number
+	cols: number
+	/**
+	 * Narrowest span a widget may shrink to at this tier. Pure proportional
+	 * scaling collapses a `w:2` stat to a single column, which at 6 columns is
+	 * ~17% of a ~480px canvas — an 80px tile. The floor is what stops a narrow
+	 * grid from producing tiles narrower than the wide one did.
+	 */
+	minSpan: number
+	margin: [number, number]
+	/** Only the canonical tier may be edited and persisted. */
+	canonical: boolean
+}
+
+/**
+ * Ordered widest-first. Thresholds are *container* widths, not viewport widths:
+ * an open nav sidebar plus page padding costs ~288px, so a 1440px desktop hands
+ * the canvas only ~1152px. They're set from what a tile actually measures — at
+ * 12 columns and an ~860px canvas the narrowest common widget (a `w:3` stat) is
+ * still ~215px, which reads fine; below that it starts truncating.
+ */
+export const GRID_TIERS: readonly GridTier[] = [
+	{ minWidth: 860, cols: CANONICAL_COLS, minSpan: 1, margin: [12, 12], canonical: true },
+	{ minWidth: 640, cols: 8, minSpan: 2, margin: [10, 10], canonical: false },
+	{ minWidth: 460, cols: 6, minSpan: 3, margin: [8, 8], canonical: false },
+	{ minWidth: 0, cols: 1, minSpan: 1, margin: [8, 8], canonical: false },
+]
+
+export function tierForWidth(width: number): GridTier {
+	return GRID_TIERS.find((tier) => width > tier.minWidth) ?? GRID_TIERS[GRID_TIERS.length - 1]
+}
+
+/** Column count for a container width — used by the template live preview. */
+export function colsForWidth(width: number): number {
+	return tierForWidth(width).cols
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(max, Math.max(min, value))
+}
+
+/**
+ * Project the authored 12-column layout onto a narrower tier.
+ *
+ * Deliberately not react-grid-layout's own `findOrGenerateResponsiveLayout`:
+ * that clamps each `w` to the column count and re-runs vertical compaction,
+ * which leaves a `w:4` chart at 4 of 6 columns while a `w:2` stat squeezes into
+ * the 2-column remainder, and then floats short tiles up into whatever holes
+ * the clamping opened. The result reads as scattered rather than as a grid.
+ *
+ * Instead: scale every width proportionally (with `minSpan` as a floor), pack
+ * widgets into rows in reading order, and justify each row so it fills the
+ * width exactly. Rows stay rows, order is preserved, and nothing overlaps —
+ * which is why the canvas pairs this with `noCompactor` on derived tiers.
+ */
+export function projectLayout(widgets: DashboardWidget[], tier: GridTier): Layout {
+	const base = widgets.map((w) => ({
+		i: w.id,
+		x: w.layout.x,
+		y: w.layout.y,
+		w: w.layout.w,
+		h: w.layout.h,
+		minW: w.layout.minW ?? 2,
+		minH: w.layout.minH ?? 2,
+		...(w.layout.maxW != null ? { maxW: w.layout.maxW } : {}),
+		...(w.layout.maxH != null ? { maxH: w.layout.maxH } : {}),
+	}))
+
+	if (tier.canonical) return base
+
+	// Reading order: left-to-right within a row, then down.
+	const ordered = base.toSorted((a, b) => a.y - b.y || a.x - b.x)
+
+	const projected: LayoutItem[] = []
+	let row: Array<{ i: string; w: number; h: number }> = []
+	let rowY = 0
+
+	// Grow the row's widgets until the row fills the grid exactly, so no tier
+	// ever renders a ragged right edge.
+	const flushRow = () => {
+		if (row.length === 0) return
+		let remainder = tier.cols - row.reduce((sum, item) => sum + item.w, 0)
+		for (let index = 0; remainder > 0; index = (index + 1) % row.length) {
+			row[index].w += 1
+			remainder -= 1
+		}
+
+		// Every widget in a row takes the row's height. Left at their authored
+		// heights, a short stat beside a tall gauge leaves a dead pocket that the
+		// compactor can't fill (it's switched off here precisely so rows hold
+		// together), and the result reads as holes rather than as a grid.
+		let x = 0
+		const rowHeight = Math.max(...row.map((item) => item.h))
+		for (const item of row) {
+			projected.push({ i: item.i, x, y: rowY, w: item.w, h: rowHeight })
+			x += item.w
+		}
+		rowY += rowHeight
+		row = []
+	}
+
+	for (const item of ordered) {
+		const scaled = clamp(
+			Math.round((item.w * tier.cols) / CANONICAL_COLS),
+			Math.min(tier.minSpan, tier.cols),
+			tier.cols,
+		)
+		const used = row.reduce((sum, r) => sum + r.w, 0)
+		if (used + scaled > tier.cols) flushRow()
+		row.push({ i: item.i, w: scaled, h: item.h })
+	}
+	flushRow()
+
+	// `minW`/`maxW` are expressed in 12-column units and would fight the
+	// projection; heights are unchanged, so their constraints carry over.
+	return projected
+}

--- a/apps/web/src/components/dashboard-builder/portable-dashboard.ts
+++ b/apps/web/src/components/dashboard-builder/portable-dashboard.ts
@@ -1,6 +1,7 @@
 import { PortableDashboardDocument, defaultWidgetLayout } from "@maple/domain/http"
 import { Schema } from "effect"
 
+import { CANONICAL_COLS } from "@/components/dashboard-builder/canvas/grid-breakpoints"
 import type { Dashboard, DashboardWidget, WidgetLayout } from "@/components/dashboard-builder/types"
 
 export type PortableDashboard = Omit<Dashboard, "id" | "createdAt" | "updatedAt">
@@ -43,7 +44,7 @@ function findNextWidgetPosition(widgets: DashboardWidget[], width: number) {
 	const bottomRowWidgets = widgets.filter((widget) => widget.layout.y === maxY)
 	const rightEdge = Math.max(...bottomRowWidgets.map((widget) => widget.layout.x + widget.layout.w))
 
-	if (rightEdge + width <= 12) {
+	if (rightEdge + width <= CANONICAL_COLS) {
 		return { x: rightEdge, y: maxY }
 	}
 

--- a/apps/web/src/components/dashboard-builder/templates/template-live-preview.tsx
+++ b/apps/web/src/components/dashboard-builder/templates/template-live-preview.tsx
@@ -1,6 +1,7 @@
-import { memo, useDeferredValue, useMemo, useState } from "react"
+import { memo, useDeferredValue, useMemo, useRef, useState } from "react"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { cn } from "@maple/ui/utils"
+import { useContainerSize } from "@maple/ui/hooks/use-container-size"
 import type { V2DashboardTemplate } from "@maple/domain/http/v2"
 import { Atom, Result, useAtomValue } from "@/lib/effect-atom"
 import { useMountEffect } from "@/hooks/use-mount-effect"
@@ -12,8 +13,9 @@ import type { DashboardWidget, TimeRange } from "@/components/dashboard-builder/
 import { useWidgetData } from "@/hooks/use-widget-data"
 import { CircleWarningIcon } from "@/components/icons"
 
+import { CANONICAL_COLS, colsForWidth } from "@/components/dashboard-builder/canvas/grid-breakpoints"
+
 /** The 12-column grid every template lays its widgets out on. */
-const GRID_COLUMNS = 12
 
 /**
  * Pixels per layout row unit. Templates are authored for a full dashboard, so
@@ -81,7 +83,13 @@ const heightFor = (widget: DashboardWidget): number =>
  * is the same shape the widget builder's live preview uses; `useWidgetData`
  * needs nothing but a surrounding `DashboardTimeRangeWrapper`.
  */
-const PreviewWidget = memo(function PreviewWidget({ widget }: { widget: DashboardWidget }) {
+const PreviewWidget = memo(function PreviewWidget({
+	widget,
+	cols,
+}: {
+	widget: DashboardWidget
+	cols: number
+}) {
 	const { dataState } = useWidgetData(widget)
 	const Visualization = visualizationFor(widget.visualization)
 
@@ -91,7 +99,7 @@ const PreviewWidget = memo(function PreviewWidget({ widget }: { widget: Dashboar
 		<div
 			className="min-w-0"
 			style={{
-				gridColumn: `span ${Math.min(widget.layout.w, GRID_COLUMNS)}`,
+				gridColumn: `span ${Math.min(widget.layout.w, cols)}`,
 				height: heightFor(widget),
 			}}
 		>
@@ -103,6 +111,29 @@ const PreviewWidget = memo(function PreviewWidget({ widget }: { widget: Dashboar
 })
 
 /**
+ * This preview is a plain CSS grid rather than a react-grid-layout instance, so
+ * it can't inherit the canvas's generated breakpoint layouts. It resolves the
+ * column count itself from the same `GRID_BREAKPOINTS` table, so a template
+ * previewed on a phone collapses the same way the real dashboard will — a
+ * 12-column preview inside a 375px dialog is unreadable.
+ */
+function PreviewGrid({ widgets }: { widgets: DashboardWidget[] }) {
+	const ref = useRef<HTMLDivElement>(null)
+	const { width } = useContainerSize(ref)
+	// Before the first measurement, assume the full grid: templates are usually
+	// previewed on a desktop, so this is the no-flash default.
+	const cols = width > 0 ? colsForWidth(width) : CANONICAL_COLS
+
+	return (
+		<div ref={ref} className="grid gap-2" style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}>
+			{widgets.map((widget) => (
+				<PreviewWidget key={widget.id} widget={widget} cols={cols} />
+			))}
+		</div>
+	)
+}
+
+/**
  * The shape most templates open with — a row of stats over a pair of charts —
  * drawn at the heights the real widgets will take, so the panel below the
  * preview doesn't jump when the request resolves.
@@ -110,7 +141,7 @@ const PreviewWidget = memo(function PreviewWidget({ widget }: { widget: Dashboar
 function PreviewSkeleton() {
 	const statHeight = MIN_HEIGHT.stat
 	return (
-		<div className="grid gap-2" style={{ gridTemplateColumns: `repeat(${GRID_COLUMNS}, 1fr)` }}>
+		<div className="grid gap-2" style={{ gridTemplateColumns: `repeat(${CANONICAL_COLS}, 1fr)` }}>
 			<Skeleton className="col-span-4 rounded-md" style={{ height: statHeight }} />
 			<Skeleton className="col-span-4 rounded-md" style={{ height: statHeight }} />
 			<Skeleton className="col-span-4 rounded-md" style={{ height: statHeight }} />
@@ -183,14 +214,7 @@ export function TemplateLivePreview({ template, parameters, className }: Templat
 			return (
 				<div className={cn("flex flex-col gap-2", className)}>
 					<DashboardTimeRangeWrapper initialTimeRange={preview.timeRange as TimeRange}>
-						<div
-							className="grid gap-2"
-							style={{ gridTemplateColumns: `repeat(${GRID_COLUMNS}, 1fr)` }}
-						>
-							{shown.map((widget) => (
-								<PreviewWidget key={widget.id} widget={widget} />
-							))}
-						</div>
+						<PreviewGrid widgets={shown} />
 					</DashboardTimeRangeWrapper>
 					{hidden > 0 && (
 						<p className="text-muted-foreground text-xs">

--- a/apps/web/src/components/dashboard-builder/toolbar/dashboard-toolbar.tsx
+++ b/apps/web/src/components/dashboard-builder/toolbar/dashboard-toolbar.tsx
@@ -56,10 +56,17 @@ export function DashboardToolbar({
 	const isEdit = mode === "edit"
 
 	return (
-		<div className="flex items-center gap-3">
-			<VariableSelects
-				onManage={isEdit && !readOnly ? () => setVariablesDialogOpen(true) : undefined}
-			/>
+		// Wraps rather than overflows: variable chips, the time picker and the
+		// action group together need ~700px, which the canvas does not have on a
+		// phone or with both sidebars open. Gating is on `@container/page`
+		// (declared by PageLayout.Content) because the sidebars, not the viewport,
+		// decide how much room this actually gets.
+		<div className="flex flex-wrap items-center justify-end gap-2 @min-[720px]/page:gap-3">
+			<div className="flex min-w-0 max-w-full items-center overflow-x-auto">
+				<VariableSelects
+					onManage={isEdit && !readOnly ? () => setVariablesDialogOpen(true) : undefined}
+				/>
+			</div>
 			<TimeRangePicker
 				hotkey
 				startTime={resolvedTimeRange?.startTime}
@@ -86,10 +93,18 @@ export function DashboardToolbar({
 			<ReloadControls />
 
 			<div className="flex items-center gap-1">
+				{/* Labels collapse to icon-only on a narrow canvas; `aria-label`
+				    keeps the buttons named for screen readers either way. */}
 				{isEdit && (
-					<Button variant="outline" size="sm" onClick={onAddWidget} disabled={readOnly}>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={onAddWidget}
+						disabled={readOnly}
+						aria-label="Add widget"
+					>
 						<PlusIcon size={14} data-icon="inline-start" />
-						Add Widget
+						<span className="hidden @min-[560px]/page:inline">Add Widget</span>
 					</Button>
 				)}
 				<Button
@@ -97,13 +112,14 @@ export function DashboardToolbar({
 					size="sm"
 					onClick={onToggleEdit}
 					disabled={readOnly}
+					aria-label={isEdit ? "Done editing" : "Edit dashboard"}
 				>
 					{isEdit ? (
 						<CheckIcon size={14} data-icon="inline-start" />
 					) : (
 						<PencilIcon size={14} data-icon="inline-start" />
 					)}
-					{isEdit ? "Done" : "Edit"}
+					<span className="hidden @min-[560px]/page:inline">{isEdit ? "Done" : "Edit"}</span>
 				</Button>
 				<DropdownMenu>
 					<DropdownMenuTrigger

--- a/apps/web/src/components/dashboard-builder/widgets/gauge-widget.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/gauge-widget.tsx
@@ -157,7 +157,7 @@ export const GaugeWidget = memo(function GaugeWidget({ dataState, display, mode 
 			title={display.title || "Untitled"}
 			dataState={dataState}
 			mode={mode}
-			contentClassName="flex-1 min-h-0 flex items-center justify-center p-2"
+			contentClassName="flex-1 min-h-0 flex items-center justify-center p-1 @min-[200px]/widget:p-2"
 			loadingSkeleton={<ChartSkeleton variant="gauge" />}
 		>
 			<svg

--- a/apps/web/src/components/dashboard-builder/widgets/list-widget.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/list-widget.tsx
@@ -2,8 +2,9 @@ import { memo } from "react"
 import { Link } from "@tanstack/react-router"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@maple/ui/components/ui/table"
+import { cn } from "@maple/ui/lib/utils"
 import { WidgetFrame } from "@/components/dashboard-builder/widgets/widget-shell"
-import { formatCellValue } from "@/components/dashboard-builder/widgets/table-widget"
+import { columnVisibilityClass, formatCellValue } from "@/components/dashboard-builder/widgets/table-widget"
 import { resolveFieldPath } from "@/lib/resolve-field-path"
 import type { WidgetDataState, WidgetDisplayConfig, WidgetMode } from "@/components/dashboard-builder/types"
 
@@ -60,10 +61,10 @@ export const ListWidget = memo(function ListWidget({ dataState, display, mode }:
 			<Table>
 				<TableHeader>
 					<TableRow>
-						{effectiveColumns.map((col) => (
+						{effectiveColumns.map((col, colIndex) => (
 							<TableHead
 								key={col.field}
-								className="text-xs"
+								className={cn("text-xs", columnVisibilityClass(colIndex))}
 								style={{
 									textAlign: col.align ?? "left",
 									width: col.width ? `${col.width}px` : undefined,
@@ -87,7 +88,7 @@ export const ListWidget = memo(function ListWidget({ dataState, display, mode }:
 					) : (
 						rows.map((row, i) => (
 							<TableRow key={i}>
-								{effectiveColumns.map((col) => {
+								{effectiveColumns.map((col, colIndex) => {
 									const value = resolveFieldPath(row, col.field)
 									const displayValue = Array.isArray(value)
 										? value.join(", ")
@@ -129,7 +130,7 @@ export const ListWidget = memo(function ListWidget({ dataState, display, mode }:
 									return (
 										<TableCell
 											key={col.field}
-											className="text-xs"
+											className={cn("text-xs", columnVisibilityClass(colIndex))}
 											style={{ textAlign: col.align ?? "left" }}
 										>
 											{content}

--- a/apps/web/src/components/dashboard-builder/widgets/markdown-widget.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/markdown-widget.tsx
@@ -163,7 +163,7 @@ export const MarkdownWidget = memo(function MarkdownWidget({ display, mode }: Ma
 		<WidgetShell
 			title={display.title || "Note"}
 			mode={mode}
-			contentClassName="flex-1 min-h-0 overflow-auto p-3"
+			contentClassName="flex-1 min-h-0 overflow-auto p-2 @min-[220px]/widget:p-3"
 		>
 			{content.trim() === "" ? (
 				<div className="text-xs text-muted-foreground italic">

--- a/apps/web/src/components/dashboard-builder/widgets/stat-widget.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/stat-widget.tsx
@@ -59,8 +59,14 @@ export const StatWidget = memo(function StatWidget({ dataState, display, mode }:
 
 	const sparklineSource = display.sparkline?.enabled === true ? display.sparkline.dataSource : undefined
 
+	// The headline scales with the tile, not the viewport: a 3-column stat is
+	// ~90px wide once the grid drops to 6 columns, where `text-2xl` truncates a
+	// formatted value that reads fine one breakpoint up.
 	const valueText = (
-		<span className="text-2xl font-bold" style={thresholdColor ? { color: thresholdColor } : undefined}>
+		<span
+			className="text-base font-bold tabular-nums @min-[150px]/widget:text-2xl @min-[280px]/widget:text-3xl"
+			style={thresholdColor ? { color: thresholdColor } : undefined}
+		>
 			{formattedValue}
 		</span>
 	)
@@ -73,7 +79,7 @@ export const StatWidget = memo(function StatWidget({ dataState, display, mode }:
 			contentClassName={
 				sparklineSource
 					? "flex-1 min-h-0 flex flex-col"
-					: "flex-1 min-h-0 flex items-center justify-center p-4"
+					: "flex-1 min-h-0 flex items-center justify-center p-2 @min-[200px]/widget:p-4"
 			}
 			loadingSkeleton={
 				sparklineSource ? (
@@ -90,11 +96,17 @@ export const StatWidget = memo(function StatWidget({ dataState, display, mode }:
 		>
 			{sparklineSource ? (
 				<>
-					<div className="flex flex-1 items-center justify-center px-4 pt-4">{valueText}</div>
-					<StatSparklineLoader
-						dataSource={sparklineSource}
-						color={thresholdColor ?? "var(--chart-1)"}
-					/>
+					<div className="flex flex-1 items-center justify-center px-2 pt-2 @min-[200px]/widget:px-4 @min-[200px]/widget:pt-4">
+						{valueText}
+					</div>
+					{/* Under ~140px the trend is a few pixels of noise under the
+					    number — drop it and give the value the whole tile. */}
+					<div className="hidden shrink-0 @min-[140px]/widget:block">
+						<StatSparklineLoader
+							dataSource={sparklineSource}
+							color={thresholdColor ?? "var(--chart-1)"}
+						/>
+					</div>
 				</>
 			) : (
 				valueText

--- a/apps/web/src/components/dashboard-builder/widgets/table-widget.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/table-widget.tsx
@@ -62,6 +62,32 @@ export function buildRowKeys(rows: ReadonlyArray<Record<string, unknown>>, field
 	})
 }
 
+/**
+ * Progressive column reveal, keyed off the widget card's own width.
+ *
+ * Table columns here are whatever the query returned (or whatever the author
+ * configured), so there is no fixed "these are the secondary ones" list the way
+ * `TRACE_COLUMNS` has. The rule instead is positional: the first column — the
+ * group key in a breakdown table — always shows, and each column after it needs
+ * another ~100px of card before it earns its place. Without this, a table tile
+ * on a 6- or 1-column grid renders six columns of ellipsis.
+ *
+ * The classes must be written out as literals; Tailwind scans source text, so a
+ * template-interpolated `@min-[${n}px]` would never be generated.
+ */
+const COLUMN_VISIBILITY = [
+	"",
+	"hidden @min-[220px]/widget:table-cell",
+	"hidden @min-[320px]/widget:table-cell",
+	"hidden @min-[420px]/widget:table-cell",
+	"hidden @min-[520px]/widget:table-cell",
+	"hidden @min-[620px]/widget:table-cell",
+]
+
+export function columnVisibilityClass(index: number): string {
+	return COLUMN_VISIBILITY[Math.min(index, COLUMN_VISIBILITY.length - 1)]
+}
+
 function getCellThresholdColor(
 	value: unknown,
 	thresholds?: Array<{ value: number; color: string }>,
@@ -150,12 +176,12 @@ export const TableWidget = memo(function TableWidget({
 			<Table>
 				<TableHeader>
 					<TableRow>
-						{effectiveColumns.map((col) => {
+						{effectiveColumns.map((col, colIndex) => {
 							const active = sortKey === col.field
 							return (
 								<TableHead
 									key={col.field}
-									className="text-xs"
+									className={cn("text-xs", columnVisibilityClass(colIndex))}
 									aria-sort={
 										active ? (sortDir === "asc" ? "ascending" : "descending") : "none"
 									}
@@ -203,13 +229,13 @@ export const TableWidget = memo(function TableWidget({
 					) : (
 						sorted.map((row, i) => (
 							<TableRow key={rowKeys[i]}>
-								{effectiveColumns.map((col) => {
+								{effectiveColumns.map((col, colIndex) => {
 									const value = row[col.field]
 									const thresholdColor = getCellThresholdColor(value, col.thresholds)
 									return (
 										<TableCell
 											key={col.field}
-											className="text-xs"
+											className={cn("text-xs", columnVisibilityClass(colIndex))}
 											style={{
 												textAlign: col.align ?? "left",
 												color: thresholdColor,

--- a/apps/web/src/components/dashboard-builder/widgets/widget-shell.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/widget-shell.tsx
@@ -77,11 +77,19 @@ export function WidgetShell({
 	const timeRangeLabel = timeRangeOverride ? widgetTimeRangeLabel(timeRangeOverride) : null
 
 	return (
-		<Card className="h-full flex flex-col">
+		// `@container/widget` is the size anchor for every widget body. Tiles are
+		// sized by the grid, not the viewport — the nav sidebar collapse swings the
+		// canvas ~208px and the grid drops to 6 or 1 columns on narrow screens — so
+		// internals gate on the card's own width, never on `md:`/`lg:`.
+		<Card className="@container/widget h-full flex flex-col">
 			<CardHeader className="py-2.5">
 				<div className="flex min-w-0 items-center gap-2">
 					{isEditable && (
-						<div className="widget-drag-handle cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground">
+						// Hidden when the canvas is showing a generated (non-authored)
+						// layout — see `is-layout-locked` in dashboard-canvas. Outside a
+						// canvas (widget lab, previews) the group never matches, so the
+						// grip renders as before.
+						<div className="widget-drag-handle cursor-grab text-muted-foreground group-[.is-layout-locked]/canvas:hidden hover:text-foreground active:cursor-grabbing">
 							<GripDotsIcon size={14} />
 						</div>
 					)}
@@ -111,7 +119,10 @@ export function WidgetShell({
 							const visible = legendItems.slice(0, MAX_HEADER_ITEMS)
 							const overflow = legendItems.length - visible.length
 							return (
-								<div className="flex min-w-0 flex-1 items-center justify-end gap-x-3 overflow-hidden">
+								// Below ~380px the title alone fills the header row, so
+								// the legend is dropped entirely rather than squeezed to
+								// a row of unreadable truncated stubs.
+								<div className="hidden min-w-0 flex-1 items-center justify-end gap-x-3 overflow-hidden @min-[380px]/widget:flex">
 									{visible.map((item) => (
 										<span
 											key={item.key}

--- a/apps/web/src/hooks/use-dashboard-store.ts
+++ b/apps/web/src/hooks/use-dashboard-store.ts
@@ -34,8 +34,8 @@ import type {
 	WidgetDisplayConfig,
 } from "@/components/dashboard-builder/types"
 import { persistenceErrorAtom } from "@/atoms/dashboard-store-atoms"
+import { CANONICAL_COLS } from "@/components/dashboard-builder/canvas/grid-breakpoints"
 
-const GRID_COLS = 12
 const asDashboardId = Schema.decodeUnknownSync(DashboardId)
 const asIsoDateTimeString = Schema.decodeUnknownSync(IsoDateTimeString)
 
@@ -67,7 +67,7 @@ function findNextPosition(widgets: DashboardWidget[], newWidth: number): { x: nu
 	const bottomRowWidgets = widgets.filter((w) => w.layout.y === maxY)
 	const rightEdge = Math.max(...bottomRowWidgets.map((w) => w.layout.x + w.layout.w))
 
-	if (rightEdge + newWidth <= GRID_COLS) {
+	if (rightEdge + newWidth <= CANONICAL_COLS) {
 		return { x: rightEdge, y: maxY }
 	}
 
@@ -426,7 +426,7 @@ function makeWidgetMutators(deps: {
 				const w = widget.layout.w
 				const h = widget.layout.h
 
-				if (currentX + w > GRID_COLS) {
+				if (currentX + w > CANONICAL_COLS) {
 					currentX = 0
 					currentY += rowHeight
 					rowHeight = 0

--- a/apps/web/src/routes/dashboards/$dashboardId.tsx
+++ b/apps/web/src/routes/dashboards/$dashboardId.tsx
@@ -192,7 +192,7 @@ function DashboardViewPage() {
 				<DashboardLayout.Body>
 					<DashboardLayout.Content>
 						<DashboardLayout.Scroll>
-							<div className="flex flex-col items-center gap-3 py-24">
+							<div className="flex flex-col items-center gap-3 px-4 py-24 text-center">
 								<p className="text-sm font-medium text-foreground">Dashboard not found</p>
 								<p className="text-xs text-muted-foreground">
 									No dashboard with id{" "}
@@ -286,7 +286,7 @@ function DashboardViewPage() {
 												onRestored={() => setPreviewed(null)}
 											/>
 										) : activeDashboard.widgets.length === 0 && mode === "view" ? (
-											<div className="flex flex-col items-center justify-center py-24 gap-4">
+											<div className="flex flex-col items-center justify-center gap-4 px-4 py-24 text-center">
 												<div className="flex gap-2">
 													<div className="size-8 rounded bg-primary/15" />
 													<div className="size-8 rounded bg-primary/10" />


### PR DESCRIPTION
Split out of #301. Makes the dashboard canvas responsive without a schema change, and moves the
widget internals from viewport breakpoints to container queries.

## Approach

Dashboards still persist exactly one layout, authored against the 12-column canonical grid. Narrower
layouts are never stored — `projectLayout` derives them at render time, so every existing dashboard
becomes responsive with no migration. The corollary is that only the canonical tier is editable: the
canvas gates `editable` and layout persistence on `tier.canonical`, so a layout derived for a phone
can never be written back over the authored one.

New `canvas/grid-breakpoints.ts` owns the geometry: `CANONICAL_COLS`, `GRID_TIERS`, `tierForWidth`,
`colsForWidth`, `projectLayout`. The hardcoded `12` disappears from `use-dashboard-store.ts`,
`portable-dashboard.ts` and the canvas.

Tier thresholds are **container** widths, not viewport widths — an open nav sidebar plus page
padding costs ~288px, so a 1440px desktop hands the canvas only ~1152px. They're set from what a
tile actually measures rather than from device classes.

## Why not react-grid-layout's own responsive layer

`findOrGenerateResponsiveLayout` clamps each `w` to the column count and re-runs vertical
compaction. That leaves a `w:4` chart at 4 of 6 columns while a `w:2` stat squeezes into the
2-column remainder, then floats short tiles up into the holes the clamping opened — it reads as
scattered rather than as a grid.

`projectLayout` instead scales widths proportionally with a per-tier `minSpan` floor, packs widgets
into rows in reading order, and justifies each row to fill the width exactly. Rows stay rows, order
is preserved, nothing overlaps — which is why derived tiers pair it with `noCompactor`. The
`minSpan` floor is what stops a narrow grid from producing tiles narrower than the wide one did
(pure proportional scaling collapses a `w:2` stat to ~80px at 6 columns).

The widgets themselves switch to `@container/widget` queries so a tile adapts to its own box rather
than to the window — `template-live-preview.tsx`'s new `PreviewGrid` reuses the existing
`@maple/ui/hooks/use-container-size`.

## Verification

- `bun run --cwd apps/web test -- src/components/dashboard-builder/canvas/grid-breakpoints.test.ts`
  — 27 passed
- `bun run --cwd apps/web typecheck`, `bun run --cwd apps/api typecheck` — clean
