### PR TITLE
feat(query-engine): harden error tracking and wire-format safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,12 @@ jobs:
               uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
               with:
                   name: native-checkpoint-failure-${{ github.run_id }}
-                  path: ${{ runner.temp }}/maple-native-checkpoint
+                  # Both probes' roots: the migration probe used to fail without
+                  # leaving any evidence because only the checkpoint dir was
+                  # collected.
+                  path: |
+                      ${{ runner.temp }}/maple-native-checkpoint
+                      ${{ runner.temp }}/maple-native-migration
                   if-no-files-found: ignore
 
     local-archive-native:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,21 +41,22 @@ To add a query: define it in `packages/query-engine/src/ch/queries/*.ts` with
 
 ```typescript
 const compiled = CH.compile(CH.myQuery({ limit: 50 }), { orgId, startTime, endTime })
-const rows =
-	yield *
-	warehouse
-		.sqlQuery(tenant, compiled.sql, { profile: "list", context: "myQuery" })
-		.pipe(Effect.mapError(mapTinybirdError))
-const typedRows = compiled.castRows(rows)
+const rows = yield* warehouse.compiledQuery(tenant, compiled, { profile: "list", context: "myQuery" })
 ```
+
+`compiledQuery` runs the SQL and decodes rows through the query's `rowSchema` (if declared);
+`profile` defaults to `"aggregation"` when omitted (`"unbounded"` is the explicit opt-out). There is
+no `castRows` — a cast that looked type-safe hid wire-format drift.
 
 - Every query **must** filter `OrgId` (`$.OrgId.eq(param.string("orgId"))`) — enforced at runtime.
 - `context` labels the `executeSql` span (`query.context`), which also carries `db.query.text`,
   `db.query.fingerprint`, `db.duration_ms`, `result.rowCount`, `orgId`, `query.profile`.
-- **64-bit ints arrive as strings on BYO-ClickHouse** (`count`/`sum`/`uniqExact`), as numbers on
-  managed Tinybird. If the value flows into a `Schema.Number`, pass a `rowSchema` built with
-  `CH.CHNumber` as `CH.compile(q, params, { rowSchema })` — otherwise BYO-CH orgs get a bare 500.
-  See `packages/query-engine/src/ch/queries/service-map.ts`.
+- **64-bit ints arrive as numbers on every backend**: ClickHouse-protocol clients pin
+  `output_format_json_quote_64bit_integers=0` (`BackendDialect.unquote64BitIntegers`), matching the
+  Tinybird SDK. Two rules remain: (1) identity UInt64s (hashes/ids) must be `toString()`-wrapped in
+  the SELECT — values above 2^53 corrupt as JS numbers; the SQL-catalog e2e sweep enforces this.
+  (2) `rowSchema`s still use `CH.CHNumber`, never `Schema.Number`, so a gateway/readonly cluster
+  that refuses the setting (quoted wire) keeps decoding.
 - `packages/domain/src/tinybird/endpoints.ts` is **type-only** — no `defineEndpoint()` calls.
 
 ## Application database (PlanetScale Postgres)

--- a/apps/api/src/lib/WarehouseQueryService.clickhouse.e2e.test.ts
+++ b/apps/api/src/lib/WarehouseQueryService.clickhouse.e2e.test.ts
@@ -8,7 +8,7 @@ import { TinybirdOrgTokenService } from "../services/TinybirdOrgTokenService"
 import type { TenantContext } from "../services/AuthService"
 import { Env } from "./Env"
 import { cleanupTestDbs, createTestDb, type TestDb } from "./test-pglite"
-import { WarehouseQueryService } from "./WarehouseQueryService"
+import { WarehouseQueryService, __testables } from "./WarehouseQueryService"
 import {
 	applyRealMigrations,
 	clickhouseE2eEnabled,
@@ -276,5 +276,31 @@ describe.skipIf(!enabled)("WarehouseQueryService ClickHouse raw-SQL E2E", () => 
 			}).pipe(Effect.provide(layer))
 		},
 		120_000,
+	)
+
+	// Pins the wire-format parity fix itself, independent of catalog coverage:
+	// the production ClickHouse client must receive 64-bit ints as JSON numbers
+	// (output_format_json_quote_64bit_integers=0), exactly like the Tinybird SDK,
+	// so schema-less queries decode identically on both backends.
+	it(
+		"returns 64-bit integers as JSON numbers through the production client",
+		async () => {
+			const client = __testables.createClickHouseSqlClient({
+				kind: "clickhouse",
+				url: clickhouseUrl,
+				username: clickhouseUser,
+				password: clickhousePassword,
+				database,
+			})
+			// No trailing FORMAT: the client owns the output format (the executor's
+			// normalizeSqlForClient strips it on the real path).
+			const result = await client.sql("SELECT toUInt64(42) AS wide, count() AS c FROM system.one")
+			const row = result.data[0]
+			assert.isDefined(row)
+			assert.strictEqual(typeof row!.wide, "number", "UInt64 arrived as a string — the quote pin is gone")
+			assert.strictEqual(row!.wide, 42)
+			assert.strictEqual(typeof row!.c, "number")
+		},
+		60_000,
 	)
 })

--- a/apps/api/src/lib/WarehouseQueryService.ts
+++ b/apps/api/src/lib/WarehouseQueryService.ts
@@ -3,6 +3,7 @@ import { Tinybird } from "@tinybirdco/sdk"
 import { Context, Effect, Layer, Option, Redacted } from "effect"
 import { WarehouseConfigError, type WarehouseQueryRequest } from "@maple/domain/http"
 import {
+	BackendDialect,
 	makeWarehouseExecutor,
 	toWarehouseQueryError,
 	WarehouseResponseLimitError,
@@ -42,11 +43,19 @@ const createClickHouseSqlClient = (config: ClickHouseProtocolBackendConfig): War
 		password: config.password,
 		database: config.database,
 	})
+	// Wire-format parity with the Tinybird SDK: without this, JSONEachRow quotes
+	// 64-bit ints ("count":"42") and every schema-less query leaks strings into
+	// Schema.Number responses on BYO-CH orgs. Sent as a per-query URL param, so
+	// the compiled SQL text (and its fingerprint) is untouched.
+	const clickhouseSettings = BackendDialect[config.kind].unquote64BitIntegers
+		? ({ output_format_json_quote_64bit_integers: 0 } as const)
+		: undefined
 	return {
 		sql: async (sql: string, options) => {
 			const resultSet = await client.query({
 				query: sql,
 				format: "JSONEachRow",
+				...(clickhouseSettings ? { clickhouse_settings: clickhouseSettings } : {}),
 			})
 			const limits = options?.responseLimits
 			if (limits === undefined) {

--- a/apps/api/src/lib/clickhouse-e2e-support.ts
+++ b/apps/api/src/lib/clickhouse-e2e-support.ts
@@ -127,30 +127,49 @@ export const describeQuery = async (
 }
 
 /**
- * ClickHouse's `FORMAT JSON` renders 64-bit integers as JSON *strings* so they
- * survive the round trip intact. Managed Tinybird hands back numbers, so a query
- * whose row schema uses a bare `Schema.Number` works there and 500s for every
- * BYO-ClickHouse org. `CH.CHNumber` accepts both.
+ * ClickHouse's JSON formats render 64-bit integers as JSON *strings* by default
+ * so they survive the round trip intact. The production read paths pin
+ * `output_format_json_quote_64bit_integers=0` for wire parity with the Tinybird
+ * SDK (see `BackendDialect.unquote64BitIntegers`), but a row schema must still
+ * accept BOTH shapes — the setting is a per-request knob that a restricted
+ * gateway or `readonly=1` BYO cluster can refuse. `CH.CHNumber` accepts both.
  */
 export const isSixtyFourBitInt = (type: string): boolean => /\b(?:U?Int64|U?Int128|U?Int256)\b/.test(type)
 
-/** A row shaped like `FORMAT JSON` output for the described columns. */
-export const syntheticRow = (columns: ReadonlyArray<DescribedColumn>): Record<string, unknown> => {
+/**
+ * A row shaped like JSON-format output for the described columns.
+ * `quote64Bit: true` models the ClickHouse default wire shape (64-bit ints as
+ * strings); `false` models the unquoted shape the production client pins.
+ */
+export const syntheticRow = (
+	columns: ReadonlyArray<DescribedColumn>,
+	opts: { readonly quote64Bit: boolean } = { quote64Bit: true },
+): Record<string, unknown> => {
 	const row: Record<string, unknown> = {}
 	for (const column of columns) {
-		row[column.name] = sampleValue(column.type)
+		row[column.name] = sampleValue(column.type, opts.quote64Bit)
 	}
 	return row
 }
 
-const sampleValue = (type: string): unknown => {
+const sampleValue = (type: string, quote64Bit: boolean): unknown => {
 	const inner = type.replace(/^(?:Nullable|LowCardinality)\((.*)\)$/, "$1")
 	if (inner.startsWith("Array(")) return []
 	if (inner.startsWith("Map(")) return {}
 	if (inner.startsWith("Tuple(")) return []
-	// The whole point: 64-bit ints come over the wire quoted.
-	if (isSixtyFourBitInt(inner)) return "1"
+	// The whole point: 64-bit ints can come over the wire quoted or not.
+	if (isSixtyFourBitInt(inner)) return quote64Bit ? "1" : 1
 	if (/^(?:U?Int|Float|Decimal|Bool)/.test(inner)) return 1
 	if (/^(?:Date|DateTime)/.test(inner)) return "2026-01-01 00:00:00"
 	return ""
 }
+
+/**
+ * 64-bit output columns that carry *identity* (hashes, ids, fingerprints) must
+ * be `toString()`-wrapped in the SELECT: with the unquoted wire format a value
+ * above 2^53 would be silently corrupted by JS number parsing. Magnitude
+ * columns (counts, sums, quantiles) are exempt — precision loss at that scale
+ * is the long-standing managed-Tinybird contract.
+ */
+export const looksLikeIdentityColumn = (name: string): boolean =>
+	/hash|fingerprint/i.test(name) || /(?:_id|Id)$/.test(name) || /^id$/i.test(name)

--- a/apps/api/src/lib/sql-catalog.clickhouse.e2e.test.ts
+++ b/apps/api/src/lib/sql-catalog.clickhouse.e2e.test.ts
@@ -22,10 +22,18 @@ import {
 	clickhouseExec,
 	describeQuery,
 	isSixtyFourBitInt,
+	looksLikeIdentityColumn,
 	syntheticRow,
 	uniqueDatabase,
 	type DescribedColumn,
 } from "./clickhouse-e2e-support"
+
+/**
+ * 64-bit identity columns that predate the identity rule and are consumed as
+ * numbers on purpose. Do NOT grow this list — `toString()`-wrap the column in
+ * the SELECT instead (see `looksLikeIdentityColumn`).
+ */
+const IDENTITY_COLUMN_ALLOWLIST: ReadonlySet<string> = new Set([])
 
 const database = uniqueDatabase("maple_sql_catalog_e2e")
 
@@ -76,21 +84,45 @@ describe.skipIf(!clickhouseE2eEnabled)("SQL catalog analyzer sweep", () => {
 					.join(", ")}`,
 			)
 
-			// Second class, same round trip: a 64-bit integer column arrives as a
-			// JSON string on BYO-ClickHouse. If the query declares a row schema, it
-			// has to accept that.
 			const wideColumns = columns.filter((column) => isSixtyFourBitInt(column.type))
+
+			// Third class, same round trip: a 64-bit column that carries IDENTITY
+			// (hash/id/fingerprint) must be `toString()`-wrapped in the SELECT. The
+			// production clients pin `output_format_json_quote_64bit_integers=0` for
+			// wire parity with Tinybird, so an unquoted identity above 2^53 would be
+			// silently corrupted by JS number parsing.
+			const identityColumns = wideColumns.filter(
+				(column) =>
+					looksLikeIdentityColumn(column.name) &&
+					!IDENTITY_COLUMN_ALLOWLIST.has(`${entry.id}:${column.name}`),
+			)
+			assert.isEmpty(
+				identityColumns,
+				`${entry.id} selects identity-like 64-bit columns as integers: ${identityColumns
+					.map((column) => `${column.name} ${column.type}`)
+					.join(", ")}\n` +
+					`Wrap them in toString(...) in the SELECT so the value survives JSON as a string.`,
+			)
+
+			// Second class, same round trip: if the query declares a row schema, it
+			// has to accept BOTH 64-bit wire shapes — unquoted is what the pinned
+			// production clients receive, quoted is what a gateway/readonly cluster
+			// that refuses the setting still sends. `CH.CHNumber` accepts both;
+			// `Schema.Number` rejects the quoted shape.
 			if (wideColumns.length > 0 && entry.compiled) {
-				const row = syntheticRow(columns)
-				const decoded = await Effect.runPromise(Effect.exit(entry.compiled.decodeRows([row])))
-				if (decoded._tag === "Failure") {
-					assert.fail(
-						`${entry.id} declares a row schema that rejects ClickHouse's own JSON output.\n` +
-							`64-bit columns arrive quoted: ${wideColumns
-								.map((column) => `${column.name} ${column.type}`)
-								.join(", ")}\n` +
-							`Decode those with CH.CHNumber, not Schema.Number.\n\n${String(decoded.cause)}\n`,
-					)
+				for (const quote64Bit of [false, true]) {
+					const row = syntheticRow(columns, { quote64Bit })
+					const decoded = await Effect.runPromise(Effect.exit(entry.compiled.decodeRows([row])))
+					if (decoded._tag === "Failure") {
+						assert.fail(
+							`${entry.id} declares a row schema that rejects ClickHouse's own JSON output ` +
+								`(64-bit ints ${quote64Bit ? "quoted" : "unquoted"}).\n` +
+								`64-bit columns: ${wideColumns
+									.map((column) => `${column.name} ${column.type}`)
+									.join(", ")}\n` +
+								`Decode those with CH.CHNumber, not Schema.Number.\n\n${String(decoded.cause)}\n`,
+						)
+					}
 				}
 			}
 		}, 60_000)

--- a/apps/api/src/lib/warehouse-error-handlers.ts
+++ b/apps/api/src/lib/warehouse-error-handlers.ts
@@ -1,0 +1,23 @@
+import type { Effect } from "effect"
+import type { WarehouseError } from "@maple/domain"
+
+/**
+ * The one place the warehouse error union is enumerated for `Effect.catchTags`.
+ * Each consumer supplies its own conversion; adding a tag to `WarehouseError`
+ * means updating this table (and the meta Record in `@maple/domain`) instead of
+ * one hand-written 9-arm table per surface. The handler receives the union
+ * (every member is assignable), so the residual error channel still infers
+ * correctly at the call site.
+ */
+export const warehouseHandlers = <A, E, R>(f: (error: WarehouseError) => Effect.Effect<A, E, R>) =>
+	({
+		"@maple/http/errors/WarehouseQueryError": f,
+		"@maple/http/errors/WarehouseUpstreamError": f,
+		"@maple/http/errors/WarehouseAuthError": f,
+		"@maple/http/errors/WarehouseConfigError": f,
+		"@maple/http/errors/WarehouseClientError": f,
+		"@maple/http/errors/WarehouseSchemaDriftError": f,
+		"@maple/http/errors/WarehouseMalformedQueryError": f,
+		"@maple/http/errors/WarehouseQuotaExceededError": f,
+		"@maple/http/errors/WarehouseValidationError": f,
+	}) as const

--- a/apps/api/src/mcp/lib/map-warehouse-error.ts
+++ b/apps/api/src/mcp/lib/map-warehouse-error.ts
@@ -1,35 +1,39 @@
 import { Effect } from "effect"
 import { type WarehouseError, WarehouseSchemaDriftError } from "@maple/domain"
+import { warehouseHandlers } from "@/lib/warehouse-error-handlers"
 import { McpQueryError } from "../tools/types"
+
+export { warehouseHandlers }
 
 const SCHEMA_DRIFT_HINT =
 	" — your ClickHouse cluster's schema is out of sync with what Maple expects. " +
 	"Run schema apply from the org's ClickHouse settings page (or POST " +
 	"/api/org-clickhouse-settings/apply-schema) to add the missing columns."
 
-const enrich = (error: WarehouseError): string =>
-	error instanceof WarehouseSchemaDriftError ? `${error.message}${SCHEMA_DRIFT_HINT}` : error.message
+/**
+ * Human-facing message for a warehouse error, with the schema-drift remediation
+ * hint appended when apt. Without this hint the customer sees only the raw CH
+ * error and has to chase infra symptoms (as happened with the SampleRate
+ * column). Every MCP surface that renders a warehouse error should go through
+ * this, not `error.message`.
+ *
+ * `kind: "decode"` drift means the cluster answered fine but the rows failed
+ * Maple's own row schema — schema apply cannot fix that, so no hint.
+ */
+export const warehouseErrorText = (error: WarehouseError): string =>
+	error instanceof WarehouseSchemaDriftError && error.kind !== "decode"
+		? `${error.message}${SCHEMA_DRIFT_HINT}`
+		: error.message
 
 /**
  * Curry the pipe label so call sites read as
  * `Effect.mapError(toMcpQueryError("service_overview"))`.
- *
- * Surfaces a remediation hint when the underlying CH error indicates schema
- * drift — i.e. the customer's BYO cluster is missing a column Maple's queries
- * reference. Without this hint the customer sees only the raw CH error and has
- * to chase infra symptoms (as happened with the SampleRate column).
  */
 export const toMcpQueryError =
 	(pipe: string) =>
 	(error: WarehouseError): McpQueryError =>
-		new McpQueryError({ message: enrich(error), pipeName: pipe, cause: error })
+		new McpQueryError({ message: warehouseErrorText(error), pipeName: pipe, cause: error })
 
-/**
- * Pipe combinator that converts every warehouse error tag into an
- * `McpQueryError` (with the schema-drift hint), leaving any non-warehouse
- * errors (e.g. the MCP auth errors from `resolveTenant`) untouched in the
- * channel. Use as `effect.pipe(catchWarehouseToMcp("pipe_label"))`.
- */
 /**
  * `Effect.catchTags` handler map that converts every warehouse error tag into an
  * `McpQueryError` (with the schema-drift hint), leaving any non-warehouse errors
@@ -37,17 +41,5 @@ export const toMcpQueryError =
  * residual error channel infers from the caught tags:
  * `effect.pipe(Effect.catchTags(warehouseToMcpHandlers("pipe_label")))`.
  */
-export const warehouseToMcpHandlers = (pipe: string) => {
-	const fail = (error: WarehouseError) => Effect.fail(toMcpQueryError(pipe)(error))
-	return {
-		"@maple/http/errors/WarehouseQueryError": fail,
-		"@maple/http/errors/WarehouseUpstreamError": fail,
-		"@maple/http/errors/WarehouseAuthError": fail,
-		"@maple/http/errors/WarehouseConfigError": fail,
-		"@maple/http/errors/WarehouseClientError": fail,
-		"@maple/http/errors/WarehouseSchemaDriftError": fail,
-		"@maple/http/errors/WarehouseMalformedQueryError": fail,
-		"@maple/http/errors/WarehouseQuotaExceededError": fail,
-		"@maple/http/errors/WarehouseValidationError": fail,
-	}
-}
+export const warehouseToMcpHandlers = (pipe: string) =>
+	warehouseHandlers((error) => Effect.fail(toMcpQueryError(pipe)(error)))

--- a/apps/api/src/mcp/tools/query-data.ts
+++ b/apps/api/src/mcp/tools/query-data.ts
@@ -26,6 +26,7 @@ import {
 	type MetricsBreakdownQuery,
 } from "@maple/query-engine"
 import { formatQueryResult } from "../lib/format-query-result"
+import { warehouseErrorText, warehouseHandlers } from "../lib/map-warehouse-error"
 import {
 	CommitSha,
 	DeploymentEnvironment,
@@ -379,24 +380,11 @@ export function registerQueryDataTool(server: McpToolRegistrar) {
 							Effect.succeed(taggedErrorResult(error._tag, error.message)),
 						"@maple/http/errors/QueryEngineTimeoutError": (error) =>
 							Effect.succeed(taggedErrorResult(error._tag, error.message)),
-						"@maple/http/errors/WarehouseQueryError": (error) =>
-							Effect.succeed(taggedErrorResult(error._tag, error.message)),
-						"@maple/http/errors/WarehouseUpstreamError": (error) =>
-							Effect.succeed(taggedErrorResult(error._tag, error.message)),
-						"@maple/http/errors/WarehouseAuthError": (error) =>
-							Effect.succeed(taggedErrorResult(error._tag, error.message)),
-						"@maple/http/errors/WarehouseConfigError": (error) =>
-							Effect.succeed(taggedErrorResult(error._tag, error.message)),
-						"@maple/http/errors/WarehouseClientError": (error) =>
-							Effect.succeed(taggedErrorResult(error._tag, error.message)),
-						"@maple/http/errors/WarehouseSchemaDriftError": (error) =>
-							Effect.succeed(taggedErrorResult(error._tag, error.message)),
-						"@maple/http/errors/WarehouseMalformedQueryError": (error) =>
-							Effect.succeed(taggedErrorResult(error._tag, error.message)),
-						"@maple/http/errors/WarehouseQuotaExceededError": (error) =>
-							Effect.succeed(taggedErrorResult(error._tag, error.message)),
-						"@maple/http/errors/WarehouseValidationError": (error) =>
-							Effect.succeed(taggedErrorResult(error._tag, error.message)),
+						// Shared 9-tag warehouse table; warehouseErrorText appends the
+						// schema-apply hint for schema drift, matching the other MCP tools.
+						...warehouseHandlers((error) =>
+							Effect.succeed(taggedErrorResult(error._tag, warehouseErrorText(error))),
+						),
 					}),
 				)
 

--- a/apps/api/src/routes/session-replay.http.ts
+++ b/apps/api/src/routes/session-replay.http.ts
@@ -87,8 +87,8 @@ export const HttpSessionReplaysLive = HttpApiBuilder.group(MapleApi, "sessionRep
 						context: "replaysFacets",
 					})
 					// ClickHouse serializes integer aggregates (`uniq(...)`) as JSON strings,
-					// while the Tinybird path returns numbers; castRows is a plain cast, so
-					// coerce at the edge before the Schema.Number response validates.
+					// while the Tinybird path returns numbers; this query declares no row
+					// schema, so coerce at the edge before the Schema.Number response validates.
 					const pick = (facetType: string) =>
 						rows
 							.filter((row) => row.facetType === facetType)

--- a/apps/api/src/routes/v2/alerts-error-map.ts
+++ b/apps/api/src/routes/v2/alerts-error-map.ts
@@ -10,6 +10,7 @@ import type {
 	WarehouseUpstreamError,
 	WarehouseValidationError,
 } from "@maple/domain/http"
+import { presentWarehouseErrorPublic, type WarehouseErrorLike } from "@maple/domain/http"
 import {
 	conflict,
 	dependencyUnavailable,
@@ -64,8 +65,12 @@ const normalizeAlertResourceType = (resourceType: string) =>
 	)
 
 const makeAlertErrorMatcher = (operation: string) => {
-	const warehouseFailure = () =>
-		upstreamError(`alert_${operation}_upstream_failed`, "The alert query could not be completed.")
+	// Forward the shared per-tag copy instead of one fixed string: a missing
+	// column on the customer's cluster and a Maple SQL bug used to be
+	// indistinguishable "The alert query could not be completed." envelopes.
+	// Redacted presentation: raw ClickHouse diagnostics stay off the public API.
+	const warehouseFailure = (error: WarehouseErrorLike) =>
+		upstreamError(`alert_${operation}_upstream_failed`, presentWarehouseErrorPublic(error).description)
 	return Match.type<V2ReachableAlertError>().pipe(
 		Match.tagsExhaustive({
 			"@maple/http/errors/AlertForbiddenError": () =>
@@ -96,8 +101,10 @@ const makeAlertErrorMatcher = (operation: string) => {
 			"@maple/http/errors/WarehouseClientError": warehouseFailure,
 			"@maple/http/errors/WarehouseSchemaDriftError": warehouseFailure,
 			// Maple generated SQL its own warehouse refused to plan: a server fault,
-			// not the caller's, so it stays a 5xx rather than becoming a 400.
-			"@maple/http/errors/WarehouseMalformedQueryError": warehouseFailure,
+			// not the caller's, so it stays a 5xx rather than becoming a 400 — but
+			// under its own code so on-call stops chasing the customer's warehouse.
+			"@maple/http/errors/WarehouseMalformedQueryError": (error) =>
+				upstreamError(`alert_${operation}_query_bug`, presentWarehouseErrorPublic(error).description),
 			// A quota breach is the caller exceeding cost limits (429), and a
 			// validation failure is a malformed request (400) — neither is an
 			// upstream outage.

--- a/apps/api/src/routes/v2/session-replays.http.ts
+++ b/apps/api/src/routes/v2/session-replays.http.ts
@@ -20,12 +20,13 @@ import type {
 import { CH } from "@maple/query-engine"
 import { Effect, Option, Schema } from "effect"
 import { WarehouseQueryService } from "../../lib/WarehouseQueryService"
+import { warehouseToV2 } from "./warehouse-error-map"
 
 const decodeSessionId = Schema.decodeSync(SessionId)
 const decodeTraceId = Schema.decodeSync(TraceId)
 
-/** Warehouse/query-engine errors → a uniform 503 (all reads). */
-const mapWarehouseError = () => dependencyUnavailable("session_replay_query_unavailable")
+/** Warehouse errors → the proper v2 envelope (400/429/502/503 per tag). */
+const mapWarehouseError = warehouseToV2("session_replay_query")
 
 /** ISO-8601 → Tinybird `YYYY-MM-DD HH:mm:ss` (UTC), validated. */
 const toTinybird = (value: string, param: string) => {

--- a/apps/api/src/routes/v2/telemetry.http.test.ts
+++ b/apps/api/src/routes/v2/telemetry.http.test.ts
@@ -642,7 +642,7 @@ describe("v2 telemetry reads over HTTP", () => {
 		await harness.dispose()
 	})
 
-	it("sanitizes warehouse failures as operation-specific 503 errors", async () => {
+	it("sanitizes warehouse failures without collapsing them to a 503", async () => {
 		const failure = new WarehouseQueryError({
 			message: "SECRET_CLICKHOUSE_DIAGNOSTIC",
 			pipeName: "traceSummaries",
@@ -656,8 +656,11 @@ describe("v2 telemetry reads over HTTP", () => {
 			start_time: START,
 			end_time: END,
 		})
-		expect(response.status).toBe(503)
-		expect(response.body.error.code).toBe("trace_search_unavailable")
+		// A generic query fault is a 502 with a stable per-tag code (503 is
+		// reserved for genuinely retryable outages) — and the raw ClickHouse
+		// diagnostic must never cross the public API boundary.
+		expect(response.status).toBe(502)
+		expect(response.body.error.code).toBe("warehouse_query_failed")
 		expect(JSON.stringify(response.body)).not.toContain("SECRET_CLICKHOUSE_DIAGNOSTIC")
 		await harness.dispose()
 	})

--- a/apps/api/src/routes/v2/telemetry.http.ts
+++ b/apps/api/src/routes/v2/telemetry.http.ts
@@ -21,6 +21,7 @@ import { computeBucketSeconds, MAX_QUERY_RANGE_SECONDS } from "@maple/query-engi
 import { Effect, Encoding, Option, Result, Schema } from "effect"
 import { WarehouseQueryService } from "../../lib/WarehouseQueryService"
 import { QueryEngineService } from "../../services/QueryEngineService"
+import { warehouseToV2 } from "./warehouse-error-map"
 
 const decodeTraceId = Schema.decodeSync(TraceId)
 const decodeSpanId = Schema.decodeSync(SpanId)
@@ -61,7 +62,7 @@ const MAX_UNFILTERED_BREAKDOWN_RANGE_SECONDS = 60 * 60 * 24
 const MAX_SUMMARY_RANGE_SECONDS = 60 * 60 * 24 * 365
 const MAX_TIMESERIES_BUCKETS = 1_500
 
-const mapWarehouseError = (operation: string) => () => dependencyUnavailable(`${operation}_unavailable`)
+const mapWarehouseError = warehouseToV2
 
 const toWarehouseDateTime = (value: string, param: string) => {
 	const ms = Date.parse(value)

--- a/apps/api/src/routes/v2/warehouse-error-map.test.ts
+++ b/apps/api/src/routes/v2/warehouse-error-map.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "@effect/vitest"
+import {
+	WAREHOUSE_ERROR_TAGS,
+	WarehouseMalformedQueryError,
+	WarehouseQuotaExceededError,
+	WarehouseSchemaDriftError,
+	WarehouseUpstreamError,
+	WarehouseValidationError,
+	type WarehouseError,
+} from "@maple/domain/http"
+import {
+	V2InvalidRequestError,
+	V2RateLimitError,
+	V2ServiceUnavailableError,
+	V2UpstreamError,
+} from "@maple/domain/http/v2"
+import { warehouseToV2 } from "./warehouse-error-map"
+
+const map = warehouseToV2("trace_search")
+
+describe("warehouseToV2", () => {
+	it("maps a validation failure to a 400, not a 503", () => {
+		const mapped = map(
+			new WarehouseValidationError({ pipeName: "sqlQuery", message: "start_time is after end_time" }),
+		)
+		expect(mapped).toBeInstanceOf(V2InvalidRequestError)
+		expect(mapped.error.message).toContain("start_time")
+	})
+
+	it("maps a quota breach to a 429, not a 503", () => {
+		const mapped = map(
+			new WarehouseQuotaExceededError({
+				pipeName: "listTraces",
+				message: "TIMEOUT_EXCEEDED",
+				setting: "max_execution_time",
+			}),
+		)
+		expect(mapped).toBeInstanceOf(V2RateLimitError)
+	})
+
+	it("keeps a genuine outage a 503 with the operation code", () => {
+		const mapped = map(
+			new WarehouseUpstreamError({ pipeName: "listTraces", message: "521 error", upstreamStatus: 521 }),
+		)
+		expect(mapped).toBeInstanceOf(V2ServiceUnavailableError)
+		expect(mapped.error.code).toBe("trace_search_unavailable")
+	})
+
+	it("maps a Maple SQL bug to a 502 under its own code", () => {
+		const mapped = map(
+			new WarehouseMalformedQueryError({ pipeName: "traces_timeseries", message: "NO_COMMON_TYPE" }),
+		)
+		expect(mapped).toBeInstanceOf(V2UpstreamError)
+		expect(mapped.error.code).toBe("warehouse_malformed_query")
+		expect(mapped.error.message).toContain("our fault")
+	})
+
+	it("carries the schema-drift remediation instead of a fixed string", () => {
+		const mapped = map(
+			new WarehouseSchemaDriftError({ pipeName: "service_overview", message: "Unknown column SampleRate" }),
+		)
+		expect(mapped).toBeInstanceOf(V2UpstreamError)
+		expect(mapped.error.code).toBe("warehouse_schema_drift")
+		expect(mapped.error.message).toContain("schema apply")
+	})
+
+	it("handles every warehouse tag", () => {
+		for (const tag of WAREHOUSE_ERROR_TAGS) {
+			// Structural stand-in per tag; Match dispatches on _tag alone.
+			const error = {
+				_tag: tag,
+				pipeName: "p",
+				message: "boom",
+				setting: "max_execution_time",
+			} as unknown as WarehouseError
+			expect(() => map(error), tag).not.toThrow()
+		}
+	})
+})

--- a/apps/api/src/routes/v2/warehouse-error-map.ts
+++ b/apps/api/src/routes/v2/warehouse-error-map.ts
@@ -1,0 +1,58 @@
+import { Match } from "effect"
+import {
+	presentWarehouseErrorPublic,
+	warehouseErrorMeta,
+	type WarehouseError,
+} from "@maple/domain/http"
+import {
+	dependencyUnavailable,
+	invalidRequest,
+	rateLimited,
+	upstreamError,
+} from "@maple/domain/http/v2"
+import type {
+	V2InvalidRequestError,
+	V2RateLimitError,
+	V2ServiceUnavailableError,
+	V2UpstreamError,
+} from "@maple/domain/http/v2"
+
+export type V2WarehouseError =
+	| V2InvalidRequestError
+	| V2RateLimitError
+	| V2ServiceUnavailableError
+	| V2UpstreamError
+
+/**
+ * Exhaustive warehouse → v2 envelope translation for public telemetry-style
+ * endpoints. Replaces the blanket `() => dependencyUnavailable(...)` lambdas
+ * that mapped all nine warehouse tags — including 400 validation failures and
+ * 429 quota breaches — to one fixed 503, so an API user sending a bad time
+ * range was told the service was down.
+ *
+ * Statuses follow `httpApiStatus` on the error classes: 400 → invalid_request,
+ * 429 → rate_limited, 503 (retryable outage) → `${operation}_unavailable`,
+ * everything else → 502 with the tag's stable meta code and shared copy.
+ *
+ * Messages use the REDACTED presentation: raw ClickHouse diagnostics never
+ * cross the public API boundary (pinned by telemetry.http.test.ts).
+ */
+export const warehouseToV2 = (operation: string): ((error: WarehouseError) => V2WarehouseError) => {
+	const fault = (error: WarehouseError): V2WarehouseError =>
+		upstreamError(warehouseErrorMeta[error._tag].code, presentWarehouseErrorPublic(error).description)
+	return Match.type<WarehouseError>().pipe(
+		Match.tagsExhaustive({
+			"@maple/http/errors/WarehouseValidationError": (error) =>
+				invalidRequest("parameter_invalid", error.message),
+			"@maple/http/errors/WarehouseQuotaExceededError": () => rateLimited(),
+			"@maple/http/errors/WarehouseUpstreamError": () =>
+				dependencyUnavailable(`${operation}_unavailable`),
+			"@maple/http/errors/WarehouseQueryError": fault,
+			"@maple/http/errors/WarehouseAuthError": fault,
+			"@maple/http/errors/WarehouseConfigError": fault,
+			"@maple/http/errors/WarehouseClientError": fault,
+			"@maple/http/errors/WarehouseSchemaDriftError": fault,
+			"@maple/http/errors/WarehouseMalformedQueryError": fault,
+		}),
+	)
+}

--- a/apps/api/src/services/AlertsService.ts
+++ b/apps/api/src/services/AlertsService.ts
@@ -64,6 +64,7 @@ import {
 	type AlertIncidentId,
 	QueryEngineExecutionError,
 	type WarehouseError,
+	type WarehouseErrorTag,
 	QueryEngineTimeoutError,
 	QueryEngineValidationError,
 	RoleName,
@@ -100,6 +101,7 @@ import {
 	Context,
 } from "effect"
 import * as AlertingMetrics from "../lib/AlertingMetrics"
+import { warehouseHandlers } from "../lib/warehouse-error-handlers"
 import { INVESTIGATION_AGENT_BINDING } from "../lib/ai-triage-enqueue"
 import { upsertAlertIssue } from "../lib/issue-hub"
 import { probeLiveness } from "../lib/telemetry-liveness"
@@ -140,6 +142,25 @@ import {
 } from "./AlertDestinationHydration"
 import { SlackBotTokenResolver } from "./slack-bot-token"
 import { dateToMs } from "../lib/time"
+
+/**
+ * Persisted evaluation-failure category per warehouse tag (`ErrorCategory` on
+ * alert_checks rows and `failureCategory` in logs). The legacy `tinybird_*`
+ * names are kept stable on purpose — dashboards and stored rows key on them.
+ * `satisfies Record<WarehouseErrorTag, string>` makes a new warehouse error
+ * class a compile error here instead of a silently-uncategorized failure.
+ */
+const WAREHOUSE_FAILURE_CATEGORIES = {
+	"@maple/http/errors/WarehouseQueryError": "tinybird_query",
+	"@maple/http/errors/WarehouseUpstreamError": "tinybird_upstream",
+	"@maple/http/errors/WarehouseAuthError": "tinybird_auth",
+	"@maple/http/errors/WarehouseConfigError": "tinybird_config",
+	"@maple/http/errors/WarehouseClientError": "tinybird_client",
+	"@maple/http/errors/WarehouseSchemaDriftError": "tinybird_schema_drift",
+	"@maple/http/errors/WarehouseMalformedQueryError": "malformed_query",
+	"@maple/http/errors/WarehouseQuotaExceededError": "tinybird_quota",
+	"@maple/http/errors/WarehouseValidationError": "tinybird_validation",
+} satisfies Record<WarehouseErrorTag, string>
 
 interface NormalizedRule {
 	readonly id: AlertRuleId
@@ -4872,45 +4893,25 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 										recordEvaluationFailure(row, error, "evaluation"),
 									"@maple/http/errors/AlertPersistenceError": (error) =>
 										recordEvaluationFailure(row, error, "unknown"),
-									"@maple/http/errors/WarehouseQuotaExceededError": (error) =>
-										recordEvaluationFailure(row, error, "tinybird_quota", {
-											quotaSetting: error.setting,
-											pipe: error.pipeName,
-										}),
-									"@maple/http/errors/WarehouseUpstreamError": (error) =>
-										recordEvaluationFailure(row, error, "tinybird_upstream", {
-											upstreamStatus: error.upstreamStatus,
-											pipe: error.pipeName,
-										}),
-									"@maple/http/errors/WarehouseAuthError": (error) =>
-										recordEvaluationFailure(row, error, "tinybird_auth", {
-											upstreamStatus: error.upstreamStatus,
-											pipe: error.pipeName,
-										}),
-									"@maple/http/errors/WarehouseConfigError": (error) =>
-										recordEvaluationFailure(row, error, "tinybird_config", {
-											pipe: error.pipeName,
-										}),
-									"@maple/http/errors/WarehouseClientError": (error) =>
-										recordEvaluationFailure(row, error, "tinybird_client", {
-											pipe: error.pipeName,
-										}),
-									"@maple/http/errors/WarehouseSchemaDriftError": (error) =>
-										recordEvaluationFailure(row, error, "tinybird_schema_drift", {
-											pipe: error.pipeName,
-										}),
-									"@maple/http/errors/WarehouseMalformedQueryError": (error) =>
-										recordEvaluationFailure(row, error, "malformed_query", {
-											pipe: error.pipeName,
-										}),
-									"@maple/http/errors/WarehouseValidationError": (error) =>
-										recordEvaluationFailure(row, error, "tinybird_validation", {
-											pipe: error.pipeName,
-										}),
-									"@maple/http/errors/WarehouseQueryError": (error) =>
-										recordEvaluationFailure(row, error, "tinybird_query", {
-											pipe: error.pipeName,
-										}),
+									...warehouseHandlers((error) =>
+										recordEvaluationFailure(
+											row,
+											error,
+											WAREHOUSE_FAILURE_CATEGORIES[error._tag],
+											{
+												pipe: error.pipeName,
+												...(error._tag ===
+												"@maple/http/errors/WarehouseQuotaExceededError"
+													? { quotaSetting: error.setting }
+													: {}),
+												...(error._tag ===
+													"@maple/http/errors/WarehouseUpstreamError" ||
+												error._tag === "@maple/http/errors/WarehouseAuthError"
+													? { upstreamStatus: error.upstreamStatus }
+													: {}),
+											},
+										),
+									),
 								}),
 							)
 						}),

--- a/apps/api/src/services/ErrorsService.test.ts
+++ b/apps/api/src/services/ErrorsService.test.ts
@@ -147,7 +147,7 @@ const testConfig = () =>
  * Typed warehouse stub. The scheduled tick is the only consumer that reaches
  * the warehouse in these tests, so the stub feeds synthetic `errorIssuesScan`
  * rows (shaped like `ErrorIssuesOutput`) through the compiled query's own
- * `castRows`, and returns empty results for every other compiled query.
+ * `decodeRows`, and returns empty results for every other compiled query.
  */
 const makeWarehouseStub = (
 	scanRows: () => ReadonlyArray<Record<string, unknown>> = () => [],
@@ -158,22 +158,22 @@ const makeWarehouseStub = (
 	sqlQuery: () => Effect.succeed([]),
 	rawSqlQuery: () => Effect.succeed([]),
 	compiledQuery: <T>(tenant: unknown, compiled: CompiledQuery<T>, options?: SqlQueryOptions) =>
-		Effect.sync(() => {
+		Effect.suspend(() => {
 			if (options?.context === "errorIssuesScan") {
 				onScan?.()
-				return compiled.castRows(scanRows())
+				return Effect.orDie(compiled.decodeRows(scanRows()))
 			}
 			// listIssues' deployment-environment filter (shaped like ErrorFingerprintsOutput).
 			if (options?.context === "errorIssueEnvFingerprints") {
-				return compiled.castRows(fingerprintRows?.() ?? [])
+				return Effect.orDie(compiled.decodeRows(fingerprintRows?.() ?? []))
 			}
 			// Active-org discovery reads the same data the scan does, so model that
 			// consistency: surface the org iff it currently has error rows.
 			if (options?.context === "errorActiveOrgsDiscovery") {
 				const orgId = (tenant as { orgId?: string }).orgId ?? ""
-				return compiled.castRows(scanRows().length > 0 ? [{ orgId }] : [])
+				return Effect.orDie(compiled.decodeRows(scanRows().length > 0 ? [{ orgId }] : []))
 			}
-			return compiled.castRows([])
+			return Effect.orDie(compiled.decodeRows([]))
 		}),
 	compiledQueryFirst: () => Effect.die(new Error("unexpected warehouse query")),
 	ingest: () => Effect.void,
@@ -264,16 +264,16 @@ const makeGatingLayer = (opts: {
 			if (options?.context === "errorActiveOrgsDiscovery") {
 				if (opts.failDiscovery) return Effect.die(new Error("discovery down"))
 				const orgId = (tenant as { orgId?: string }).orgId ?? ""
-				return Effect.sync(() => compiled.castRows(scanRows().length > 0 ? [{ orgId }] : []))
+				return Effect.orDie(compiled.decodeRows(scanRows().length > 0 ? [{ orgId }] : []))
 			}
 			if (options?.context === "errorIssuesScan") {
 				const orgId = (tenant as { orgId?: string }).orgId ?? ""
-				return Effect.sync(() => {
+				return Effect.suspend(() => {
 					opts.scanned?.add(orgId)
-					return compiled.castRows(scanRows())
+					return Effect.orDie(compiled.decodeRows(scanRows()))
 				})
 			}
-			return Effect.sync(() => compiled.castRows([]))
+			return Effect.orDie(compiled.decodeRows([]))
 		},
 		compiledQueryFirst: () => Effect.die(new Error("unexpected warehouse query")),
 		ingest: () => Effect.void,

--- a/apps/cli/src/server/chdb.ts
+++ b/apps/cli/src/server/chdb.ts
@@ -102,6 +102,10 @@ export const chdbArgv = (options: Pick<ChdbOptions, "dataDir" | "configFile">): 
 	"--tables_loader_foreground_pool_size=1",
 	"--tables_loader_background_pool_size=1",
 	"--restore_threads=1",
+	// Wire-format parity with the cloud read paths (BackendDialect
+	// unquote64BitIntegers): emit 64-bit ints as JSON numbers, not strings, so
+	// local mode decodes rows exactly like managed Tinybird / BYO ClickHouse.
+	"--output_format_json_quote_64bit_integers=0",
 	`--path=${options.dataDir}`,
 	...(options.configFile ? [`--config-file=${options.configFile}`] : []),
 ]

--- a/apps/cli/test/chdb-args.test.ts
+++ b/apps/cli/test/chdb-args.test.ts
@@ -11,6 +11,7 @@ describe("embedded chDB arguments", () => {
 			"--tables_loader_foreground_pool_size=1",
 			"--tables_loader_background_pool_size=1",
 			"--restore_threads=1",
+			"--output_format_json_quote_64bit_integers=0",
 			"--path=/tmp/maple-data",
 		])
 	})
@@ -23,6 +24,7 @@ describe("embedded chDB arguments", () => {
 			"--tables_loader_foreground_pool_size=1",
 			"--tables_loader_background_pool_size=1",
 			"--restore_threads=1",
+			"--output_format_json_quote_64bit_integers=0",
 			"--path=/tmp/maple-data",
 			"--config-file=/tmp/backups.xml",
 		])

--- a/apps/cli/test/native-local-store-migration-fixture.ts
+++ b/apps/cli/test/native-local-store-migration-fixture.ts
@@ -231,7 +231,11 @@ const sharedAttributes =
 	"map('db.system', 'postgresql', 'db.namespace', 'orders', 'db.operation.name', 'SELECT', 'db.query.text', 'SELECT * FROM orders')"
 const insertStatements = [
 	"INSERT INTO logs (OrgId, Timestamp, TimestampTime, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber, ServiceName, Body) SELECT 'native-migration', now64(9), now(), 'trace-native-log', 'span-native-log', 1, 'INFO', 9, 'native-migration', 'legacy source'",
-	`INSERT INTO traces (OrgId, Timestamp, TraceId, SpanId, ParentSpanId, TraceState, SpanName, SpanKind, ServiceName, ResourceAttributes, SpanAttributes, StatusCode, StatusMessage) SELECT 'native-migration', now64(9), 'trace-native-db', 'span-native-db', '', '', 'SELECT orders', 'Client', 'native-migration', ${sharedResourceAttributes}, ${sharedAttributes}, 'Ok', ''`,
+	// The DB call is a CHILD Client span on purpose: with an empty ParentSpanId it
+	// would count as an entry span (`service_overview_spans_mv` is `SpanKind IN
+	// ('Server','Consumer') OR ParentSpanId = ''`) and the probe's namespace
+	// aggregate expectation of exactly one entry span would read 2.
+	`INSERT INTO traces (OrgId, Timestamp, TraceId, SpanId, ParentSpanId, TraceState, SpanName, SpanKind, ServiceName, ResourceAttributes, SpanAttributes, StatusCode, StatusMessage) SELECT 'native-migration', now64(9), 'trace-native-db', 'span-native-db', 'span-native-parent', '', 'SELECT orders', 'Client', 'native-migration', ${sharedResourceAttributes}, ${sharedAttributes}, 'Ok', ''`,
 	`INSERT INTO traces (OrgId, Timestamp, TraceId, SpanId, ParentSpanId, TraceState, SpanName, SpanKind, ServiceName, ResourceAttributes, SpanAttributes, StatusCode, StatusMessage) SELECT 'native-migration', now64(9), 'trace-native-server', 'span-native-server', '', '', 'GET /orders', 'Server', 'native-migration', ${sharedResourceAttributes}, map(), 'Ok', ''`,
 	"INSERT INTO metrics_sum (OrgId, ServiceName, MetricName, StartTimeUnix, TimeUnix, Value, AggregationTemporality, IsMonotonic) SELECT 'native-migration', 'native-migration', 'sum-native', now64(9), now64(9), 1, 2, true",
 	"INSERT INTO metrics_gauge (OrgId, ServiceName, MetricName, StartTimeUnix, TimeUnix, Value) SELECT 'native-migration', 'native-migration', 'gauge-native', now64(9), now64(9), 1",

--- a/apps/cli/test/native-local-store-migration.sh
+++ b/apps/cli/test/native-local-store-migration.sh
@@ -40,8 +40,29 @@ trap cleanup EXIT
 
 fail() {
 	echo "FAIL: $*" >&2
+	if [[ -f "$ROOT/migrate.out" ]]; then tail -80 "$ROOT/migrate.out" >&2 || true; fi
 	if [[ -f "$ROOT/server.log" ]]; then tail -80 "$ROOT/server.log" >&2 || true; fi
 	exit 1
+}
+
+# Every phase announces itself and runs under a wall-clock bound (when
+# `timeout` exists — Linux CI; macOS dev boxes run unbounded). Before this the
+# probe printed NOTHING until the final PASS, so a hung maple invocation ate
+# the job's whole 20-minute budget with an empty log and no evidence.
+step() { echo "probe: $*"; }
+
+bounded() {
+	local secs="$1" label="$2"
+	shift 2
+	if command -v timeout >/dev/null 2>&1; then
+		timeout --kill-after=20 "$secs" "$@" || {
+			local rc=$?
+			[[ "$rc" == 124 || "$rc" == 137 ]] && fail "$label did not finish within ${secs}s"
+			return "$rc"
+		}
+	else
+		"$@"
+	fi
 }
 
 query() {
@@ -70,7 +91,16 @@ start_server() {
 }
 
 stop_server() {
-	MAPLE_LIBCHDB="$LIBCHDB" "$MAPLE" stop --data-dir "$DATA" >/dev/null 2>&1 || true
+	bounded 60 "maple stop" env MAPLE_LIBCHDB="$LIBCHDB" "$MAPLE" stop --data-dir "$DATA" >/dev/null 2>&1 || true
+	# Bounded wait: a server that ignores the stop must not eat the job budget.
+	for _ in $(seq 1 300); do
+		kill -0 "$SERVER_PID" 2>/dev/null || break
+		sleep 0.1
+	done
+	if kill -0 "$SERVER_PID" 2>/dev/null; then
+		kill -9 "$SERVER_PID" 2>/dev/null || true
+		fail "native Maple server did not exit within 30s of maple stop"
+	fi
 	wait "$SERVER_PID" 2>/dev/null || true
 	SERVER_PID=""
 }
@@ -84,17 +114,22 @@ printf '%s\n' \
 	'</clickhouse>' >"$CONFIG"
 chmod 600 "$CONFIG"
 
-MAPLE_LIBCHDB="$LIBCHDB" bun "$REPO_ROOT/apps/cli/test/native-local-store-migration-fixture.ts" "$DATA" "$CONFIG"
+step "creating legacy v0 source store"
+bounded 300 "legacy source fixture" \
+	env MAPLE_LIBCHDB="$LIBCHDB" bun "$REPO_ROOT/apps/cli/test/native-local-store-migration-fixture.ts" "$DATA" "$CONFIG"
 
 # Replace the newly-created active v2 marker with the historical v1 marker.
 # The physical source was created by native chDB; the marker is the only
 # compatibility evidence the v0 resolver is allowed to use.
-CHDB_VERSION="$(MAPLE_LIBCHDB="$LIBCHDB" "$MAPLE" --version 2>/dev/null | sed -n 's/.*chdb \([^ ]*\).*/\1/p')"
+step "installing legacy marker"
+CHDB_VERSION="$(bounded 60 "maple --version" env MAPLE_LIBCHDB="$LIBCHDB" "$MAPLE" --version 2>/dev/null | sed -n 's/.*chdb \([^ ]*\).*/\1/p')"
 [[ -n "$CHDB_VERSION" ]] || CHDB_VERSION="v26.1.0"
 printf '%s\n' "{\"chdb\":\"$CHDB_VERSION\",\"maple\":\"native-probe\",\"createdAt\":\"unknown\",\"schema\":\"428701854f9fd30e\"}" >"$ROOT/maple-store-version.json"
 chmod 600 "$ROOT/maple-store-version.json"
 
-MAPLE_LIBCHDB="$LIBCHDB" "$MAPLE" schema migrate --data-dir "$DATA" --yes >"$ROOT/migrate.out" 2>&1 || {
+step "running maple schema migrate"
+bounded 600 "maple schema migrate" \
+	env MAPLE_LIBCHDB="$LIBCHDB" "$MAPLE" schema migrate --data-dir "$DATA" --yes >"$ROOT/migrate.out" 2>&1 || {
 	cat "$ROOT/migrate.out" >&2
 	fail "native schema migration failed"
 }
@@ -103,7 +138,9 @@ grep -q "local store migrated" "$ROOT/migrate.out" || fail "native migration did
 jq -e '.formatVersion == 2 and .activation == "active" and .schemaVersion == 1 and .schema == "718581a523cbf01c"' \
 	"$ROOT/maple-store-version.json" >/dev/null || fail "native migration wrote the wrong active identity"
 
+step "reopening promoted store in a fresh server"
 start_server
+step "verifying migrated tables"
 for table in logs traces metrics_sum metrics_gauge metrics_histogram metrics_exponential_histogram; do
 	count="$(query "SELECT count() AS count FROM $table WHERE ServiceName = 'native-migration'" | jq -r '.[0].count | tonumber')"
 	expected="1"
@@ -116,6 +153,7 @@ namespace_count="$(query "SELECT count() AS count FROM service_overview_spans WH
 [[ "$namespace_count" == "1" ]] || fail "service namespace aggregate after native migration: expected 1, got $namespace_count"
 db_edge_count="$(query "SELECT count() AS count FROM service_map_db_edges_hourly WHERE OrgId = 'native-migration' AND ServiceName = 'native-migration' AND DbSystem = 'postgresql' AND DbNamespace = 'orders'" | jq -r '.[0].count | tonumber')"
 [[ "$db_edge_count" == "1" ]] || fail "database aggregate after native migration: expected 1, got $db_edge_count"
+step "stopping server and checking rollback retention"
 stop_server
 
 rollback="$(sed -n 's/^.*rollback *//p' "$ROOT/migrate.out" | tail -1)"

--- a/apps/web/src/lib/error-messages.test.ts
+++ b/apps/web/src/lib/error-messages.test.ts
@@ -1,5 +1,6 @@
 import { HttpClientError, HttpClientRequest } from "effect/unstable/http"
 import { describe, expect, it } from "vitest"
+import { WAREHOUSE_ERROR_TAGS } from "@maple/domain"
 import { formatBackendError } from "./error-messages"
 
 describe("formatBackendError", () => {
@@ -117,6 +118,35 @@ describe("formatBackendError", () => {
 		})
 		expect(result.title).toBe("Database schema is out of date")
 		expect(result.description).toContain("schema apply")
+	})
+
+	it("formats decode-kind WarehouseSchemaDriftError without the schema-apply hint", () => {
+		const result = formatBackendError({
+			_tag: "@maple/http/errors/WarehouseSchemaDriftError",
+			message: "Compiled query row 0 did not match its declared output schema",
+			kind: "decode",
+			pipe: "serviceOverview",
+		})
+		expect(result.description).not.toContain("schema apply")
+		expect(result.description).toContain("Maple bug")
+	})
+
+	it("formats WarehouseMalformedQueryError as a Maple bug, not a database problem", () => {
+		const result = formatBackendError({
+			_tag: "@maple/http/errors/WarehouseMalformedQueryError",
+			message: "NO_COMMON_TYPE: There is no supertype for types UInt64, Float64",
+			pipe: "traces_timeseries",
+		})
+		expect(result.title).toBe("This chart hit a bug in Maple")
+		expect(result.description).toContain("our fault")
+		expect(result.description).not.toContain("schema apply")
+	})
+
+	it("gives every warehouse tag a specific title", () => {
+		for (const tag of WAREHOUSE_ERROR_TAGS) {
+			const result = formatBackendError({ _tag: tag, message: "boom" })
+			expect(result.title, tag).not.toBe("Something went wrong")
+		}
 	})
 
 	it("formats WarehouseValidationError as an invalid query", () => {

--- a/apps/web/src/lib/error-messages.ts
+++ b/apps/web/src/lib/error-messages.ts
@@ -1,5 +1,11 @@
 import { Cause, Exit, Option } from "effect"
 import { HttpClientError } from "effect/unstable/http"
+import {
+	cleanErrorMessage,
+	isWarehouseErrorTag,
+	presentWarehouseError,
+	type WarehouseErrorLike,
+} from "@maple/domain"
 import { isChunkLoadError } from "./chunk-reload"
 
 export interface FormattedError {
@@ -9,29 +15,13 @@ export interface FormattedError {
 	readonly kind?: "network"
 }
 
-const QUOTA_DESCRIPTIONS: Record<string, string> = {
-	max_execution_time: "Query exceeded the 30s execution limit. Narrow the time range or add filters.",
-	max_memory_usage: "Query exceeded the memory limit. Add filters or reduce cardinality.",
-	max_threads: "Query exceeded the thread limit. Try a smaller scan.",
-}
-
 const hasTag = (value: unknown): value is { _tag: string; [key: string]: unknown } =>
 	typeof value === "object" &&
 	value !== null &&
 	"_tag" in value &&
 	typeof (value as { _tag: unknown })._tag === "string"
 
-const sanitizeMessage = (raw: string): string => {
-	let cleaned = raw
-	const htmlIndex = cleaned.search(/<\s*(html|head|body|center|h1|hr|title)\b/i)
-	if (htmlIndex >= 0) cleaned = cleaned.slice(0, htmlIndex)
-	cleaned = cleaned
-		.replace(/<[^>]+>/g, " ")
-		.replace(/\s+/g, " ")
-		.trim()
-	if (cleaned.endsWith(":")) cleaned = cleaned.slice(0, -1).trim()
-	return cleaned || raw.slice(0, 200)
-}
+const sanitizeMessage = cleanErrorMessage
 
 const stringField = (value: unknown, key: string): string | undefined => {
 	if (typeof value === "object" && value !== null && key in value) {
@@ -45,14 +35,6 @@ const stringArrayField = (value: unknown, key: string): ReadonlyArray<string> | 
 	if (typeof value === "object" && value !== null && key in value) {
 		const v = (value as Record<string, unknown>)[key]
 		if (Array.isArray(v)) return v.filter((item): item is string => typeof item === "string")
-	}
-	return undefined
-}
-
-const numberField = (value: unknown, key: string): number | undefined => {
-	if (typeof value === "object" && value !== null && key in value) {
-		const v = (value as Record<string, unknown>)[key]
-		if (typeof v === "number") return v
 	}
 	return undefined
 }
@@ -110,17 +92,22 @@ export const formatBackendError = (input: unknown): FormattedError => {
 		}
 	}
 
+	// All nine warehouse tags share one presenter in @maple/domain
+	// (warehouse-error-meta) — the same copy the API surfaces elsewhere, and the
+	// one place a new warehouse tag must be described.
+	if (hasTag(error) && isWarehouseErrorTag(error._tag)) {
+		const like: WarehouseErrorLike = {
+			_tag: error._tag,
+			...(typeof error.message === "string" ? { message: error.message } : {}),
+			...(typeof error.setting === "string" ? { setting: error.setting } : {}),
+			...(typeof error.upstreamStatus === "number" ? { upstreamStatus: error.upstreamStatus } : {}),
+			...(typeof error.kind === "string" ? { kind: error.kind } : {}),
+		}
+		return presentWarehouseError(like)
+	}
+
 	if (hasTag(error)) {
 		switch (error._tag) {
-			case "@maple/http/errors/WarehouseQuotaExceededError": {
-				const setting = stringField(error, "setting") ?? "limit"
-				return {
-					title: "Query was too expensive",
-					description:
-						QUOTA_DESCRIPTIONS[setting] ??
-						`Query exceeded the ${setting} limit. Narrow the time range or add filters.`,
-				}
-			}
 			case "@maple/http/errors/QueryEngineTimeoutError": {
 				return {
 					title: "Query timed out",
@@ -142,87 +129,6 @@ export const formatBackendError = (input: unknown): FormattedError => {
 				return {
 					title: "Query failed",
 					description: causeMessage ? `${message}: ${causeMessage}` : message,
-				}
-			}
-			case "@maple/http/errors/WarehouseAuthError": {
-				const upstreamStatus = numberField(error, "upstreamStatus")
-				return {
-					title: "Database rejected our credentials",
-					description:
-						upstreamStatus === 403
-							? "The configured database credentials are missing required permissions."
-							: "The configured database credentials are invalid or expired. Update them in settings.",
-				}
-			}
-			case "@maple/http/errors/WarehouseUpstreamError": {
-				const upstreamStatus = numberField(error, "upstreamStatus")
-				return {
-					title: "Database is temporarily unavailable",
-					description:
-						upstreamStatus !== undefined
-							? `The query backend returned ${upstreamStatus}. Retry in a few seconds.`
-							: "The query backend is unreachable. Retry in a few seconds.",
-				}
-			}
-			case "@maple/http/errors/WarehouseConfigError": {
-				return {
-					title: "Database is not configured correctly",
-					description: stringField(error, "message") ?? "Database is not configured correctly.",
-				}
-			}
-			case "@maple/http/errors/WarehouseClientError": {
-				return {
-					title: "Database response could not be decoded",
-					description: stringField(error, "message") ?? "Database response could not be decoded.",
-				}
-			}
-			case "@maple/http/errors/WarehouseSchemaDriftError": {
-				const message = stringField(error, "message")
-				return {
-					title: "Database schema is out of date",
-					description: `${message ?? "A column Maple expects is missing from the cluster."} Run schema apply from your ClickHouse settings.`,
-				}
-			}
-			case "@maple/http/errors/WarehouseMalformedQueryError": {
-				// Maple generated SQL the database refused to plan. Nothing the user
-				// can do — do not send them to their database settings.
-				return {
-					title: "This chart hit a bug in Maple",
-					description:
-						"Maple built a query its own database rejected. This is our fault, not a problem with your data or your cluster — we have been alerted.",
-				}
-			}
-			case "@maple/http/errors/WarehouseValidationError": {
-				return {
-					title: "Invalid query",
-					description: stringField(error, "message") ?? "The query was rejected before running.",
-				}
-			}
-			case "@maple/http/errors/WarehouseQueryError": {
-				// Generic SQL/query failure. Some transient failures still arrive with
-				// only a status code embedded in the message (e.g. a 5xx HTML body),
-				// so keep the message-sniff fallback to surface those nicely.
-				const message = stringField(error, "message") ?? "Database query failed"
-				const sniffed = message.match(/status[:\s]+(\d{3})/i)?.[1]
-				const upstreamStatus = sniffed ? Number(sniffed) : undefined
-				if (upstreamStatus === 401 || upstreamStatus === 403) {
-					return {
-						title: "Database rejected our credentials",
-						description:
-							upstreamStatus === 403
-								? "The configured database credentials are missing required permissions."
-								: "The configured database credentials are invalid or expired. Update them in settings.",
-					}
-				}
-				if (upstreamStatus !== undefined && upstreamStatus >= 500 && upstreamStatus < 600) {
-					return {
-						title: "Database is temporarily unavailable",
-						description: `The query backend returned ${upstreamStatus}. Retry in a few seconds.`,
-					}
-				}
-				return {
-					title: "Database query failed",
-					description: message,
 				}
 			}
 			case "@maple/http/errors/UnauthorizedError": {

--- a/lib/clickhouse-builder/src/ch/compile.ts
+++ b/lib/clickhouse-builder/src/ch/compile.ts
@@ -51,12 +51,11 @@ export interface CompiledQuery<Output> {
 	 *  the query definition), so executors read it there instead of a per-org
 	 *  warehouse override. */
 	readonly routing?: "ingest"
-	/** Type-safe cast of raw query results. The cast is sound because the
-	 *  Output type is derived from the SELECT clause that produced the SQL. */
-	readonly castRows: (rows: ReadonlyArray<Record<string, unknown>>) => ReadonlyArray<Output>
 	/** Runtime decode of raw query results. Queries built from handwritten SQL
 	 *  should provide a row schema so schema drift is caught before consumers
-	 *  read fields from `Record<string, unknown>`. */
+	 *  read fields from `Record<string, unknown>`. Without a schema this is an
+	 *  identity cast — there is deliberately no separate `castRows`: a cast that
+	 *  looked type-safe hid wire-format drift (64-bit ints arriving as strings). */
 	readonly decodeRows: (
 		rows: ReadonlyArray<Record<string, unknown>>,
 	) => Effect.Effect<ReadonlyArray<Output>, CompiledQueryDecodeError>
@@ -99,7 +98,6 @@ const makeCompiledQuery = <Output>(
 	return {
 		sql,
 		...(routing === undefined ? {} : { routing }),
-		castRows: (rows) => rows as unknown as ReadonlyArray<Output>,
 		decodeRows,
 		decodeFirstRow: (rows) => {
 			const row = rows[0]

--- a/lib/clickhouse-builder/src/ch/query.test-d.ts
+++ b/lib/clickhouse-builder/src/ch/query.test-d.ts
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import { expectTypeOf } from "expect-type"
+import type { Effect } from "effect"
 import * as CH from "./index"
 import type { InferQueryOutput } from "./query"
 import type { InferUnionOutput } from "./union"
@@ -327,9 +328,9 @@ const compiled = CH.compile(compileTarget, {})
 
 expectTypeOf(compiled).toMatchTypeOf<CompiledQuery<{ readonly id: string; readonly age: number }>>()
 
-// castRows returns correctly typed array
-expectTypeOf(compiled.castRows([])).toEqualTypeOf<
-	ReadonlyArray<{ readonly id: string; readonly age: number }>
+// decodeRows resolves to the correctly typed array
+expectTypeOf(compiled.decodeRows([])).toMatchTypeOf<
+	Effect.Effect<ReadonlyArray<{ readonly id: string; readonly age: number }>, unknown>
 >()
 
 // ---------------------------------------------------------------------------

--- a/packages/domain/src/http/v2/session-replays.ts
+++ b/packages/domain/src/http/v2/session-replays.ts
@@ -3,7 +3,13 @@ import { Schema } from "effect"
 import { SessionId, TraceId } from "../../primitives"
 import { AuthorizationV2, V2SchemaErrors } from "./auth"
 import { ListOf, ListQuery, Timestamp } from "./envelopes"
-import { V2InvalidRequestError, V2NotFoundError, V2ServiceUnavailableError } from "./errors"
+import {
+	V2InvalidRequestError,
+	V2NotFoundError,
+	V2RateLimitError,
+	V2ServiceUnavailableError,
+	V2UpstreamError,
+} from "./errors"
 import { PublicId, PublicIdPrefixes } from "./public-id"
 
 /** See api-keys.ts: examples are authored in wire (encoded) shape. */
@@ -294,7 +300,13 @@ export const V2SessionReplaysForTraceParams = Schema.Struct({
 })
 export type V2SessionReplaysForTraceParams = Schema.Schema.Type<typeof V2SessionReplaysForTraceParams>
 
-const commonErrors = [V2InvalidRequestError, V2ServiceUnavailableError] as const
+// Full warehouse outcome range — see the matching comment in ./telemetry.ts.
+const commonErrors = [
+	V2InvalidRequestError,
+	V2RateLimitError,
+	V2ServiceUnavailableError,
+	V2UpstreamError,
+] as const
 
 const SessionReplayList = ListOf(V2SessionReplayListItem).annotate({
 	identifier: "SessionReplayList",

--- a/packages/domain/src/http/v2/telemetry.ts
+++ b/packages/domain/src/http/v2/telemetry.ts
@@ -3,11 +3,27 @@ import { Schema } from "effect"
 import { MetricName, ServiceName, SpanId, TraceId } from "../../primitives"
 import { AuthorizationV2, V2SchemaErrors } from "./auth"
 import { ListOf, ListQuery, Timestamp } from "./envelopes"
-import { V2InvalidRequestError, V2NotFoundError, V2ServiceUnavailableError } from "./errors"
+import {
+	V2InvalidRequestError,
+	V2NotFoundError,
+	V2RateLimitError,
+	V2ServiceUnavailableError,
+	V2UpstreamError,
+} from "./errors"
 import { PublicId, PublicIdPrefixes } from "./public-id"
 
 const wireExample = <A>(example: object): A => example as A
-const commonErrors = [V2InvalidRequestError, V2ServiceUnavailableError] as const
+// Warehouse-backed endpoints surface the full outcome range: 400 for a bad
+// request, 429 for a quota breach, 502 for an upstream/query fault, 503 for a
+// genuine outage. These used to be collapsed into one 503 (see
+// telemetry.http.ts's mapWarehouseError), which told a user with a bad time
+// range that the service was down.
+const commonErrors = [
+	V2InvalidRequestError,
+	V2RateLimitError,
+	V2ServiceUnavailableError,
+	V2UpstreamError,
+] as const
 const PositiveInteger = Schema.Number.check(Schema.isInt(), Schema.isGreaterThan(0))
 const PositiveFinite = Schema.Number.check(Schema.isFinite(), Schema.isGreaterThan(0))
 const NonNegativeFinite = Schema.Number.check(Schema.isFinite(), Schema.isGreaterThanOrEqualTo(0))

--- a/packages/domain/src/http/warehouse-error-meta.test.ts
+++ b/packages/domain/src/http/warehouse-error-meta.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "@effect/vitest"
+import {
+	WAREHOUSE_ERROR_TAGS,
+	warehouseErrorMeta,
+	warehouseErrorStatus,
+	presentWarehouseError,
+	isWarehouseErrorTag,
+} from "./warehouse-error-meta"
+import { warehouseHttpErrors } from "./warehouse-errors"
+
+describe("warehouse error meta", () => {
+	it("derives one tag per error class", () => {
+		expect(WAREHOUSE_ERROR_TAGS).toHaveLength(warehouseHttpErrors.length)
+		expect(new Set(WAREHOUSE_ERROR_TAGS).size).toBe(warehouseHttpErrors.length)
+	})
+
+	it("covers every derived tag in the meta table and the status map", () => {
+		// The Record type already fails compilation on a missing key; this guards
+		// the other direction — a stray key for a tag that no longer exists.
+		expect(Object.keys(warehouseErrorMeta).sort()).toEqual([...WAREHOUSE_ERROR_TAGS].sort())
+		for (const tag of WAREHOUSE_ERROR_TAGS) {
+			expect(warehouseErrorStatus.get(tag), tag).toBeTypeOf("number")
+			expect(isWarehouseErrorTag(tag)).toBe(true)
+		}
+	})
+
+	it("gives every tag a non-generic presentation", () => {
+		for (const tag of WAREHOUSE_ERROR_TAGS) {
+			const presented = presentWarehouseError({ _tag: tag, message: "boom" })
+			expect(presented.title, tag).not.toBe("")
+			expect(presented.title, tag).not.toBe("Something went wrong")
+			expect(presented.description, tag).not.toBe("")
+		}
+	})
+
+	it("unique codes per tag", () => {
+		const codes = Object.values(warehouseErrorMeta).map((meta) => meta.code)
+		expect(new Set(codes).size).toBe(codes.length)
+	})
+
+	it("suppresses the schema-apply advice for decode-kind drift", () => {
+		const cluster = presentWarehouseError({
+			_tag: "@maple/http/errors/WarehouseSchemaDriftError",
+			message: "Missing column SampleRate",
+		})
+		expect(cluster.description).toContain("schema apply")
+
+		const decode = presentWarehouseError({
+			_tag: "@maple/http/errors/WarehouseSchemaDriftError",
+			message: "Compiled query row 0 did not match its declared output schema",
+			kind: "decode",
+		})
+		expect(decode.description).not.toContain("schema apply")
+		expect(decode.description).toContain("Maple bug")
+	})
+
+	it("re-sniffs embedded statuses out of generic query failures", () => {
+		const auth = presentWarehouseError({
+			_tag: "@maple/http/errors/WarehouseQueryError",
+			message: "Request failed, response status code: 403",
+		})
+		expect(auth.title).toBe("Database rejected our credentials")
+
+		const upstream = presentWarehouseError({
+			_tag: "@maple/http/errors/WarehouseQueryError",
+			message: "503 Service Temporarily Unavailable",
+		})
+		expect(upstream.title).toBe("Database is temporarily unavailable")
+	})
+})

--- a/packages/domain/src/http/warehouse-error-meta.ts
+++ b/packages/domain/src/http/warehouse-error-meta.ts
@@ -1,0 +1,282 @@
+// ---------------------------------------------------------------------------
+// Warehouse error presentation metadata — the single source of truth.
+//
+// The nine warehouse error classes used to be re-enumerated by hand in five
+// places (two MCP tables, the alerts v2 map, AlertsService's failure
+// categories, and the web's error formatter), so adding a tag meant five
+// lockstep edits across five packages and any missed arm silently changed
+// where the error went. This module owns everything derivable per tag:
+//
+// - `WAREHOUSE_ERROR_TAGS` / `warehouseErrorStatus` are DERIVED from the error
+//   classes themselves (same annotation-reading as `anticipated-errors.ts`).
+// - `warehouseErrorMeta` is a `Record` keyed by the tag union, so a tenth tag
+//   is a compile error HERE and nowhere else.
+// - `presentWarehouseError` is the shared human-facing formatter. It is
+//   structural (works on wire-decoded objects, not just class instances) so
+//   the web app can feed it errors that crossed the HTTP boundary.
+//
+// Imports nothing beyond `./warehouse-errors` (which imports only `effect`
+// Schema), so web/CLI bundles stay driver-free.
+// ---------------------------------------------------------------------------
+
+import type { WarehouseError } from "./warehouse-errors"
+import { warehouseHttpErrors } from "./warehouse-errors"
+
+export type WarehouseErrorTag = WarehouseError["_tag"]
+
+const prop = (obj: unknown, key: string): unknown =>
+	(typeof obj === "object" || typeof obj === "function") && obj !== null && key in obj
+		? (obj as Record<string, unknown>)[key]
+		: undefined
+
+const readTag = (value: unknown): string | undefined => {
+	const literal = prop(prop(prop(prop(value, "fields"), "_tag"), "schema"), "literal")
+	return typeof literal === "string" ? literal : undefined
+}
+
+const readHttpStatus = (value: unknown): number | undefined => {
+	const status = prop(prop(prop(value, "ast"), "annotations"), "httpApiStatus")
+	return typeof status === "number" ? status : undefined
+}
+
+/** Every warehouse error tag, derived from the classes — never hand-listed. */
+export const WAREHOUSE_ERROR_TAGS: ReadonlyArray<WarehouseErrorTag> = warehouseHttpErrors.map(
+	(cls) => {
+		const tag = readTag(cls)
+		if (tag === undefined) throw new Error("warehouse error class without a _tag literal")
+		return tag as WarehouseErrorTag
+	},
+)
+
+/** `httpApiStatus` per tag, derived from the class annotations. */
+export const warehouseErrorStatus: ReadonlyMap<WarehouseErrorTag, number> = new Map(
+	warehouseHttpErrors.map((cls) => {
+		const tag = readTag(cls) as WarehouseErrorTag
+		const status = readHttpStatus(cls)
+		if (status === undefined) throw new Error(`warehouse error ${tag} without httpApiStatus`)
+		return [tag, status] as const
+	}),
+)
+
+export interface WarehouseErrorMeta {
+	/** Stable machine-readable slug for envelopes/failure categories. */
+	readonly code: string
+	/** Whose fault this is — drives copy tone, alerting, and on-call routing. */
+	readonly blame: "maple" | "customer" | "upstream"
+	/** Whether an identical retry can plausibly succeed. */
+	readonly retryable: boolean
+	/** Human title shown by UIs when no more specific copy applies. */
+	readonly title: string
+}
+
+/**
+ * Per-tag presentation metadata. Keyed by the tag UNION, so adding a warehouse
+ * error class without extending this table is a compile error — in exactly one
+ * file.
+ */
+export const warehouseErrorMeta: Record<WarehouseErrorTag, WarehouseErrorMeta> = {
+	"@maple/http/errors/WarehouseQueryError": {
+		code: "warehouse_query_failed",
+		blame: "upstream",
+		retryable: false,
+		title: "Database query failed",
+	},
+	"@maple/http/errors/WarehouseUpstreamError": {
+		code: "warehouse_unavailable",
+		blame: "upstream",
+		retryable: true,
+		title: "Database is temporarily unavailable",
+	},
+	"@maple/http/errors/WarehouseAuthError": {
+		code: "warehouse_auth_failed",
+		blame: "customer",
+		retryable: false,
+		title: "Database rejected our credentials",
+	},
+	"@maple/http/errors/WarehouseConfigError": {
+		code: "warehouse_config_invalid",
+		blame: "customer",
+		retryable: false,
+		title: "Database is not configured correctly",
+	},
+	"@maple/http/errors/WarehouseClientError": {
+		code: "warehouse_client_error",
+		blame: "upstream",
+		retryable: false,
+		title: "Database response could not be decoded",
+	},
+	"@maple/http/errors/WarehouseSchemaDriftError": {
+		code: "warehouse_schema_drift",
+		blame: "customer",
+		retryable: false,
+		title: "Database schema is out of date",
+	},
+	"@maple/http/errors/WarehouseMalformedQueryError": {
+		code: "warehouse_malformed_query",
+		blame: "maple",
+		retryable: false,
+		title: "This chart hit a bug in Maple",
+	},
+	"@maple/http/errors/WarehouseQuotaExceededError": {
+		code: "warehouse_quota_exceeded",
+		blame: "customer",
+		retryable: false,
+		title: "Query was too expensive",
+	},
+	"@maple/http/errors/WarehouseValidationError": {
+		code: "warehouse_validation_failed",
+		blame: "customer",
+		retryable: false,
+		title: "Invalid query",
+	},
+}
+
+/**
+ * Strip HTML error pages / whitespace noise out of an upstream error message.
+ * Shared by the classifier (query-engine) and the web formatter — this used to
+ * be two byte-identical copies.
+ */
+export const cleanErrorMessage = (raw: string): string => {
+	let cleaned = raw
+	const htmlIndex = cleaned.search(/<\s*(html|head|body|center|h1|hr|title)\b/i)
+	if (htmlIndex >= 0) cleaned = cleaned.slice(0, htmlIndex)
+	cleaned = cleaned
+		.replace(/<[^>]+>/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+	if (cleaned.endsWith(":")) cleaned = cleaned.slice(0, -1).trim()
+	return cleaned || raw.slice(0, 200)
+}
+
+/** Sniff an HTTP status embedded in an upstream error message. */
+export const extractUpstreamStatus = (message: string): number | undefined => {
+	const match = message.match(/(?:status|HTTP status|response status code)[:\s]+(\d{3})/i)
+	if (match) return Number(match[1])
+	const titleMatch = message.match(/\b(\d{3})\s+(?:error|service temporarily unavailable)\b/i)
+	if (titleMatch) return Number(titleMatch[1])
+	return undefined
+}
+
+const QUOTA_DESCRIPTIONS: Record<string, string> = {
+	max_execution_time: "Query exceeded the 30s execution limit. Narrow the time range or add filters.",
+	max_memory_usage: "Query exceeded the memory limit. Add filters or reduce cardinality.",
+	max_threads: "Query exceeded the thread limit. Try a smaller scan.",
+}
+
+const authDescription = (upstreamStatus: number | undefined): string =>
+	upstreamStatus === 403
+		? "The configured database credentials are missing required permissions."
+		: "The configured database credentials are invalid or expired. Update them in settings."
+
+/**
+ * A warehouse error as seen AFTER crossing the HTTP boundary: a plain decoded
+ * object, not necessarily a class instance. Every field beyond `_tag` is
+ * optional so the presenter never trusts the wire.
+ */
+export interface WarehouseErrorLike {
+	readonly _tag: WarehouseErrorTag
+	readonly message?: string
+	readonly setting?: string
+	readonly upstreamStatus?: number
+	readonly kind?: string
+}
+
+export interface PresentedWarehouseError {
+	readonly title: string
+	readonly description: string
+}
+
+/**
+ * Shared human-facing copy per warehouse error. Structural on purpose — the
+ * web formatter feeds it wire-decoded objects, the MCP layer feeds it class
+ * instances; both get identical copy.
+ */
+export const presentWarehouseError = (error: WarehouseErrorLike): PresentedWarehouseError => {
+	const meta = warehouseErrorMeta[error._tag]
+	const message = error.message !== undefined ? cleanErrorMessage(error.message) : undefined
+	switch (error._tag) {
+		case "@maple/http/errors/WarehouseQuotaExceededError": {
+			const setting = error.setting ?? "limit"
+			return {
+				title: meta.title,
+				description:
+					QUOTA_DESCRIPTIONS[setting] ??
+					`Query exceeded the ${setting} limit. Narrow the time range or add filters.`,
+			}
+		}
+		case "@maple/http/errors/WarehouseAuthError":
+			return { title: meta.title, description: authDescription(error.upstreamStatus) }
+		case "@maple/http/errors/WarehouseUpstreamError":
+			return {
+				title: meta.title,
+				description:
+					error.upstreamStatus !== undefined
+						? `The query backend returned ${error.upstreamStatus}. Retry in a few seconds.`
+						: "The query backend is unreachable. Retry in a few seconds.",
+			}
+		case "@maple/http/errors/WarehouseConfigError":
+			return { title: meta.title, description: message ?? "Database is not configured correctly." }
+		case "@maple/http/errors/WarehouseClientError":
+			return { title: meta.title, description: message ?? "Database response could not be decoded." }
+		case "@maple/http/errors/WarehouseSchemaDriftError": {
+			// `kind: "decode"` = the CLUSTER answered fine but the rows failed
+			// Maple's own row schema — schema apply cannot fix that, so don't
+			// advise it (the advice sent people chasing infra symptoms).
+			if (error.kind === "decode") {
+				return {
+					title: "Query results did not match what Maple expected",
+					description: `${message ?? "The database answered with rows Maple could not decode."} This is likely a Maple bug, not a problem with your cluster.`,
+				}
+			}
+			return {
+				title: meta.title,
+				description: `${message ?? "A column Maple expects is missing from the cluster."} Run schema apply from your ClickHouse settings.`,
+			}
+		}
+		case "@maple/http/errors/WarehouseMalformedQueryError":
+			// Maple generated SQL the database refused to plan. Nothing the user
+			// can do — do not send them to their database settings.
+			return {
+				title: meta.title,
+				description:
+					"Maple built a query its own database rejected. This is our fault, not a problem with your data or your cluster — we have been alerted.",
+			}
+		case "@maple/http/errors/WarehouseValidationError":
+			return { title: meta.title, description: message ?? "The query was rejected before running." }
+		case "@maple/http/errors/WarehouseQueryError": {
+			// Generic SQL/query failure. Some transient failures still arrive with
+			// only a status code embedded in the message (e.g. a 5xx HTML body), so
+			// sniff it to surface those nicely.
+			const text = message ?? "Database query failed"
+			const upstreamStatus = extractUpstreamStatus(text)
+			if (upstreamStatus === 401 || upstreamStatus === 403) {
+				return {
+					title: warehouseErrorMeta["@maple/http/errors/WarehouseAuthError"].title,
+					description: authDescription(upstreamStatus),
+				}
+			}
+			if (upstreamStatus !== undefined && upstreamStatus >= 500 && upstreamStatus < 600) {
+				return {
+					title: warehouseErrorMeta["@maple/http/errors/WarehouseUpstreamError"].title,
+					description: `The query backend returned ${upstreamStatus}. Retry in a few seconds.`,
+				}
+			}
+			return { title: meta.title, description: text }
+		}
+	}
+}
+
+export const isWarehouseErrorTag = (tag: string): tag is WarehouseErrorTag =>
+	tag in warehouseErrorMeta
+
+/**
+ * Presentation with the raw upstream message REDACTED — every description
+ * falls back to Maple-authored copy. Public API envelopes use this: ClickHouse
+ * diagnostics can echo generated SQL and internal identifiers, and the v2
+ * surface deliberately never forwards them (the web app, talking to its own
+ * org's data, uses `presentWarehouseError` directly).
+ */
+export const presentWarehouseErrorPublic = (error: WarehouseErrorLike): PresentedWarehouseError => {
+	const { message: _message, ...rest } = error
+	return presentWarehouseError(rest)
+}

--- a/packages/domain/src/http/warehouse-errors.ts
+++ b/packages/domain/src/http/warehouse-errors.ts
@@ -66,10 +66,16 @@ export class WarehouseClientError extends Schema.TaggedErrorClass<WarehouseClien
  * A BYO ClickHouse cluster is missing a column or has the wrong type for one
  * Maple expects; remediated by running schema apply on the cluster. The MCP
  * layer enriches this with an actionable hint.
+ *
+ * `kind` splits two failure modes that need opposite advice: `"cluster"`
+ * (absent = cluster, for wire compatibility) means the cluster itself rejected
+ * the query — run schema apply; `"decode"` means the cluster answered but the
+ * rows failed Maple's own row schema — schema apply cannot fix that and the
+ * presenter must not suggest it.
  */
 export class WarehouseSchemaDriftError extends Schema.TaggedErrorClass<WarehouseSchemaDriftError>()(
 	"@maple/http/errors/WarehouseSchemaDriftError",
-	warehouseErrorBaseFields,
+	{ ...warehouseErrorBaseFields, kind: Schema.optional(Schema.Literals(["cluster", "decode"])) },
 	{ httpApiStatus: 502 },
 ) {}
 

--- a/packages/domain/src/http/warehouse.ts
+++ b/packages/domain/src/http/warehouse.ts
@@ -11,6 +11,7 @@ export { UnauthorizedError } from "./current-tenant"
 // so `@maple/domain/http`'s barrel keeps surfacing every class and there is a
 // single definition site (keeps `instanceof` identity-safe across import paths).
 export * from "./warehouse-errors"
+export * from "./warehouse-error-meta"
 
 const WarehouseQueryNameSchema = Schema.Literals(warehouseQueries)
 

--- a/packages/query-engine/src/ch/builder-fixtures.ts
+++ b/packages/query-engine/src/ch/builder-fixtures.ts
@@ -1,0 +1,191 @@
+// ---------------------------------------------------------------------------
+// Fixtures for query builders that never pass through the pipe registry or the
+// QuerySpec lowering — the ~125 exports reached only via direct
+// `warehouse.compiledQuery` call sites in apps/api. Without a fixture here a
+// builder never meets the ClickHouse analyzer until production.
+//
+// Each fixture calls the REAL exported builder with parameters shaped like its
+// production call site (file:line noted per fixture), so the catalog sweeps the
+// SQL the app actually emits. `sql-catalog.test.ts`'s `uncoveredBuilders`
+// anti-rot test enforces that every module export is either fixtured here or
+// explicitly exempted there — adding a builder without either breaks the build.
+//
+// Batch ① (2026-08): session-replays, session-events, and the errors builders
+// only reachable from ErrorsService/telemetry. Remaining modules live on the
+// exemption list and shrink batch by batch.
+// ---------------------------------------------------------------------------
+
+import type { CompiledQuery } from "@maple-dev/clickhouse-builder"
+import * as CH from "./index"
+
+export interface BuilderFixture {
+	/** Module basename under `src/ch/queries/`, e.g. `"session-replays"`. */
+	readonly module: string
+	/** The exported builder this fixture covers — must match the export name. */
+	readonly name: string
+	/** Distinguishes fixtures for one builder; appears in failure output. */
+	readonly label: string
+	readonly compile: () => CompiledQuery<unknown>
+}
+
+const ORG_ID = "org_sql_catalog"
+const START_TIME = "2026-01-01 10:30:00"
+const END_TIME = "2026-01-03 14:15:00"
+const SESSION_ID = "sess_0af7651916cd43dd"
+const TRACE_ID = "0af7651916cd43dd8448eb211c80319c"
+const SPAN_ID = "b7ad6b7169203331"
+const FINGERPRINT = "11640393269246331608"
+
+const window = { orgId: ORG_ID, startTime: START_TIME, endTime: END_TIME }
+
+export const builderFixtures: ReadonlyArray<BuilderFixture> = [
+	// ----- session-replays (routes/session-replay.http.ts, routes/v2/session-replays.http.ts) -----
+	{
+		module: "session-replays",
+		name: "sessionReplaysListQuery",
+		label: "default",
+		compile: () => CH.compile(CH.sessionReplaysListQuery({}), window),
+	},
+	{
+		// Filters force the session_events semi-join + activity join branches.
+		module: "session-replays",
+		name: "sessionReplaysListQuery",
+		label: "filtered",
+		compile: () =>
+			CH.compile(
+				CH.sessionReplaysListQuery({
+					serviceName: "web",
+					hasErrors: true,
+					search: "checkout",
+					durationMinMs: 1_000,
+					activeTimeMinMs: 500,
+					limit: 50,
+				}),
+				window,
+			),
+	},
+	{
+		module: "session-replays",
+		name: "sessionReplaysFacetsQuery",
+		label: "default",
+		compile: () => CH.compileUnion(CH.sessionReplaysFacetsQuery({}), window),
+	},
+	{
+		module: "session-replays",
+		name: "getSessionReplayQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(CH.getSessionReplayQuery({ startTime: START_TIME, endTime: END_TIME }), {
+				orgId: ORG_ID,
+				sessionId: SESSION_ID,
+			}),
+	},
+	{
+		module: "session-replays",
+		name: "sessionReplayEventsQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(CH.sessionReplayEventsQuery({ startTime: START_TIME, endTime: END_TIME }), {
+				orgId: ORG_ID,
+				sessionId: SESSION_ID,
+			}),
+	},
+	{
+		module: "session-replays",
+		name: "sessionsForTraceQuery",
+		label: "default",
+		compile: () => CH.compile(CH.sessionsForTraceQuery({ traceId: TRACE_ID }), window),
+	},
+	{
+		module: "session-replays",
+		name: "sessionTraceSummariesQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(
+				CH.sessionTraceSummariesQuery({
+					traceIds: [TRACE_ID],
+					startTime: START_TIME,
+					endTime: END_TIME,
+				}),
+				{ orgId: ORG_ID },
+			),
+	},
+
+	// ----- session-events (routes/session-replay.http.ts, v2/session-replays.http.ts) -----
+	{
+		module: "session-events",
+		name: "sessionTranscriptQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(CH.sessionTranscriptQuery({ startTime: START_TIME, endTime: END_TIME }), {
+				orgId: ORG_ID,
+				sessionId: SESSION_ID,
+			}),
+	},
+	{
+		module: "session-events",
+		name: "sessionActivityQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(CH.sessionActivityQuery({ startTime: START_TIME, endTime: END_TIME }), {
+				orgId: ORG_ID,
+				sessionId: SESSION_ID,
+			}),
+	},
+
+	// ----- errors builders reached only via direct calls (ErrorsService, v2 telemetry, observability) -----
+	{
+		// telemetry.http.ts v2GetSpan / observability/span-detail.ts
+		module: "errors",
+		name: "spanDetailQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(CH.spanDetailQuery({ traceId: TRACE_ID, spanId: SPAN_ID }), { orgId: ORG_ID }),
+	},
+	{
+		module: "errors",
+		name: "spanDetailQuery",
+		label: "narrowByTime",
+		compile: () =>
+			CH.compile(CH.spanDetailQuery({ traceId: TRACE_ID, spanId: SPAN_ID, narrowByTime: true }), window),
+	},
+	{
+		// ErrorsService errorIssuesScan (the scheduled sweep)
+		module: "errors",
+		name: "errorIssuesQuery",
+		label: "scan",
+		compile: () => CH.compile(CH.errorIssuesQuery({ limit: 500 }), window),
+	},
+	{
+		// ErrorsService errorIssueEnvFingerprints
+		module: "errors",
+		name: "errorFingerprintsQuery",
+		label: "envFiltered",
+		compile: () =>
+			CH.compile(
+				CH.errorFingerprintsQuery({ services: ["api"], deploymentEnvs: ["production"] }),
+				window,
+			),
+	},
+	{
+		module: "errors",
+		name: "errorIssueTimeseriesQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(CH.errorIssueTimeseriesQuery(), {
+				...window,
+				fingerprintHash: FINGERPRINT,
+				bucketSeconds: 300,
+			}),
+	},
+	{
+		module: "errors",
+		name: "errorIssueSampleTracesQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(CH.errorIssueSampleTracesQuery({ limit: 5 }), {
+				...window,
+				fingerprintHash: FINGERPRINT,
+			}),
+	},
+]

--- a/packages/query-engine/src/ch/pipe-dispatch.test.ts
+++ b/packages/query-engine/src/ch/pipe-dispatch.test.ts
@@ -60,7 +60,6 @@ describe("compilePipeQuery", () => {
 				})
 				expect(result).toBeDefined()
 				expect(result!.sql).toContain("test-org")
-				expect(typeof result!.castRows).toBe("function")
 				expect(typeof result!.decodeRows).toBe("function")
 			})
 		}
@@ -145,12 +144,6 @@ describe("compilePipeQuery", () => {
 		const result = compilePipeQuery("list_traces", baseParams())
 		expect(result!.sql).toContain("2024-01-01 00:00:00")
 		expect(result!.sql).toContain("2024-01-02 00:00:00")
-	})
-
-	it("castRows passes through rows", () => {
-		const result = compilePipeQuery("list_traces", baseParams())
-		const rows = [{ traceId: "abc" }]
-		expect(result!.castRows(rows)).toEqual(rows)
 	})
 
 	it.effect("decodeRows passes through rows for DSL-backed pipes without row schemas", () =>

--- a/packages/query-engine/src/execution/backend.ts
+++ b/packages/query-engine/src/execution/backend.ts
@@ -50,6 +50,17 @@ export interface WarehouseBackendDialect {
 	readonly dbSystemName: "tinybird" | "clickhouse"
 	/** Logical destination used by the service-map `peer.service` edge. */
 	readonly peerService: string
+	/**
+	 * ClickHouse JSON formats quote 64-bit integers by default
+	 * (`output_format_json_quote_64bit_integers=1`), so `count()`/`sum()`/
+	 * `uniqExact()` arrive as strings on ClickHouse-protocol backends while the
+	 * Tinybird SDK returns numbers. Setting the flag to 0 restores wire parity so
+	 * every query decodes identically on both — magnitudes above 2^53 lose
+	 * precision either way (the existing managed-Tinybird contract); identity
+	 * UInt64s (hashes/ids) must be `toString()`-wrapped in the SELECT, which the
+	 * SQL-catalog e2e sweep enforces.
+	 */
+	readonly unquote64BitIntegers: boolean
 }
 
 /** Single source of truth for per-backend behavior. */
@@ -61,6 +72,8 @@ export const BackendDialect: Record<WarehouseBackendKind, WarehouseBackendDialec
 		normalizeSqlForClient: false,
 		dbSystemName: "tinybird",
 		peerService: "tinybird",
+		// The SDK's /v0/sql JSON already returns 64-bit ints as numbers.
+		unquote64BitIntegers: false,
 	},
 	"tinybird-gateway": {
 		driver: "clickhouse-web",
@@ -69,6 +82,7 @@ export const BackendDialect: Record<WarehouseBackendKind, WarehouseBackendDialec
 		normalizeSqlForClient: true,
 		dbSystemName: "clickhouse",
 		peerService: "clickhouse",
+		unquote64BitIntegers: true,
 	},
 	clickhouse: {
 		driver: "clickhouse-web",
@@ -77,6 +91,7 @@ export const BackendDialect: Record<WarehouseBackendKind, WarehouseBackendDialec
 		normalizeSqlForClient: true,
 		dbSystemName: "clickhouse",
 		peerService: "clickhouse",
+		unquote64BitIntegers: true,
 	},
 	chdb: {
 		driver: "clickhouse-web",
@@ -85,5 +100,6 @@ export const BackendDialect: Record<WarehouseBackendKind, WarehouseBackendDialec
 		normalizeSqlForClient: true,
 		dbSystemName: "clickhouse",
 		peerService: "chdb",
+		unquote64BitIntegers: true,
 	},
 }

--- a/packages/query-engine/src/execution/errors.ts
+++ b/packages/query-engine/src/execution/errors.ts
@@ -1,4 +1,6 @@
 import {
+	cleanErrorMessage,
+	extractUpstreamStatus,
 	WarehouseAuthError,
 	WarehouseClientError,
 	WarehouseConfigError,
@@ -9,6 +11,11 @@ import {
 	WarehouseUpstreamError,
 } from "@maple/domain/http"
 import { detectQuotaSetting } from "../profiles"
+
+// The message sanitizer and status sniffer moved to `@maple/domain/http`
+// (warehouse-error-meta) so the web formatter shares one implementation;
+// re-exported here for existing consumers/tests.
+export { cleanErrorMessage, extractUpstreamStatus }
 
 /**
  * Every warehouse error `mapWarehouseError` can produce. Precondition failures
@@ -52,26 +59,6 @@ const getClickHouseErrorDetails = (error: unknown): ClickHouseErrorDetails => {
 		code: optionalString(error.code),
 		type: typeof error.type === "string" ? error.type : undefined,
 	}
-}
-
-export const cleanErrorMessage = (raw: string): string => {
-	let cleaned = raw
-	const htmlIndex = cleaned.search(/<\s*(html|head|body|center|h1|hr|title)\b/i)
-	if (htmlIndex >= 0) cleaned = cleaned.slice(0, htmlIndex)
-	cleaned = cleaned
-		.replace(/<[^>]+>/g, " ")
-		.replace(/\s+/g, " ")
-		.trim()
-	if (cleaned.endsWith(":")) cleaned = cleaned.slice(0, -1).trim()
-	return cleaned || raw.slice(0, 200)
-}
-
-const extractUpstreamStatus = (message: string): number | undefined => {
-	const match = message.match(/(?:status|HTTP status|response status code)[:\s]+(\d{3})/i)
-	if (match) return Number(match[1])
-	const titleMatch = message.match(/\b(\d{3})\s+(?:error|service temporarily unavailable)\b/i)
-	if (titleMatch) return Number(titleMatch[1])
-	return undefined
 }
 
 /** Fields shared by every warehouse error, built once per classification. */

--- a/packages/query-engine/src/execution/executor.test.ts
+++ b/packages/query-engine/src/execution/executor.test.ts
@@ -272,6 +272,62 @@ const makeRecordingDeps = (
 		}),
 })
 
+describe("makeWarehouseExecutor compiled-query defaults", () => {
+	it.effect("defaults the profile to 'aggregation' when none is passed", () =>
+		Effect.gen(function* () {
+			const sqls: Array<string> = []
+			const executor = makeWarehouseExecutor(
+				makeRecordingDeps({ config: clickhouseConfig, clientCacheKey: "read:org_test" }, sqls),
+			)
+			yield* executor.compiledQuery(tenant, untaggedCompiled, { context: "test" })
+			// aggregation = { maxExecutionTime: 30, maxMemoryUsage: 4GB }; previously a
+			// profile-less call emitted no SETTINGS clause at all.
+			assert.isTrue(sqls[0]?.includes("max_execution_time=30"))
+			assert.isTrue(sqls[0]?.includes("max_memory_usage=4000000000"))
+		}),
+	)
+
+	it.effect("an explicit profile still wins over the default", () =>
+		Effect.gen(function* () {
+			const sqls: Array<string> = []
+			const executor = makeWarehouseExecutor(
+				makeRecordingDeps({ config: clickhouseConfig, clientCacheKey: "read:org_test" }, sqls),
+			)
+			yield* executor.compiledQuery(tenant, untaggedCompiled, { context: "test", profile: "list" })
+			assert.isTrue(sqls[0]?.includes("max_execution_time=15"))
+			assert.isFalse(sqls[0]?.includes("max_execution_time=30"))
+		}),
+	)
+
+	it.effect("reports the caller's context as pipeName when row decode fails", () =>
+		Effect.gen(function* () {
+			const badRowDeps: WarehouseExecutorDeps = {
+				createClient: () => ({
+					sql: async () => ({ data: [{ c: "not-a-number" }] }),
+					insert: async () => {},
+				}),
+				resolveRoute: () =>
+					Effect.succeed({
+						source: "managed" as const,
+						config: clickhouseConfig,
+						clientCacheKey: "read:org_test",
+					}),
+			}
+			const withSchema = unsafeCompiledQuery<{ readonly c: number }>({
+				sql: "SELECT count() AS c FROM traces WHERE OrgId = 'org_test'\nFORMAT JSON",
+				rowSchema: Schema.Struct({ c: Schema.Number }),
+			})
+			const executor = makeWarehouseExecutor(badRowDeps)
+			const error = yield* executor
+				.compiledQuery(tenant, withSchema, { context: "serviceOverview" })
+				.pipe(Effect.flip)
+			assert.strictEqual(error._tag, "@maple/http/errors/WarehouseSchemaDriftError")
+			// The real query identity, not the old constant "compiledQuery".
+			assert.strictEqual(error.pipeName, "serviceOverview")
+		}),
+	)
+})
+
 describe("makeWarehouseExecutor restricted-settings strip", () => {
 	it.effect("strips max_block_size for the managed Tinybird CH-gateway", () =>
 		Effect.gen(function* () {

--- a/packages/query-engine/src/execution/executor.ts
+++ b/packages/query-engine/src/execution/executor.ts
@@ -597,6 +597,7 @@ WHERE name = 'enable_full_text_index'`,
 					new WarehouseSchemaDriftError({
 						pipeName: payload.pipeName,
 						message: error.message,
+						kind: "decode",
 						cause: error,
 					}),
 			),
@@ -650,11 +651,22 @@ WHERE name = 'enable_full_text_index'`,
 	): SqlQueryOptions | undefined =>
 		compiled.routing === "ingest" ? { ...options, route: "ingest" } : options
 
+	// Every compiled query runs under a cost profile: an omitted `profile` used to
+	// mean "no SETTINGS clause at all" (no server-side memory/time budget, flat
+	// 30s client cap), which ~20 call sites hit by accident. Default to
+	// "aggregation" like the QuerySpec lowering does; "unbounded" stays the
+	// explicit opt-out.
+	const withDefaultProfile = (options?: SqlQueryOptions): SqlQueryOptions => ({
+		...options,
+		profile: options?.profile ?? "aggregation",
+	})
+
 	const executeCompiledQuery = Effect.fn("WarehouseQueryService.executeCompiledQuery")(function* <T>(
 		tenant: ExecutionTenant,
 		compiled: CompiledQuery<T> | ((capabilities: WarehouseCapabilities) => CompiledQuery<T>),
-		options?: SqlQueryOptions,
+		rawOptions?: SqlQueryOptions,
 	) {
+		const options = withDefaultProfile(rawOptions)
 		const capabilities =
 			typeof compiled === "function" ? yield* resolveCapabilities(tenant, options) : undefined
 		if (capabilities) yield* annotateCapabilityPlan(capabilities)
@@ -669,8 +681,9 @@ WHERE name = 'enable_full_text_index'`,
 			Effect.mapError(
 				(error) =>
 					new WarehouseSchemaDriftError({
-						pipeName: "compiledQuery",
+						pipeName: options.context ?? "compiledQuery",
 						message: error.message,
+						kind: "decode",
 						cause: error,
 					}),
 			),
@@ -692,8 +705,9 @@ WHERE name = 'enable_full_text_index'`,
 	const compiledQueryFirst = Effect.fn("WarehouseQueryService.compiledQueryFirst")(function* <T>(
 		tenant: ExecutionTenant,
 		compiled: CompiledQuery<T> | ((capabilities: WarehouseCapabilities) => CompiledQuery<T>),
-		options?: SqlQueryOptions,
+		rawOptions?: SqlQueryOptions,
 	) {
+		const options = withDefaultProfile(rawOptions)
 		const capabilities =
 			typeof compiled === "function" ? yield* resolveCapabilities(tenant, options) : undefined
 		if (capabilities) yield* annotateCapabilityPlan(capabilities)
@@ -708,8 +722,9 @@ WHERE name = 'enable_full_text_index'`,
 			Effect.mapError(
 				(error) =>
 					new WarehouseSchemaDriftError({
-						pipeName: "compiledQueryFirst",
+						pipeName: options.context ?? "compiledQueryFirst",
 						message: error.message,
+						kind: "decode",
 						cause: error,
 					}),
 			),

--- a/packages/query-engine/src/sql-catalog.test.ts
+++ b/packages/query-engine/src/sql-catalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { warehouseQueries } from "@maple/domain"
 import {
+	collectBuilderCatalog,
 	collectPipeCatalog,
 	collectQuerySpecCatalog,
 	collectSqlCatalog,
@@ -10,6 +11,36 @@ import {
 	routeCoverage,
 	uncoveredPipes,
 } from "./sql-catalog"
+import { builderFixtures } from "./ch/builder-fixtures"
+import * as activityQueries from "./ch/queries/activity"
+import * as alertCheckQueries from "./ch/queries/alert-checks"
+import * as anomalyQueries from "./ch/queries/anomaly"
+import * as attributeKeyQueries from "./ch/queries/attribute-keys"
+import * as billingUsageQueries from "./ch/queries/billing-usage"
+import * as cloudflareInfraBreakdownQueries from "./ch/queries/cloudflare-infra-breakdowns"
+import * as cloudflareInfraExtendedQueries from "./ch/queries/cloudflare-infra-extended"
+import * as cloudflareInfraFilterQueries from "./ch/queries/cloudflare-infra-filters"
+import * as cloudflareInfraQueries from "./ch/queries/cloudflare-infra"
+import * as cloudflareMapQueries from "./ch/queries/cloudflare-map"
+import * as cloudflareUsageQueries from "./ch/queries/cloudflare-usage"
+import * as errorQueries from "./ch/queries/errors"
+import * as infraQueries from "./ch/queries/infra"
+import * as internalQueries from "./ch/queries/internal"
+import * as livenessQueries from "./ch/queries/liveness"
+import * as logQueries from "./ch/queries/logs"
+import * as metricQueries from "./ch/queries/metrics"
+import * as planetscaleInfraQueries from "./ch/queries/planetscale-infra"
+import * as planetscaleMapQueries from "./ch/queries/planetscale-map"
+import * as serviceInfraQueries from "./ch/queries/service-infra"
+import * as serviceMapRollupQueries from "./ch/queries/service-map-rollup"
+import * as serviceMapQueries from "./ch/queries/service-map"
+import * as serviceOperationQueries from "./ch/queries/service-operations"
+import * as serviceQueries from "./ch/queries/services"
+import * as sessionEventQueries from "./ch/queries/session-events"
+import * as sessionReplayQueries from "./ch/queries/session-replays"
+import * as setupAuditQueries from "./ch/queries/setup-audit"
+import * as topOperationQueries from "./ch/queries/top-operations"
+import * as traceQueries from "./ch/queries/traces"
 
 // These run on every PR with no ClickHouse. They guarantee the catalog the
 // DESCRIBE sweep consumes is complete and actually compiles; the sweep itself
@@ -97,6 +128,263 @@ describe("sql catalog", () => {
 		const known = new Set<string>(warehouseQueries)
 		for (const fixture of pipeFixtures) {
 			expect(known.has(fixture.pipe), `unknown pipe ${fixture.pipe}`).toBe(true)
+		}
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Builder coverage — the third entry surface.
+//
+// Every `*Query`/`*SQL` export under ch/queries must be either fixtured in
+// ch/builder-fixtures.ts or explicitly exempted below. Adding a builder
+// without either fails here — the same playbook as `uncoveredPipes`, extended
+// to the ~125 builders reached only through direct compiledQuery call sites.
+// ---------------------------------------------------------------------------
+
+const QUERY_MODULES: Record<string, Record<string, unknown>> = {
+	activity: activityQueries,
+	"alert-checks": alertCheckQueries,
+	anomaly: anomalyQueries,
+	"attribute-keys": attributeKeyQueries,
+	"billing-usage": billingUsageQueries,
+	"cloudflare-infra-breakdowns": cloudflareInfraBreakdownQueries,
+	"cloudflare-infra-extended": cloudflareInfraExtendedQueries,
+	"cloudflare-infra-filters": cloudflareInfraFilterQueries,
+	"cloudflare-infra": cloudflareInfraQueries,
+	"cloudflare-map": cloudflareMapQueries,
+	"cloudflare-usage": cloudflareUsageQueries,
+	errors: errorQueries,
+	infra: infraQueries,
+	internal: internalQueries,
+	liveness: livenessQueries,
+	logs: logQueries,
+	metrics: metricQueries,
+	"planetscale-infra": planetscaleInfraQueries,
+	"planetscale-map": planetscaleMapQueries,
+	"service-infra": serviceInfraQueries,
+	"service-map-rollup": serviceMapRollupQueries,
+	"service-map": serviceMapQueries,
+	"service-operations": serviceOperationQueries,
+	services: serviceQueries,
+	"session-events": sessionEventQueries,
+	"session-replays": sessionReplayQueries,
+	"setup-audit": setupAuditQueries,
+	"top-operations": topOperationQueries,
+	traces: traceQueries,
+}
+
+/**
+ * Builders not (yet) in the fixture set. THREE reasons only, and each group
+ * says which: `pipe` = reached through the pipe registry / QuerySpec lowering,
+ * so those fixtures already sweep it; `helper` = composed into another
+ * fixtured builder, never compiled standalone; `todo` = a follow-up batch —
+ * SHRINK this list, never grow it.
+ */
+const EXEMPT_BUILDERS: ReadonlySet<string> = new Set([
+	// pipe: swept via pipeFixtures / querySpecFixtures (pipe-dispatch.ts, runtime lowering)
+	"attribute-keys/attributeKeysQuery",
+	"attribute-keys/spanAttributeValuesQuery",
+	"attribute-keys/resourceAttributeValuesQuery",
+	"attribute-keys/logAttributeValuesQuery",
+	"attribute-keys/metricScopedAttributeKeysQuery",
+	"attribute-keys/metricScopedAttributeValuesQuery",
+	"attribute-keys/metricAttributeValuesQuery",
+	"errors/errorsByTypeQuery",
+	"errors/errorsTimeseriesQuery",
+	"errors/spanHierarchyQuery",
+	"errors/tracesDurationStatsQuery",
+	"errors/tracesFacetsQuery",
+	"errors/errorsFacetsQuery",
+	"errors/errorsSummaryQuery",
+	"errors/errorDetailTracesQuery",
+	"logs/logsTimeseriesQuery",
+	"logs/logsBreakdownQuery",
+	"logs/logsCountQuery",
+	"logs/logsListQuery",
+	"logs/errorRateByServiceQuery",
+	"logs/logsFacetsQuery",
+	"metrics/metricsTimeseriesQuery",
+	"metrics/metricsTimeseriesRateQuery",
+	"metrics/metricsSparklinesQuery",
+	"metrics/metricsBreakdownQuery",
+	"metrics/listMetricsQuery",
+	"metrics/metricsSummaryQuery",
+	"service-map/serviceDependenciesSQL",
+	"services/serviceOverviewQuery",
+	"services/serviceReleasesTimelineQuery",
+	"services/serviceApdexTimeseriesQuery",
+	"services/serviceUsageQuery",
+	"services/servicesFacetsQuery",
+	"top-operations/topOperationsQuery",
+	"traces/tracesTimeseriesQuery",
+	"traces/tracesBreakdownQuery",
+	"traces/tracesListQuery",
+	"traces/slowTracesQuery",
+	"traces/spanSearchQuery",
+	"traces/tracesRootListQuery",
+
+	// helper: composed into sessionReplaysListQuery, never compiled standalone
+	"session-events/sessionEventMatchQuery",
+	"session-events/sessionActivityAggregateQuery",
+
+	// todo (dead export — removal tracked separately; zero consumers)
+	"errors/traceTimeProbeQuery",
+
+	// todo batch ② — alerting correctness (anomaly, alert-checks, setup-audit, activity, liveness, internal)
+	"activity/activeOrgsByErrorEventsQuery",
+	"activity/activeOrgsByTracesQuery",
+	"activity/activeOrgsByLogsQuery",
+	"alert-checks/listRuleChecksQuery",
+	"alert-checks/alertCheckGroupTotalsQuery",
+	"alert-checks/alertChecksSummaryQuery",
+	"anomaly/anomalyTraceSignalsQuery",
+	"anomaly/anomalyLogVolumeQuery",
+	"anomaly/anomalyErrorSpikeCurrentQuery",
+	"anomaly/anomalyErrorSpikeBaselineQuery",
+	"anomaly/anomalyTraceSignalTimeseriesQuery",
+	"anomaly/anomalyLogVolumeTimeseriesQuery",
+	"anomaly/anomalyErrorSpikeTimeseriesQuery",
+	"anomaly/anomalyErrorSpikeServiceTimeseriesQuery",
+	"setup-audit/auditAttributeKeyInventoryQuery",
+	"setup-audit/auditSpanShapeByServiceQuery",
+	"setup-audit/auditSamplingByServiceQuery",
+	"setup-audit/auditLogSeverityByServiceQuery",
+	"setup-audit/auditMetricLabelCardinalityQuery",
+	"setup-audit/auditPeerValueInventoryQuery",
+	"setup-audit/auditDbEdgeIdentityQuery",
+	"setup-audit/auditLogCorrelationQuery",
+	"setup-audit/auditOrphanSpansSQL",
+	"setup-audit/auditRootlessTracesSQL",
+	"liveness/serviceLivenessQuery",
+	"liveness/orgTelemetryPulseQuery",
+	"internal/dbStatementSamplesQuery",
+
+	// todo batch ③ — infra + integrations (infra, cloudflare-*, planetscale-*, service-map, rollups)
+	"infra/listHostsQuery",
+	"infra/hostDetailSummaryQuery",
+	"infra/hostGaugeTimeseriesQuery",
+	"infra/fleetUtilizationTimeseriesQuery",
+	"infra/hostNetworkTimeseriesQuery",
+	"infra/listPodsQuery",
+	"infra/listPodsSummaryQuery",
+	"infra/podDetailSummaryQuery",
+	"infra/podGaugeTimeseriesQuery",
+	"infra/listNodesQuery",
+	"infra/nodeDetailSummaryQuery",
+	"infra/nodeGaugeTimeseriesQuery",
+	"infra/listWorkloadsQuery",
+	"infra/workloadDetailSummaryQuery",
+	"infra/workloadGaugeTimeseriesQuery",
+	"infra/podFacetsQuery",
+	"infra/nodeFacetsQuery",
+	"infra/workloadFacetsQuery",
+	"cloudflare-infra-breakdowns/cloudflareZoneBreakdownTotalsSQL",
+	"cloudflare-infra-breakdowns/cloudflareZoneBreakdownTimeseriesSQL",
+	"cloudflare-infra-breakdowns/cloudflareZoneBreakdownCoverageSQL",
+	"cloudflare-infra-breakdowns/cloudflareZoneFacetsQuery",
+	"cloudflare-infra-extended/cloudflareZoneHostBreakdownSQL",
+	"cloudflare-infra-extended/cloudflareZoneHostTimeseriesSQL",
+	"cloudflare-infra-extended/cloudflareZoneFirewallTimeseriesSQL",
+	"cloudflare-infra-extended/cloudflareZoneFirewallTopSQL",
+	"cloudflare-infra-extended/cloudflareZoneDnsTimeseriesSQL",
+	"cloudflare-infra-extended/cloudflareZoneDnsBreakdownSQL",
+	"cloudflare-infra-extended/cloudflareQueueGaugesSQL",
+	"cloudflare-infra-extended/cloudflareDurableObjectCountersSQL",
+	"cloudflare-infra/cloudflareZoneCountersSQL",
+	"cloudflare-infra/cloudflareZoneLatencySQL",
+	"cloudflare-infra/cloudflareZoneTimeseriesSQL",
+	"cloudflare-infra/cloudflareZoneStatusTimeseriesSQL",
+	"cloudflare-infra/cloudflareZoneCacheTimeseriesSQL",
+	"cloudflare-infra/cloudflareZoneLatencyTimeseriesSQL",
+	"cloudflare-infra/cloudflareWorkerCountersSQL",
+	"cloudflare-infra/cloudflareWorkerLatencySQL",
+	"cloudflare-infra/cloudflareWorkerTimeseriesSQL",
+	"cloudflare-map/cloudflareServiceCountersSQL",
+	"cloudflare-map/cloudflareServiceLatencySQL",
+	"planetscale-infra/planetscaleInfraTimeseriesSQL",
+	"planetscale-infra/planetscaleBranchInfraTimeseriesSQL",
+	"planetscale-map/planetscaleGaugesSQL",
+	"planetscale-map/planetscaleBranchGaugesSQL",
+	"planetscale-map/planetscaleStorageSQL",
+	"planetscale-map/planetscaleBranchStorageSQL",
+	"planetscale-map/planetscaleConnectionsSQL",
+	"planetscale-map/planetscaleBranchConnectionsSQL",
+	"service-infra/serviceWorkloadsSQL",
+	"service-map-rollup/serviceMapEdgesExistingHoursSQL",
+	"service-map-rollup/serviceMapEdgesRollupSQL",
+	"service-map-rollup/serviceMapResolutionsRollupSQL",
+	"service-map/serviceMapEdgeJoinSQL",
+	"service-map/serviceDependenciesForServiceQuery",
+	"service-map/serviceDbEdgesSQL",
+	"service-map/serviceDbEdgesForServiceQuery",
+	"service-map/serviceDbQuerySummarySQL",
+	"service-map/serviceDbQueryTimeseriesSQL",
+	"service-map/serviceDbTopQueriesSQL",
+	"service-map/serviceExternalEdgesSQL",
+	"service-map/servicePlatformsSQL",
+
+	// todo batch ④ — remainder (billing, service detail, operations, stray trace/log lookups)
+	"billing-usage/dailySignalVolumeQuery",
+	"billing-usage/dailySessionCountQuery",
+	"cloudflare-usage/cloudflareUsageStatsQuery",
+	"cloudflare-usage/cloudflareUsageQuery",
+	"logs/getLogByKeyQuery",
+	"service-operations/serviceOperationsSummaryRawQuery",
+	"service-operations/serviceOperationsSummaryQuery",
+	"service-operations/serviceOperationsTimeseriesRawQuery",
+	"service-operations/serviceOperationsTimeseriesQuery",
+	"services/serviceCatalogQuery",
+	"services/serviceHealthSnapshotQuery",
+	"services/serviceHealthBaselineQuery",
+	"services/serviceEnvironmentsQuery",
+	"services/serviceUsageWithPreviousQuery",
+	"traces/traceSummariesQuery",
+	"traces/traceListQuery",
+])
+
+describe("builder coverage", () => {
+	const fixtured = new Set(builderFixtures.map((fixture) => `${fixture.module}/${fixture.name}`))
+
+	it("compiles every builder fixture into the catalog", () => {
+		const entries = collectBuilderCatalog()
+		expect(entries.length).toBe(builderFixtures.length)
+		for (const entry of entries) {
+			expect(entry.sql, entry.id).toContain("OrgId")
+		}
+	})
+
+	it("declares fixtures whose module/name actually exists", () => {
+		for (const fixture of builderFixtures) {
+			const module = QUERY_MODULES[fixture.module]
+			expect(module, `unknown module ${fixture.module}`).toBeDefined()
+			expect(
+				typeof module?.[fixture.name],
+				`${fixture.module} does not export ${fixture.name}`,
+			).toBe("function")
+		}
+	})
+
+	it("covers or exempts every exported builder", () => {
+		const missing: Array<string> = []
+		for (const [moduleName, module] of Object.entries(QUERY_MODULES)) {
+			for (const [exportName, value] of Object.entries(module)) {
+				if (typeof value !== "function") continue
+				if (!/(Query|SQL)$/.test(exportName)) continue
+				const key = `${moduleName}/${exportName}`
+				if (!fixtured.has(key) && !EXEMPT_BUILDERS.has(key)) missing.push(key)
+			}
+		}
+		expect(missing, `builders with no fixture and no exemption:\n${missing.join("\n")}`).toEqual([])
+	})
+
+	it("keeps the exemption list free of stale entries", () => {
+		for (const key of EXEMPT_BUILDERS) {
+			const [moduleName, exportName] = key.split("/") as [string, string]
+			expect(
+				typeof QUERY_MODULES[moduleName]?.[exportName],
+				`${key} is exempt but no longer exported`,
+			).toBe("function")
+			expect(fixtured.has(key), `${key} is exempt AND fixtured — drop the exemption`).toBe(false)
 		}
 	})
 })

--- a/packages/query-engine/src/sql-catalog.ts
+++ b/packages/query-engine/src/sql-catalog.ts
@@ -40,6 +40,7 @@ import {
 } from "@maple/domain"
 import { baselineWarehouseCapabilities, type WarehouseCapabilities } from "./capabilities"
 import * as CH from "./ch"
+import { builderFixtures } from "./ch/builder-fixtures"
 import { compilePipeQuery } from "./ch/pipe-dispatch"
 import { fingerprintSql } from "./execution/fingerprint"
 import { makeQueryEngineExecute, type QueryEngineWarehouse, type QueryTenant } from "./runtime"
@@ -314,7 +315,7 @@ export const pipeFixtures: ReadonlyArray<PipeFixture> = [
 export interface CatalogEntry {
 	/** Stable identifier, e.g. `pipe:list_traces:filtered:bloom`. */
 	readonly id: string
-	readonly source: "pipe" | "query-spec"
+	readonly source: "pipe" | "query-spec" | "builder"
 	readonly name: string
 	readonly label: string
 	readonly capabilityLabel: string
@@ -801,9 +802,46 @@ export function collectQuerySpecCatalog(): ReadonlyArray<CatalogEntry> {
 	return entries
 }
 
-/** The full catalog: every SQL shape reachable from either entry surface. */
+// ---------------------------------------------------------------------------
+// Builder collection (direct `warehouse.compiledQuery` call sites)
+//
+// The pipe registry + QuerySpec lowering cover only ~36 of 161 exported query
+// builders; the rest are compiled directly at call sites in apps/api and never
+// met the analyzer. `builderFixtures` (ch/builder-fixtures.ts) enumerates them
+// with production-shaped params; the e2e sweep picks these entries up with
+// zero test changes because it iterates the catalog.
+// ---------------------------------------------------------------------------
+
+export function collectBuilderCatalog(): ReadonlyArray<CatalogEntry> {
+	const entries: Array<CatalogEntry> = []
+	for (const fixture of builderFixtures) {
+		const compiled = fixture.compile()
+		// The executor dies on unresolved placeholders at runtime; a fixture with a
+		// missing compile param must fail HERE, in the unit test, not in the sweep.
+		if (compiled.sql.includes("__PARAM_")) {
+			throw new Error(
+				`SQL catalog: builder fixture ${fixture.module}/${fixture.name} (${fixture.label}) ` +
+					`left an unresolved __PARAM_ placeholder — a compile param is missing.`,
+			)
+		}
+		entries.push({
+			id: `builder:${fixture.module}:${fixture.name}:${fixture.label}`,
+			source: "builder",
+			name: fixture.name,
+			label: fixture.label,
+			capabilityLabel: "baseline",
+			route: undefined,
+			sql: compiled.sql,
+			fingerprint: fingerprintSql(compiled.sql),
+			compiled,
+		})
+	}
+	return entries
+}
+
+/** The full catalog: every SQL shape reachable from any entry surface. */
 export function collectSqlCatalog(): ReadonlyArray<CatalogEntry> {
-	return [...collectPipeCatalog(), ...collectQuerySpecCatalog()]
+	return [...collectPipeCatalog(), ...collectQuerySpecCatalog(), ...collectBuilderCatalog()]
 }
 
 /** One entry per distinct SQL shape, keeping the first fixture that produced it. */


### PR DESCRIPTION
## What

Fixes the query engine's two long-standing pain axes — queries breaking in prod with green CI, and failures that are opaque when they happen.

### Wire-format safety (error-proneness)

- **64-bit ints are now JSON numbers on every backend.** ClickHouse-protocol clients pin `output_format_json_quote_64bit_integers=0` (new `BackendDialect.unquote64BitIntegers`); the local chDB CLI sets the same flag. This kills the UInt64-as-string bug class at the transport layer instead of requiring ~125 hand-written `rowSchema`s, with wire parity to the Tinybird SDK. Pinned by an e2e test through the real production client.
- **The catalog sweep can no longer pass vacuously.** Schema-carrying queries must decode *both* wire shapes (a gateway or `readonly=1` cluster can refuse the setting), and a new identity-column rule fails any 64-bit id/hash/fingerprint output column that isn't `toString()`-wrapped (allowlist is empty — the convention already holds everywhere).
- **Third catalog surface** (`ch/builder-fixtures.ts`): builders reached only via direct `warehouse.compiledQuery` call sites now enter the `DESCRIBE` sweep. Batch ① covers session-replays, session-events, and the direct-only errors builders (16 shapes). An `uncoveredBuilders` anti-rot test forces fixture-or-exempt for every `*Query`/`*SQL` export; the exemption list is classified (pipe-covered / helper / todo batches ②–④) and may only shrink.
- **`CompiledQuery.castRows` is deleted** — a pure cast that hid this whole bug class; `decodeRows` is the only row API. `profile` defaults to `"aggregation"` in `compiledQuery`/`compiledQueryFirst` (~20 call sites silently ran with no server-side budget). Note: this changes `db.query.fingerprint` for those previously profile-less queries.

### Error tracking (opacity)

- **Single source of truth**: `packages/domain/src/http/warehouse-error-meta.ts` derives the tag list + HTTP statuses from the error classes and holds per-tag metadata in a `Record` keyed by the tag union — adding a 10th warehouse error is a compile error in exactly one file, instead of five lockstep edits across five packages (what the `WarehouseMalformedQueryError` commit required). The five hand-maintained 9-arm tables (MCP ×2, alerts ×2, web) now derive from it, with exhaustiveness tests both ways.
- **Public v2 endpoints stop lying**: telemetry + session-replays no longer collapse all nine warehouse tags into one fixed 503. A bad time range is a 400, a quota breach a 429, a Maple SQL bug a 502 under `warehouse_malformed_query`. Their contracts gain `V2RateLimitError` + `V2UpstreamError`. Public envelopes use a **redacted** presenter, so raw ClickHouse diagnostics still never cross the API boundary (pinned by the existing sanitization test, updated to the new statuses).
- **Decode failures stop misleading**: they carry the real query context as `pipeName` (was the constant `"compiledQuery"`) and `kind: "decode"` on `WarehouseSchemaDriftError`, which suppresses the "run schema apply" advice everywhere — schema apply can't fix a row-decode mismatch.
- `query_data` (MCP) reuses the shared mapper and gains the schema-apply hint it silently lacked.

## Reviewer notes

- **Behavior change on public v2**: ~16 endpoints return 400/429/502 where they previously always returned 503. OpenAPI contract tests pass; the alerts map keeps its published `alert_*` codes but stops discarding per-tag copy, and `WarehouseMalformedQueryError` gets its own `alert_*_query_bug` code so on-call stops chasing customers' warehouses for Maple bugs.
- **Follow-up flagged in code**: whether the Tinybird CH gateway accepts the quote setting is unverified — `tinybird-gateway` is tentatively `true`; check on staging and flip with a comment if it rejects it. `CHNumber` remains mandatory in rowSchemas as the safety net either way.
- Fixture batches ②–④ (anomaly/alert-checks/setup-audit → infra/cloudflare/planetscale → remainder) are queued as classified todo-exemptions in `sql-catalog.test.ts`.

## Verification

- Scoped vitest: domain (26), query-engine (77+), api v2 routes (44), web error-messages (25) — all green.
- Full ClickHouse e2e sweep against a real 26.2 server: **98/98**, including the new transport-parity test and the 16 new builder shapes.
- `turbo typecheck` clean on domain, query-engine, api, cli, clickhouse-builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788296061&installation_model_id=427786&pr_number=315&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F315&signature=8e74f422490a22dda2a6b529d74624ba5545c7ab5dd7d425813191ae8a10d305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->