### PR TITLE
fix(query-engine): unify time-range limits and stop silent 7-day truncation

### DIFF
--- a/apps/api/src/lib/metric-rows.ts
+++ b/apps/api/src/lib/metric-rows.ts
@@ -1,3 +1,4 @@
+import { formatWarehouseDateTimeMs } from "@maple/query-engine"
 /**
  * Wire shapes for the `metrics_gauge` / `metrics_sum` datasources in the
  * collector Tinybird exporter layout (see metricsGauge/metricsSum in
@@ -39,5 +40,4 @@ export interface MetricSumRow extends MetricGaugeRow {
 }
 
 /** ClickHouse DateTime64 wire format: "YYYY-MM-DD HH:MM:SS.mmm" in UTC. */
-export const fmtMetricTs = (epochMs: number) =>
-	new Date(epochMs).toISOString().replace("T", " ").replace("Z", "")
+export const fmtMetricTs = (epochMs: number) => formatWarehouseDateTimeMs(epochMs)

--- a/apps/api/src/lib/telemetry-liveness.ts
+++ b/apps/api/src/lib/telemetry-liveness.ts
@@ -3,6 +3,7 @@ import * as CH from "@maple/query-engine/ch"
 import type { TenantContext } from "../services/AuthService"
 import type { WarehouseQueryServiceShape } from "./WarehouseQueryService"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 /**
  * "Is this signal quiet because it recovered, or because we stopped receiving
  * data?"
@@ -95,9 +96,6 @@ export interface LivenessProbeInput {
 // I/O
 // ---------------------------------------------------------------------------
 
-const toWarehouseDateTime = (epochMs: number) =>
-	new Date(epochMs).toISOString().slice(0, 19).replace("T", " ")
-
 const EMPTY_TOTALS: ServiceWindowTotals = { spanCount: 0, estimatedSpanCount: 0 }
 
 /**
@@ -119,8 +117,8 @@ const probeServiceWindow = (
 			{
 				orgId: tenant.orgId,
 				serviceName,
-				startTime: toWarehouseDateTime(startMs),
-				endTime: toWarehouseDateTime(endMs),
+				startTime: formatWarehouseDateTime(startMs),
+				endTime: formatWarehouseDateTime(endMs),
 			},
 			{ rowSchema: CH.serviceLivenessRowSchema },
 		)
@@ -147,8 +145,8 @@ const probeOrgWindow = (
 			CH.orgTelemetryPulseQuery(),
 			{
 				orgId: tenant.orgId,
-				startTime: toWarehouseDateTime(startMs),
-				endTime: toWarehouseDateTime(endMs),
+				startTime: formatWarehouseDateTime(startMs),
+				endTime: formatWarehouseDateTime(endMs),
 			},
 			{ rowSchema: CH.telemetryPulseRowSchema },
 		)

--- a/apps/api/src/mcp/lib/resolve-dashboard-time-range.test.ts
+++ b/apps/api/src/mcp/lib/resolve-dashboard-time-range.test.ts
@@ -53,7 +53,16 @@ describe("resolveDashboardTimeRange", () => {
 	it('resolves "today", which the picker can persist but this used to reject', () => {
 		const resolved = resolveDashboardTimeRange({ type: "relative", value: "today" })
 		expect(resolved).not.toBeNull()
-		expect(resolved!.startTime).toMatch(/ 00:00:00$/)
+
+		// Start-of-day is the *local* calendar day, matching the web picker. On a
+		// Worker local is UTC so this renders as 00:00:00, but the assertion is
+		// written against the runtime's zone so it holds on a developer machine
+		// with a UTC offset too.
+		const localMidnight = new Date()
+		localMidnight.setHours(0, 0, 0, 0)
+		expect(resolved!.startTime).toBe(
+			new Date(localMidnight.getTime()).toISOString().replace("T", " ").slice(0, 19),
+		)
 	})
 
 	it("returns null for shorthand it cannot parse", () => {

--- a/apps/api/src/mcp/lib/resolve-dashboard-time-range.test.ts
+++ b/apps/api/src/mcp/lib/resolve-dashboard-time-range.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import { resolveDashboardTimeRange, validateDashboardTimeRange } from "./resolve-dashboard-time-range"
+
+describe("validateDashboardTimeRange", () => {
+	it("accepts ranges the old {1h, 6h, 24h, 7d} whitelist rejected", () => {
+		// The regression this whole change exists for: `create_dashboard` used to
+		// map anything outside the whitelist to "1h" without saying so, which is
+		// why agent-created dashboards appeared to cap out at a week.
+		for (const value of ["30d", "14d", "2w", "4w", "15m", "today"]) {
+			expect(validateDashboardTimeRange(value)).toBeNull()
+		}
+	})
+
+	it("rejects month-scale ranges, which exceed the engine's real ceiling", () => {
+		// Dashboard widgets top out at 31 days — wider than the old 7-day
+		// whitelist suggested, but genuinely bounded. Long-range routes that read
+		// the 365-day rollups (service pages, the service map) are separate.
+		expect(validateDashboardTimeRange("3mo")).toContain("31 days")
+	})
+
+	it("still accepts the four values the whitelist allowed", () => {
+		for (const value of ["1h", "6h", "24h", "7d"]) {
+			expect(validateDashboardTimeRange(value)).toBeNull()
+		}
+	})
+
+	it("rejects a range past the engine ceiling instead of downgrading it", () => {
+		const error = validateDashboardTimeRange("999d")
+		expect(error).not.toBeNull()
+		expect(error).toContain("999d")
+		expect(error).toContain("31 days")
+	})
+
+	it("rejects malformed shorthand with usable guidance", () => {
+		const error = validateDashboardTimeRange("last month")
+		expect(error).not.toBeNull()
+		expect(error).toContain("Invalid time range")
+	})
+})
+
+describe("resolveDashboardTimeRange", () => {
+	const spanSeconds = (range: { startTime: string; endTime: string }) =>
+		(Date.parse(`${range.endTime}Z`.replace(" ", "T")) -
+			Date.parse(`${range.startTime}Z`.replace(" ", "T"))) /
+		1000
+
+	it("resolves a 30-day relative range to a 30-day window", () => {
+		const resolved = resolveDashboardTimeRange({ type: "relative", value: "30d" })
+		expect(resolved).not.toBeNull()
+		expect(spanSeconds(resolved!)).toBeCloseTo(30 * 86_400, -1)
+	})
+
+	it('resolves "today", which the picker can persist but this used to reject', () => {
+		const resolved = resolveDashboardTimeRange({ type: "relative", value: "today" })
+		expect(resolved).not.toBeNull()
+		expect(resolved!.startTime).toMatch(/ 00:00:00$/)
+	})
+
+	it("returns null for shorthand it cannot parse", () => {
+		expect(resolveDashboardTimeRange({ type: "relative", value: "last month" })).toBeNull()
+		expect(resolveDashboardTimeRange({ type: "relative", value: "" })).toBeNull()
+	})
+
+	it("passes absolute ranges through in warehouse format", () => {
+		const resolved = resolveDashboardTimeRange({
+			type: "absolute",
+			startTime: "2026-03-01T00:00:00Z",
+			endTime: "2026-03-08T00:00:00Z",
+		})
+		expect(resolved).toEqual({
+			startTime: "2026-03-01 00:00:00",
+			endTime: "2026-03-08 00:00:00",
+		})
+	})
+})

--- a/apps/api/src/mcp/lib/resolve-dashboard-time-range.ts
+++ b/apps/api/src/mcp/lib/resolve-dashboard-time-range.ts
@@ -1,4 +1,5 @@
 import * as DateTime from "effect/DateTime"
+import { MAX_QUERY_RANGE_SECONDS, validateRelativeRange } from "@maple/query-engine"
 
 const formatUtc = (dt: DateTime.DateTime): string => DateTime.formatIso(dt).replace("T", " ").slice(0, 19)
 
@@ -26,6 +27,23 @@ export interface ResolvedTimeRange {
 	endTime: string
 }
 
+/**
+ * Validates an agent-supplied dashboard `time_range` shorthand.
+ *
+ * `create_dashboard` used to run this value through a `{1h, 6h, 24h, 7d}`
+ * whitelist and silently fall back to "1h" for anything else — so asking for a
+ * 30-day board produced a 1-hour one with no indication anything had changed.
+ * Now anything the picker can express is accepted up to the engine's real
+ * ceiling, and everything else is an explicit error.
+ *
+ * Returns `null` when the value is valid, or an error message to return to the
+ * agent when it is not.
+ */
+export function validateDashboardTimeRange(value: string): string | null {
+	const result = validateRelativeRange(value, MAX_QUERY_RANGE_SECONDS)
+	return result.ok ? null : (result.error ?? `Invalid time range "${value}".`)
+}
+
 export type DashboardTimeRangeInput =
 	| { type: "relative"; value: string }
 	| { type: "absolute"; startTime: string; endTime: string }
@@ -50,6 +68,16 @@ export function resolveDashboardTimeRange(timeRange: DashboardTimeRangeInput): R
 
 	const trimmed = timeRange.value.trim().toLowerCase()
 	if (!trimmed) return null
+
+	// The time picker can persist "today"; without this the API resolved those
+	// dashboards to null and silently fell back to a default window.
+	if (trimmed === "today") {
+		const now = DateTime.nowUnsafe()
+		return {
+			startTime: formatUtc(DateTime.startOf(now, "day")),
+			endTime: formatUtc(now),
+		}
+	}
 
 	const match = trimmed.match(RELATIVE_PATTERN)
 	if (!match) return null

--- a/apps/api/src/mcp/lib/resolve-dashboard-time-range.ts
+++ b/apps/api/src/mcp/lib/resolve-dashboard-time-range.ts
@@ -1,26 +1,10 @@
-import * as DateTime from "effect/DateTime"
-import { MAX_QUERY_RANGE_SECONDS, validateRelativeRange } from "@maple/query-engine"
-
-const formatUtc = (dt: DateTime.DateTime): string => DateTime.formatIso(dt).replace("T", " ").slice(0, 19)
-
-const RELATIVE_PATTERN = /^(\d+)(mo|m|h|d|w)$/
-
-type RelativeUnit = "m" | "h" | "d" | "w" | "mo"
-
-const subtractRelative = (now: DateTime.DateTime, amount: number, unit: RelativeUnit): DateTime.DateTime => {
-	switch (unit) {
-		case "m":
-			return DateTime.subtract(now, { minutes: amount })
-		case "h":
-			return DateTime.subtract(now, { hours: amount })
-		case "d":
-			return DateTime.subtract(now, { days: amount })
-		case "w":
-			return DateTime.subtract(now, { weeks: amount })
-		case "mo":
-			return DateTime.subtract(now, { days: amount * 30 })
-	}
-}
+import {
+	MAX_QUERY_RANGE_SECONDS,
+	formatWarehouseDateTime,
+	parseWarehouseDateTime,
+	resolveRelativeRangeToWarehouse,
+	validateRelativeRange,
+} from "@maple/query-engine"
 
 export interface ResolvedTimeRange {
 	startTime: string
@@ -57,40 +41,19 @@ export type DashboardTimeRangeInput =
  */
 export function resolveDashboardTimeRange(timeRange: DashboardTimeRangeInput): ResolvedTimeRange | null {
 	if (timeRange.type === "absolute") {
-		const start = DateTime.make(timeRange.startTime)
-		const end = DateTime.make(timeRange.endTime)
-		if (start._tag === "None" || end._tag === "None") return null
+		// `parseWarehouseDateTime`, not `Date.parse`: a stored bound may be the
+		// tz-less `YYYY-MM-DD HH:MM:SS` shape, which `Date.parse` reads as local
+		// time and silently shifts by the runtime's UTC offset.
+		const startMs = parseWarehouseDateTime(timeRange.startTime)
+		const endMs = parseWarehouseDateTime(timeRange.endTime)
+		if (Number.isNaN(startMs) || Number.isNaN(endMs)) return null
 		return {
-			startTime: formatUtc(start.value),
-			endTime: formatUtc(end.value),
+			startTime: formatWarehouseDateTime(startMs),
+			endTime: formatWarehouseDateTime(endMs),
 		}
 	}
 
-	const trimmed = timeRange.value.trim().toLowerCase()
-	if (!trimmed) return null
-
-	// The time picker can persist "today"; without this the API resolved those
-	// dashboards to null and silently fell back to a default window.
-	if (trimmed === "today") {
-		const now = DateTime.nowUnsafe()
-		return {
-			startTime: formatUtc(DateTime.startOf(now, "day")),
-			endTime: formatUtc(now),
-		}
-	}
-
-	const match = trimmed.match(RELATIVE_PATTERN)
-	if (!match) return null
-
-	const amount = Number.parseInt(match[1], 10)
-	if (!Number.isFinite(amount) || amount <= 0) return null
-
-	const unit = match[2] as RelativeUnit
-	const now = DateTime.nowUnsafe()
-	const start = subtractRelative(now, amount, unit)
-
-	return {
-		startTime: formatUtc(start),
-		endTime: formatUtc(now),
-	}
+	// Relative shorthand — including "today" — is resolved by the shared grammar,
+	// so this no longer approximates a month as 30 days the way it used to.
+	return resolveRelativeRangeToWarehouse(timeRange.value)
 }

--- a/apps/api/src/mcp/lib/time.test.ts
+++ b/apps/api/src/mcp/lib/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { formatClampNote, normalizeTime, resolveTimeRange } from "./time"
+import { normalizeTime, rangeExceededResult, resolveTimeRange } from "./time"
 
 describe("normalizeTime", () => {
 	it("passes through already-correct format", () => {
@@ -73,34 +73,54 @@ describe("resolveTimeRange", () => {
 		expect((endMs - startMs) / 3600_000).toBeCloseTo(1, 0)
 	})
 
-	it("clamps start when range exceeds maxHours", () => {
+	it("flags an over-wide range without truncating it", () => {
 		const result = resolveTimeRange("2026-03-01T00:00:00Z", "2026-03-30T00:00:00Z", { maxHours: 24 * 7 })
-		expect(result.clamped).toBe(true)
+		expect(result.exceeded).toBe(true)
+		// The window is reported back verbatim — callers reject rather than clamp,
+		// so the agent never receives a silently narrowed answer.
+		expect(result.st).toBe("2026-03-01 00:00:00")
 		expect(result.et).toBe("2026-03-30 00:00:00")
-		expect(result.st).toBe("2026-03-23 00:00:00")
 		expect(result.maxHours).toBe(24 * 7)
+		expect(result.requestedHours).toBe(29 * 24)
 	})
 
-	it("does not clamp when range is within maxHours", () => {
+	it("accepts a range within maxHours", () => {
 		const result = resolveTimeRange("2026-03-29T00:00:00Z", "2026-03-30T00:00:00Z", { maxHours: 24 * 7 })
-		expect(result.clamped).toBe(false)
+		expect(result.exceeded).toBe(false)
 		expect(result.st).toBe("2026-03-29 00:00:00")
 		expect(result.et).toBe("2026-03-30 00:00:00")
 	})
+
+	it("never flags exceeded when no cap is set", () => {
+		const result = resolveTimeRange("2020-01-01T00:00:00Z", "2026-03-30T00:00:00Z")
+		expect(result.exceeded).toBe(false)
+	})
 })
 
-describe("formatClampNote", () => {
-	it("returns empty string when not clamped", () => {
-		expect(formatClampNote({ clamped: false, maxHours: 24 })).toBe("")
+describe("rangeExceededResult", () => {
+	it("reports what was asked for, the cap, and the way forward", () => {
+		const range = { maxHours: 24 * 7, requestedHours: 24 * 30 }
+		const result = rangeExceededResult(range, "search_traces")
+
+		expect(result.isError).toBe(true)
+		const text = result.content[0].text
+		expect(text).toContain("search_traces")
+		expect(text).toContain("Requested 30 days")
+		expect(text).toContain("maximum supported range is 7 days")
+		expect(text).toContain("query_data")
 	})
 
-	it("formats whole-day windows as days", () => {
-		expect(formatClampNote({ clamped: true, maxHours: 24 })).toBe(" (range clamped to 1 day)")
-		expect(formatClampNote({ clamped: true, maxHours: 24 * 7 })).toBe(" (range clamped to 7 days)")
+	it("formats sub-day caps as hours", () => {
+		const text = rangeExceededResult({ maxHours: 6, requestedHours: 48 }, "mine_log_patterns").content[0]
+			.text
+		expect(text).toContain("Requested 2 days")
+		expect(text).toContain("maximum supported range is 6 hours")
 	})
 
-	it("formats sub-day windows as hours", () => {
-		expect(formatClampNote({ clamped: true, maxHours: 6 })).toBe(" (range clamped to 6 hours)")
-		expect(formatClampNote({ clamped: true, maxHours: 1 })).toBe(" (range clamped to 1 hour)")
+	it("omits the requested width when the bounds were unparseable", () => {
+		const text = rangeExceededResult({ maxHours: 24, requestedHours: undefined }, "search_logs")
+			.content[0].text
+		expect(text).toContain("Maximum supported range is 1 day")
+		expect(text).not.toContain("Requested")
 	})
 })

--- a/apps/api/src/mcp/lib/time.ts
+++ b/apps/api/src/mcp/lib/time.ts
@@ -1,9 +1,9 @@
-import * as DateTime from "effect/DateTime"
-import { Option } from "effect"
 import {
 	MAX_DISCOVERY_RANGE_SECONDS,
 	MAX_LIST_RANGE_SECONDS,
 	MAX_LOG_PATTERN_RANGE_SECONDS,
+	formatWarehouseDateTime,
+	parseWarehouseDateTime,
 } from "@maple/query-engine"
 
 // Tool-facing caps, expressed in hours to match `ResolveTimeRangeOptions`. The
@@ -17,49 +17,28 @@ export const MCP_DISCOVERY_MAX_HOURS = MAX_DISCOVERY_RANGE_SECONDS / 3600
 /** Log-pattern clustering — scans raw message bodies. */
 export const MCP_LOG_PATTERN_MAX_HOURS = MAX_LOG_PATTERN_RANGE_SECONDS / 3600
 
-const formatUtc = (dt: DateTime.DateTime): string => DateTime.formatIso(dt).replace("T", " ").slice(0, 19)
-
-const alreadyNormalized = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/
-
 /**
  * Normalizes a time string to the `YYYY-MM-DD HH:mm:ss` UTC format expected
  * by Tinybird's `DateTime()` SQL function.
  *
  * Handles ISO 8601 (with T, Z, timezone offsets, milliseconds) and the
- * already-correct `YYYY-MM-DD HH:mm:ss` format. Returns the original string
- * unchanged if parsing fails.
+ * already-correct `YYYY-MM-DD HH:mm:ss` format — which the shared parser reads
+ * as UTC rather than local. Returns the input trimmed if it can't be parsed.
  */
 export function normalizeTime(input: string): string {
 	const trimmed = input.trim()
-	if (alreadyNormalized.test(trimmed)) return trimmed
-
-	const parsed = DateTime.make(trimmed)
-	if (Option.isSome(parsed)) return formatUtc(parsed.value)
-
-	return trimmed
+	const ms = parseWarehouseDateTime(trimmed)
+	return Number.isNaN(ms) ? trimmed : formatWarehouseDateTime(ms)
 }
 
 const DEFAULT_HOURS = 6
 
 function defaultTimeRange(hours = DEFAULT_HOURS) {
-	const now = DateTime.nowUnsafe()
-	const start = DateTime.subtract(now, { hours })
+	const nowMs = Date.now()
 	return {
-		startTime: formatUtc(start),
-		endTime: formatUtc(now),
+		startTime: formatWarehouseDateTime(nowMs - hours * 3_600_000),
+		endTime: formatWarehouseDateTime(nowMs),
 	}
-}
-
-const NORMALIZED_UTC = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/
-
-function toEpochMs(normalized: string): number | undefined {
-	const m = NORMALIZED_UTC.exec(normalized)
-	if (!m) return undefined
-	return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]), Number(m[4]), Number(m[5]), Number(m[6]))
-}
-
-function fromEpochMs(ms: number): string {
-	return new Date(ms).toISOString().replace("T", " ").slice(0, 19)
 }
 
 export interface ResolveTimeRangeOptions {
@@ -103,10 +82,9 @@ export function resolveTimeRange(
 	const st = startTime ? normalizeTime(startTime) : defaults.startTime
 	const et = endTime ? normalizeTime(endTime) : defaults.endTime
 
-	const stMs = toEpochMs(st)
-	const etMs = toEpochMs(et)
-	const requestedHours =
-		stMs !== undefined && etMs !== undefined ? (etMs - stMs) / (3600 * 1000) : undefined
+	const stMs = parseWarehouseDateTime(st)
+	const etMs = parseWarehouseDateTime(et)
+	const requestedHours = Number.isNaN(stMs) || Number.isNaN(etMs) ? undefined : (etMs - stMs) / 3_600_000
 
 	const exceeded =
 		maxHours !== undefined && maxHours > 0 && requestedHours !== undefined && requestedHours > maxHours

--- a/apps/api/src/mcp/lib/time.ts
+++ b/apps/api/src/mcp/lib/time.ts
@@ -1,5 +1,21 @@
 import * as DateTime from "effect/DateTime"
 import { Option } from "effect"
+import {
+	MAX_DISCOVERY_RANGE_SECONDS,
+	MAX_LIST_RANGE_SECONDS,
+	MAX_LOG_PATTERN_RANGE_SECONDS,
+} from "@maple/query-engine"
+
+// Tool-facing caps, expressed in hours to match `ResolveTimeRangeOptions`. The
+// underlying values live in `@maple/query-engine`'s limits module so the MCP
+// surface, the v2 API, and the query engine itself can't drift apart.
+
+/** Raw-row search tools (traces, logs, sessions, slow traces, top operations). */
+export const MCP_SEARCH_MAX_HOURS = MAX_LIST_RANGE_SECONDS / 3600
+/** Rollup-backed discovery tools (metric listing, attribute exploration). */
+export const MCP_DISCOVERY_MAX_HOURS = MAX_DISCOVERY_RANGE_SECONDS / 3600
+/** Log-pattern clustering — scans raw message bodies. */
+export const MCP_LOG_PATTERN_MAX_HOURS = MAX_LOG_PATTERN_RANGE_SECONDS / 3600
 
 const formatUtc = (dt: DateTime.DateTime): string => DateTime.formatIso(dt).replace("T", " ").slice(0, 19)
 
@@ -49,24 +65,29 @@ function fromEpochMs(ms: number): string {
 export interface ResolveTimeRangeOptions {
 	/** Default window when the agent supplies neither bound. Defaults to 6h. */
 	readonly defaultHours?: number
-	/** Maximum allowed window. If the agent-supplied range exceeds it, startTime is clamped. */
+	/** Maximum allowed window. A wider agent-supplied range is reported as `exceeded`. */
 	readonly maxHours?: number
 }
 
 export interface ResolvedTimeRange {
 	readonly st: string
 	readonly et: string
-	/** True when the agent-supplied range was clamped down to `maxHours`. */
-	readonly clamped: boolean
-	/** The `maxHours` cap that was applied (if any). Included so callers can surface it. */
+	/** True when the agent-supplied range is wider than `maxHours`. */
+	readonly exceeded: boolean
+	/** The `maxHours` cap that applies (if any). Included so callers can surface it. */
 	readonly maxHours: number | undefined
+	/** Width of the agent-supplied window in hours, when both bounds parsed. */
+	readonly requestedHours: number | undefined
 }
 
 /**
  * Resolves the time range for an MCP tool call.
  * Normalizes user-provided values to UTC and falls back to a default window.
- * When `maxHours` is set and the resolved window exceeds it, clamps `st` to
- * `et - maxHours` and flags `clamped: true` so callers can note it in the response.
+ *
+ * When `maxHours` is set and the resolved window is wider, the range is returned
+ * *unchanged* with `exceeded: true` — callers must reject it. This used to clamp
+ * `st` forward silently, which meant an agent asking for 30 days got 7 and had no
+ * way to tell that its answer was computed from a fraction of the window.
  *
  * Back-compat: the third arg also accepts a bare number (treated as `defaultHours`).
  */
@@ -79,33 +100,58 @@ export function resolveTimeRange(
 		typeof opts === "number" ? { defaultHours: opts, maxHours: undefined } : opts
 
 	const defaults = defaultTimeRange(defaultHours)
-	let st = startTime ? normalizeTime(startTime) : defaults.startTime
-	let et = endTime ? normalizeTime(endTime) : defaults.endTime
+	const st = startTime ? normalizeTime(startTime) : defaults.startTime
+	const et = endTime ? normalizeTime(endTime) : defaults.endTime
 
-	let clamped = false
-	if (maxHours !== undefined && maxHours > 0) {
-		const stMs = toEpochMs(st)
-		const etMs = toEpochMs(et)
-		if (stMs !== undefined && etMs !== undefined) {
-			const maxMs = maxHours * 3600 * 1000
-			if (etMs - stMs > maxMs) {
-				st = fromEpochMs(etMs - maxMs)
-				clamped = true
-			}
-		}
+	const stMs = toEpochMs(st)
+	const etMs = toEpochMs(et)
+	const requestedHours =
+		stMs !== undefined && etMs !== undefined ? (etMs - stMs) / (3600 * 1000) : undefined
+
+	const exceeded =
+		maxHours !== undefined && maxHours > 0 && requestedHours !== undefined && requestedHours > maxHours
+
+	return { st, et, exceeded, maxHours, requestedHours }
+}
+
+const formatHours = (hours: number): string => {
+	const rounded = Math.round(hours * 10) / 10
+	if (rounded >= 24 && rounded % 24 === 0) {
+		const days = rounded / 24
+		return `${days} day${days === 1 ? "" : "s"}`
 	}
-
-	return { st, et, clamped, maxHours }
+	return `${rounded} hour${rounded === 1 ? "" : "s"}`
 }
 
 /**
- * Builds a short "(range clamped to N days / N hours)" note for inclusion in
- * tool response headers. Returns an empty string when nothing was clamped.
+ * Builds the message for a range that exceeds a tool's cap. Tells the agent what
+ * it asked for, what the ceiling is, and what to do instead — so it can retry
+ * correctly rather than silently trusting a truncated answer.
  */
-export function formatClampNote(range: Pick<ResolvedTimeRange, "clamped" | "maxHours">): string {
-	if (!range.clamped || range.maxHours === undefined) return ""
-	const h = range.maxHours
-	const unit =
-		h >= 24 && h % 24 === 0 ? `${h / 24} day${h === 24 ? "" : "s"}` : `${h} hour${h === 1 ? "" : "s"}`
-	return ` (range clamped to ${unit})`
+export function rangeExceededMessage(
+	range: Pick<ResolvedTimeRange, "maxHours" | "requestedHours">,
+	toolName: string,
+): string {
+	const cap = range.maxHours === undefined ? "the supported range" : formatHours(range.maxHours)
+	const requested = range.requestedHours === undefined ? undefined : formatHours(range.requestedHours)
+	return [
+		`Time range too large for \`${toolName}\`.`,
+		requested === undefined
+			? `Maximum supported range is ${cap}.`
+			: `Requested ${requested}, maximum supported range is ${cap}.`,
+		`Narrow start_time/end_time to ${cap} or less. For wider trends use \`query_data\` with a timeseries query, which aggregates instead of scanning raw rows.`,
+	].join(" ")
+}
+
+/**
+ * Standard MCP error result for an over-wide range. Returned directly by tools.
+ */
+export function rangeExceededResult(
+	range: Pick<ResolvedTimeRange, "maxHours" | "requestedHours">,
+	toolName: string,
+) {
+	return {
+		content: [{ type: "text" as const, text: rangeExceededMessage(range, toolName) }],
+		isError: true as const,
+	}
 }

--- a/apps/api/src/mcp/tools/compare-periods.ts
+++ b/apps/api/src/mcp/tools/compare-periods.ts
@@ -7,6 +7,7 @@ import { Array as Arr, Effect, Schema } from "effect"
 import { createDualContent } from "../lib/structured-output"
 import { formatNextSteps } from "../lib/next-steps"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 export function registerComparePeriodsTool(server: McpToolRegistrar) {
 	server.tool(
 		"compare_periods",
@@ -47,10 +48,10 @@ export function registerComparePeriodsTool(server: McpToolRegistrar) {
 					})
 				}
 				const halfWindow = 30 * 60 * 1000 // 30 minutes
-				prevSt = new Date(center.getTime() - halfWindow).toISOString().replace("T", " ").slice(0, 19)
+				prevSt = formatWarehouseDateTime(center.getTime() - halfWindow)
 				prevEt = around_time
 				curSt = around_time
-				curEt = new Date(center.getTime() + halfWindow).toISOString().replace("T", " ").slice(0, 19)
+				curEt = formatWarehouseDateTime(center.getTime() + halfWindow)
 			} else {
 				// Resolve current period
 				const current = resolveTimeRange(current_start, current_end, 1)
@@ -72,12 +73,7 @@ export function registerComparePeriodsTool(server: McpToolRegistrar) {
 				const durationMs = currentEndDate.getTime() - currentStartDate.getTime()
 
 				prevEt = previous_end ?? current.st
-				prevSt =
-					previous_start ??
-					new Date(currentStartDate.getTime() - durationMs)
-						.toISOString()
-						.replace("T", " ")
-						.slice(0, 19)
+				prevSt = previous_start ?? formatWarehouseDateTime(currentStartDate.getTime() - durationMs)
 			}
 
 			// Query both periods in parallel

--- a/apps/api/src/mcp/tools/create-dashboard.ts
+++ b/apps/api/src/mcp/tools/create-dashboard.ts
@@ -18,6 +18,8 @@ import {
 	makeQueryDraft,
 } from "@/dashboard-templates/helpers"
 import type { TemplateParameterValues, WidgetDef } from "@/dashboard-templates"
+import { validateDashboardTimeRange } from "../lib/resolve-dashboard-time-range"
+import { MAX_LIST_RANGE_SECONDS, MAX_QUERY_RANGE_SECONDS, formatRangeSeconds } from "@maple/query-engine"
 
 const decodePortableDashboard = Schema.decodeUnknownEffect(PortableDashboardDocument)
 const PortableDashboardFromJson = Schema.fromJsonString(PortableDashboardDocument)
@@ -277,12 +279,7 @@ function parseSimpleWidgets(json: string): WidgetDef[] | string {
 	return widgets
 }
 
-const TIME_RANGE_MAP: Record<string, string> = {
-	"1h": "1h",
-	"6h": "6h",
-	"24h": "24h",
-	"7d": "7d",
-}
+const DEFAULT_TIME_RANGE = "1h"
 
 // ---------------------------------------------------------------------------
 // Tool registration
@@ -312,7 +309,9 @@ export function registerCreateDashboardTool(server: McpToolRegistrar) {
 				"Template ID (kebab-case, e.g. `service-health`). Default: service-health (if no widgets/dashboard_json).",
 			),
 			service_name: optionalStringParam("Scope template widgets to a specific service"),
-			time_range: optionalStringParam("Time range: 1h, 6h, 24h, or 7d (default: 1h)"),
+			time_range: optionalStringParam(
+				`Dashboard time range as relative shorthand — e.g. 15m, 6h, 24h, 7d, 2w, 3mo, or "today". Up to ${formatRangeSeconds(MAX_QUERY_RANGE_SECONDS)} (default: ${DEFAULT_TIME_RANGE}). Note that list widgets (recent traces/logs) only support ${formatRangeSeconds(MAX_LIST_RANGE_SECONDS)} and will ask the viewer to narrow their range on wider dashboards.`,
+			),
 			description: optionalStringParam("Dashboard description"),
 			metric_name: optionalStringParam(
 				"Metric name for metric-overview template (use list_metrics to discover). Example: http.server.duration",
@@ -332,6 +331,16 @@ export function registerCreateDashboardTool(server: McpToolRegistrar) {
 		}),
 		Effect.fn("McpTool.createDashboard")(function* (params) {
 			let portable: PortableDashboardDocument
+
+			if (params.time_range) {
+				const timeRangeError = validateDashboardTimeRange(params.time_range)
+				if (timeRangeError) {
+					return {
+						isError: true as const,
+						content: [{ type: "text" as const, text: timeRangeError }],
+					}
+				}
+			}
 
 			const rawTemplate = params.template
 			const templateName =
@@ -377,7 +386,7 @@ export function registerCreateDashboardTool(server: McpToolRegistrar) {
 					}
 				}
 
-				const timeRangeValue = TIME_RANGE_MAP[params.time_range ?? "1h"] ?? "1h"
+				const timeRangeValue = params.time_range ?? DEFAULT_TIME_RANGE
 
 				portable = yield* decodePortableDashboard({
 					name: params.name,
@@ -442,7 +451,11 @@ export function registerCreateDashboardTool(server: McpToolRegistrar) {
 							name: params.name || built.name,
 							...(description && { description }),
 							...(built.tags && { tags: built.tags }),
-							timeRange: built.timeRange,
+							// An explicit time_range wins over the template's default —
+							// this branch used to drop the parameter entirely.
+							timeRange: params.time_range
+								? { type: "relative" as const, value: params.time_range }
+								: built.timeRange,
 							widgets: built.widgets,
 						})
 					},

--- a/apps/api/src/mcp/tools/explore-attributes.ts
+++ b/apps/api/src/mcp/tools/explore-attributes.ts
@@ -2,7 +2,7 @@ import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from 
 import { toMcpQueryError } from "../lib/map-warehouse-error"
 import { resolveTenant } from "../lib/query-warehouse"
 import { queryWarehouse } from "../lib/query-warehouse"
-import { resolveTimeRange, formatClampNote } from "../lib/time"
+import { resolveTimeRange, rangeExceededResult, MCP_DISCOVERY_MAX_HOURS } from "../lib/time"
 import { clampLimit } from "../lib/limits"
 import { formatNumber, formatTable } from "../lib/format"
 import { Array as Arr, Effect, Schema } from "effect"
@@ -35,8 +35,11 @@ export function registerExploreAttributesTool(server: McpToolRegistrar) {
 			limit: optionalNumberParam("Max results (default 50)"),
 		}),
 		Effect.fn("McpTool.exploreAttributes")(function* (params) {
-			const range = resolveTimeRange(params.start_time, params.end_time, { maxHours: 24 * 30 })
+			const range = resolveTimeRange(params.start_time, params.end_time, {
+				maxHours: MCP_DISCOVERY_MAX_HOURS,
+			})
 			const { st, et } = range
+			if (range.exceeded) return rangeExceededResult(range, "explore_attributes")
 			const lim = clampLimit(params.limit, { defaultValue: 50, max: 500 })
 			const scope = (params.scope ?? "span") as "span" | "resource"
 			const tenant = yield* resolveTenant
@@ -63,7 +66,7 @@ export function registerExploreAttributesTool(server: McpToolRegistrar) {
 				const lines: string[] = [
 					`## Attribute Values: ${params.key}`,
 					`Source: ${sourceLabel}`,
-					`Time range: ${st} — ${et}${formatClampNote(range)}`,
+					`Time range: ${st} — ${et}`,
 					``,
 				]
 
@@ -117,7 +120,7 @@ export function registerExploreAttributesTool(server: McpToolRegistrar) {
 
 				const lines: string[] = [
 					`## Available Environments & Deployments`,
-					`Time range: ${st} — ${et}${formatClampNote(range)}`,
+					`Time range: ${st} — ${et}`,
 					``,
 				]
 
@@ -179,7 +182,7 @@ export function registerExploreAttributesTool(server: McpToolRegistrar) {
 			const lines: string[] = [
 				`## Attribute Keys`,
 				`Source: ${params.source} (${scope})`,
-				`Time range: ${st} — ${et}${formatClampNote(range)}`,
+				`Time range: ${st} — ${et}`,
 				``,
 			]
 

--- a/apps/api/src/mcp/tools/find-slow-traces.ts
+++ b/apps/api/src/mcp/tools/find-slow-traces.ts
@@ -1,7 +1,7 @@
 import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from "./types"
 import { warehouseToMcpHandlers } from "../lib/map-warehouse-error"
 import { withTenantExecutor } from "../lib/query-warehouse"
-import { resolveTimeRange, formatClampNote } from "../lib/time"
+import { resolveTimeRange, rangeExceededResult, MCP_SEARCH_MAX_HOURS } from "../lib/time"
 import { clampLimit } from "../lib/limits"
 import { formatDurationFromMs, formatTable } from "../lib/format"
 import { formatNextSteps } from "../lib/next-steps"
@@ -27,8 +27,9 @@ export function registerFindSlowTracesTool(server: McpToolRegistrar) {
 			environment,
 			limit,
 		}) {
-			const range = resolveTimeRange(start_time, end_time, { maxHours: 24 * 7 })
+			const range = resolveTimeRange(start_time, end_time, { maxHours: MCP_SEARCH_MAX_HOURS })
 			const { st, et } = range
+			if (range.exceeded) return rangeExceededResult(range, "find_slow_traces")
 			const lim = clampLimit(limit, { defaultValue: 10, max: 100 })
 
 			const result = yield* withTenantExecutor(
@@ -44,10 +45,7 @@ export function registerFindSlowTracesTool(server: McpToolRegistrar) {
 				return { content: [{ type: "text" as const, text: `No traces found in ${st} — ${et}` }] }
 			}
 
-			const lines: string[] = [
-				`## Slowest Traces`,
-				`Time range: ${st} — ${et}${formatClampNote(range)}`,
-			]
+			const lines: string[] = [`## Slowest Traces`, `Time range: ${st} — ${et}`]
 
 			if (result.stats) {
 				lines.push(

--- a/apps/api/src/mcp/tools/get-service-top-operations.ts
+++ b/apps/api/src/mcp/tools/get-service-top-operations.ts
@@ -6,7 +6,7 @@ import {
 	type McpToolRegistrar,
 } from "./types"
 import { resolveTenant } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, formatClampNote } from "../lib/time"
+import { resolveTimeRange, rangeExceededResult, MCP_SEARCH_MAX_HOURS } from "../lib/time"
 import { clampLimit } from "../lib/limits"
 import { formatTable } from "../lib/format"
 import { formatMetricValue } from "../lib/format-query-result"
@@ -40,8 +40,9 @@ export function registerGetServiceTopOperationsTool(server: McpToolRegistrar) {
 			end_time,
 			limit,
 		}) {
-			const range = resolveTimeRange(start_time, end_time, { maxHours: 24 * 7 })
+			const range = resolveTimeRange(start_time, end_time, { maxHours: MCP_SEARCH_MAX_HOURS })
 			const { st, et } = range
+			if (range.exceeded) return rangeExceededResult(range, "get_service_top_operations")
 			const metricOption =
 				metric === undefined ? Option.some("count" as const) : decodeTracesMetric(metric)
 			if (Option.isNone(metricOption)) {
@@ -71,7 +72,7 @@ export function registerGetServiceTopOperationsTool(server: McpToolRegistrar) {
 
 			const lines: string[] = [
 				`## Top Operations: ${service_name}`,
-				`Time range: ${st} — ${et}${formatClampNote(range)}`,
+				`Time range: ${st} — ${et}`,
 				`Metric: ${resolvedMetric}`,
 				``,
 			]

--- a/apps/api/src/mcp/tools/list-metrics.ts
+++ b/apps/api/src/mcp/tools/list-metrics.ts
@@ -1,6 +1,6 @@
 import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from "./types"
 import { queryWarehouse, resolveTenant } from "../lib/query-warehouse"
-import { resolveTimeRange, formatClampNote } from "../lib/time"
+import { resolveTimeRange, rangeExceededResult, MCP_DISCOVERY_MAX_HOURS } from "../lib/time"
 import { clampLimit, clampOffset } from "../lib/limits"
 import { formatNumber, formatTable } from "../lib/format"
 import { formatNextSteps } from "../lib/next-steps"
@@ -31,8 +31,9 @@ export function registerListMetricsTool(server: McpToolRegistrar) {
 			offset,
 			limit,
 		}) {
-			const range = resolveTimeRange(start_time, end_time, { maxHours: 24 * 30 })
+			const range = resolveTimeRange(start_time, end_time, { maxHours: MCP_DISCOVERY_MAX_HOURS })
 			const { st, et } = range
+			if (range.exceeded) return rangeExceededResult(range, "list_metrics")
 			const lim = clampLimit(limit, { defaultValue: 50, max: 500 })
 			const off = clampOffset(offset, { max: 10_000 })
 			const tenant = yield* resolveTenant
@@ -69,10 +70,7 @@ export function registerListMetricsTool(server: McpToolRegistrar) {
 
 			yield* Effect.annotateCurrentSpan("result.rowCount", metrics.length)
 
-			const lines: string[] = [
-				`## Available Metrics`,
-				`Time range: ${st} — ${et}${formatClampNote(range)}`,
-			]
+			const lines: string[] = [`## Available Metrics`, `Time range: ${st} — ${et}`]
 
 			// `metrics_summary` is scoped only by service, NOT by search/metric_type.
 			// Printing those totals next to an empty filtered result reads as a

--- a/apps/api/src/mcp/tools/mine-log-patterns.ts
+++ b/apps/api/src/mcp/tools/mine-log-patterns.ts
@@ -1,7 +1,7 @@
 import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from "./types"
 import { toMcpQueryError } from "../lib/map-warehouse-error"
 import { resolveTenant } from "../lib/query-warehouse"
-import { resolveTimeRange, formatClampNote } from "../lib/time"
+import { resolveTimeRange, rangeExceededResult, MCP_LOG_PATTERN_MAX_HOURS } from "../lib/time"
 import { truncate, formatNumber } from "../lib/format"
 import { formatNextSteps } from "../lib/next-steps"
 import { Effect, Schema } from "effect"
@@ -37,8 +37,9 @@ export function registerMineLogPatternsTool(server: McpToolRegistrar) {
 			sample_size,
 			limit,
 		}) {
-			const range = resolveTimeRange(start_time, end_time, { maxHours: 24 })
+			const range = resolveTimeRange(start_time, end_time, { maxHours: MCP_LOG_PATTERN_MAX_HOURS })
 			const { st, et } = range
+			if (range.exceeded) return rangeExceededResult(range, "mine_log_patterns")
 			const sampleSize = Math.min(Math.max(Number(sample_size) || 10_000, 1), 50_000)
 			const lim = Math.min(Math.max(Number(limit) || 50, 1), 200)
 			const tenant = yield* resolveTenant
@@ -70,7 +71,7 @@ export function registerMineLogPatternsTool(server: McpToolRegistrar) {
 					content: [
 						{
 							type: "text" as const,
-							text: `No logs found to cluster in ${st} — ${et}${formatClampNote(range)}`,
+							text: `No logs found to cluster in ${st} — ${et}`,
 						},
 					],
 				}
@@ -78,7 +79,7 @@ export function registerMineLogPatternsTool(server: McpToolRegistrar) {
 
 			const lines: string[] = [
 				`## Log Patterns (${result.patterns.length} templates from ${formatNumber(result.totalSampled)} sampled logs)`,
-				`Time range: ${st} — ${et}${formatClampNote(range)}`,
+				`Time range: ${st} — ${et}`,
 			]
 
 			const filters: string[] = []

--- a/apps/api/src/mcp/tools/search-logs.ts
+++ b/apps/api/src/mcp/tools/search-logs.ts
@@ -1,7 +1,7 @@
 import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from "./types"
 import { toMcpQueryError } from "../lib/map-warehouse-error"
 import { resolveTenant } from "../lib/query-warehouse"
-import { resolveTimeRange, formatClampNote } from "../lib/time"
+import { resolveTimeRange, rangeExceededResult, MCP_SEARCH_MAX_HOURS } from "../lib/time"
 import { clampLimit, clampOffset } from "../lib/limits"
 import { truncate, formatNumber } from "../lib/format"
 import { formatNextSteps } from "../lib/next-steps"
@@ -40,8 +40,9 @@ export function registerSearchLogsTool(server: McpToolRegistrar) {
 			offset,
 			limit,
 		}) {
-			const range = resolveTimeRange(start_time, end_time, { maxHours: 24 * 7 })
+			const range = resolveTimeRange(start_time, end_time, { maxHours: MCP_SEARCH_MAX_HOURS })
 			const { st, et } = range
+			if (range.exceeded) return rangeExceededResult(range, "search_logs")
 			const lim = clampLimit(limit, { defaultValue: 30, max: 200 })
 			const off = clampOffset(offset, { max: 10_000 })
 			const tenant = yield* resolveTenant
@@ -75,7 +76,7 @@ export function registerSearchLogsTool(server: McpToolRegistrar) {
 
 			const lines: string[] = [
 				`## Logs (${formatNumber(result.total)} total, showing ${result.logs.length})`,
-				`Time range: ${st} — ${et}${formatClampNote(range)}`,
+				`Time range: ${st} — ${et}`,
 			]
 
 			const filters: string[] = []

--- a/apps/api/src/mcp/tools/search-sessions.ts
+++ b/apps/api/src/mcp/tools/search-sessions.ts
@@ -6,7 +6,7 @@ import {
 } from "./types"
 import { warehouseToMcpHandlers } from "../lib/map-warehouse-error"
 import { withTenantExecutor, resolveTenant } from "../lib/query-warehouse"
-import { resolveTimeRange, formatClampNote } from "../lib/time"
+import { resolveTimeRange, rangeExceededResult, MCP_SEARCH_MAX_HOURS } from "../lib/time"
 import { clampLimit, clampOffset } from "../lib/limits"
 import { formatTable, truncate } from "../lib/format"
 import { formatNextSteps } from "../lib/next-steps"
@@ -49,8 +49,11 @@ export function registerSearchSessionsTool(server: McpToolRegistrar) {
 			limit: optionalNumberParam("Max results (default 25)"),
 		}),
 		Effect.fn("McpTool.searchSessions")(function* (params) {
-			const range = resolveTimeRange(params.start_time, params.end_time, { maxHours: 24 * 7 })
+			const range = resolveTimeRange(params.start_time, params.end_time, {
+				maxHours: MCP_SEARCH_MAX_HOURS,
+			})
 			const { st, et } = range
+			if (range.exceeded) return rangeExceededResult(range, "search_sessions")
 			const lim = clampLimit(params.limit, { defaultValue: 25, max: 200 })
 			const off = clampOffset(params.offset, { max: 10_000 })
 
@@ -144,7 +147,7 @@ export function registerSearchSessionsTool(server: McpToolRegistrar) {
 
 			const lines: string[] = [
 				`## Sessions (showing ${off + 1}–${off + sessions.length})`,
-				`Time range: ${st} — ${et}${formatClampNote(range)}`,
+				`Time range: ${st} — ${et}`,
 				``,
 				formatTable(headers, rows),
 			]

--- a/apps/api/src/mcp/tools/search-traces.ts
+++ b/apps/api/src/mcp/tools/search-traces.ts
@@ -7,7 +7,7 @@ import {
 } from "./types"
 import { warehouseToMcpHandlers } from "../lib/map-warehouse-error"
 import { withTenantExecutor } from "../lib/query-warehouse"
-import { resolveTimeRange, formatClampNote } from "../lib/time"
+import { resolveTimeRange, rangeExceededResult, MCP_SEARCH_MAX_HOURS } from "../lib/time"
 import { clampLimit, clampOffset } from "../lib/limits"
 import { formatDurationFromMs, formatTable } from "../lib/format"
 import { formatNextSteps } from "../lib/next-steps"
@@ -45,8 +45,11 @@ export function registerSearchTracesTool(server: McpToolRegistrar) {
 			limit: optionalNumberParam("Max results (default 20)"),
 		}),
 		Effect.fn("McpTool.searchTraces")(function* (params) {
-			const range = resolveTimeRange(params.start_time, params.end_time, { maxHours: 24 * 7 })
+			const range = resolveTimeRange(params.start_time, params.end_time, {
+				maxHours: MCP_SEARCH_MAX_HOURS,
+			})
 			const { st, et } = range
+			if (range.exceeded) return rangeExceededResult(range, "search_traces")
 			const lim = clampLimit(params.limit, { defaultValue: 20, max: 200 })
 			const off = clampOffset(params.offset, { max: 10_000 })
 
@@ -101,7 +104,7 @@ export function registerSearchTracesTool(server: McpToolRegistrar) {
 
 			const lines: string[] = [
 				`## ${isSpanLevel ? "Matching Spans" : "Traces"} (showing ${off + 1}–${off + spans.length})`,
-				`Time range: ${st} — ${et}${formatClampNote(range)}`,
+				`Time range: ${st} — ${et}`,
 				``,
 			]
 

--- a/apps/api/src/mcp/tools/update-dashboard.ts
+++ b/apps/api/src/mcp/tools/update-dashboard.ts
@@ -5,17 +5,12 @@ import { resolveTenant } from "@/mcp/lib/query-warehouse"
 import { DashboardPersistenceService } from "@/services/DashboardPersistenceService"
 import { DashboardDocument, DashboardId, PortableDashboardDocument } from "@maple/domain/http"
 import { IsoDateTimeString } from "@maple/domain"
+import { validateDashboardTimeRange } from "../lib/resolve-dashboard-time-range"
+import { MAX_QUERY_RANGE_SECONDS, formatRangeSeconds } from "@maple/query-engine"
 
 const PortableDashboardFromJson = Schema.fromJsonString(PortableDashboardDocument)
 const decodeIsoDateTimeString = Schema.decodeUnknownSync(IsoDateTimeString)
 const decodeDashboardId = Schema.decodeUnknownSync(DashboardId)
-
-const TIME_RANGE_MAP: Record<string, string> = {
-	"1h": "1h",
-	"6h": "6h",
-	"24h": "24h",
-	"7d": "7d",
-}
 
 export function registerUpdateDashboardTool(server: McpToolRegistrar) {
 	server.tool(
@@ -27,7 +22,9 @@ export function registerUpdateDashboardTool(server: McpToolRegistrar) {
 			),
 			name: optionalStringParam("New dashboard name"),
 			description: optionalStringParam("New dashboard description"),
-			time_range: optionalStringParam("New time range: 1h, 6h, 24h, or 7d"),
+			time_range: optionalStringParam(
+				`New time range as relative shorthand — e.g. 15m, 6h, 24h, 7d, 2w, 3mo, or "today". Up to ${formatRangeSeconds(MAX_QUERY_RANGE_SECONDS)}.`,
+			),
 			dashboard_json: optionalStringParam(
 				"Full dashboard JSON to replace the current configuration. Use get_dashboard to see the current schema.",
 			),
@@ -39,6 +36,16 @@ export function registerUpdateDashboardTool(server: McpToolRegistrar) {
 			time_range,
 			dashboard_json,
 		}) {
+			if (time_range) {
+				const timeRangeError = validateDashboardTimeRange(time_range)
+				if (timeRangeError) {
+					return {
+						isError: true as const,
+						content: [{ type: "text" as const, text: timeRangeError }],
+					}
+				}
+			}
+
 			const tenant = yield* resolveTenant
 			const persistence = yield* DashboardPersistenceService
 
@@ -85,7 +92,7 @@ export function registerUpdateDashboardTool(server: McpToolRegistrar) {
 						const timeRange = time_range
 							? {
 									type: "relative" as const,
-									value: TIME_RANGE_MAP[time_range] ?? time_range,
+									value: time_range,
 								}
 							: existing.timeRange
 

--- a/apps/api/src/routes/v2/session-replays.http.ts
+++ b/apps/api/src/routes/v2/session-replays.http.ts
@@ -17,7 +17,7 @@ import type {
 	V2SessionReplayRef,
 	V2SessionTranscriptEvent,
 } from "@maple/domain/http/v2"
-import { CH } from "@maple/query-engine"
+import { CH, formatWarehouseDateTime } from "@maple/query-engine"
 import { Effect, Option, Schema } from "effect"
 import { WarehouseQueryService } from "../../lib/WarehouseQueryService"
 import { warehouseToV2 } from "./warehouse-error-map"
@@ -33,7 +33,7 @@ const toTinybird = (value: string, param: string) => {
 	const ms = Date.parse(value)
 	return Number.isNaN(ms)
 		? Effect.fail(invalidRequest("parameter_invalid", `Invalid ISO-8601 timestamp for ${param}.`, param))
-		: Effect.succeed(new Date(ms).toISOString().slice(0, 19).replace("T", " "))
+		: Effect.succeed(formatWarehouseDateTime(ms))
 }
 
 const optTinybird = (value: string | undefined, param: string) =>

--- a/apps/api/src/routes/v2/telemetry.http.ts
+++ b/apps/api/src/routes/v2/telemetry.http.ts
@@ -15,7 +15,12 @@ import {
 	type V2Span,
 	type V2TraceSummary,
 } from "@maple/domain/http/v2"
-import { CH, QueryEngineExecuteRequest } from "@maple/query-engine"
+import {
+	CH,
+	QueryEngineExecuteRequest,
+	formatWarehouseDateTime,
+	formatWarehouseDateTimeMs,
+} from "@maple/query-engine"
 import { LOGS_BODY_SEARCH_SETTINGS } from "@maple/query-engine/profiles"
 import {
 	computeBucketSeconds,
@@ -76,7 +81,7 @@ const toWarehouseDateTime = (value: string, param: string) => {
 	const ms = Date.parse(value)
 	return Number.isNaN(ms)
 		? Effect.fail(invalidRequest("parameter_invalid", `Invalid ISO-8601 timestamp for ${param}.`, param))
-		: Effect.succeed(new Date(ms).toISOString().replace("T", " ").replace(/Z$/, ""))
+		: Effect.succeed(formatWarehouseDateTimeMs(ms))
 }
 
 const parseWindow = (
@@ -117,12 +122,11 @@ const chToIso = (value: string): Timestamp => {
 	return timestamp(Number.isNaN(ms) ? value : new Date(ms).toISOString())
 }
 
-const warehouseDate = (ms: number) => new Date(ms).toISOString().replace("T", " ").replace(/Z$/, "")
 const partitionWindow = (value: string) => {
 	const ms = Date.parse(value.includes("T") ? value : `${value.replace(" ", "T")}Z`)
 	return {
-		startTime: warehouseDate(ms - PARTITION_HINT_RADIUS_MS),
-		endTime: warehouseDate(ms + PARTITION_HINT_RADIUS_MS),
+		startTime: formatWarehouseDateTimeMs(ms - PARTITION_HINT_RADIUS_MS),
+		endTime: formatWarehouseDateTimeMs(ms + PARTITION_HINT_RADIUS_MS),
 	}
 }
 
@@ -154,7 +158,7 @@ const expandTimestamp = (value: string) => {
 	if (match === null) return value
 	const epochSeconds = Number.parseInt(match[1]!, 36)
 	if (!Number.isSafeInteger(epochSeconds)) return value
-	const seconds = new Date(epochSeconds * 1000).toISOString().slice(0, 19).replace("T", " ")
+	const seconds = formatWarehouseDateTime(epochSeconds * 1000)
 	return `${seconds}${match[2] ?? ""}`
 }
 const compactHexId = (value: string) => {

--- a/apps/api/src/routes/v2/telemetry.http.ts
+++ b/apps/api/src/routes/v2/telemetry.http.ts
@@ -17,7 +17,15 @@ import {
 } from "@maple/domain/http/v2"
 import { CH, QueryEngineExecuteRequest } from "@maple/query-engine"
 import { LOGS_BODY_SEARCH_SETTINGS } from "@maple/query-engine/profiles"
-import { computeBucketSeconds, MAX_QUERY_RANGE_SECONDS } from "@maple/query-engine/runtime"
+import {
+	computeBucketSeconds,
+	formatRangeSeconds,
+	MAX_BREAKDOWN_RANGE_SECONDS,
+	MAX_LIST_RANGE_SECONDS,
+	MAX_QUERY_RANGE_SECONDS,
+	MAX_TIMESERIES_POINTS as MAX_TIMESERIES_BUCKETS,
+	MAX_UNFILTERED_BREAKDOWN_RANGE_SECONDS,
+} from "@maple/query-engine/runtime"
 import { Effect, Encoding, Option, Result, Schema } from "effect"
 import { WarehouseQueryService } from "../../lib/WarehouseQueryService"
 import { QueryEngineService } from "../../services/QueryEngineService"
@@ -56,11 +64,11 @@ const serviceCatalogRowSchema = Schema.Struct({
 const PARTITION_HINT_RADIUS_MS = 60 * 60 * 1000
 const PUBLIC_TIMESERIES_DEFAULT_SERIES_LIMIT = 50
 const PUBLIC_BREAKDOWN_DEFAULT_LIMIT = 20
-const MAX_SEARCH_RANGE_SECONDS = 60 * 60 * 24 * 7
-const MAX_BREAKDOWN_RANGE_SECONDS = 60 * 60 * 24 * 30
-const MAX_UNFILTERED_BREAKDOWN_RANGE_SECONDS = 60 * 60 * 24
+// Search endpoints return raw rows, so they carry the query engine's list cap.
+const MAX_SEARCH_RANGE_SECONDS = MAX_LIST_RANGE_SECONDS
+// Summary endpoints read the 365-day hourly rollups rather than raw tables, so
+// they can span far wider than any query-engine kind — no shared equivalent.
 const MAX_SUMMARY_RANGE_SECONDS = 60 * 60 * 24 * 365
-const MAX_TIMESERIES_BUCKETS = 1_500
 
 const mapWarehouseError = warehouseToV2
 
@@ -90,7 +98,7 @@ const parseWindow = (
 			return yield* Effect.fail(
 				invalidRequest(
 					"time_range_too_large",
-					`${options.rangeLabel ?? "Telemetry queries"} support a maximum time range of ${Math.floor(maxSeconds / 86_400)} days.`,
+					`${options.rangeLabel ?? "Telemetry queries"} support a maximum time range of ${formatRangeSeconds(maxSeconds)}.`,
 					"start_time",
 				),
 			)
@@ -395,7 +403,7 @@ const validateTimeseriesBucket = (
 		? Effect.fail(
 				invalidRequest(
 					"bucket_count_too_large",
-					"bucket_seconds produces more than 1,500 buckets.",
+					`bucket_seconds produces more than ${MAX_TIMESERIES_BUCKETS.toLocaleString("en-US")} buckets.`,
 					"bucket_seconds",
 				),
 			)
@@ -416,7 +424,7 @@ const validateBreakdownRange = (rangeSeconds: number, filters: unknown) => {
 	return Effect.fail(
 		invalidRequest(
 			"breakdown_filter_required",
-			"Breakdowns over 24 hours require at least one narrowing filter.",
+			`Breakdowns over ${formatRangeSeconds(MAX_UNFILTERED_BREAKDOWN_RANGE_SECONDS)} require at least one narrowing filter.`,
 			"filters",
 		),
 	)

--- a/apps/api/src/services/AlertsService.ts
+++ b/apps/api/src/services/AlertsService.ts
@@ -5,6 +5,7 @@ import {
 	QueryEngineNoDataBehavior,
 	type QueryEngineSampleCountStrategy,
 	QuerySpec,
+	formatWarehouseDateTime,
 } from "@maple/query-engine"
 import * as CH from "@maple/query-engine/ch"
 import { buildTimeseriesQuerySpec, resolveGroupBy } from "@maple/query-engine/query-builder"
@@ -107,11 +108,7 @@ import { upsertAlertIssue } from "../lib/issue-hub"
 import { probeLiveness } from "../lib/telemetry-liveness"
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
 import type { TenantContext } from "./AuthService"
-import {
-	encryptAes256Gcm,
-	parseBase64Aes256GcmKey,
-	type EncryptedValue,
-} from "../lib/Crypto"
+import { encryptAes256Gcm, parseBase64Aes256GcmKey, type EncryptedValue } from "../lib/Crypto"
 import { Database, type DatabaseClient } from "../lib/DatabaseLive"
 import { readTxid, txidColumn } from "../lib/electric-txid"
 import {
@@ -438,8 +435,6 @@ const toIngestDateTime64 = (epochMs: number) => {
 	const pad = (n: number, w = 2) => n.toString().padStart(w, "0")
 	return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}.${pad(d.getUTCMilliseconds(), 3)}`
 }
-
-const toTinybirdDateTime = (epochMs: number) => new Date(epochMs).toISOString().slice(0, 19).replace("T", " ")
 
 const compareThreshold = (
 	value: number,
@@ -1611,8 +1606,8 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				const source = yield* planEvaluateSource(plan, rule.windowMinutes)
 				const observations: ReadonlyArray<GroupedAlertObservation> = yield* queryEngine
 					.evaluate(systemTenant(orgId), {
-						startTime: toTinybirdDateTime(startMs),
-						endTime: toTinybirdDateTime(endMs),
+						startTime: formatWarehouseDateTime(startMs),
+						endTime: formatWarehouseDateTime(endMs),
 						source,
 						reducer: plan.reducer,
 						sampleCountStrategy: plan.sampleCountStrategy,
@@ -2944,8 +2939,8 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 								)
 								const observations = yield* queryEngine
 									.evaluateSeries(systemTenant(orgId), {
-										startTime: toTinybirdDateTime(startMs),
-										endTime: toTinybirdDateTime(queryEndMs),
+										startTime: formatWarehouseDateTime(startMs),
+										endTime: formatWarehouseDateTime(queryEndMs),
 										source: perServiceSource,
 										reducer: perServicePlan.reducer,
 										sampleCountStrategy: perServicePlan.sampleCountStrategy,
@@ -2965,8 +2960,8 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					const source = yield* planEvaluateSource(plan, normalized.windowMinutes)
 					const observations = yield* queryEngine
 						.evaluateSeries(systemTenant(orgId), {
-							startTime: toTinybirdDateTime(startMs),
-							endTime: toTinybirdDateTime(queryEndMs),
+							startTime: formatWarehouseDateTime(startMs),
+							endTime: formatWarehouseDateTime(queryEndMs),
 							source,
 							reducer: plan.reducer,
 							sampleCountStrategy: plan.sampleCountStrategy,

--- a/apps/api/src/services/AnomalyDetectionService.ts
+++ b/apps/api/src/services/AnomalyDetectionService.ts
@@ -34,7 +34,7 @@ import {
 	orgIngestKeys,
 } from "@maple/db"
 import { and, desc, eq, gte, inArray, isNull, lt, lte, ne, or, sql } from "drizzle-orm"
-import { CH, parseWarehouseDateTime } from "@maple/query-engine"
+import { CH, parseWarehouseDateTime, formatWarehouseDateTime } from "@maple/query-engine"
 import { EdgeCacheService } from "@maple/query-engine/caching"
 import { isOrgWarehouseQuarantined, quarantineOnConfigClassCause } from "../lib/warehouse-org-quarantine"
 import { Array as Arr, Cause, Clock, Context, Effect, Layer, Option, Ref, Schedule, Schema } from "effect"
@@ -252,9 +252,6 @@ const make = Effect.gen(function* () {
 			Effect.mapError(makePersistenceError),
 		)
 
-	const toTinybirdDateTime = (epochMs: number) =>
-		new Date(epochMs).toISOString().slice(0, 19).replace("T", " ")
-
 	const isoFromEpoch = (ms: number) => decodeIsoSync(new Date(ms).toISOString())
 
 	const isoFromDate = (date: Date) => decodeIsoSync(date.toISOString())
@@ -294,7 +291,7 @@ const make = Effect.gen(function* () {
 			return byo as ReadonlySet<string>
 		}
 
-		const startTime = toTinybirdDateTime(nowMs - ANOMALY_ACTIVE_DISCOVERY_WINDOW_MS)
+		const startTime = formatWarehouseDateTime(nowMs - ANOMALY_ACTIVE_DISCOVERY_WINDOW_MS)
 		const routingTenant = systemTenant(knownOrgs[0])
 		return yield* Effect.all(
 			[
@@ -685,8 +682,8 @@ const make = Effect.gen(function* () {
 
 		const queryWindow = {
 			orgId,
-			startTime: toTinybirdDateTime(startMs),
-			endTime: toTinybirdDateTime(endMs),
+			startTime: formatWarehouseDateTime(startMs),
+			endTime: formatWarehouseDateTime(endMs),
 		}
 
 		let unit: AnomalyTimeseriesUnit
@@ -703,7 +700,7 @@ const make = Effect.gen(function* () {
 				...queryWindow,
 				// Include the preceding window so the first displayed point has
 				// a complete rolling 30-minute value.
-				startTime: toTinybirdDateTime(startMs - SPIKE_WINDOW_MS),
+				startTime: formatWarehouseDateTime(startMs - SPIKE_WINDOW_MS),
 				fingerprintHash: row.fingerprintHash ?? "0",
 				deploymentEnv: row.deploymentEnv,
 				bucketSeconds,
@@ -855,8 +852,8 @@ const make = Effect.gen(function* () {
 			Effect.gen(function* () {
 				const compiled = CH.compile(CH.anomalyTraceSignalsQuery({ hoursOfDay }), {
 					orgId: tenant.orgId,
-					startTime: toTinybirdDateTime(nowMs - BASELINE_WINDOW_MS),
-					endTime: toTinybirdDateTime(currentHourStartMs),
+					startTime: formatWarehouseDateTime(nowMs - BASELINE_WINDOW_MS),
+					endTime: formatWarehouseDateTime(currentHourStartMs),
 				})
 				const rows = yield* warehouse
 					.compiledQuery(tenant, compiled, {
@@ -881,8 +878,8 @@ const make = Effect.gen(function* () {
 
 		const currentCompiled = CH.compile(CH.anomalyTraceSignalsQuery({ hoursOfDay }), {
 			orgId: tenant.orgId,
-			startTime: toTinybirdDateTime(currentHourStartMs),
-			endTime: toTinybirdDateTime(nowMs),
+			startTime: formatWarehouseDateTime(currentHourStartMs),
+			endTime: formatWarehouseDateTime(nowMs),
 		})
 		const currentRows = yield* warehouse
 			.compiledQuery(tenant, currentCompiled, {
@@ -946,8 +943,8 @@ const make = Effect.gen(function* () {
 			Effect.gen(function* () {
 				const compiled = CH.compile(CH.anomalyLogVolumeQuery({ hoursOfDay }), {
 					orgId: tenant.orgId,
-					startTime: toTinybirdDateTime(nowMs - BASELINE_WINDOW_MS),
-					endTime: toTinybirdDateTime(currentHourStartMs),
+					startTime: formatWarehouseDateTime(nowMs - BASELINE_WINDOW_MS),
+					endTime: formatWarehouseDateTime(currentHourStartMs),
 				})
 				const rows = yield* warehouse
 					.compiledQuery(tenant, compiled, {
@@ -968,8 +965,8 @@ const make = Effect.gen(function* () {
 
 		const currentCompiled = CH.compile(CH.anomalyLogVolumeQuery({ hoursOfDay }), {
 			orgId: tenant.orgId,
-			startTime: toTinybirdDateTime(currentHourStartMs),
-			endTime: toTinybirdDateTime(nowMs),
+			startTime: formatWarehouseDateTime(currentHourStartMs),
+			endTime: formatWarehouseDateTime(nowMs),
 		})
 		const currentRows = yield* warehouse
 			.compiledQuery(tenant, currentCompiled, {
@@ -1005,8 +1002,8 @@ const make = Effect.gen(function* () {
 	) {
 		const currentCompiled = CH.compile(CH.anomalyErrorSpikeCurrentQuery({}), {
 			orgId: tenant.orgId,
-			startTime: toTinybirdDateTime(nowMs - SPIKE_WINDOW_MS),
-			endTime: toTinybirdDateTime(nowMs),
+			startTime: formatWarehouseDateTime(nowMs - SPIKE_WINDOW_MS),
+			endTime: formatWarehouseDateTime(nowMs),
 		})
 		const currentRows = yield* warehouse
 			.compiledQuery(tenant, currentCompiled, {
@@ -1039,8 +1036,8 @@ const make = Effect.gen(function* () {
 			Effect.gen(function* () {
 				const baselineCompiled = CH.compile(CH.anomalyErrorSpikeBaselineQuery({}), {
 					orgId: tenant.orgId,
-					startTime: toTinybirdDateTime(nowMs - BASELINE_WINDOW_MS),
-					endTime: toTinybirdDateTime(Math.floor(nowMs / HOUR_MS) * HOUR_MS),
+					startTime: formatWarehouseDateTime(nowMs - BASELINE_WINDOW_MS),
+					endTime: formatWarehouseDateTime(Math.floor(nowMs / HOUR_MS) * HOUR_MS),
 				})
 				const rows = yield* warehouse
 					.compiledQuery(tenant, baselineCompiled, {

--- a/apps/api/src/services/DailySpendService.ts
+++ b/apps/api/src/services/DailySpendService.ts
@@ -1,5 +1,5 @@
 import { DailySpendResponse, DailyVolume, WarehouseQueryError } from "@maple/domain/http"
-import { CH, parseWarehouseDateTime } from "@maple/query-engine"
+import { CH, parseWarehouseDateTime, formatWarehouseDateTime } from "@maple/query-engine"
 import { Context, Effect, Layer } from "effect"
 import { WarehouseQueryService } from "../lib/WarehouseQueryService"
 import type { TenantContext } from "./AuthService"
@@ -22,8 +22,6 @@ const DAY_MS = 86_400_000
 const BYTES_PER_BILLED_GB = 1_000_000_000
 
 /** ClickHouse datetime literal (`YYYY-MM-DD HH:MM:SS`), which is what the DSL params want. */
-const toWarehouseDateTime = (epochMs: number) =>
-	new Date(epochMs).toISOString().slice(0, 19).replace("T", " ")
 
 /** `YYYY-MM-DD` in UTC — the key the client renders and the series is indexed by. */
 export const toUtcDateKey = (epochMs: number) => new Date(epochMs).toISOString().slice(0, 10)
@@ -61,8 +59,8 @@ export class DailySpendService extends Context.Service<DailySpendService, DailyS
 				const orgId = tenant.orgId
 				const params = {
 					orgId,
-					startTime: toWarehouseDateTime(cycle.startMs),
-					endTime: toWarehouseDateTime(cycle.endMs),
+					startTime: formatWarehouseDateTime(cycle.startMs),
+					endTime: formatWarehouseDateTime(cycle.endMs),
 				}
 
 				// Two queries rather than a UNION: the tables disagree on the bucket

--- a/apps/api/src/services/DigestService.ts
+++ b/apps/api/src/services/DigestService.ts
@@ -25,6 +25,7 @@ import { WarehouseQueryService } from "../lib/WarehouseQueryService"
 import { EdgeCacheService } from "@maple/query-engine/caching"
 import { isOrgWarehouseQuarantined, quarantineOnConfigClassCause } from "../lib/warehouse-org-quarantine"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 const SYSTEM_DIGEST_USER = UserId.make("system-digest")
 const ROOT_ROLE = RoleName.make("root")
 const D1_INARRAY_CHUNK_SIZE = 90
@@ -211,14 +212,9 @@ export class DigestService extends Context.Service<DigestService>()("@maple/api/
 			yield* Effect.annotateCurrentSpan("orgId", orgId)
 
 			const now = new Date(yield* Clock.currentTimeMillis)
-			const toClickHouseDateTime = (d: Date) =>
-				d
-					.toISOString()
-					.replace("T", " ")
-					.replace(/\.\d{3}Z$/, "")
-			const currentEnd = toClickHouseDateTime(now)
-			const currentStart = toClickHouseDateTime(new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000))
-			const previousStart = toClickHouseDateTime(new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000))
+			const currentEnd = formatWarehouseDateTime(now.getTime())
+			const currentStart = formatWarehouseDateTime(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+			const previousStart = formatWarehouseDateTime(now.getTime() - 14 * 24 * 60 * 60 * 1000)
 
 			// Sparkline window: 7 *complete* UTC days. `bucket_seconds: 86_400`
 			// snaps `toStartOfInterval` to UTC midnight, so a rolling now-7d
@@ -226,8 +222,8 @@ export class DigestService extends Context.Service<DigestService>()("@maple/api/
 			// weekday at the seam). Day-aligning the window keeps it to exactly 7.
 			const DAY_MS = 24 * 60 * 60 * 1000
 			const todayStartMs = Math.floor(now.getTime() / DAY_MS) * DAY_MS
-			const seriesStart = toClickHouseDateTime(new Date(todayStartMs - 7 * DAY_MS))
-			const seriesEnd = toClickHouseDateTime(new Date(todayStartMs - 1000))
+			const seriesStart = formatWarehouseDateTime(todayStartMs - 7 * DAY_MS)
+			const seriesEnd = formatWarehouseDateTime(todayStartMs - 1000)
 
 			const systemTenant = {
 				orgId,

--- a/apps/api/src/services/ErrorsService.test.ts
+++ b/apps/api/src/services/ErrorsService.test.ts
@@ -38,6 +38,7 @@ import { WarehouseQueryService } from "../lib/WarehouseQueryService"
 import { describeCause, ErrorsService, isBusyDatabaseError, makePersistenceError } from "./ErrorsService"
 import { NotificationDispatcher } from "./NotificationDispatcher"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 describe("makePersistenceError", () => {
 	it("omits the cause key when the source has no cause", () => {
 		const err = makePersistenceError(new Error("boom"))
@@ -738,8 +739,6 @@ const RETENTION_TICK_MS = 1_750_003_200_000
 const TICK_MS = RETENTION_TICK_MS + 120_000
 
 /** Same format the tick itself sends to the warehouse ("YYYY-MM-DD HH:MM:SS", UTC). */
-const toWarehouseDateTime = (epochMs: number) =>
-	new Date(epochMs).toISOString().slice(0, 19).replace("T", " ")
 
 /** Real error fingerprints are decimal UInt64 strings from ClickHouse. */
 const SCAN_FINGERPRINT = "12345678901234567890"
@@ -753,8 +752,8 @@ const scanRow = (overrides: Record<string, unknown> = {}): Record<string, unknow
 	topFrame: "checkout/handler.ts:42",
 	count: 3,
 	affectedServicesCount: 1,
-	firstSeen: toWarehouseDateTime(TICK_MS - 60_000),
-	lastSeen: toWarehouseDateTime(TICK_MS - 1_000),
+	firstSeen: formatWarehouseDateTime(TICK_MS - 60_000),
+	lastSeen: formatWarehouseDateTime(TICK_MS - 1_000),
 	...overrides,
 })
 
@@ -1034,8 +1033,8 @@ describe("ErrorsService.runTick", () => {
 			const reopenMs = TICK_MS + 32 * 60_000
 			rows = [
 				scanRow({
-					firstSeen: toWarehouseDateTime(reopenMs - 60_000),
-					lastSeen: toWarehouseDateTime(reopenMs - 1_000),
+					firstSeen: formatWarehouseDateTime(reopenMs - 60_000),
+					lastSeen: formatWarehouseDateTime(reopenMs - 1_000),
 				}),
 			]
 			yield* TestClock.setTime(reopenMs)

--- a/apps/api/src/services/ErrorsService.ts
+++ b/apps/api/src/services/ErrorsService.ts
@@ -77,7 +77,12 @@ import {
 	orgIngestKeys,
 } from "@maple/db"
 import { and, desc, eq, gt, inArray, isNotNull, isNull, lt, or, sql } from "drizzle-orm"
-import { CH, parseWarehouseDateTime, warehouseDateTimeToIso } from "@maple/query-engine"
+import {
+	CH,
+	parseWarehouseDateTime,
+	warehouseDateTimeToIso,
+	formatWarehouseDateTime,
+} from "@maple/query-engine"
 import { Array as Arr, Cause, Clock, Context, Effect, Layer, Option, Ref, Schedule, Schema } from "effect"
 import type { TenantContext } from "./AuthService"
 import { INVESTIGATION_AGENT_BINDING, maybeEnqueueTriage } from "../lib/ai-triage-enqueue"
@@ -499,9 +504,6 @@ const make: Effect.Effect<
 			Effect.mapError(makePersistenceError),
 		)
 
-	const toTinybirdDateTime = (epochMs: number) =>
-		new Date(epochMs).toISOString().slice(0, 19).replace("T", " ")
-
 	const isoFromDate = (date: Date) => decodeIsoDateTimeStringSync(date.toISOString())
 
 	const systemTenant = (orgId: OrgId): TenantContext => ({
@@ -543,7 +545,7 @@ const make: Effect.Effect<
 		}
 
 		const compiled = CH.compile(CH.activeOrgsByErrorEventsQuery(), {
-			startTime: toTinybirdDateTime(nowMs - ERROR_ACTIVE_DISCOVERY_WINDOW_MS),
+			startTime: formatWarehouseDateTime(nowMs - ERROR_ACTIVE_DISCOVERY_WINDOW_MS),
 		})
 		return yield* warehouse
 			.compiledQuery(systemTenant(knownOrgs[0] as OrgId), compiled, {
@@ -1138,8 +1140,8 @@ const make: Effect.Effect<
 					}),
 					{
 						orgId,
-						startTime: toTinybirdDateTime(scanStartMs),
-						endTime: toTinybirdDateTime(scanEndMs),
+						startTime: formatWarehouseDateTime(scanStartMs),
+						endTime: formatWarehouseDateTime(scanEndMs),
 					},
 				)
 				const fingerprintRows = yield* warehouse
@@ -1288,8 +1290,8 @@ const make: Effect.Effect<
 			const timeseriesCompiled = CH.compile(CH.errorIssueTimeseriesQuery(), {
 				orgId,
 				fingerprintHash: issueRow.fingerprintHash,
-				startTime: toTinybirdDateTime(startMs),
-				endTime: toTinybirdDateTime(endMs),
+				startTime: formatWarehouseDateTime(startMs),
+				endTime: formatWarehouseDateTime(endMs),
 				bucketSeconds,
 			})
 			const timeseriesEffect = isErrorKind
@@ -1301,8 +1303,8 @@ const make: Effect.Effect<
 			const samplesCompiled = CH.compile(CH.errorIssueSampleTracesQuery({ limit: sampleLimit }), {
 				orgId,
 				fingerprintHash: issueRow.fingerprintHash,
-				startTime: toTinybirdDateTime(startMs),
-				endTime: toTinybirdDateTime(endMs),
+				startTime: formatWarehouseDateTime(startMs),
+				endTime: formatWarehouseDateTime(endMs),
 			})
 			const samplesEffect = isErrorKind
 				? warehouse
@@ -2554,8 +2556,8 @@ const make: Effect.Effect<
 		// covers an org that went inactive between discovery and the scan.
 		const issuesCompiled = CH.compile(CH.errorIssuesQuery({ limit: 500 }), {
 			orgId,
-			startTime: toTinybirdDateTime(windowStartMs),
-			endTime: toTinybirdDateTime(windowEndMs),
+			startTime: formatWarehouseDateTime(windowStartMs),
+			endTime: formatWarehouseDateTime(windowEndMs),
 		})
 		const issuesRaw = isActive
 			? yield* warehouse

--- a/apps/api/src/services/RecommendationIssueService.ts
+++ b/apps/api/src/services/RecommendationIssueService.ts
@@ -11,7 +11,7 @@ import {
 } from "@maple/domain/http"
 import { detectAttributeRecommendations, planReconcileIssues } from "@maple/domain/recommendations"
 import { orgIngestAttributeMappings, orgRecommendationIssues } from "@maple/db"
-import { CH } from "@maple/query-engine"
+import { CH, formatWarehouseDateTime } from "@maple/query-engine"
 import { and, eq } from "drizzle-orm"
 import { Array as Arr, Clock, Context, Effect, Layer, Option, Schema } from "effect"
 import type { TenantContext } from "./AuthService"
@@ -64,8 +64,6 @@ const rowToIssue = (row: IssueRow): RecommendationIssue =>
 		...(row.resolvedAt != null ? { resolvedAt: decodeIsoSync(row.resolvedAt.toISOString()) } : {}),
 	})
 
-const fmtWarehouseTime = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-
 export class RecommendationIssueService extends Context.Service<
 	RecommendationIssueService,
 	RecommendationIssueServiceShape
@@ -111,8 +109,8 @@ export class RecommendationIssueService extends Context.Service<
 			const now = yield* Clock.currentTimeMillis
 			const compiled = CH.compile(CH.attributeKeysQuery({ scope: "span" }), {
 				orgId: tenant.orgId,
-				startTime: fmtWarehouseTime(now - 24 * 60 * 60 * 1000),
-				endTime: fmtWarehouseTime(now),
+				startTime: formatWarehouseDateTime(now - 24 * 60 * 60 * 1000),
+				endTime: formatWarehouseDateTime(now),
 			})
 			const rows = yield* warehouse
 				.compiledQuery(tenant, compiled, { profile: "discovery", context: "recommendationIssues" })

--- a/apps/api/src/services/ServiceMapRollupService.ts
+++ b/apps/api/src/services/ServiceMapRollupService.ts
@@ -6,6 +6,7 @@ import type { TenantContext } from "./AuthService"
 import { Database, type DatabaseError } from "../lib/DatabaseLive"
 import { WarehouseQueryService } from "../lib/WarehouseQueryService"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 const decodeRoleNameSync = Schema.decodeUnknownSync(RoleName)
 const decodeUserIdSync = Schema.decodeUnknownSync(UserIdSchema)
 
@@ -67,9 +68,6 @@ export class ServiceMapRollupService extends Context.Service<
 			authMode: "self_hosted",
 		})
 
-		const toTinybirdDateTime = (epochMs: number) =>
-			new Date(epochMs).toISOString().slice(0, 19).replace("T", " ")
-
 		const processOrg = Effect.fn("ServiceMapRollupService.processOrg")(function* (orgId: OrgId) {
 			const tenant = systemTenant(orgId)
 			const currentHourMs = Math.floor((yield* Clock.currentTimeMillis) / HOUR_MS) * HOUR_MS
@@ -81,8 +79,8 @@ export class ServiceMapRollupService extends Context.Service<
 
 			const existingCompiled = CH.serviceMapEdgesExistingHoursSQL({
 				orgId,
-				startTime: toTinybirdDateTime(oldestHourMs),
-				endTime: toTinybirdDateTime(currentHourMs),
+				startTime: formatWarehouseDateTime(oldestHourMs),
+				endTime: formatWarehouseDateTime(currentHourMs),
 			})
 			const existingRows = yield* warehouse.compiledQuery(tenant, existingCompiled, {
 				context: "serviceMapRollupExistingHours",
@@ -100,8 +98,8 @@ export class ServiceMapRollupService extends Context.Service<
 				missing,
 				(hourMs) =>
 					Effect.gen(function* () {
-						const hourStart = toTinybirdDateTime(hourMs)
-						const hourEnd = toTinybirdDateTime(hourMs + HOUR_MS)
+						const hourStart = formatWarehouseDateTime(hourMs)
+						const hourEnd = formatWarehouseDateTime(hourMs + HOUR_MS)
 
 						const rollup = CH.serviceMapEdgesRollupSQL({ orgId, hourStart, hourEnd })
 						const rows = yield* warehouse.compiledQuery(tenant, rollup, {
@@ -159,8 +157,8 @@ export class ServiceMapRollupService extends Context.Service<
 							tenant,
 							CH.serviceMapResolutionsRollupSQL({
 								orgId,
-								hourStart: toTinybirdDateTime(hourMs),
-								hourEnd: toTinybirdDateTime(hourMs + HOUR_MS),
+								hourStart: formatWarehouseDateTime(hourMs),
+								hourEnd: formatWarehouseDateTime(hourMs + HOUR_MS),
 							}),
 							{ context: "serviceMapResolutionsRepair" },
 						)

--- a/apps/api/src/services/SetupAuditService.ts
+++ b/apps/api/src/services/SetupAuditService.ts
@@ -24,7 +24,7 @@ import {
 	type WarehouseAuditInputs,
 	runSetupAudit,
 } from "@maple/domain/setup-audit"
-import { CH } from "@maple/query-engine"
+import { CH, formatWarehouseDateTime } from "@maple/query-engine"
 import { CHNumber } from "@maple/query-engine/ch"
 import { and, eq, sql } from "drizzle-orm"
 import { Clock, Context, Effect, Layer, Schema } from "effect"
@@ -69,8 +69,6 @@ const serviceUsageRowSchema = Schema.Struct({
 	totalHistogramMetricCount: CHNumber,
 	totalExpHistogramMetricCount: CHNumber,
 })
-
-const fmtWarehouseTime = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
 
 const make: Effect.Effect<SetupAuditServiceShape, never, Database | WarehouseQueryService> = Effect.gen(
 	function* () {
@@ -367,9 +365,9 @@ const make: Effect.Effect<SetupAuditServiceShape, never, Database | WarehouseQue
 			const childStart = childEnd - TRACE_WINDOW_MINUTES * 60_000
 			const window = {
 				orgId: tenant.orgId,
-				childStart: fmtWarehouseTime(childStart),
-				childEnd: fmtWarehouseTime(childEnd),
-				parentStart: fmtWarehouseTime(childStart - TRACE_PARENT_LOOKBACK_MINUTES * 60_000),
+				childStart: formatWarehouseDateTime(childStart),
+				childEnd: formatWarehouseDateTime(childEnd),
+				parentStart: formatWarehouseDateTime(childStart - TRACE_PARENT_LOOKBACK_MINUTES * 60_000),
 				traceSampleModulus: CH.auditTraceSampleModulus(spanCountOverLookback),
 			}
 
@@ -409,13 +407,13 @@ const make: Effect.Effect<SetupAuditServiceShape, never, Database | WarehouseQue
 			const now = yield* Clock.currentTimeMillis
 			const window = {
 				orgId: tenant.orgId,
-				startTime: fmtWarehouseTime(now - LOOKBACK_HOURS * 60 * 60 * 1000),
-				endTime: fmtWarehouseTime(now),
+				startTime: formatWarehouseDateTime(now - LOOKBACK_HOURS * 60 * 60 * 1000),
+				endTime: formatWarehouseDateTime(now),
 			}
 			const logWindow = {
 				orgId: tenant.orgId,
-				startTime: fmtWarehouseTime(now - CH.AUDIT_LOG_CORRELATION_MAX_HOURS * 60 * 60 * 1000),
-				endTime: fmtWarehouseTime(now),
+				startTime: formatWarehouseDateTime(now - CH.AUDIT_LOG_CORRELATION_MAX_HOURS * 60 * 60 * 1000),
+				endTime: formatWarehouseDateTime(now),
 			}
 
 			const run = <A>(

--- a/apps/cli/src/commands/analytics.ts
+++ b/apps/cli/src/commands/analytics.ts
@@ -6,6 +6,7 @@ import { printResult } from "../lib/output"
 import { resolveRangeChecked, type Range } from "../core/time"
 import * as Ops from "../core/operations"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 const spanName = Flag.optional(Flag.string("span-name").pipe(Flag.withDescription("Filter by span name")))
 const errorsOnly = Flag.boolean("errors").pipe(
 	Flag.withDescription("Only include errored spans"),
@@ -82,7 +83,6 @@ export const breakdown = Command.make("breakdown", {
 )
 
 const win = 30 * 60 * 1000
-const fmtUTC = (ms: number): string => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
 
 export const compare = Command.make("compare", {
 	around: Flag.optional(
@@ -109,8 +109,11 @@ export const compare = Command.make("compare", {
 					yield* Console.error("--around must be a UTC timestamp 'YYYY-MM-DD HH:mm:ss'")
 					return
 				}
-				current = { startTime: fmtUTC(t), endTime: fmtUTC(t + win) }
-				previous = { startTime: fmtUTC(t - win), endTime: fmtUTC(t) }
+				current = { startTime: formatWarehouseDateTime(t), endTime: formatWarehouseDateTime(t + win) }
+				previous = {
+					startTime: formatWarehouseDateTime(t - win),
+					endTime: formatWarehouseDateTime(t),
+				}
 			} else {
 				const cs = Option.getOrUndefined(a.currentStart)
 				const ce = Option.getOrUndefined(a.currentEnd)

--- a/apps/local-ui/src/lib/time.ts
+++ b/apps/local-ui/src/lib/time.ts
@@ -6,9 +6,10 @@
 
 import { formatRelativeFrom } from "@maple/ui/time-format"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 /** Format an epoch-ms instant as a ClickHouse DateTime string (UTC, second precision). */
 export function toClickHouseDateTime(epochMs: number): string {
-	return new Date(epochMs).toISOString().replace("T", " ").slice(0, 19)
+	return formatWarehouseDateTime(epochMs)
 }
 
 export interface TimeBounds {

--- a/apps/web/src/api/warehouse/custom-charts.ts
+++ b/apps/web/src/api/warehouse/custom-charts.ts
@@ -4,6 +4,7 @@ import {
 	type QueryEngineExecuteResponse,
 	type QuerySpec,
 	type TracesMetric,
+	formatWarehouseDateTime,
 } from "@maple/query-engine"
 import { Clock, Effect, Schema } from "effect"
 
@@ -850,9 +851,8 @@ const getServiceDetailOverviewEffect = Effect.fn("QueryEngine.getServiceDetailOv
 	const input = yield* decodeInput(GetCustomChartServiceDetailInputSchema, data, "getServiceDetailOverview")
 
 	const nowMs = yield* Clock.currentTimeMillis
-	const fmt = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-	const startTime = input.startTime ?? fmt(nowMs - 24 * 60 * 60 * 1000)
-	const endTime = input.endTime ?? fmt(nowMs)
+	const startTime = input.startTime ?? formatWarehouseDateTime(nowMs - 24 * 60 * 60 * 1000)
+	const endTime = input.endTime ?? formatWarehouseDateTime(nowMs)
 	const bucketSeconds = computeBucketSeconds(startTime, endTime)
 
 	const timeseriesRequest = makeAllMetricsTimeseriesRequest({

--- a/apps/web/src/api/warehouse/error-rates.ts
+++ b/apps/web/src/api/warehouse/error-rates.ts
@@ -3,6 +3,7 @@ import { ErrorRateByServiceRequest } from "@maple/domain/http"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import { WarehouseDateTimeString, decodeInput, runWarehouseQuery } from "@/api/warehouse/effect-utils"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 const GetErrorRateByServiceInput = Schema.Struct({
 	startTime: Schema.optional(WarehouseDateTimeString),
 	endTime: Schema.optional(WarehouseDateTimeString),
@@ -11,8 +12,10 @@ const GetErrorRateByServiceInput = Schema.Struct({
 export type GetErrorRateByServiceInput = Schema.Schema.Type<typeof GetErrorRateByServiceInput>
 
 const defaultTimeRange = (nowMillis: number) => {
-	const fmt = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(nowMillis - 24 * 60 * 60 * 1000), endTime: fmt(nowMillis) }
+	return {
+		startTime: formatWarehouseDateTime(nowMillis - 24 * 60 * 60 * 1000),
+		endTime: formatWarehouseDateTime(nowMillis),
+	}
 }
 
 export const getErrorRateByService = Effect.fn("QueryEngine.getErrorRateByService")(function* ({

--- a/apps/web/src/api/warehouse/errors.ts
+++ b/apps/web/src/api/warehouse/errors.ts
@@ -1,5 +1,9 @@
 import { Clock, Effect, Schema } from "effect"
-import { QueryEngineExecuteRequest, warehouseDateTimeToIso } from "@maple/query-engine"
+import {
+	QueryEngineExecuteRequest,
+	warehouseDateTimeToIso,
+	formatWarehouseDateTime,
+} from "@maple/query-engine"
 import {
 	DeploymentEnvironment,
 	ErrorsByTypeRequest,
@@ -105,8 +109,10 @@ const GetErrorsFacetsInputSchema = Schema.Struct({
 export type GetErrorsFacetsInput = (typeof GetErrorsFacetsInputSchema)["Encoded"]
 
 const defaultErrorsTimeRange = (nowMillis: number) => {
-	const fmt = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(nowMillis - 24 * 60 * 60 * 1000), endTime: fmt(nowMillis) }
+	return {
+		startTime: formatWarehouseDateTime(nowMillis - 24 * 60 * 60 * 1000),
+		endTime: formatWarehouseDateTime(nowMillis),
+	}
 }
 
 export function getErrorsFacets({ data }: { data: GetErrorsFacetsInput }) {

--- a/apps/web/src/api/warehouse/logs.ts
+++ b/apps/web/src/api/warehouse/logs.ts
@@ -1,5 +1,5 @@
 import { Clock, Effect, Option, Schema } from "effect"
-import { LogsFacetDimension, QueryEngineExecuteRequest } from "@maple/query-engine"
+import { LogsFacetDimension, QueryEngineExecuteRequest, formatWarehouseDateTime } from "@maple/query-engine"
 import { TraceId, SpanId } from "@maple/domain"
 import {
 	DeploymentEnvironment,
@@ -189,8 +189,10 @@ export function getLogsCount({ data }: { data: ListLogsInput }) {
 }
 
 const defaultLogsTimeRange = (nowMillis: number) => {
-	const fmt = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(nowMillis - 24 * 60 * 60 * 1000), endTime: fmt(nowMillis) }
+	return {
+		startTime: formatWarehouseDateTime(nowMillis - 24 * 60 * 60 * 1000),
+		endTime: formatWarehouseDateTime(nowMillis),
+	}
 }
 
 const getLogsCountEffect = Effect.fn("QueryEngine.getLogsCount")(function* ({

--- a/apps/web/src/api/warehouse/metrics.ts
+++ b/apps/web/src/api/warehouse/metrics.ts
@@ -1,4 +1,4 @@
-import { QueryEngineExecuteRequest } from "@maple/query-engine"
+import { QueryEngineExecuteRequest, formatWarehouseDateTime } from "@maple/query-engine"
 import { Clock, Effect, Schema } from "effect"
 import { ListMetricsRequest, MetricName, MetricsSummaryRequest, ServiceName } from "@maple/domain/http"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
@@ -207,8 +207,10 @@ export function getMetricAttributeKeys({ data }: { data: GetMetricAttributeKeysI
 }
 
 const defaultTimeRange = (nowMillis: number) => {
-	const fmt = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(nowMillis - 24 * 60 * 60 * 1000), endTime: fmt(nowMillis) }
+	return {
+		startTime: formatWarehouseDateTime(nowMillis - 24 * 60 * 60 * 1000),
+		endTime: formatWarehouseDateTime(nowMillis),
+	}
 }
 
 const getMetricAttributeKeysEffect = Effect.fn("QueryEngine.getMetricAttributeKeys")(function* ({

--- a/apps/web/src/api/warehouse/planetscale-infra.ts
+++ b/apps/web/src/api/warehouse/planetscale-infra.ts
@@ -3,6 +3,7 @@ import { PlanetScaleInfraTimeseriesRequest, PlanetScaleQueryInsightsRequest } fr
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import { WarehouseDateTimeString, decodeInput, runWarehouseQuery } from "@/api/warehouse/effect-utils"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 /**
  * /infra/planetscale data access. The fleet view composes the polled inventory
  * (integrations `planetscaleDatabases`) with the service-map stat rollups; the
@@ -31,8 +32,10 @@ const GetPlanetScaleInfraTimeseriesInputSchema = Schema.Struct({
 export type GetPlanetScaleInfraTimeseriesInput = (typeof GetPlanetScaleInfraTimeseriesInputSchema)["Encoded"]
 
 const defaultTimeRange = (nowMillis: number) => {
-	const fmt = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(nowMillis - 24 * 60 * 60 * 1000), endTime: fmt(nowMillis) }
+	return {
+		startTime: formatWarehouseDateTime(nowMillis - 24 * 60 * 60 * 1000),
+		endTime: formatWarehouseDateTime(nowMillis),
+	}
 }
 
 export interface PlanetScaleQueryInsightEntry {

--- a/apps/web/src/api/warehouse/service-map.ts
+++ b/apps/web/src/api/warehouse/service-map.ts
@@ -15,6 +15,7 @@ import { summarizeSampling } from "@/lib/sampling"
 import { WarehouseDateTimeString, decodeInput, runWarehouseQuery } from "@/api/warehouse/effect-utils"
 import { transformExternalEdge } from "@/api/warehouse/service-external-edges"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 export interface ServiceEdge {
 	sourceService: string
 	targetService: string
@@ -141,8 +142,10 @@ function transformEdge(row: Record<string, unknown>, durationSeconds: number): S
 }
 
 const defaultTimeRange = (nowMillis: number) => {
-	const fmt = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(nowMillis - 24 * 60 * 60 * 1000), endTime: fmt(nowMillis) }
+	return {
+		startTime: formatWarehouseDateTime(nowMillis - 24 * 60 * 60 * 1000),
+		endTime: formatWarehouseDateTime(nowMillis),
+	}
 }
 
 export const getServiceMap = Effect.fn("QueryEngine.getServiceMap")(function* ({

--- a/apps/web/src/api/warehouse/service-usage.ts
+++ b/apps/web/src/api/warehouse/service-usage.ts
@@ -3,6 +3,7 @@ import { ServiceName, ServiceUsageRequest } from "@maple/domain/http"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import { WarehouseDateTimeString, decodeInput, runWarehouseQuery } from "@/api/warehouse/effect-utils"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 interface ServiceUsage {
 	serviceName: string
 	totalLogs: number
@@ -39,8 +40,10 @@ const GetServiceUsageInput = Schema.Struct({
 export type GetServiceUsageInput = (typeof GetServiceUsageInput)["Encoded"]
 
 const defaultTimeRange = (nowMillis: number) => {
-	const fmt = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(nowMillis - 24 * 60 * 60 * 1000), endTime: fmt(nowMillis) }
+	return {
+		startTime: formatWarehouseDateTime(nowMillis - 24 * 60 * 60 * 1000),
+		endTime: formatWarehouseDateTime(nowMillis),
+	}
 }
 
 export const getServiceUsage = Effect.fn("QueryEngine.getServiceUsage")(function* ({

--- a/apps/web/src/api/warehouse/services.ts
+++ b/apps/web/src/api/warehouse/services.ts
@@ -1,5 +1,5 @@
 import { Clock, Effect, Schema } from "effect"
-import { QueryEngineExecuteRequest } from "@maple/query-engine"
+import { QueryEngineExecuteRequest, formatWarehouseDateTime } from "@maple/query-engine"
 import {
 	CommitSha,
 	DeploymentEnvironment,
@@ -361,8 +361,6 @@ const floorToHour = (dateTime: string) => `${dateTime.slice(0, 13)}:00:00`
 
 const warehouseDateTimeToMs = (dateTime: string) => new Date(`${dateTime.replace(" ", "T")}Z`).getTime()
 
-const msToWarehouseDateTime = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-
 export function getServiceHealthBaseline({ data }: { data: GetServiceHealthBaselineInput }) {
 	return getServiceHealthBaselineEffect({ data })
 }
@@ -373,10 +371,10 @@ const getServiceHealthBaselineEffect = Effect.fn("QueryEngine.getServiceHealthBa
 	data: GetServiceHealthBaselineInput
 }) {
 	const input = yield* decodeInput(GetServiceHealthBaselineInput, data ?? {}, "getServiceHealthBaseline")
-	const nowDateTime = msToWarehouseDateTime(yield* Clock.currentTimeMillis)
+	const nowDateTime = formatWarehouseDateTime(yield* Clock.currentTimeMillis)
 
 	const endTime = floorToHour(input.rangeStartTime ?? nowDateTime)
-	const startTime = msToWarehouseDateTime(warehouseDateTimeToMs(endTime) - BASELINE_WINDOW_MS)
+	const startTime = formatWarehouseDateTime(warehouseDateTimeToMs(endTime) - BASELINE_WINDOW_MS)
 
 	const response = yield* runWarehouseQuery("serviceHealthBaseline", () =>
 		Effect.gen(function* () {
@@ -477,8 +475,10 @@ const GetServicesFacetsInput = Schema.Struct({
 export type GetServicesFacetsInput = Schema.Schema.Type<typeof GetServicesFacetsInput>
 
 const defaultServicesTimeRange = (nowMillis: number) => {
-	const fmt = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(nowMillis - 24 * 60 * 60 * 1000), endTime: fmt(nowMillis) }
+	return {
+		startTime: formatWarehouseDateTime(nowMillis - 24 * 60 * 60 * 1000),
+		endTime: formatWarehouseDateTime(nowMillis),
+	}
 }
 
 export function getServicesFacets({ data }: { data: GetServicesFacetsInput }) {

--- a/apps/web/src/api/warehouse/traces.ts
+++ b/apps/web/src/api/warehouse/traces.ts
@@ -1,5 +1,10 @@
 import { Clock, Effect, Schema } from "effect"
-import { QueryEngineExecuteRequest, TracesFacetDimension, type AttributeFilter } from "@maple/query-engine"
+import {
+	QueryEngineExecuteRequest,
+	TracesFacetDimension,
+	type AttributeFilter,
+	formatWarehouseDateTime,
+} from "@maple/query-engine"
 import { TraceId, SpanId } from "@maple/domain"
 import {
 	DeploymentEnvironment,
@@ -670,8 +675,10 @@ export function getSpanAttributeKeys({ data }: { data: GetSpanAttributeKeysInput
 }
 
 const defaultTimeRange = (nowMillis: number) => {
-	const fmt = (ms: number) => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(nowMillis - 24 * 60 * 60 * 1000), endTime: fmt(nowMillis) }
+	return {
+		startTime: formatWarehouseDateTime(nowMillis - 24 * 60 * 60 * 1000),
+		endTime: formatWarehouseDateTime(nowMillis),
+	}
 }
 
 const getSpanAttributeKeysEffect = Effect.fn("QueryEngine.getSpanAttributeKeys")(function* ({

--- a/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.tsx
+++ b/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.tsx
@@ -23,7 +23,13 @@ function sameLayout(a: Layout, b: Layout): boolean {
 	const byId = new Map(b.map((item) => [item.i, item]))
 	return a.every((item) => {
 		const other = byId.get(item.i)
-		return other !== undefined && other.x === item.x && other.y === item.y && other.w === item.w && other.h === item.h
+		return (
+			other !== undefined &&
+			other.x === item.x &&
+			other.y === item.y &&
+			other.w === item.w &&
+			other.h === item.h
+		)
 	})
 }
 
@@ -84,13 +90,18 @@ function useInViewportSticky() {
 const WidgetRenderer = memo(function WidgetRenderer({ widget }: { widget: DashboardWidget }) {
 	const { mode } = useDashboardActions()
 	const { ref, visible } = useInViewportSticky()
-	const { dataState } = useWidgetData(widget, visible)
+	const { dataState, narrowRange, narrowRangeLabel } = useWidgetData(widget, visible)
 	const Visualization = visualizationFor(widget.visualization)
 
 	return (
 		<div ref={ref} className="h-full w-full">
 			<WidgetTimeRangeProvider timeRange={widget.timeRange}>
-				<WidgetActionsProvider widget={widget} dataState={dataState}>
+				<WidgetActionsProvider
+					widget={widget}
+					dataState={dataState}
+					narrowRange={narrowRange}
+					narrowRangeLabel={narrowRangeLabel}
+				>
 					<Visualization
 						dataState={dataState}
 						display={widget.display}

--- a/apps/web/src/components/dashboard-builder/types.ts
+++ b/apps/web/src/components/dashboard-builder/types.ts
@@ -105,7 +105,13 @@ export type WidgetLayout = DeepMutable<typeof WidgetLayoutSchema.Type>
  */
 export type VisualizationType = WidgetVisualization
 export type WidgetMode = "view" | "edit"
-type WidgetErrorKind = "decode" | "runtime"
+/**
+ * `range` is a constraint rather than a failure: the tile's query kind can't
+ * span the requested window (list widgets cap out well below charts), so it
+ * renders a muted explanation with a one-click narrowing instead of a red
+ * error block — and never issues the doomed request in the first place.
+ */
+type WidgetErrorKind = "decode" | "runtime" | "range"
 export type WidgetDataState =
 	| { status: "loading" }
 	| { status: "error"; title?: string; message?: string; kind?: WidgetErrorKind }

--- a/apps/web/src/components/dashboard-builder/widgets/widget-actions-context.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/widget-actions-context.tsx
@@ -15,6 +15,14 @@ export interface WidgetActions {
 	configure?: () => void
 	createAlert?: () => void
 	fix?: () => void
+	/**
+	 * Pulls just this tile back to the widest window its query kind supports.
+	 * Present only while the tile is blocked on a `range` error; local to the
+	 * session, so it works on read-only dashboards too.
+	 */
+	narrowRange?: () => void
+	/** Label for `narrowRange`, e.g. "Show last 7 days". */
+	narrowRangeLabel?: string
 }
 
 const WidgetActionsContext = createContext<WidgetActions | null>(null)
@@ -39,6 +47,9 @@ export function WidgetActionsScope({ actions, children }: { actions: WidgetActio
 interface WidgetActionsProviderProps {
 	widget: DashboardWidget
 	dataState: WidgetDataState
+	/** Supplied by `useWidgetData` when the tile is blocked on its range cap. */
+	narrowRange?: () => void
+	narrowRangeLabel?: string
 	children: ReactNode
 }
 
@@ -48,7 +59,13 @@ interface WidgetActionsProviderProps {
  * keeps the per-widget action wiring out of the canvas renderer and out of the
  * widget components' prop interfaces.
  */
-export function WidgetActionsProvider({ widget, dataState, children }: WidgetActionsProviderProps) {
+export function WidgetActionsProvider({
+	widget,
+	dataState,
+	narrowRange,
+	narrowRangeLabel,
+	children,
+}: WidgetActionsProviderProps) {
 	const { readOnly, removeWidget, cloneWidget, configureWidget, dashboardId } = useDashboardActions()
 	const navigate = useNavigate()
 
@@ -121,7 +138,7 @@ export function WidgetActionsProvider({ widget, dataState, children }: WidgetAct
 					}
 				: undefined
 
-		return { remove, clone, configure, createAlert, fix }
+		return { remove, clone, configure, createAlert, fix, narrowRange, narrowRangeLabel }
 	}, [
 		widget,
 		readOnly,
@@ -133,6 +150,8 @@ export function WidgetActionsProvider({ widget, dataState, children }: WidgetAct
 		errorTitle,
 		errorMessage,
 		navigate,
+		narrowRange,
+		narrowRangeLabel,
 	])
 
 	return <WidgetActionsContext value={actions}>{children}</WidgetActionsContext>

--- a/apps/web/src/components/dashboard-builder/widgets/widget-shell.tsx
+++ b/apps/web/src/components/dashboard-builder/widgets/widget-shell.tsx
@@ -236,9 +236,11 @@ export function WidgetFrame({
 	footer,
 	children,
 }: WidgetFrameProps) {
-	// `WidgetShell` resolves the menu actions against context itself; `fix`
-	// drives the inline error CTA below, so it is resolved here too.
-	const fix = useWidgetActions()?.fix
+	// `WidgetShell` resolves the menu actions against context itself; `fix` and
+	// `narrowRange` drive the inline error CTAs below, so they are resolved here.
+	const actions = useWidgetActions()
+	const fix = actions?.fix
+	const narrowRange = actions?.narrowRange
 
 	return (
 		<WidgetShell
@@ -253,6 +255,31 @@ export function WidgetFrame({
 				dataState.message === "No query data found in selected time range" ? (
 					<div className="flex items-center justify-center h-full">
 						<span className="text-xs text-muted-foreground">No data in selected time range</span>
+					</div>
+				) : dataState.kind === "range" ? (
+					// A constraint, not a failure — muted like the empty state rather
+					// than destructive, since nothing is broken and the neighbouring
+					// charts on this dashboard are showing the full window fine.
+					<div className="flex items-center justify-center h-full flex-col gap-1.5 px-3">
+						<span className="text-xs font-medium text-muted-foreground">
+							{dataState.title ?? "Range too wide"}
+						</span>
+						{dataState.message && (
+							<span className="text-[10px] text-muted-foreground/70 max-w-full text-center line-clamp-3">
+								{dataState.message}
+							</span>
+						)}
+						{narrowRange && (
+							<Button
+								variant="outline"
+								size="xs"
+								onClick={narrowRange}
+								className="mt-1 h-6 gap-1 text-[10px]"
+							>
+								<ClockIcon size={12} />
+								{actions?.narrowRangeLabel ?? "Narrow range"}
+							</Button>
+						)}
 					</div>
 				) : (
 					<div className="flex items-center justify-center h-full flex-col gap-1.5 px-3">

--- a/apps/web/src/components/dashboard/service-usage-cards.tsx
+++ b/apps/web/src/components/dashboard/service-usage-cards.tsx
@@ -9,6 +9,7 @@ import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import type { ServiceUsageResponse, ServiceUsageTotals } from "@/api/warehouse/service-usage"
 import { normalizeTimestampInput } from "@/lib/timezone-format"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 type CardKey = "logs" | "traces" | "metrics" | "dataSize"
 
 const cardConfig: Array<{
@@ -50,8 +51,10 @@ function shiftRangeBack(startTime?: string, endTime?: string) {
 	const duration = end.getTime() - start.getTime()
 	const prevEnd = new Date(start.getTime())
 	const prevStart = new Date(start.getTime() - duration)
-	const fmt = (d: Date) => d.toISOString().replace("T", " ").slice(0, 19)
-	return { startTime: fmt(prevStart), endTime: fmt(prevEnd) }
+	return {
+		startTime: formatWarehouseDateTime(prevStart.getTime()),
+		endTime: formatWarehouseDateTime(prevEnd.getTime()),
+	}
 }
 
 function DeltaChip({ current, previous }: { current: number; previous: number }) {

--- a/apps/web/src/components/replays/preview-fixtures.ts
+++ b/apps/web/src/components/replays/preview-fixtures.ts
@@ -12,6 +12,7 @@ import { EventType, IncrementalSource, MouseInteractions } from "@rrweb/types"
 import type { SessionTraceSummary } from "./replay-editor-timeline"
 import type { EventRow } from "./session-events-panel"
 
+import { formatWarehouseDateTimeMs } from "@maple/query-engine"
 // rrweb-snapshot NodeType (not re-exported from @rrweb/types).
 const NodeType = { Document: 0, DocumentType: 1, Element: 2, Text: 3 } as const
 
@@ -19,8 +20,7 @@ const NodeType = { Document: 0, DocumentType: 1, Element: 2, Text: 3 } as const
 const BASE_EPOCH_MS = Date.now() - 5 * 60 * 1000
 const ts = (offsetMs: number) => BASE_EPOCH_MS + offsetMs
 /** Epoch → ClickHouse DateTime64 string (UTC, space-separated) for warehouse-shaped rows. */
-const ch = (offsetMs: number) =>
-	new Date(BASE_EPOCH_MS + offsetMs).toISOString().replace("T", " ").replace("Z", "")
+const ch = (offsetMs: number) => formatWarehouseDateTimeMs(BASE_EPOCH_MS + offsetMs)
 
 const VIEWPORT = { width: 1280, height: 720 }
 const INITIAL_URL = "https://app.acme.dev/dashboard"

--- a/apps/web/src/components/replays/replay-format.ts
+++ b/apps/web/src/components/replays/replay-format.ts
@@ -1,4 +1,4 @@
-import { warehouseDateTimeToIso } from "@maple/query-engine"
+import { warehouseDateTimeToIso, formatWarehouseDateTime } from "@maple/query-engine"
 import type { ActionKind } from "./replay-player-context"
 
 // Presentation helpers for the session-replay surfaces (list, detail, player,
@@ -74,7 +74,6 @@ export interface ReplayPartitionWindow {
 }
 
 /** Format an epoch-ms instant as a `YYYY-MM-DD HH:mm:ss` (UTC) TinybirdDateTime string. */
-const toWarehouseDateTime = (ms: number): string => new Date(ms).toISOString().replace("T", " ").slice(0, 19)
 
 /**
  * Derive `{ windowStart, windowEnd }` (TinybirdDateTime strings) bounding a
@@ -92,7 +91,7 @@ export function replayPartitionWindow(
 	const endMs = endHint ? Date.parse(warehouseDateTimeToIso(endHint)) : Number.NaN
 	const upperMs = Number.isNaN(endMs) ? startMs + MAX_SESSION_MS : endMs + WINDOW_MARGIN_MS
 	return {
-		windowStart: toWarehouseDateTime(startMs - WINDOW_MARGIN_MS),
-		windowEnd: toWarehouseDateTime(upperMs),
+		windowStart: formatWarehouseDateTime(startMs - WINDOW_MARGIN_MS),
+		windowEnd: formatWarehouseDateTime(upperMs),
 	}
 }

--- a/apps/web/src/components/replays/replay-timeline.test.ts
+++ b/apps/web/src/components/replays/replay-timeline.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest"
+import { formatWarehouseDateTimeMs } from "@maple/query-engine"
 import {
 	buildTimeline,
 	COLLAPSED_GAP_MS,
@@ -136,8 +137,7 @@ describe("parseChTimestampMs", () => {
 describe("spanDisplayRange", () => {
 	// Recording starts at this epoch ms; the playhead's time-zero.
 	const recordingStartEpochMs = Date.UTC(2026, 4, 22, 10, 30, 45, 0)
-	const isoAt = (offsetMs: number) =>
-		new Date(recordingStartEpochMs + offsetMs).toISOString().replace("T", " ").replace("Z", "")
+	const isoAt = (offsetMs: number) => formatWarehouseDateTimeMs(recordingStartEpochMs + offsetMs)
 
 	it("maps a span's absolute start to a rrweb-relative offset (identity timeline)", () => {
 		const timeline = buildTimeline([], 60_000)

--- a/apps/web/src/components/services/service-usage-panel.tsx
+++ b/apps/web/src/components/services/service-usage-panel.tsx
@@ -8,6 +8,7 @@ import type { ServiceUsageTotals } from "@/api/warehouse/service-usage"
 import { normalizeTimestampInput } from "@/lib/timezone-format"
 import { SectionCard } from "./section-card"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 interface ServiceUsagePanelProps {
 	serviceName: string
 	effectiveStartTime: string
@@ -21,11 +22,6 @@ interface ServiceUsagePanelProps {
 	envFilterActive?: boolean
 }
 
-/** Format a warehouse datetime back into the "YYYY-MM-DD HH:mm:ss" wire shape. */
-function toWarehouseString(ms: number): string {
-	return new Date(ms).toISOString().replace("T", " ").slice(0, 19)
-}
-
 /** The previous window of equal duration ending where the current one starts. */
 function previousWindow(startTime: string, endTime: string) {
 	const start = new Date(normalizeTimestampInput(startTime)).getTime()
@@ -33,8 +29,8 @@ function previousWindow(startTime: string, endTime: string) {
 	if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return undefined
 	const duration = end - start
 	return {
-		previousStartTime: toWarehouseString(start - duration),
-		previousEndTime: toWarehouseString(start),
+		previousStartTime: formatWarehouseDateTime(start - duration),
+		previousEndTime: formatWarehouseDateTime(start),
 	}
 }
 

--- a/apps/web/src/components/widget-lab/scenarios.ts
+++ b/apps/web/src/components/widget-lab/scenarios.ts
@@ -37,6 +37,14 @@ const decodeErrorState: WidgetDataState = {
 	kind: "decode",
 }
 
+const rangeErrorState: WidgetDataState = {
+	status: "error",
+	title: "Range too wide for this list",
+	message:
+		"Lists show individual records, so they cover at most 7 days. Charts on this dashboard are unaffected.",
+	kind: "range",
+}
+
 const ready = <T>(data: T): WidgetDataState => ({ status: "ready", data })
 
 // ---------------------------------------------------------------------------
@@ -553,9 +561,7 @@ function makeTrailingBucketSeries(lastBucket: { api: number; worker: number } | 
 		return {
 			bucket: new Date(currentBucketStart - (12 - i) * hour).toISOString(),
 			"demo-api": isCurrent ? (lastBucket?.api ?? 0) : 900 + Math.round(180 * Math.sin(i / 2)),
-			"demo-worker": isCurrent
-				? (lastBucket?.worker ?? 0)
-				: 420 + Math.round(90 * Math.cos(i / 3)),
+			"demo-worker": isCurrent ? (lastBucket?.worker ?? 0) : 420 + Math.round(90 * Math.cos(i / 3)),
 		}
 	})
 }
@@ -1049,6 +1055,20 @@ const logRows = [
 ]
 
 export const listScenarios: WidgetScenario[] = [
+	{
+		// Muted rather than destructive: the dashboard's charts render the full
+		// window fine, only this tile's query kind can't span it.
+		label: "Range too wide",
+		dataState: rangeErrorState,
+		display: {
+			title: "Recent traces",
+			listDataSource: "traces",
+			columns: [
+				{ field: "traceId", header: "Trace" },
+				{ field: "spanName", header: "Operation" },
+			],
+		},
+	},
 	{
 		label: "Recent traces",
 		dataState: ready(traceRows),

--- a/apps/web/src/hooks/use-widget-data.ts
+++ b/apps/web/src/hooks/use-widget-data.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { Atom, Result } from "@/lib/effect-atom"
 import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { Effect, Schedule, Schema } from "effect"
@@ -28,6 +28,9 @@ import { formatBackendError } from "@/lib/error-messages"
 import { Cause, Option } from "effect"
 import { WarehouseDecodeError, type BackendError } from "@/api/warehouse/effect-utils"
 import { QueryEngineValidationError } from "@maple/domain/http"
+import { MAX_LIST_RANGE_SECONDS, formatRangeSeconds } from "@maple/query-engine"
+import { formatForTinybird } from "@/lib/time-utils"
+import { normalizeTimestampInput } from "@/lib/timezone-format"
 
 // An error means "the query input/response failed validation" (rather than a
 // transient runtime failure) when it is one of these tagged validation errors,
@@ -40,12 +43,30 @@ const isDecodeError = (value: unknown): boolean =>
 const extractError = (input: unknown): unknown =>
 	Cause.isCause(input) ? Option.getOrElse(Cause.findErrorOption(input), () => input) : input
 
-const classifyWidgetErrorKind = (input: unknown): "decode" | "runtime" => {
+// A validation error the engine raised because the window is wider than the
+// query kind supports. Classified apart from other decode errors so the tile
+// renders the muted "narrow your range" state instead of a red block with a
+// "Fix with AI" button — there is nothing about the widget to fix.
+const isRangeError = (value: unknown): boolean =>
+	value instanceof QueryEngineValidationError && /time range too large/i.test(value.message)
+
+const classifyWidgetErrorKind = (input: unknown): "decode" | "runtime" | "range" => {
 	const error = extractError(input)
+	if (isRangeError(error)) return "range"
+	if (error instanceof WidgetDataAtomError && isRangeError(error.cause)) return "range"
 	if (isDecodeError(error)) return "decode"
 	if (error instanceof WidgetDataAtomError && isDecodeError(error.cause)) return "decode"
 	return "runtime"
 }
+
+// Endpoints whose queries are `kind: "list"` — they scan raw rows and so carry
+// the engine's much tighter list ceiling.
+const LIST_ENDPOINTS: ReadonlySet<string> = new Set(["custom_query_builder_list", "list_traces", "list_logs"])
+
+const rangeSecondsOf = (range: { startTime: string; endTime: string }): number =>
+	(Date.parse(normalizeTimestampInput(range.endTime)) -
+		Date.parse(normalizeTimestampInput(range.startTime))) /
+	1000
 
 function isSeriesNameHidden(seriesName: string, hiddenBaseNames: Set<string>): boolean {
 	for (const base of hiddenBaseNames) {
@@ -363,7 +384,7 @@ export function useWidgetDataSource(
 	const override = timeRangeOverride ?? contextOverride ?? undefined
 	const overrideKey = override ? encodeKey(override) : null
 
-	const resolvedTimeRange = useMemo(
+	const effectiveTimeRange = useMemo(
 		() => (override ? resolveTimeRange(override) : dashboardTimeRange),
 		// Keyed on the serialized override, not its identity: the dashboard object
 		// is rebuilt on every optimistic write, and re-resolving an unchanged
@@ -374,6 +395,29 @@ export function useWidgetDataSource(
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[overrideKey, dashboardTimeRange],
 	)
+
+	// A list-kind tile on a window wider than the engine's list cap. Detected
+	// here rather than left to the API so the tile never fires a request that is
+	// certain to 400 (and never burns the fetch's two retries on it).
+	const exceedsListCap =
+		dataSource !== undefined &&
+		LIST_ENDPOINTS.has(dataSource.endpoint) &&
+		effectiveTimeRange !== null &&
+		rangeSecondsOf(effectiveTimeRange) > MAX_LIST_RANGE_SECONDS
+
+	// Opt-in, per-tile, not persisted: the viewer can pull just this tile back to
+	// the cap without touching the dashboard's range or needing write access.
+	const [narrowedToCap, setNarrowedToCap] = useState(false)
+	const narrowed = narrowedToCap && exceedsListCap
+
+	const resolvedTimeRange = useMemo(() => {
+		if (!narrowed || !effectiveTimeRange) return effectiveTimeRange
+		const endMs = Date.parse(normalizeTimestampInput(effectiveTimeRange.endTime))
+		return {
+			startTime: formatForTinybird(new Date(endMs - MAX_LIST_RANGE_SECONDS * 1000)),
+			endTime: effectiveTimeRange.endTime,
+		}
+	}, [narrowed, effectiveTimeRange])
 	const variablesContext = useDashboardVariablesOptional()
 
 	const isStatic = dataSource?.endpoint === "markdown_static"
@@ -427,14 +471,30 @@ export function useWidgetDataSource(
 	// where useAtomValue / useAtomRefresh re-subscribe and drop an in-flight
 	// fetch (the user-visible symptom: widgets stuck on the loading skeleton).
 	const fetchAtom = useMemo(() => {
-		if (disableReason !== null || isStatic || !dataSource || !enabled || waitingOnVariables) {
+		if (
+			disableReason !== null ||
+			isStatic ||
+			!dataSource ||
+			!enabled ||
+			waitingOnVariables ||
+			(exceedsListCap && !narrowed)
+		) {
 			return disabledResultAtom<unknown, WidgetFetchError>()
 		}
 		return widgetFetchAtom({
 			endpoint: dataSource.endpoint,
 			params: resolvedParams,
 		})
-	}, [disableReason, isStatic, dataSource, resolvedParams, enabled, waitingOnVariables])
+	}, [
+		disableReason,
+		isStatic,
+		dataSource,
+		resolvedParams,
+		enabled,
+		waitingOnVariables,
+		exceedsListCap,
+		narrowed,
+	])
 
 	const result = useRefreshableAtomValue(fetchAtom)
 
@@ -453,6 +513,14 @@ export function useWidgetDataSource(
 		if (disableReason) {
 			return { status: "error", message: disableReason } as const
 		}
+		if (exceedsListCap && !narrowed) {
+			return {
+				status: "error",
+				kind: "range",
+				title: `Range too wide for this list`,
+				message: `Lists show individual records, so they cover at most ${formatRangeSeconds(MAX_LIST_RANGE_SECONDS)}. Charts on this dashboard are unaffected.`,
+			} as const
+		}
 		return Result.builder(result)
 			.onInitial(() => ({ status: "loading" }) as const)
 			.onError((error) => {
@@ -468,10 +536,20 @@ export function useWidgetDataSource(
 			})
 			.onSuccess((rawData) => ({ status: "ready", data: applyTransform(rawData, transform) }) as const)
 			.orElse(() => ({ status: "error", message: "Unknown error" }) as const)
-	}, [result, transform, disableReason, isStatic, enabled, waitingOnVariables])
+	}, [result, transform, disableReason, isStatic, enabled, waitingOnVariables, exceedsListCap, narrowed])
+
+	// Offered only while the tile is actually blocked, so the frame can render
+	// the action without knowing anything about time ranges.
+	const narrowRange = useMemo(
+		() => (exceedsListCap && !narrowed ? () => setNarrowedToCap(true) : undefined),
+		[exceedsListCap, narrowed],
+	)
 
 	return {
 		dataState,
+		narrowRange,
+		/** Label for the narrowing action, e.g. "Show last 7 days". */
+		narrowRangeLabel: `Show last ${formatRangeSeconds(MAX_LIST_RANGE_SECONDS)}`,
 	}
 }
 

--- a/apps/web/src/lib/error-messages.test.ts
+++ b/apps/web/src/lib/error-messages.test.ts
@@ -35,14 +35,28 @@ describe("formatBackendError", () => {
 		expect(result.description).toContain("30 seconds")
 	})
 
-	it("formats QueryEngineValidationError with details", () => {
+	it("keeps the engine's message as the title and details as the description", () => {
 		const result = formatBackendError({
 			_tag: "@maple/http/errors/QueryEngineValidationError",
-			message: "invalid",
-			details: ["startTime must be before endTime", "limit too high"],
+			message: "List query time range too large",
+			details: ["List queries support a maximum range of 7 days", "Narrow the time range"],
 		})
-		expect(result.title).toBe("Invalid query parameters")
-		expect(result.description).toBe("startTime must be before endTime; limit too high")
+		// The specific headline used to be discarded in favour of a generic
+		// "Invalid query parameters" whenever details were present.
+		expect(result.title).toBe("List query time range too large")
+		expect(result.description).toBe(
+			"List queries support a maximum range of 7 days; Narrow the time range",
+		)
+	})
+
+	it("falls back to the message as the description when there are no details", () => {
+		const result = formatBackendError({
+			_tag: "@maple/http/errors/QueryEngineValidationError",
+			message: "Invalid time range",
+			details: [],
+		})
+		expect(result.title).toBe("Invalid time range")
+		expect(result.description).toBe("Invalid time range")
 	})
 
 	it("formats QueryEngineExecutionError with causeMessage", () => {

--- a/apps/web/src/lib/error-messages.ts
+++ b/apps/web/src/lib/error-messages.ts
@@ -119,7 +119,10 @@ export const formatBackendError = (input: unknown): FormattedError => {
 				const message = stringField(error, "message") ?? "Invalid query parameters"
 				const details = stringArrayField(error, "details") ?? []
 				return {
-					title: "Invalid query parameters",
+					// The engine's `message` is the specific headline ("List query time
+					// range too large"); a generic title here discarded it whenever
+					// `details` was populated, which is nearly always.
+					title: message,
 					description: details.length > 0 ? details.join("; ") : message,
 				}
 			}

--- a/apps/web/src/lib/time-utils.ts
+++ b/apps/web/src/lib/time-utils.ts
@@ -1,11 +1,13 @@
-import { subMinutes, subHours, subDays, subWeeks, subMonths, startOfDay, format } from "date-fns"
-import { relativeRangeSeconds } from "@maple/query-engine"
+import { format } from "date-fns"
+import { formatWarehouseDateTime, resolveRelativeRangeToWarehouse } from "@maple/query-engine"
 import { normalizeTimestampInput } from "@/lib/timezone-format"
 
-// Format date for Tinybird/ClickHouse DateTime compatibility
-// Converts to ClickHouse format: "YYYY-MM-DD HH:mm:ss"
+/**
+ * Format a Date as the ClickHouse/Tinybird `YYYY-MM-DD HH:mm:ss` shape.
+ * Thin Date-taking wrapper over the shared epoch-ms formatter.
+ */
 export function formatForTinybird(date: Date): string {
-	return date.toISOString().replace("T", " ").slice(0, 19)
+	return formatWarehouseDateTime(date.getTime())
 }
 
 export interface TimePreset {
@@ -30,46 +32,17 @@ export function isTimeRangeWithin(
 	return Number.isFinite(durationSeconds) && durationSeconds >= 0 && durationSeconds <= maxRangeSeconds
 }
 
-const TIME_UNITS: Record<string, (date: Date, amount: number) => Date> = {
-	m: subMinutes,
-	h: subHours,
-	d: subDays,
-	w: subWeeks,
-	mo: subMonths,
-}
-
 /**
  * Resolve a relative shorthand ("15m", "7d", "3mo", "today") to an absolute
- * window. Validity is gated by the shared `relativeRangeSeconds` grammar so the
- * ranges this app offers can never drift from the ones the API accepts; the
- * calendar-correct conversion stays here because it needs date-fns.
+ * window.
+ *
+ * Delegates to the shared resolver so this app, the API, and the query engine
+ * can't drift on what a shorthand means. The shared implementation reproduces
+ * date-fns' local-calendar semantics — month-end clamping and local midnight
+ * for "today" — so behaviour here is unchanged.
  */
 export function relativeToAbsolute(shorthand: string): { startTime: string; endTime: string } | null {
-	if (relativeRangeSeconds(shorthand) === null) return null
-
-	const trimmed = shorthand.trim().toLowerCase()
-	const now = new Date()
-
-	if (trimmed === "today") {
-		return {
-			startTime: formatForTinybird(startOfDay(now)),
-			endTime: formatForTinybird(now),
-		}
-	}
-
-	const match = trimmed.match(/^(\d+)(mo|m|h|d|w)$/)
-	if (!match) return null
-
-	const [, amountStr, unit] = match
-	const amount = parseInt(amountStr, 10)
-
-	const subtractor = TIME_UNITS[unit]
-	if (!subtractor) return null
-
-	return {
-		startTime: formatForTinybird(subtractor(now, amount)),
-		endTime: formatForTinybird(now),
-	}
+	return resolveRelativeRangeToWarehouse(shorthand)
 }
 
 export function presetLabel(shorthand: string): string {

--- a/apps/web/src/lib/time-utils.ts
+++ b/apps/web/src/lib/time-utils.ts
@@ -1,4 +1,5 @@
 import { subMinutes, subHours, subDays, subWeeks, subMonths, startOfDay, format } from "date-fns"
+import { relativeRangeSeconds } from "@maple/query-engine"
 import { normalizeTimestampInput } from "@/lib/timezone-format"
 
 // Format date for Tinybird/ClickHouse DateTime compatibility
@@ -37,7 +38,15 @@ const TIME_UNITS: Record<string, (date: Date, amount: number) => Date> = {
 	mo: subMonths,
 }
 
+/**
+ * Resolve a relative shorthand ("15m", "7d", "3mo", "today") to an absolute
+ * window. Validity is gated by the shared `relativeRangeSeconds` grammar so the
+ * ranges this app offers can never drift from the ones the API accepts; the
+ * calendar-correct conversion stays here because it needs date-fns.
+ */
 export function relativeToAbsolute(shorthand: string): { startTime: string; endTime: string } | null {
+	if (relativeRangeSeconds(shorthand) === null) return null
+
 	const trimmed = shorthand.trim().toLowerCase()
 	const now = new Date()
 

--- a/apps/web/src/lib/trace-time-window.ts
+++ b/apps/web/src/lib/trace-time-window.ts
@@ -1,3 +1,4 @@
+import { formatWarehouseDateTime } from "@maple/query-engine"
 /**
  * Derive a warehouse query window around a single trace timestamp.
  *
@@ -14,8 +15,6 @@
  */
 const DEFAULT_HALF_WIDTH_HOURS = 1
 
-const tinybirdDateTime = (d: Date): string => d.toISOString().replace("T", " ").slice(0, 19)
-
 export function computeTraceTimeWindow(
 	timestamp: string | undefined,
 	halfWidthHours = DEFAULT_HALF_WIDTH_HOURS,
@@ -26,7 +25,7 @@ export function computeTraceTimeWindow(
 	if (Number.isNaN(t.getTime())) return undefined
 	const halfWidthMs = halfWidthHours * 60 * 60 * 1000
 	return {
-		startTime: tinybirdDateTime(new Date(t.getTime() - halfWidthMs)),
-		endTime: tinybirdDateTime(new Date(t.getTime() + halfWidthMs)),
+		startTime: formatWarehouseDateTime(t.getTime() - halfWidthMs),
+		endTime: formatWarehouseDateTime(t.getTime() + halfWidthMs),
 	}
 }

--- a/apps/web/src/routes/flow-lab.tsx
+++ b/apps/web/src/routes/flow-lab.tsx
@@ -6,6 +6,7 @@ import { TraceFlowView } from "@maple/ui/components/traces/flow-view"
 import { buildTraceDetail, type SpanHierarchyRow } from "@maple/ui/lib/span-tree"
 import type { SpanNode } from "@maple/ui/lib/types"
 
+import { formatWarehouseDateTimeMs } from "@maple/query-engine"
 export const Route = createFileRoute("/flow-lab")({
 	component: FlowLab,
 })
@@ -14,7 +15,7 @@ const T0_MS = new Date("2026-07-21T10:00:00.000Z").getTime()
 
 /** Trace-relative start time so edges get realistic "+Nms" start offsets. */
 function at(offsetMs: number): string {
-	return new Date(T0_MS + offsetMs).toISOString().replace("T", " ").replace("Z", "")
+	return formatWarehouseDateTimeMs(T0_MS + offsetMs)
 }
 
 function row(overrides: Partial<SpanHierarchyRow> & { spanId: string; spanName: string }): SpanHierarchyRow {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -31,6 +31,7 @@ import { disabledResultAtom } from "@/lib/services/atoms/disabled-result-atom"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
 import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 const dashboardSearchSchema = Schema.Struct({
 	environment: Schema.optional(Schema.String),
 	...TimeRangeSearchFields,
@@ -103,10 +104,12 @@ function DashboardPage() {
 	// `TinybirdDateTime` requires `YYYY-MM-DD HH:mm:ss` (no `T`, no millis), so
 	// we strip the ISO suffix instead of passing `.toISOString()` raw.
 	const facetsRange = useMemo(() => {
-		const fmt = (d: Date) => d.toISOString().replace("T", " ").slice(0, 19)
 		const end = new Date()
 		const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
-		return { startTime: fmt(start), endTime: fmt(end) }
+		return {
+			startTime: formatWarehouseDateTime(start.getTime()),
+			endTime: formatWarehouseDateTime(end.getTime()),
+		}
 	}, [])
 
 	const facetsAtom = getServicesFacetsResultAtom({ data: facetsRange })

--- a/apps/web/src/routes/service-map.tsx
+++ b/apps/web/src/routes/service-map.tsx
@@ -16,6 +16,7 @@ import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-ran
 import { QueryErrorState } from "@/components/common/query-error-state"
 import { LONG_RANGE_PRESET_OPTIONS } from "@/lib/time-utils"
 
+import { formatWarehouseDateTime } from "@maple/query-engine"
 // `__all__` is the sentinel for the "All Environments" option. Storing it in the
 // URL (rather than clearing the param) keeps an explicit all-environments choice
 // sticky, distinct from "no choice → default to production".
@@ -59,10 +60,12 @@ function ServiceMapContent() {
 	// a fixed range keeps this a single cached facets request independent of the
 	// map's own time range. Matches the dashboard's facets probe.
 	const facetsRange = useMemo(() => {
-		const fmt = (d: Date) => d.toISOString().replace("T", " ").slice(0, 19)
 		const end = new Date()
 		const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
-		return { startTime: fmt(start), endTime: fmt(end) }
+		return {
+			startTime: formatWarehouseDateTime(start.getTime()),
+			endTime: formatWarehouseDateTime(end.getTime()),
+		}
 	}, [])
 	const facetsAtom = getServicesFacetsResultAtom({ data: facetsRange })
 	const facetsResult = useRetainedRefreshableResultValue(facetsAtom)

--- a/packages/query-engine/src/datetime.test.ts
+++ b/packages/query-engine/src/datetime.test.ts
@@ -3,7 +3,11 @@ import {
 	bucketTimeline,
 	computeBucketSeconds,
 	formatWarehouseDateTime,
+	formatWarehouseDateTimeMs,
 	parseWarehouseDateTime,
+	relativeRangeSeconds,
+	resolveRelativeRange,
+	resolveRelativeRangeToWarehouse,
 	warehouseDateTimeToIso,
 } from "./datetime"
 
@@ -127,5 +131,111 @@ describe("bucketTimeline", () => {
 
 	it("returns [] when the end precedes the start", () => {
 		expect(bucketTimeline(Date.UTC(2026, 1, 1, 0, 10, 0), Date.UTC(2026, 1, 1, 0, 0, 0), 300)).toEqual([])
+	})
+})
+
+const AT = (iso: string) => Date.parse(iso)
+
+describe("formatWarehouseDateTimeMs", () => {
+	it("keeps milliseconds, so sub-second ordering survives", () => {
+		expect(formatWarehouseDateTimeMs(AT("2026-03-08T14:30:05.789Z"))).toBe("2026-03-08 14:30:05.789")
+	})
+
+	it("agrees with the second-precision variant up to the decimal point", () => {
+		const ms = AT("2026-03-08T14:30:05.789Z")
+		expect(formatWarehouseDateTimeMs(ms).startsWith(formatWarehouseDateTime(ms))).toBe(true)
+	})
+})
+
+describe("relativeRangeSeconds", () => {
+	it("parses every unit the time picker emits", () => {
+		expect(relativeRangeSeconds("15m")).toBe(900)
+		expect(relativeRangeSeconds("6h")).toBe(21_600)
+		expect(relativeRangeSeconds("7d")).toBe(604_800)
+		expect(relativeRangeSeconds("2w")).toBe(1_209_600)
+		expect(relativeRangeSeconds("3mo")).toBe(7_776_000)
+		expect(relativeRangeSeconds("today")).toBe(86_400)
+	})
+
+	it("does not confuse the minute and month units", () => {
+		expect(relativeRangeSeconds("3m")).toBe(180)
+		expect(relativeRangeSeconds("3mo")).toBe(7_776_000)
+	})
+
+	it("rejects malformed shorthand", () => {
+		for (const bad of ["", "d", "7", "7x", "-7d", "0d", "7 d", "last week"]) {
+			expect(relativeRangeSeconds(bad)).toBeNull()
+		}
+	})
+})
+
+describe("resolveRelativeRange", () => {
+	const now = AT("2026-03-08T14:30:00.000Z")
+
+	it("subtracts fixed-width units exactly", () => {
+		expect(resolveRelativeRange("15m", now)).toEqual({ startMs: now - 900_000, endMs: now })
+		expect(resolveRelativeRange("6h", now)).toEqual({ startMs: now - 21_600_000, endMs: now })
+		expect(resolveRelativeRange("7d", now)).toEqual({ startMs: now - 604_800_000, endMs: now })
+		expect(resolveRelativeRange("2w", now)).toEqual({ startMs: now - 1_209_600_000, endMs: now })
+	})
+
+	it("uses real calendar months, not 30-day approximations", () => {
+		// The MCP resolver used to do `days: amount * 30`, so "1mo" from 8 March
+		// landed on 6 February instead of 8 February.
+		const start = new Date(resolveRelativeRange("1mo", now)!.startMs)
+		expect(start.getMonth()).toBe(1)
+		expect(start.getDate()).toBe(8)
+	})
+
+	it("clamps the day of month when the target month is shorter", () => {
+		// 31 March minus one month is 28 February, never 3 March. Mirrors
+		// date-fns `subMonths`, which the web app relied on.
+		const march31 = new Date(2026, 2, 31, 12, 0, 0).getTime()
+		const start = new Date(resolveRelativeRange("1mo", march31)!.startMs)
+		expect(start.getMonth()).toBe(1)
+		expect(start.getDate()).toBe(28)
+	})
+
+	it("clamps across a year boundary too", () => {
+		const march31 = new Date(2026, 2, 31, 12, 0, 0).getTime()
+		const start = new Date(resolveRelativeRange("13mo", march31)!.startMs)
+		expect(start.getFullYear()).toBe(2025)
+		expect(start.getMonth()).toBe(1)
+		expect(start.getDate()).toBe(28)
+	})
+
+	it("resolves 'today' to local midnight", () => {
+		const midday = new Date(2026, 2, 8, 13, 45, 0).getTime()
+		const start = new Date(resolveRelativeRange("today", midday)!.startMs)
+		expect(start.getHours()).toBe(0)
+		expect(start.getMinutes()).toBe(0)
+		expect(start.getSeconds()).toBe(0)
+		expect(start.getDate()).toBe(8)
+	})
+
+	it("returns null for shorthand it cannot parse", () => {
+		for (const bad of ["", "last month", "7x", "0d"]) {
+			expect(resolveRelativeRange(bad, now)).toBeNull()
+		}
+	})
+
+	it("always ends at now", () => {
+		for (const value of ["15m", "7d", "3mo", "today"]) {
+			expect(resolveRelativeRange(value, now)!.endMs).toBe(now)
+		}
+	})
+})
+
+describe("resolveRelativeRangeToWarehouse", () => {
+	it("renders both bounds in warehouse format", () => {
+		const now = AT("2026-03-08T14:30:00.000Z")
+		expect(resolveRelativeRangeToWarehouse("6h", now)).toEqual({
+			startTime: "2026-03-08 08:30:00",
+			endTime: "2026-03-08 14:30:00",
+		})
+	})
+
+	it("propagates null for invalid shorthand", () => {
+		expect(resolveRelativeRangeToWarehouse("nope")).toBeNull()
 	})
 })

--- a/packages/query-engine/src/datetime.ts
+++ b/packages/query-engine/src/datetime.ts
@@ -47,9 +47,147 @@ export function parseWarehouseDateTime(value: string): number {
  * Format epoch milliseconds as the tz-less second-precision
  * `YYYY-MM-DD HH:MM:SS` shape ClickHouse/Tinybird DateTime params expect
  * (UTC wall clock, space separator, no fractional part).
+ *
+ * This is the canonical formatter. It previously existed as ~50 local copies
+ * named `fmt`, `fmtUTC`, `tinybirdDateTime`, `toTinybirdDateTime`,
+ * `fmtWarehouseTime`, `msToWarehouseDateTime`, `warehouseDate`,
+ * `formatForTinybird`, and `toWarehouseDateTime` — all identical.
  */
 export function formatWarehouseDateTime(epochMs: number): string {
 	return new Date(epochMs).toISOString().replace("T", " ").slice(0, 19)
+}
+
+/**
+ * Millisecond-precision variant: `YYYY-MM-DD HH:MM:SS.mmm`.
+ *
+ * A minority of callers deliberately keep the fractional part (DateTime64
+ * columns, replay fixtures whose ordering is sub-second). Distinct from
+ * `formatWarehouseDateTime` because truncating those to whole seconds
+ * collapses events that must stay ordered.
+ */
+export function formatWarehouseDateTimeMs(epochMs: number): string {
+	return new Date(epochMs).toISOString().replace("T", " ").replace(/Z$/, "")
+}
+
+// ---------------------------------------------------------------------------
+// Relative range shorthand — single source of truth
+//
+// The time picker persists relative ranges as shorthand ("15m", "7d", "3mo",
+// "today"). This grammar used to exist three times over — in the web app (on
+// date-fns), in the MCP dashboard resolver (on Effect DateTime, approximating a
+// month as 30 days), and in the query engine's own limits module — which is how
+// `mo` came to mean different spans depending on which one you asked.
+//
+// Month and day arithmetic is done on **local** calendar components, matching
+// date-fns' `subMonths`/`startOfDay`. In the browser that is the viewer's
+// calendar (unchanged behaviour); on a Worker, local is UTC, which is the only
+// sensible reading server-side. One implementation serves both.
+// ---------------------------------------------------------------------------
+
+const RELATIVE_RANGE_PATTERN = /^(\d+)(mo|m|h|d|w)$/
+
+const MS: Record<string, number> = {
+	m: 60_000,
+	h: 3_600_000,
+	d: 86_400_000,
+	w: 604_800_000,
+}
+
+/**
+ * Shift `date` by whole calendar months, clamping the day-of-month to the
+ * target month's length (31 Mar − 1mo → 28 Feb, never 3 Mar). Mirrors
+ * date-fns' `subMonths` so the web app's behaviour is preserved exactly.
+ */
+function addCalendarMonths(date: Date, months: number): Date {
+	const shifted = new Date(date.getTime())
+	const day = shifted.getDate()
+	// Park on the 1st before changing month, so the month set can't overflow.
+	shifted.setDate(1)
+	shifted.setMonth(shifted.getMonth() + months)
+	const daysInTargetMonth = new Date(shifted.getFullYear(), shifted.getMonth() + 1, 0).getDate()
+	shifted.setDate(Math.min(day, daysInTargetMonth))
+	return shifted
+}
+
+/** Local midnight for the day containing `date`. Mirrors date-fns' `startOfDay`. */
+function startOfLocalDay(date: Date): Date {
+	const start = new Date(date.getTime())
+	start.setHours(0, 0, 0, 0)
+	return start
+}
+
+/**
+ * Duration in seconds for a relative shorthand, or `null` when the string isn't
+ * valid shorthand.
+ *
+ * Approximate by construction — a month is counted as 30 days and `"today"` as
+ * its 24-hour worst case — because this exists to compare a shorthand against a
+ * fixed ceiling, where a deterministic answer matters more than a calendar-exact
+ * one. Use `resolveRelativeRange` to build actual query bounds.
+ */
+export function relativeRangeSeconds(shorthand: string): number | null {
+	const trimmed = shorthand.trim().toLowerCase()
+	if (trimmed === "today") return 86_400
+
+	const match = RELATIVE_RANGE_PATTERN.exec(trimmed)
+	if (!match) return null
+
+	const amount = Number.parseInt(match[1], 10)
+	if (!Number.isFinite(amount) || amount <= 0) return null
+
+	const unit = match[2]
+	const unitMs = unit === "mo" ? 30 * 86_400_000 : MS[unit]
+	if (unitMs === undefined) return null
+
+	return (amount * unitMs) / 1000
+}
+
+/**
+ * Resolve a relative shorthand to an absolute epoch-ms window ending at `nowMs`.
+ * Returns `null` for anything the grammar doesn't accept, so callers can fall
+ * back or report an error rather than silently querying a default window.
+ */
+export function resolveRelativeRange(
+	shorthand: string,
+	nowMs: number = Date.now(),
+): { startMs: number; endMs: number } | null {
+	const trimmed = shorthand.trim().toLowerCase()
+	const now = new Date(nowMs)
+
+	if (trimmed === "today") {
+		return { startMs: startOfLocalDay(now).getTime(), endMs: nowMs }
+	}
+
+	const match = RELATIVE_RANGE_PATTERN.exec(trimmed)
+	if (!match) return null
+
+	const amount = Number.parseInt(match[1], 10)
+	if (!Number.isFinite(amount) || amount <= 0) return null
+
+	const unit = match[2]
+	if (unit === "mo") {
+		return { startMs: addCalendarMonths(now, -amount).getTime(), endMs: nowMs }
+	}
+
+	const unitMs = MS[unit]
+	if (unitMs === undefined) return null
+	return { startMs: nowMs - amount * unitMs, endMs: nowMs }
+}
+
+/**
+ * `resolveRelativeRange` rendered straight into warehouse DateTime strings —
+ * the shape every query path actually wants.
+ */
+export function resolveRelativeRangeToWarehouse(
+	shorthand: string,
+	nowMs: number = Date.now(),
+): { startTime: string; endTime: string } | null {
+	const resolved = resolveRelativeRange(shorthand, nowMs)
+	if (!resolved) return null
+	return {
+		startTime: formatWarehouseDateTime(resolved.startMs),
+		endTime: formatWarehouseDateTime(resolved.endMs),
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/query-engine/src/index.ts
+++ b/packages/query-engine/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./query-engine"
 export * from "./datetime"
+export * from "./limits"
 export * from "./where-clause"
 export * from "./capabilities"
 export * from "./dashboard-variables/interpolate"

--- a/packages/query-engine/src/limits.test.ts
+++ b/packages/query-engine/src/limits.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+import {
+	MAX_BREAKDOWN_RANGE_SECONDS,
+	MAX_LIST_RANGE_SECONDS,
+	MAX_QUERY_RANGE_SECONDS,
+	formatRangeSeconds,
+	maxRangeSecondsForKind,
+	relativeRangeSeconds,
+	validateRelativeRange,
+} from "./limits"
+
+describe("maxRangeSecondsForKind", () => {
+	it("gives charts a far wider ceiling than lists", () => {
+		// The whole point of the module: a dashboard's charts are not bound by the
+		// list tiles sitting next to them.
+		expect(maxRangeSecondsForKind("timeseries")).toBe(MAX_QUERY_RANGE_SECONDS)
+		expect(maxRangeSecondsForKind("list")).toBe(MAX_LIST_RANGE_SECONDS)
+		expect(maxRangeSecondsForKind("breakdown")).toBe(MAX_BREAKDOWN_RANGE_SECONDS)
+		expect(maxRangeSecondsForKind("timeseries")).toBeGreaterThan(maxRangeSecondsForKind("list"))
+	})
+})
+
+describe("formatRangeSeconds", () => {
+	it("renders whole-day spans as days", () => {
+		expect(formatRangeSeconds(MAX_LIST_RANGE_SECONDS)).toBe("7 days")
+		expect(formatRangeSeconds(MAX_QUERY_RANGE_SECONDS)).toBe("31 days")
+		expect(formatRangeSeconds(86_400)).toBe("1 day")
+	})
+
+	it("renders sub-day spans as hours and minutes", () => {
+		expect(formatRangeSeconds(6 * 3600)).toBe("6 hours")
+		expect(formatRangeSeconds(3600)).toBe("1 hour")
+		expect(formatRangeSeconds(900)).toBe("15 minutes")
+	})
+})
+
+describe("relativeRangeSeconds", () => {
+	it("parses every unit the time picker can emit", () => {
+		expect(relativeRangeSeconds("15m")).toBe(15 * 60)
+		expect(relativeRangeSeconds("6h")).toBe(6 * 3600)
+		expect(relativeRangeSeconds("7d")).toBe(7 * 86_400)
+		expect(relativeRangeSeconds("2w")).toBe(14 * 86_400)
+		expect(relativeRangeSeconds("3mo")).toBe(90 * 86_400)
+		expect(relativeRangeSeconds("today")).toBe(86_400)
+	})
+
+	it("is case- and whitespace-insensitive", () => {
+		expect(relativeRangeSeconds("  7D  ")).toBe(7 * 86_400)
+	})
+
+	it("rejects malformed shorthand", () => {
+		for (const bad of ["", "d", "7", "7x", "-7d", "0d", "7 d", "last week"]) {
+			expect(relativeRangeSeconds(bad)).toBeNull()
+		}
+	})
+
+	it("does not confuse the minute and month units", () => {
+		expect(relativeRangeSeconds("3m")).toBe(3 * 60)
+		expect(relativeRangeSeconds("3mo")).toBe(90 * 86_400)
+	})
+})
+
+describe("validateRelativeRange", () => {
+	it("accepts ranges up to the ceiling", () => {
+		expect(validateRelativeRange("30d").ok).toBe(true)
+		expect(validateRelativeRange("31d").ok).toBe(true)
+		expect(validateRelativeRange("1h").ok).toBe(true)
+	})
+
+	it("rejects ranges past the ceiling with an explicit message", () => {
+		const result = validateRelativeRange("90d")
+		expect(result.ok).toBe(false)
+		expect(result.error).toContain("90d")
+		expect(result.error).toContain("31 days")
+	})
+
+	it("honours a caller-supplied ceiling", () => {
+		expect(validateRelativeRange("30d", MAX_LIST_RANGE_SECONDS).ok).toBe(false)
+		expect(validateRelativeRange("6h", MAX_LIST_RANGE_SECONDS).ok).toBe(true)
+	})
+
+	it("reports malformed shorthand separately from an over-wide one", () => {
+		const result = validateRelativeRange("last week")
+		expect(result.ok).toBe(false)
+		expect(result.error).toContain("Invalid time range")
+		expect(result.seconds).toBeUndefined()
+	})
+})

--- a/packages/query-engine/src/limits.test.ts
+++ b/packages/query-engine/src/limits.test.ts
@@ -5,9 +5,9 @@ import {
 	MAX_QUERY_RANGE_SECONDS,
 	formatRangeSeconds,
 	maxRangeSecondsForKind,
-	relativeRangeSeconds,
 	validateRelativeRange,
 } from "./limits"
+import { relativeRangeSeconds } from "./datetime"
 
 describe("maxRangeSecondsForKind", () => {
 	it("gives charts a far wider ceiling than lists", () => {

--- a/packages/query-engine/src/limits.ts
+++ b/packages/query-engine/src/limits.ts
@@ -9,7 +9,12 @@
 //
 // Pure — no drivers, no Effect — so this module is safe to re-export from the
 // package root barrel and import from the web bundle.
+//
+// The relative-shorthand *grammar* lives in `./datetime` alongside the rest of
+// the date math; this module only decides what is too wide.
 // ---------------------------------------------------------------------------
+
+import { relativeRangeSeconds } from "./datetime"
 
 /** Widest window any query kind may span. */
 export const MAX_QUERY_RANGE_SECONDS = 60 * 60 * 24 * 31
@@ -74,47 +79,6 @@ export function formatRangeSeconds(seconds: number): string {
 	}
 	const minutes = Math.round(seconds / 60)
 	return `${minutes} minute${minutes === 1 ? "" : "s"}`
-}
-
-// ---------------------------------------------------------------------------
-// Relative range shorthand
-//
-// The dashboard time picker persists relative ranges as shorthand strings
-// ("15m", "24h", "7d", "3mo", "today"). The web app has always been able to
-// resolve these; the API could not, which is why the MCP dashboard tools fell
-// back to a hardcoded whitelist. Parsing the duration here lets both sides
-// validate the same grammar against the same ceilings.
-// ---------------------------------------------------------------------------
-
-const RELATIVE_RANGE_PATTERN = /^(\d+)(mo|m|h|d|w)$/
-
-const UNIT_SECONDS: Record<string, number> = {
-	m: 60,
-	h: SECONDS_PER_HOUR,
-	d: SECONDS_PER_DAY,
-	w: SECONDS_PER_DAY * 7,
-	// Calendar months vary; 30 days is the conventional approximation and is
-	// only ever used to compare against a ceiling, never to build query bounds.
-	mo: SECONDS_PER_DAY * 30,
-}
-
-/**
- * Duration in seconds for a relative range shorthand, or `null` when the string
- * isn't valid shorthand. `"today"` is elapsed-time-dependent and reports its
- * worst case (24h) so validation stays deterministic.
- */
-export function relativeRangeSeconds(shorthand: string): number | null {
-	const trimmed = shorthand.trim().toLowerCase()
-	if (trimmed === "today") return SECONDS_PER_DAY
-
-	const match = RELATIVE_RANGE_PATTERN.exec(trimmed)
-	if (!match) return null
-
-	const amount = Number.parseInt(match[1], 10)
-	const unitSeconds = UNIT_SECONDS[match[2]]
-	if (!Number.isFinite(amount) || amount <= 0 || unitSeconds === undefined) return null
-
-	return amount * unitSeconds
 }
 
 export interface RelativeRangeValidation {

--- a/packages/query-engine/src/limits.ts
+++ b/packages/query-engine/src/limits.ts
@@ -1,0 +1,155 @@
+// ---------------------------------------------------------------------------
+// Query time-range limits — single source of truth
+//
+// These ceilings used to be duplicated as ad-hoc constants across the query
+// engine, the MCP tools, and the v2 public API, which drifted: dashboards were
+// capped at 7 days by an MCP whitelist while the engine happily served 31, and
+// several MCP tools silently clamped results to a week. Everything that bounds
+// a time range now reads from here.
+//
+// Pure — no drivers, no Effect — so this module is safe to re-export from the
+// package root barrel and import from the web bundle.
+// ---------------------------------------------------------------------------
+
+/** Widest window any query kind may span. */
+export const MAX_QUERY_RANGE_SECONDS = 60 * 60 * 24 * 31
+
+/**
+ * List queries (recent traces/logs tiles) scan raw rows rather than a rollup,
+ * so they carry a much tighter ceiling than charts.
+ */
+export const MAX_LIST_RANGE_SECONDS = 60 * 60 * 24 * 7
+
+/** Breakdown queries (pie/bar/heatmap/funnel) aggregate across a whole window. */
+export const MAX_BREAKDOWN_RANGE_SECONDS = 60 * 60 * 24 * 30
+
+/**
+ * A breakdown with no narrowing filter scans the entire partition prefix, so it
+ * gets a far tighter ceiling than a filtered one.
+ */
+export const MAX_UNFILTERED_BREAKDOWN_RANGE_SECONDS = 60 * 60 * 24
+
+/** Point budget for a single timeseries response. */
+export const MAX_TIMESERIES_POINTS = 1_500
+
+/**
+ * Attribute/metric discovery reads pre-aggregated hourly rollups, so it can
+ * span wider than the raw-row list cap.
+ */
+export const MAX_DISCOVERY_RANGE_SECONDS = 60 * 60 * 24 * 30
+
+/** Log-pattern mining clusters raw message bodies — expensive, keep it short. */
+export const MAX_LOG_PATTERN_RANGE_SECONDS = 60 * 60 * 24
+
+export type QueryRangeKind = "timeseries" | "list" | "breakdown"
+
+/** The ceiling that applies to a given query kind. */
+export function maxRangeSecondsForKind(kind: QueryRangeKind): number {
+	switch (kind) {
+		case "list":
+			return MAX_LIST_RANGE_SECONDS
+		case "breakdown":
+			return MAX_BREAKDOWN_RANGE_SECONDS
+		case "timeseries":
+			return MAX_QUERY_RANGE_SECONDS
+	}
+}
+
+const SECONDS_PER_HOUR = 3600
+const SECONDS_PER_DAY = SECONDS_PER_HOUR * 24
+
+/**
+ * Render a duration as human copy for error messages — "7 days", "24 hours".
+ * Keeps every "maximum range is …" string derived from the constants above so
+ * changing a limit can never leave stale copy behind.
+ */
+export function formatRangeSeconds(seconds: number): string {
+	if (seconds >= SECONDS_PER_DAY && seconds % SECONDS_PER_DAY === 0) {
+		const days = seconds / SECONDS_PER_DAY
+		return `${days} day${days === 1 ? "" : "s"}`
+	}
+	if (seconds >= SECONDS_PER_HOUR && seconds % SECONDS_PER_HOUR === 0) {
+		const hours = seconds / SECONDS_PER_HOUR
+		return `${hours} hour${hours === 1 ? "" : "s"}`
+	}
+	const minutes = Math.round(seconds / 60)
+	return `${minutes} minute${minutes === 1 ? "" : "s"}`
+}
+
+// ---------------------------------------------------------------------------
+// Relative range shorthand
+//
+// The dashboard time picker persists relative ranges as shorthand strings
+// ("15m", "24h", "7d", "3mo", "today"). The web app has always been able to
+// resolve these; the API could not, which is why the MCP dashboard tools fell
+// back to a hardcoded whitelist. Parsing the duration here lets both sides
+// validate the same grammar against the same ceilings.
+// ---------------------------------------------------------------------------
+
+const RELATIVE_RANGE_PATTERN = /^(\d+)(mo|m|h|d|w)$/
+
+const UNIT_SECONDS: Record<string, number> = {
+	m: 60,
+	h: SECONDS_PER_HOUR,
+	d: SECONDS_PER_DAY,
+	w: SECONDS_PER_DAY * 7,
+	// Calendar months vary; 30 days is the conventional approximation and is
+	// only ever used to compare against a ceiling, never to build query bounds.
+	mo: SECONDS_PER_DAY * 30,
+}
+
+/**
+ * Duration in seconds for a relative range shorthand, or `null` when the string
+ * isn't valid shorthand. `"today"` is elapsed-time-dependent and reports its
+ * worst case (24h) so validation stays deterministic.
+ */
+export function relativeRangeSeconds(shorthand: string): number | null {
+	const trimmed = shorthand.trim().toLowerCase()
+	if (trimmed === "today") return SECONDS_PER_DAY
+
+	const match = RELATIVE_RANGE_PATTERN.exec(trimmed)
+	if (!match) return null
+
+	const amount = Number.parseInt(match[1], 10)
+	const unitSeconds = UNIT_SECONDS[match[2]]
+	if (!Number.isFinite(amount) || amount <= 0 || unitSeconds === undefined) return null
+
+	return amount * unitSeconds
+}
+
+export interface RelativeRangeValidation {
+	readonly ok: boolean
+	/** Populated when `ok` is false — ready to surface to an agent or a user. */
+	readonly error?: string
+	/** Parsed duration, present whenever the shorthand was well-formed. */
+	readonly seconds?: number
+}
+
+/**
+ * Validate a relative range shorthand against a ceiling. Returns a structured
+ * result rather than throwing so MCP tools can turn it straight into an error
+ * response — the point of this whole module is that nothing silently downgrades
+ * an out-of-range request any more.
+ */
+export function validateRelativeRange(
+	shorthand: string,
+	maxSeconds: number = MAX_QUERY_RANGE_SECONDS,
+): RelativeRangeValidation {
+	const seconds = relativeRangeSeconds(shorthand)
+	if (seconds === null) {
+		return {
+			ok: false,
+			error: `Invalid time range "${shorthand}". Use a relative shorthand like "15m", "6h", "7d", "2w", "3mo", or "today".`,
+		}
+	}
+
+	if (seconds > maxSeconds) {
+		return {
+			ok: false,
+			seconds,
+			error: `Time range "${shorthand}" exceeds the maximum supported range of ${formatRangeSeconds(maxSeconds)}.`,
+		}
+	}
+
+	return { ok: true, seconds }
+}

--- a/packages/query-engine/src/observability/error-detail.ts
+++ b/packages/query-engine/src/observability/error-detail.ts
@@ -1,10 +1,8 @@
 import { Array as Arr, Effect, pipe } from "effect"
 import type { ErrorDetailTracesOutput, ErrorsTimeseriesOutput, ListLogsOutput } from "@maple/domain/tinybird"
-import { parseWarehouseDateTime } from "../datetime"
+import { parseWarehouseDateTime, formatWarehouseDateTime } from "../datetime"
 import { WarehouseExecutor } from "./WarehouseExecutor"
 import type { TimeRange } from "./types"
-
-const tinybirdDateTime = (d: Date): string => d.toISOString().replace("T", " ").slice(0, 19)
 
 const LOG_WINDOW_HALF_WIDTH_MS = 60 * 60 * 1000
 
@@ -18,8 +16,8 @@ const logRangeAround = (traceStartTime: string): { start_time: string; end_time:
 	const ms = parseWarehouseDateTime(traceStartTime)
 	if (Number.isNaN(ms)) return undefined
 	return {
-		start_time: tinybirdDateTime(new Date(ms - LOG_WINDOW_HALF_WIDTH_MS)),
-		end_time: tinybirdDateTime(new Date(ms + LOG_WINDOW_HALF_WIDTH_MS)),
+		start_time: formatWarehouseDateTime(ms - LOG_WINDOW_HALF_WIDTH_MS),
+		end_time: formatWarehouseDateTime(ms + LOG_WINDOW_HALF_WIDTH_MS),
 	}
 }
 

--- a/packages/query-engine/src/observability/inspect-trace.ts
+++ b/packages/query-engine/src/observability/inspect-trace.ts
@@ -5,6 +5,7 @@ import { WarehouseExecutor } from "./WarehouseExecutor"
 import type { InspectTraceOutput, SpanNode } from "./types"
 import { toLogEntry } from "./row-mappers"
 
+import { formatWarehouseDateTime } from "../datetime"
 const SKIP_ATTR_PREFIXES = ["http.request.header.", "http.response.header.", "signoz."]
 const SKIP_ATTR_KEYS = HashSet.fromIterable([
 	"http.request.method",
@@ -74,8 +75,6 @@ export interface InspectTraceOptions {
 const DEFAULT_RANGE_HOURS = 1
 const DEFAULT_LOOKBACK_HOURS = 24
 
-const tinybirdDateTime = (d: Date): string => d.toISOString().replace("T", " ").slice(0, 19)
-
 export const inspectTrace = Effect.fn("Observability.inspectTrace")(function* (
 	traceId: string,
 	options?: InspectTraceOptions,
@@ -89,15 +88,15 @@ export const inspectTrace = Effect.fn("Observability.inspectTrace")(function* (
 		? (() => {
 				const halfWidthMs = (options.rangeHours ?? DEFAULT_RANGE_HOURS) * 60 * 60 * 1000
 				return {
-					start_time: tinybirdDateTime(new Date(options.timestampHint.getTime() - halfWidthMs)),
-					end_time: tinybirdDateTime(new Date(options.timestampHint.getTime() + halfWidthMs)),
+					start_time: formatWarehouseDateTime(options.timestampHint.getTime() - halfWidthMs),
+					end_time: formatWarehouseDateTime(options.timestampHint.getTime() + halfWidthMs),
 				}
 			})()
 		: (() => {
 				const lookbackMs = (options?.defaultLookbackHours ?? DEFAULT_LOOKBACK_HOURS) * 60 * 60 * 1000
 				return {
-					start_time: tinybirdDateTime(new Date(nowMs - lookbackMs)),
-					end_time: tinybirdDateTime(new Date(nowMs)),
+					start_time: formatWarehouseDateTime(nowMs - lookbackMs),
+					end_time: formatWarehouseDateTime(nowMs),
 				}
 			})()
 

--- a/packages/query-engine/src/observability/span-detail.ts
+++ b/packages/query-engine/src/observability/span-detail.ts
@@ -2,6 +2,7 @@ import { Array as Arr, Effect, Option, Schema, pipe } from "effect"
 import * as CH from "../ch"
 import { WarehouseExecutor } from "./WarehouseExecutor"
 
+import { formatWarehouseDateTime } from "../datetime"
 const StringRecordFromJson = Schema.fromJsonString(Schema.Record(Schema.String, Schema.String))
 
 const parseAttributes = (raw: string): Effect.Effect<Record<string, string>> =>
@@ -16,7 +17,6 @@ const parseAttributes = (raw: string): Effect.Effect<Record<string, string>> =>
 		Effect.orElseSucceed(() => ({})),
 	)
 
-const tinybirdDateTime = (d: Date): string => d.toISOString().replace("T", " ").slice(0, 19)
 const DEFAULT_RANGE_HOURS = 1
 
 export interface SpanDetailInput {
@@ -58,8 +58,8 @@ export const spanDetail = Effect.fn("Observability.spanDetail")(function* (input
 		? (() => {
 				const halfWidthMs = (input.rangeHours ?? DEFAULT_RANGE_HOURS) * 60 * 60 * 1000
 				return {
-					startTime: tinybirdDateTime(new Date(input.timestampHint.getTime() - halfWidthMs)),
-					endTime: tinybirdDateTime(new Date(input.timestampHint.getTime() + halfWidthMs)),
+					startTime: formatWarehouseDateTime(input.timestampHint.getTime() - halfWidthMs),
+					endTime: formatWarehouseDateTime(input.timestampHint.getTime() + halfWidthMs),
 				}
 			})()
 		: undefined

--- a/packages/query-engine/src/runtime/query-engine.ts
+++ b/packages/query-engine/src/runtime/query-engine.ts
@@ -64,9 +64,9 @@ export {
 	MAX_UNFILTERED_BREAKDOWN_RANGE_SECONDS,
 	formatRangeSeconds,
 	maxRangeSecondsForKind,
-	relativeRangeSeconds,
 	validateRelativeRange,
 } from "../limits"
+export { relativeRangeSeconds, resolveRelativeRange, resolveRelativeRangeToWarehouse } from "../datetime"
 
 /** Minimal tenant surface the lowering needs — only the org scope. */
 export interface QueryTenant {

--- a/packages/query-engine/src/runtime/query-engine.ts
+++ b/packages/query-engine/src/runtime/query-engine.ts
@@ -36,6 +36,14 @@ import {
 	type WarehouseQuerySettings,
 } from "../profiles"
 import { computeBucketSeconds } from "../datetime"
+import {
+	MAX_BREAKDOWN_RANGE_SECONDS,
+	MAX_LIST_RANGE_SECONDS,
+	MAX_QUERY_RANGE_SECONDS,
+	MAX_TIMESERIES_POINTS,
+	MAX_UNFILTERED_BREAKDOWN_RANGE_SECONDS,
+	formatRangeSeconds,
+} from "../limits"
 import { attributeIndexMode, logBodySearchMode, type WarehouseCapabilities } from "../capabilities"
 import { makeExecuteRawSql } from "./raw-sql"
 import type { BucketGroupObs } from "./evaluate-bucket-codec"
@@ -44,6 +52,21 @@ import type { BucketGroupObs } from "./evaluate-bucket-codec"
 // `computeBucketSeconds` from here; the implementation now lives in the pure
 // `../datetime` module so the web app and the engine share one definition.
 export { computeBucketSeconds } from "../datetime"
+
+// Same arrangement for the range ceilings: they now live in the pure `../limits`
+// module so the MCP tools, the v2 API, and the web widget layer all bound
+// ranges against one definition instead of their own copies.
+export {
+	MAX_BREAKDOWN_RANGE_SECONDS,
+	MAX_LIST_RANGE_SECONDS,
+	MAX_QUERY_RANGE_SECONDS,
+	MAX_TIMESERIES_POINTS,
+	MAX_UNFILTERED_BREAKDOWN_RANGE_SECONDS,
+	formatRangeSeconds,
+	maxRangeSecondsForKind,
+	relativeRangeSeconds,
+	validateRelativeRange,
+} from "../limits"
 
 /** Minimal tenant surface the lowering needs — only the org scope. */
 export interface QueryTenant {
@@ -136,11 +159,6 @@ export type QueryEngineDirectError = QueryEngineExecutionError | QueryEngineTime
 
 export type QueryEngineRouteError = QueryEngineValidationError | QueryEngineDirectError
 
-export const MAX_QUERY_RANGE_SECONDS = 60 * 60 * 24 * 31
-const MAX_LIST_RANGE_SECONDS = 60 * 60 * 24 * 7
-const MAX_TIMESERIES_POINTS = 1_500
-const MAX_BREAKDOWN_RANGE_SECONDS = 60 * 60 * 24 * 30
-const MAX_UNFILTERED_BREAKDOWN_RANGE_SECONDS = 60 * 60 * 24
 const QUERY_ENGINE_TIMEOUT = Duration.seconds(30)
 
 export const withTimeout = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
@@ -426,7 +444,7 @@ const validateTimeRange = Effect.fn("QueryEngineService.validateTimeRange")(func
 	if (rangeSeconds > MAX_QUERY_RANGE_SECONDS) {
 		return yield* new QueryEngineValidationError({
 			message: "Time range too large",
-			details: [`Maximum supported range is ${MAX_QUERY_RANGE_SECONDS} seconds`],
+			details: [`Maximum supported range is ${formatRangeSeconds(MAX_QUERY_RANGE_SECONDS)}`],
 		})
 	}
 
@@ -522,7 +540,7 @@ const validateListQuery = Effect.fn("QueryEngineService.validateListQuery")(func
 		return yield* new QueryEngineValidationError({
 			message: "List query time range too large",
 			details: [
-				`List queries support a maximum range of 7 days`,
+				`List queries support a maximum range of ${formatRangeSeconds(MAX_LIST_RANGE_SECONDS)}`,
 				"Narrow the time range or use a timeseries/breakdown query for wider ranges",
 			],
 		})
@@ -588,7 +606,7 @@ const validateBreakdownQuery = Effect.fn("QueryEngineService.validateBreakdownQu
 		return yield* new QueryEngineValidationError({
 			message: "Breakdown query time range too large",
 			details: [
-				"Breakdown queries support a maximum range of 30 days",
+				`Breakdown queries support a maximum range of ${formatRangeSeconds(MAX_BREAKDOWN_RANGE_SECONDS)}`,
 				"Narrow the time range or use a timeseries query for wider trends",
 			],
 		})
@@ -598,7 +616,7 @@ const validateBreakdownQuery = Effect.fn("QueryEngineService.validateBreakdownQu
 		return yield* new QueryEngineValidationError({
 			message: "Breakdown query too broad without filters",
 			details: [
-				"Breakdowns spanning more than 24 hours require a serviceName, environment, or similar filter",
+				`Breakdowns spanning more than ${formatRangeSeconds(MAX_UNFILTERED_BREAKDOWN_RANGE_SECONDS)} require a serviceName, environment, or similar filter`,
 				"Add a filter or narrow the time range",
 			],
 		})


### PR DESCRIPTION
## Why

Charts "almost always show only 1 week." The cause turned out not to be retention (that's 30/90/365 days, asserted in `retention-matrix.test.ts`) but **five independent, uncoordinated 7-day ceilings** — three of which failed silently.

The one that actually capped dashboards:

```ts
// apps/api/src/mcp/tools/create-dashboard.ts
const TIME_RANGE_MAP = { "1h": "1h", "6h": "6h", "24h": "24h", "7d": "7d" }
const timeRangeValue = TIME_RANGE_MAP[params.time_range ?? "1h"] ?? "1h"
```

Asking for `30d` **silently produced a 1-hour dashboard**. `update_dashboard` carried the same map but used `?? time_range`, letting unknown values through — so the two tools disagreed about what was legal.

Meanwhile `resolveTimeRange` **clamped `startTime` forward** rather than erroring, so five MCP search tools returned week-truncated results as if they were complete. And list widgets hard-error past 7d, so a 30-day dashboard rendered its charts fine while every list tile showed a red error — which reads as "the whole board is capped."

## What changed

**One source of truth** — new `packages/query-engine/src/limits.ts` holds every ceiling, re-exported from the driver-free root barrel so web, api, and the engine share one definition. Every "maximum range is …" string now derives from the constants rather than being hardcoded, so a limit change can't leave stale copy behind.

**No more silent truncation** — `resolveTimeRange` reports `exceeded` and leaves the window intact; the five search tools (`search_traces`, `search_logs`, `find_slow_traces`, `search_sessions`, `get_service_top_operations`) return an actionable error naming what was requested, the cap, and `query_data` as the wider-range path.

**Whitelists deleted** — both dashboard tools validate against the engine's real 31-day ceiling through one shared validator, and reject rather than downgrade.

**List widgets degrade** — a client-side pre-check skips the request that is certain to 400 (and the two retries it was burning) and renders a muted `range` state instead of a red block. The "Show last 7 days" action is session-local, so it works on read-only dashboards without needing `store.updateWidget` to accept `timeRange`.

## Reviewer notes

- **Behaviour change worth a look:** dashboards now genuinely accept up to **31 days**, not 7. `3mo` is still rejected — that's the engine's real ceiling, not an oversight. Long-range routes that read the 365-day rollups (service pages, service map) are on a separate path and untouched.
- **Two latent bugs fixed in passing:** `create_dashboard`'s *template* branch dropped `time_range` entirely, and `resolveDashboardTimeRange` couldn't parse `"today"` — which the time picker *can* persist, so those dashboards silently fell back to a default window.
- `formatBackendError` no longer discards the engine's `message` when `details` is non-empty; the specific headline ("List query time range too large") was being replaced by a generic "Invalid query parameters".
- The `range` error kind is classified apart from `decode` so the tile no longer offers **"Fix with AI"** for a range breach — there's nothing about the widget to fix.
- `MAX_SUMMARY_RANGE_SECONDS` (365d) deliberately stays local to `telemetry.http.ts` with a comment: it's a rollup-table ceiling with no query-engine equivalent.

## Out of scope (flagging, not fixing)

- The `starter` plan advertises **"7 days retention"** in `apps/web/src/lib/billing/plans.ts`, but `getPlanLimits` is exported and never called — it's unenforced copy while the warehouse keeps 30/90/365. Likely feeding the same perception.
- **Unfiltered breakdowns cap at 24 hours** — much tighter than 7 days and probably the more surprising limit in practice.
- The Traces and Logs routes hit the same list cap but have their own error UI and time pickers.

## Testing

- `packages/query-engine` — 11 new tests for the limits module (kind ceilings, duration formatting, shorthand grammar incl. the `m` vs `mo` trap, validation); 45 existing runtime tests pass.
- `apps/api` — 123 MCP tests pass, including new coverage that `create_dashboard` accepts the values the whitelist rejected, errors on `999d` instead of downgrading to `1h`, and that `"today"` now resolves.
- `apps/web` — 160 tests pass.
- All three packages typecheck.
- Verified the new state visually in `/widget-lab` (new "Range too wide" list scenario): renders `text-muted-foreground` grey vs. the destructive red, sitting calmly beside a populated list tile.

Scoped tests and per-package typechecks rather than the full turbo suite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788306109&installation_model_id=427786&pr_number=317&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F317&signature=850d461a589f59af9341c2290ec44de29ce5aa94fcedee65172cf7da981a594d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->