### PR TITLE
perf(browser): lazy-load the rrweb replay engine

### DIFF
--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -31,7 +31,9 @@ That single call:
   ingest (`POST /v1/traces`);
 - records the session with rrweb, chunking events (~5s / 100KB windows),
   gzipping them with the native `CompressionStream`, and uploading to
-  `POST /v1/sessionReplays/blob`;
+  `POST /v1/sessionReplays/blob`. rrweb ships in a lazy code-split chunk loaded
+  only once a session is sampled in, so a `sampleRate` below 1 costs the
+  unsampled visitors nothing beyond the ~8 kB gzipped base SDK;
 - writes session metadata at start (`active`) and on page hide (`ended`),
   including the trace ids observed during the session.
 

--- a/packages/browser/src/init.test.ts
+++ b/packages/browser/src/init.test.ts
@@ -9,6 +9,16 @@ vi.mock("./tracing", () => ({
 	},
 }))
 
+// Stands in for the lazily imported rrweb chunk: the point under test is that
+// `init` reaches it only through `import()`, not that rrweb records here.
+const replay = vi.hoisted(() => ({ start: vi.fn(), shutdown: vi.fn(async () => {}) }))
+vi.mock("@maple/browser-session/replay", () => ({
+	startReplaySession: (options: unknown) => {
+		replay.start(options)
+		return { sessionId: "replay-session", shutdown: replay.shutdown }
+	},
+}))
+
 import { resetSinkForTests } from "../../browser-session/src/events-sink"
 import { init } from "./init"
 
@@ -32,7 +42,63 @@ afterEach(() => {
 	clearSessionSink()
 	tracing.setup.mockClear()
 	tracing.shutdown.mockClear()
+	replay.start.mockClear()
+	replay.shutdown.mockClear()
 	vi.unstubAllGlobals()
+})
+
+const stubBrowser = (): void => {
+	vi.stubGlobal("fetch", async () => new Response(null, { status: 200 }))
+	vi.stubGlobal("window", {
+		sessionStorage: new MemoryStorage(),
+		localStorage: new MemoryStorage(),
+		location: { href: "https://app.example.com/", host: "app.example.com" },
+	})
+}
+
+describe("lazy replay chunk", () => {
+	it("starts the recorder once the chunk lands and shuts it down on shutdown", async () => {
+		stubBrowser()
+		const handle = init({
+			ingestKey: "public-key",
+			serviceName: "test-web",
+			endpoint: "https://collector.test",
+			tracing: { enabled: false },
+			replay: { enabled: true, sampleRate: 1 },
+		})
+
+		// The sampling decision is synchronous; only the handle arrives late.
+		expect(replay.start).not.toHaveBeenCalled()
+		expect(handle.sessionId).not.toBe("")
+		await vi.waitFor(() => expect(replay.start).toHaveBeenCalledTimes(1))
+		expect(handle.sessionId).toBe("replay-session")
+
+		await handle.shutdown()
+		expect(replay.shutdown).toHaveBeenCalledWith({ flush: true })
+	})
+
+	it("never attaches a recorder when consent is revoked before the chunk lands", async () => {
+		setConsent(true)
+		stubBrowser()
+		const handle = init({
+			ingestKey: "public-key",
+			serviceName: "test-web",
+			endpoint: "https://collector.test",
+			tracing: { enabled: false },
+			replay: { enabled: true, sampleRate: 1 },
+			privacy: { requireConsent: true },
+		})
+		setConsent(false)
+
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		expect(replay.start).not.toHaveBeenCalled()
+
+		// A later grant still records — the revoke poisoned that one chunk's
+		// callback, not the sampling decision.
+		setConsent(true)
+		await vi.waitFor(() => expect(replay.start).toHaveBeenCalledTimes(1))
+		await handle.shutdown()
+	})
 })
 
 describe("browser consent lifecycle", () => {

--- a/packages/browser/src/init.ts
+++ b/packages/browser/src/init.ts
@@ -12,17 +12,16 @@ import {
 	onConsentChange,
 	publishSessionSink,
 	rotateSession,
+	setActiveTraceIdProvider,
 	setVisitorTracking,
 	startEventSink,
 	startMetadataSession,
 	type MetadataSessionHandle,
 	type SessionEventSink,
 } from "@maple/browser-session"
-import {
-	type ReplaySessionHandle,
-	setActiveTraceIdProvider,
-	startReplaySession,
-} from "@maple/browser-session/replay"
+// Type-only: the replay entry pulls rrweb, so it may only be reached through the
+// dynamic import in `startRuntime`.
+import type { ReplaySessionHandle } from "@maple/browser-session/replay"
 import { trace } from "@opentelemetry/api"
 import { type MapleBrowserConfig, type ResolvedConfig, resolveConfig } from "./config"
 import { setupTracing } from "./tracing"
@@ -37,8 +36,10 @@ export interface MapleBrowserHandle {
 interface BrowserRuntime {
 	readonly initialSessionId: string
 	readonly sink: SessionEventSink
-	readonly replay?: ReplaySessionHandle | undefined
-	readonly metadata?: MetadataSessionHandle | undefined
+	replay?: ReplaySessionHandle | undefined
+	metadata?: MetadataSessionHandle | undefined
+	/** Settles when the lazy replay chunk resolved; absent on the metadata path. */
+	replayPending?: Promise<void> | undefined
 }
 
 let active: MapleBrowserHandle | undefined
@@ -68,6 +69,9 @@ export function init(rawConfig: MapleBrowserConfig): MapleBrowserHandle {
 	let stopped = false
 	let rotateOnNextStart = false
 	let shutdownTracing: (() => Promise<void>) | undefined
+	// Bumped by every start and stop, so a replay chunk that lands after a
+	// consent revoke (or a rotation) never attaches a recorder to a dead runtime.
+	let generation = 0
 
 	const startRuntime = (): void => {
 		if (stopped || runtime || !hasConsent()) return
@@ -97,24 +101,46 @@ export function init(rawConfig: MapleBrowserConfig): MapleBrowserHandle {
 		// The replay path publishes the sink and sources trace ids itself — the
 		// Effect SDK drives it with neither wired — so only the metadata path takes
 		// them from here. Passing both would republish the sink twice per rotation.
-		const replay = recordReplay
-			? startReplaySession({
+		const startMetadata = (): MetadataSessionHandle | undefined =>
+			startMetadataSession({
+				...shared,
+				getTraceIds: getObservedTraceIds,
+				onSessionChange: publishSessionSink,
+			})
+
+		if (!recordReplay) {
+			runtime = { initialSessionId: session.id, sink, metadata: startMetadata() }
+			return
+		}
+
+		// Sampled in: rrweb rides in a code-split chunk so the ~90% of visitors a
+		// sample rate excludes never download it. The sampling decision above is
+		// synchronous — only the recorder handle arrives late.
+		const next: BrowserRuntime = { initialSessionId: session.id, sink }
+		runtime = next
+		const ownGeneration = ++generation
+		const stale = (): boolean =>
+			stopped || !hasConsent() || generation !== ownGeneration || runtime !== next
+		next.replayPending = import("@maple/browser-session/replay")
+			.then(({ startReplaySession }) => {
+				if (stale()) return
+				next.replay = startReplaySession({
 					...shared,
 					maskAllInputs: config.maskAllInputs,
 					maskAllText: config.maskAllText,
 				})
-			: undefined
-		const metadata = replay
-			? undefined
-			: startMetadataSession({
-					...shared,
-					getTraceIds: getObservedTraceIds,
-					onSessionChange: publishSessionSink,
-				})
-		runtime = { initialSessionId: session.id, sink, replay, metadata }
+			})
+			.catch(() => {
+				// A blocked or failed chunk should still leave a session row behind.
+				if (stale()) return
+				next.metadata = startMetadata()
+			})
 	}
 
 	const stopRuntime = async (flush: boolean): Promise<void> => {
+		// Before the first await, so an in-flight replay chunk sees a stale
+		// generation and never starts a recorder behind the teardown.
+		generation++
 		const previous = runtime
 		runtime = undefined
 		if (!previous) return
@@ -128,7 +154,9 @@ export function init(rawConfig: MapleBrowserConfig): MapleBrowserHandle {
 		sink.stop()
 		if (sink !== previous.sink) previous.sink.stop()
 		clearSessionSink(currentSessionId ?? previous.initialSessionId)
-		await Promise.all([replayShutdown, metadataShutdown])
+		// Awaiting the import too keeps `shutdown()` a real quiescence point: it
+		// resolves with no replay work still scheduled behind it.
+		await Promise.all([replayShutdown, metadataShutdown, previous.replayPending])
 	}
 
 	startRuntime()


### PR DESCRIPTION
`packages/browser/src/init.ts` imported `startReplaySession` statically from `@maple/browser-session/replay`, so rrweb landed in the SDK's main chunk and every visitor downloaded it — including the ~90% that a `replaySampleRate` of 0.1 excludes. On the marketing site that was **280 kB raw / 87 kB gzipped on every page load**. `lib/effect-sdk/src/client/replay-loader.ts` already avoided this ("rrweb in a lazy code-split chunk"); the public browser SDK was the one lagging.

## What changed

- `@maple/browser-session/replay` is reached only through `await import()`, taken when the sampling decision says to record. That decision stays **synchronous** — only the recorder handle arrives late, so the metadata-vs-replay branch is unchanged.
- `setActiveTraceIdProvider` now comes from the root `@maple/browser-session` barrel. It was always the same function (`replay-session.ts` just re-exported it from `events-sink`), so this is a pure import move — the non-replay path no longer touches the replay entry at all. `ReplaySessionHandle` is an `import type`, erased at build.
- Lifecycle safety mirrors the Effect client SDK: a `generation` counter plus a `runtime !== next` / `stopped` / `hasConsent()` guard means a chunk landing after a consent revoke, a session rotation, or shutdown never attaches a recorder to a dead runtime. `stopRuntime` bumps `generation` **before its first await**, so revocation still detaches every producer synchronously, and awaits `replayPending` alongside the two shutdowns so `shutdown()` stays a real quiescence point. A blocked or failed chunk falls back to a metadata-only session.

## Bundle impact

`bun run --cwd packages/browser build` now splits:

| chunk | raw | gzip |
| --- | --- | --- |
| `dist/index.mjs` | 21.9 kB | 7.7 kB |
| `dist/sink-*.mjs` | 40.0 kB | 13.3 kB |
| `dist/replay-session-*.mjs` (rrweb) | 12.5 kB | 4.2 kB |

`rrweb` appears only in the replay chunk, reached solely via `import("./replay-session-*.mjs")`.

`apps/landing` `dist/_astro/telemetry.*.js`: **280 kB / 87 kB gz → 95.7 kB / 31.6 kB gz**. rrweb moves to a sibling `replay-session-*.js` (186 kB / 59 kB gz) that no HTML references and no `modulepreload` pulls.

## Verification

Session replay is a shipped paid feature, so the recorder lifecycle was checked directly, not just inferred.

- **End to end**, against the built `dist` served to a real browser with a local echo server standing in for ingest:
  - _sampled in_ — the browser fetches `replay-session-*.js` as a **separate network request**, then `POST /v1/sessionReplays/meta`, and after click + keyboard input four `POST /v1/sessionReplays/blob` chunks arrive. Recording still works.
  - _sampled out (`sampleRate: 0`)_ — the replay chunk is **never requested**; only the metadata row posts. That is the code-splitting win, confirmed at runtime.
- **Unit tests** (two added to `init.test.ts`, with the replay entry mocked so the test proves `init` reaches it only via `import()`): the recorder starts once the chunk lands and shuts down with `{ flush: true }`; a consent revoke *before* the chunk lands starts no recorder, and a later grant still records.
- `packages/browser` 7/7, `packages/browser-session` 97/97, `tsc --noEmit` clean.

Note: the landing-site numbers were measured while the (separately branched) `apps/landing` instrumentation was in the tree; this PR touches `packages/browser` only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788307567&installation_model_id=427786&pr_number=319&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F319&signature=7ef672c66f2d950f9a1d31f9b10ccf1ec2f6c8048fdf93d6ce23b062e53ee2ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->