### PR TITLE
refactor(query-engine): derive tenant scope structurally, add a SQL baseline gate

### DIFF
--- a/apps/api/src/lib/WarehouseQueryService.test.ts
+++ b/apps/api/src/lib/WarehouseQueryService.test.ts
@@ -83,6 +83,12 @@ const makeTenant = (): TenantContext => ({
 	authMode: "self_hosted",
 })
 
+// A scoped stand-in for the removed `sqlQuery(tenant, sql)` entry point: these
+// tests exercise retry/routing/caching, not scope, so the SQL travels wrapped in
+// a compiled query that declares it.
+const scopedSql = (sql: string) =>
+	unsafeCompiledQuery<Record<string, unknown>>({ sql, tenantScope: "org" })
+
 const transient503 = () => new Error("HTTP status 503 service temporarily unavailable")
 
 const decodeJwtPayload = (token: string): Record<string, unknown> =>
@@ -287,7 +293,7 @@ describe("bounded Tinybird response fetch", () => {
 	})
 })
 
-describe("WarehouseQueryService.sqlQuery retry on transient upstream failures", () => {
+describe("WarehouseQueryService.compiledQuery retry on transient upstream failures", () => {
 	// Runs under it.live: the retry schedule uses real exponential backoff
 	// delays, so the default TestClock would stall the retries.
 	it.live("recovers after two 503s on the third attempt", () => {
@@ -306,7 +312,7 @@ describe("WarehouseQueryService.sqlQuery retry on transient upstream failures", 
 
 		return Effect.gen(function* () {
 			const result = yield* WarehouseQueryService.use((service) =>
-				service.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_test'"),
+				service.compiledQuery(tenant, scopedSql("SELECT 1 FROM traces WHERE OrgId = 'org_test'")),
 			)
 
 			assert.strictEqual(attempts, 3)
@@ -330,7 +336,7 @@ describe("WarehouseQueryService.sqlQuery retry on transient upstream failures", 
 		return Effect.gen(function* () {
 			const exit = yield* Effect.exit(
 				WarehouseQueryService.use((service) =>
-					service.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_test'"),
+					service.compiledQuery(tenant, scopedSql("SELECT 1 FROM traces WHERE OrgId = 'org_test'")),
 				),
 			)
 
@@ -356,7 +362,7 @@ describe("WarehouseQueryService.sqlQuery retry on transient upstream failures", 
 		return Effect.gen(function* () {
 			const exit = yield* Effect.exit(
 				WarehouseQueryService.use((service) =>
-					service.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_test'"),
+					service.compiledQuery(tenant, scopedSql("SELECT 1 FROM traces WHERE OrgId = 'org_test'")),
 				),
 			)
 
@@ -383,6 +389,7 @@ describe("WarehouseQueryService.compiledQuery", () => {
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
 		const compiled = unsafeCompiledQuery<{ readonly serviceName: string; readonly count: number }>({
+			tenantScope: "org",
 			sql: "SELECT ServiceName AS serviceName, count() AS count FROM traces WHERE OrgId = 'org_test'",
 			rowSchema: Schema.Struct({ serviceName: Schema.String, count: RowNumber }),
 		})
@@ -405,6 +412,7 @@ describe("WarehouseQueryService.compiledQuery", () => {
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
 		const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+			tenantScope: "org",
 			sql: "SELECT count() AS count FROM traces WHERE OrgId = 'org_test'",
 			rowSchema: Schema.Struct({ count: RowNumber }),
 		})
@@ -428,8 +436,12 @@ describe("WarehouseQueryService.compiledQuery", () => {
 
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
+		// No top-level OrgId predicate. Previously expressed as SQL lacking the
+		// substring "OrgId"; scope is now a property of the compiled query, so a
+		// query that merely mentions the column can no longer sneak through.
 		const compiled = unsafeCompiledQuery<{ readonly count: number }>({
-			sql: "SELECT count() AS count FROM traces",
+			sql: "SELECT count() AS count, 'x' AS OrgId FROM traces",
+			tenantScope: "cross-org",
 			rowSchema: Schema.Struct({ count: RowNumber }),
 		})
 
@@ -442,7 +454,8 @@ describe("WarehouseQueryService.compiledQuery", () => {
 			const failure = getError(exit)
 			assert.strictEqual(
 				(failure as { message?: string } | undefined)?.message,
-				"SQL query must contain OrgId filter (sqlQuery)",
+				"compiled query is not tenant-scoped: no top-level OrgId predicate (compiledQuery). " +
+					"Deliberate cross-tenant reads must declare .crossOrg() and run through crossOrgQuery.",
 			)
 		}).pipe(Effect.provide(layer))
 	})
@@ -465,6 +478,7 @@ describe("WarehouseQueryService.compiledQueryFirst", () => {
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
 		const compiled = unsafeCompiledQuery<{ readonly serviceName: string; readonly count: number }>({
+			tenantScope: "org",
 			sql: "SELECT ServiceName AS serviceName, count() AS count FROM traces WHERE OrgId = 'org_test'",
 			rowSchema: Schema.Struct({ serviceName: Schema.String, count: RowNumber }),
 		})
@@ -490,6 +504,7 @@ describe("WarehouseQueryService.compiledQueryFirst", () => {
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
 		const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+			tenantScope: "org",
 			sql: "SELECT count() AS count FROM traces WHERE OrgId = 'org_test'",
 			rowSchema: Schema.Struct({ count: RowNumber }),
 		})
@@ -512,6 +527,7 @@ describe("WarehouseQueryService.compiledQueryFirst", () => {
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
 		const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+			tenantScope: "org",
 			sql: "SELECT count() AS count FROM traces WHERE OrgId = 'org_test'",
 			rowSchema: Schema.Struct({ count: RowNumber }),
 		})
@@ -799,7 +815,7 @@ describe("ingest routes writes to the managed pipeline, not a per-org read overr
 		const tenant = makeTenant()
 
 		return Effect.gen(function* () {
-			yield* executor.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_test'")
+			yield* executor.compiledQuery(tenant, scopedSql("SELECT 1 FROM traces WHERE OrgId = 'org_test'"))
 			yield* executor.ingest(tenant, "traces", [{ trace_id: "a" }])
 
 			assert.deepStrictEqual(purposes, ["read", "ingest"])
@@ -838,7 +854,7 @@ describe("ingest pins writes to Tinybird even when CLICKHOUSE_URL makes managed 
 
 		return Effect.gen(function* () {
 			yield* WarehouseQueryService.use((service) =>
-				service.sqlQuery(tenant, "SELECT 1 FROM traces WHERE OrgId = 'org_test'"),
+				service.compiledQuery(tenant, scopedSql("SELECT 1 FROM traces WHERE OrgId = 'org_test'")),
 			)
 			yield* WarehouseQueryService.use((service) =>
 				service.ingest(tenant, "traces", [{ trace_id: "a" }]),
@@ -869,7 +885,7 @@ describe("WarehouseUpstreamError surfaces transient classification", () => {
 describe("isEmptyJsonBodyError (empty Tinybird body ⇒ zero rows)", () => {
 	// The Tinybird SDK's sql() parses the response body as JSON; a successful (2xx) query that
 	// matches zero rows can return an empty body, throwing `SyntaxError: "Unexpected end of JSON
-	// input"`. That must be treated as zero rows so alert rules (and every sqlQuery caller) hit the
+	// input"`. That must be treated as zero rows so alert rules (and every compiledQuery caller) hit the
 	// no-data path instead of surfacing a spurious WarehouseClientError.
 	it("treats an empty-body SyntaxError as zero rows", () => {
 		assert.isTrue(__testables.isEmptyJsonBodyError(new SyntaxError("Unexpected end of JSON input")))

--- a/apps/api/src/routes/v2/v2-test-support.ts
+++ b/apps/api/src/routes/v2/v2-test-support.ts
@@ -145,7 +145,7 @@ export const Phase1ResourceStubsLayer = Layer.mergeAll(
 /** Inert WarehouseQueryService for harnesses that never touch warehouse-backed groups. */
 export const WarehouseServiceStubLayer = Layer.succeed(WarehouseQueryService, {
 	query: die,
-	sqlQuery: die,
+	crossOrgQuery: die,
 	rawSqlQuery: die,
 	compiledQuery: die,
 	compiledQueryWithCapabilities: die,

--- a/apps/api/src/services/AnomalyDetectionService.ts
+++ b/apps/api/src/services/AnomalyDetectionService.ts
@@ -295,15 +295,25 @@ const make = Effect.gen(function* () {
 		const routingTenant = systemTenant(knownOrgs[0])
 		return yield* Effect.all(
 			[
-				warehouse.compiledQuery(
+				warehouse.crossOrgQuery(
 					routingTenant,
 					CH.compile(CH.activeOrgsByTracesQuery(), { startTime }),
-					{ profile: "discovery", context: "anomalyActiveOrgsTraces" },
+					{
+						profile: "discovery",
+						context: "anomalyActiveOrgsTraces",
+						justification:
+							"enumerate orgs with recent span aggregates so the anomaly tick skips idle orgs",
+					},
 				),
-				warehouse.compiledQuery(
+				warehouse.crossOrgQuery(
 					routingTenant,
 					CH.compile(CH.activeOrgsByLogsQuery(), { startTime }),
-					{ profile: "discovery", context: "anomalyActiveOrgsLogs" },
+					{
+						profile: "discovery",
+						context: "anomalyActiveOrgsLogs",
+						justification:
+							"enumerate orgs with recent log aggregates so the anomaly tick skips idle orgs",
+					},
 				),
 			],
 			{ concurrency: 2 },

--- a/apps/api/src/services/ErrorsService.test.ts
+++ b/apps/api/src/services/ErrorsService.test.ts
@@ -156,8 +156,15 @@ const makeWarehouseStub = (
 	fingerprintRows?: () => ReadonlyArray<Record<string, unknown>>,
 ): WarehouseQueryServiceShape => ({
 	query: () => Effect.die(new Error("unexpected warehouse query")),
-	sqlQuery: () => Effect.succeed([]),
 	rawSqlQuery: () => Effect.succeed([]),
+	// Active-org discovery is a declared cross-org read, so it arrives here
+	// rather than on compiledQuery. Same modelling as before: surface the org
+	// iff it currently has error rows.
+	crossOrgQuery: <T>(tenant: unknown, compiled: CompiledQuery<T>) =>
+		Effect.suspend(() => {
+			const orgId = (tenant as { orgId?: string }).orgId ?? ""
+			return Effect.orDie(compiled.decodeRows(scanRows().length > 0 ? [{ orgId }] : []))
+		}),
 	compiledQuery: <T>(tenant: unknown, compiled: CompiledQuery<T>, options?: SqlQueryOptions) =>
 		Effect.suspend(() => {
 			if (options?.context === "errorIssuesScan") {
@@ -258,8 +265,18 @@ const makeGatingLayer = (opts: {
 	const scanRows = opts.scanRows ?? (() => [])
 	const warehouseStub: WarehouseQueryServiceShape = {
 		query: () => Effect.die(new Error("unexpected warehouse query")),
-		sqlQuery: () => Effect.succeed([]),
 		rawSqlQuery: () => Effect.succeed([]),
+		crossOrgQuery: <T>(
+			tenant: unknown,
+			compiled: CompiledQuery<T>,
+			options: SqlQueryOptions & { readonly justification: string },
+		) =>
+			Effect.suspend(() => {
+				if (options?.context) opts.profiles?.set(options.context, options.profile)
+				if (opts.failDiscovery) return Effect.die(new Error("discovery down"))
+				const orgId = (tenant as { orgId?: string }).orgId ?? ""
+				return Effect.orDie(compiled.decodeRows(scanRows().length > 0 ? [{ orgId }] : []))
+			}),
 		compiledQuery: <T>(tenant: unknown, compiled: CompiledQuery<T>, options?: SqlQueryOptions) => {
 			if (options?.context) opts.profiles?.set(options.context, options.profile)
 			if (options?.context === "errorActiveOrgsDiscovery") {

--- a/apps/api/src/services/ErrorsService.ts
+++ b/apps/api/src/services/ErrorsService.ts
@@ -548,12 +548,14 @@ const make: Effect.Effect<
 			startTime: formatWarehouseDateTime(nowMs - ERROR_ACTIVE_DISCOVERY_WINDOW_MS),
 		})
 		return yield* warehouse
-			.compiledQuery(systemTenant(knownOrgs[0] as OrgId), compiled, {
+			.crossOrgQuery(systemTenant(knownOrgs[0] as OrgId), compiled, {
 				// Bound the one cross-org scan (no OrgId predicate ⇒ can't prune the
 				// primary key): abort server-side at 5s instead of riding the ~30s
 				// client timeout when the warehouse is slow.
 				profile: "discovery",
 				context: "errorActiveOrgsDiscovery",
+				justification:
+					"enumerate orgs with recent error events so the error-issue sweep skips idle orgs",
 			})
 			.pipe(
 				Effect.map((rows) => {

--- a/apps/cli/src/core/executor.test.ts
+++ b/apps/cli/src/core/executor.test.ts
@@ -37,6 +37,7 @@ describe("makeLocalWarehouseExecutorShape", () => {
 			const requests = stubLocalServer([{ c: 1 }])
 			const shape = makeLocalWarehouseExecutorShape("http://127.0.0.1:4318")
 			const compiled = unsafeCompiledQuery<{ readonly c: number }>({
+				tenantScope: "org",
 				sql: "SELECT count() AS c FROM traces WHERE OrgId = 'local'\nFORMAT JSON",
 			})
 
@@ -57,7 +58,11 @@ describe("makeLocalWarehouseExecutorShape", () => {
 			stubLocalServer([])
 			const shape = makeLocalWarehouseExecutorShape("http://127.0.0.1:4318")
 
-			const exit = yield* shape.sqlQuery("SELECT 1").pipe(Effect.exit)
+			// Scope now rides on the compiled query rather than being sniffed out
+			// of the SQL string, so an unscoped one is rejected before execution.
+			const exit = yield* shape
+				.compiledQuery(unsafeCompiledQuery({ sql: "SELECT 1", tenantScope: "cross-org" }))
+				.pipe(Effect.exit)
 
 			expect(Exit.isFailure(exit)).toBe(true)
 		}),
@@ -73,7 +78,12 @@ describe("makeLocalWarehouseExecutorShape", () => {
 			const shape = makeLocalWarehouseExecutorShape("http://127.0.0.1:4318")
 
 			const exit = yield* shape
-				.sqlQuery("SELECT nope FROM traces WHERE OrgId = 'local'")
+				.compiledQuery(
+					unsafeCompiledQuery({
+						sql: "SELECT nope FROM traces WHERE OrgId = 'local'",
+						tenantScope: "org",
+					}),
+				)
 				.pipe(Effect.exit)
 
 			expect(Exit.isFailure(exit)).toBe(true)

--- a/apps/cli/src/core/remote-executor.ts
+++ b/apps/cli/src/core/remote-executor.ts
@@ -136,8 +136,6 @@ export const makeRemoteWarehouseExecutorShape = (
 					},
 				}),
 			),
-		sqlQuery: <T = Record<string, unknown>>(_sql: string, _options?: SqlQueryOptions) =>
-			unsupported<ReadonlyArray<T>>("sqlQuery"),
 		compiledQuery: <T>(_compiled: unknown, _options?: SqlQueryOptions) =>
 			unsupported<ReadonlyArray<T>>("compiledQuery"),
 		compiledQueryFirst: <T>(_compiled: unknown, _options?: SqlQueryOptions) =>

--- a/apps/cli/src/core/warehouse.ts
+++ b/apps/cli/src/core/warehouse.ts
@@ -48,8 +48,6 @@ export const WarehouseExecutorFromMode = Layer.effect(
 				getShape.pipe(
 					Effect.flatMap((shape) => shape.query<T>(pipe as WarehouseQueryName, params, options)),
 				),
-			sqlQuery: <T = Record<string, unknown>>(sql: string, options?: SqlQueryOptions) =>
-				getShape.pipe(Effect.flatMap((shape) => shape.sqlQuery<T>(sql, options))),
 			compiledQuery: (compiled, options?: SqlQueryOptions) =>
 				getShape.pipe(Effect.flatMap((shape) => shape.compiledQuery(compiled, options))),
 			compiledQueryFirst: (compiled, options?: SqlQueryOptions) =>

--- a/lib/clickhouse-builder/src/ch/compile.test.ts
+++ b/lib/clickhouse-builder/src/ch/compile.test.ts
@@ -25,6 +25,7 @@ describe("CompiledQuery.decodeRows", () => {
 	it.effect("decodes rows with the declared schema for handwritten SQL", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly name: string; readonly count: number }>({
+				tenantScope: "org",
 				sql: "SELECT name, count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ name: Schema.String, count: RowNumber }),
 			})
@@ -38,6 +39,7 @@ describe("CompiledQuery.decodeRows", () => {
 	it.effect("fails with CompiledQueryDecodeError when a row does not match its schema", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+				tenantScope: "org",
 				sql: "SELECT count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ count: RowNumber }),
 			})
@@ -58,6 +60,7 @@ describe("CompiledQuery.decodeFirstRow", () => {
 	it.effect("returns Some with the first decoded row", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly name: string; readonly count: number }>({
+				tenantScope: "org",
 				sql: "SELECT name, count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ name: Schema.String, count: RowNumber }),
 			})
@@ -77,6 +80,7 @@ describe("CompiledQuery.decodeFirstRow", () => {
 	it.effect("returns None when the result set is empty", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+				tenantScope: "org",
 				sql: "SELECT count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ count: RowNumber }),
 			})
@@ -90,6 +94,7 @@ describe("CompiledQuery.decodeFirstRow", () => {
 	it.effect("fails when the first row does not match the declared schema", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+				tenantScope: "org",
 				sql: "SELECT count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ count: RowNumber }),
 			})
@@ -108,6 +113,7 @@ describe("CompiledQuery.decodeFirstRow", () => {
 	it.effect("does not decode later rows when only the first row is requested", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+				tenantScope: "org",
 				sql: "SELECT count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ count: RowNumber }),
 			})
@@ -120,4 +126,155 @@ describe("CompiledQuery.decodeFirstRow", () => {
 			}
 		}),
 	)
+})
+
+// ---------------------------------------------------------------------------
+// Tenant scope
+//
+// `tenantScope` is what executors gate on, so these cases pin the exact shapes
+// that must NOT read as scoped. Each one compiles to SQL that mentions the
+// tenant column — which is why a substring check can't tell them apart.
+// ---------------------------------------------------------------------------
+
+describe("CompiledQuery.tenantScope", () => {
+	const events = CH.table("events", { OrgId: CH.string, Count: CH.uint64 })
+	const other = CH.table("other", { OrgId: CH.string, Count: CH.uint64 })
+
+	const scopeOf = (build: (q: typeof events) => any) => compileCH(build(events), {}).tenantScope
+
+	it("is 'org' for a top-level equality on the tenant column", () => {
+		expect(
+			scopeOf((t) =>
+				CH.from(t)
+					.select(($) => ({ count: $.Count }))
+					.where(($) => [$.OrgId.eq("org")]),
+			),
+		).toBe("org")
+	})
+
+	it("is 'org' for a top-level membership test", () => {
+		expect(
+			scopeOf((t) =>
+				CH.from(t)
+					.select(($) => ({ count: $.Count }))
+					.where(($) => [$.OrgId.in_("a", "b")]),
+			),
+		).toBe("org")
+	})
+
+	it("is 'cross-org' when the tenant predicate is disjoined away", () => {
+		// `OrgId = 'x' OR Count > 0` matches every tenant's rows.
+		expect(
+			scopeOf((t) =>
+				CH.from(t)
+					.select(($) => ({ count: $.Count }))
+					.where(($) => [$.OrgId.eq("org").or($.Count.gt(0))]),
+			),
+		).toBe("cross-org")
+	})
+
+	it("is 'cross-org' for a negated tenant predicate", () => {
+		expect(
+			scopeOf((t) =>
+				CH.from(t)
+					.select(($) => ({ count: $.Count }))
+					.where(($) => [$.OrgId.neq("org")]),
+			),
+		).toBe("cross-org")
+	})
+
+	it("is 'cross-org' when only the SELECT mentions the tenant column", () => {
+		// The shape that satisfied the old `sql.includes("OrgId")` guard.
+		const compiled = compileCH(
+			CH.from(events)
+				.select(($) => ({ OrgId: $.OrgId, count: $.Count }))
+				.groupBy("OrgId"),
+			{},
+		)
+		expect(compiled.sql).toContain("OrgId")
+		expect(compiled.tenantScope).toBe("cross-org")
+	})
+
+	// A query reading only from a scoped source is itself confined to that
+	// tenant, even with no WHERE of its own — this is the
+	// `SELECT sum(total) FROM (scoped UNION scoped)` shape that rollup-splice
+	// queries compile to.
+	it("is 'org' when the FROM source is already scoped", () => {
+		const inner = CH.from(events)
+			.select(($) => ({ OrgId: $.OrgId, count: $.Count }))
+			.where(($) => [$.OrgId.eq("org")])
+		expect(
+			compileCH(
+				CH.fromQuery(inner, "i")
+					.select(($) => ({ total: CH.sum($.count) }))
+					.where(($) => [$.count.gt(0)]),
+				{},
+			).tenantScope,
+		).toBe("org")
+	})
+
+	it("is 'cross-org' when the FROM source is unscoped", () => {
+		const inner = CH.from(events).select(($) => ({ OrgId: $.OrgId, count: $.Count }))
+		expect(
+			compileCH(
+				CH.fromQuery(inner, "i").select(($) => ({ total: CH.sum($.count) })),
+				{},
+			).tenantScope,
+		).toBe("cross-org")
+	})
+
+	// Joins add row sources the FROM scope says nothing about, so a joined query
+	// has to pin the tenant at its own level.
+	it("is 'cross-org' when a scoped source is joined to an unscoped table", () => {
+		const inner = CH.from(events)
+			.select(($) => ({ OrgId: $.OrgId, count: $.Count }))
+			.where(($) => [$.OrgId.eq("org")])
+		expect(
+			compileCH(
+				CH.fromQuery(inner, "i")
+					.leftJoin(other, "o", (main, o) => main.OrgId.eq(o.OrgId))
+					.select(($) => ({ total: CH.sum($.count) })),
+				{},
+			).tenantScope,
+		).toBe("cross-org")
+	})
+
+	it("is 'org' for a tenant predicate on a joined alias", () => {
+		expect(
+			compileCH(
+				CH.from(events)
+					.leftJoin(other, "o", (main, o) => main.OrgId.eq(o.OrgId))
+					.select(($) => ({ count: $.Count }))
+					.where(($) => [$.o.OrgId.eq("org")]),
+				{},
+			).tenantScope,
+		).toBe("org")
+	})
+
+	it("is 'cross-org' for a union with one unscoped branch", () => {
+		const scoped = CH.from(events)
+			.select(($) => ({ count: $.Count }))
+			.where(($) => [$.OrgId.eq("org")])
+		const unscoped = CH.from(other).select(($) => ({ count: $.Count }))
+
+		expect(CH.compileUnion(CH.unionAll(scoped, scoped), {}).tenantScope).toBe("org")
+		expect(CH.compileUnion(CH.unionAll(scoped, unscoped), {}).tenantScope).toBe("cross-org")
+	})
+
+	it("is 'cross-org' when .crossOrg() overrides a tenant predicate", () => {
+		expect(
+			scopeOf((t) =>
+				CH.from(t)
+					.select(($) => ({ count: $.Count }))
+					.where(($) => [$.OrgId.eq("org")])
+					.crossOrg(),
+			),
+		).toBe("cross-org")
+	})
+
+	it("requires handwritten SQL to state its scope", () => {
+		expect(
+			unsafeCompiledQuery({ sql: "SELECT 1", tenantScope: "cross-org" }).tenantScope,
+		).toBe("cross-org")
+	})
 })

--- a/lib/clickhouse-builder/src/ch/compile.ts
+++ b/lib/clickhouse-builder/src/ch/compile.ts
@@ -44,8 +44,24 @@ export class CompiledQueryDecodeError extends Schema.TaggedErrorClass<CompiledQu
 // never need to cast manually.
 // ---------------------------------------------------------------------------
 
+/**
+ * Whether a compiled query is confined to one tenant.
+ *
+ * `"org"` means a top-level `WHERE` predicate pins the tenant column; anything
+ * else is `"cross-org"` and reads every tenant the credentials can see.
+ * Executors are expected to refuse `"cross-org"` on their normal read path and
+ * require an explicit privileged entry point instead — which is why this is a
+ * derived fact on the compiled query rather than a convention in a doc comment.
+ */
+export type TenantScope = "org" | "cross-org"
+
 export interface CompiledQuery<Output> {
 	readonly sql: string
+	readonly tenantScope: TenantScope
+	/** Whether a `rowSchema` was supplied. Lets a catalog sweep see the queries
+	 *  that decode nothing — a missing schema is otherwise invisible, because
+	 *  `decodeRows` silently degrades to an identity cast. */
+	readonly rowSchemaDeclared: boolean
 	/** Execution-routing metadata: `"ingest"` marks a query whose datasource only
 	 *  exists in the managed ingest pipeline (declared via `.routing("ingest")` at
 	 *  the query definition), so executors read it there instead of a per-org
@@ -70,6 +86,7 @@ export type CompiledQueryRowSchema<Output> = Schema.Schema<Output>
 
 const makeCompiledQuery = <Output>(
 	sql: string,
+	tenantScope: TenantScope,
 	rowSchema?: CompiledQueryRowSchema<Output>,
 	routing?: "ingest",
 ): CompiledQuery<Output> => {
@@ -97,6 +114,8 @@ const makeCompiledQuery = <Output>(
 
 	return {
 		sql,
+		tenantScope,
+		rowSchemaDeclared: rowSchema !== undefined,
 		...(routing === undefined ? {} : { routing }),
 		decodeRows,
 		decodeFirstRow: (rows) => {
@@ -123,12 +142,18 @@ const makeCompiledQuery = <Output>(
  * Explicit constructor for SQL that cannot yet be expressed through the typed
  * DSL. Prefer `compile(CH.from(...))`; use this only for deliberately
  * handwritten ClickHouse SQL and pass `rowSchema` whenever possible.
+ *
+ * `tenantScope` is required and cannot be inferred here — there is no query AST
+ * to inspect, only a string. Stating it is the point: a handwritten query that
+ * forgets its tenant predicate should fail to compile until someone has looked.
  */
 export const unsafeCompiledQuery = <Output>(args: {
 	readonly sql: string
+	readonly tenantScope: TenantScope
 	readonly rowSchema?: CompiledQueryRowSchema<Output>
 	readonly routing?: "ingest"
-}): CompiledQuery<Output> => makeCompiledQuery(args.sql, args.rowSchema, args.routing)
+}): CompiledQuery<Output> =>
+	makeCompiledQuery(args.sql, args.tenantScope, args.rowSchema, args.routing)
 
 export function compileCH<
 	Cols extends ColumnDefs,
@@ -165,16 +190,29 @@ export function compileCH<
 		.filter((c): c is NonNullable<typeof c> => c != null)
 		.map((c) => c.toFragment())
 
+	// Tenant scope is read off THIS query's top-level predicates only. A filter
+	// inside `fromQuery`/`fromUnion`/a join that the outer query doesn't repeat
+	// does not scope the result — that is precisely the shape (an inner-scoped
+	// subquery joined to an unscoped outer) this is meant to catch. The
+	// top-level list is AND-joined below, so one marked entry is sufficient.
+	const hasOwnTenantPredicate = whereConditions.some((c) => c?.scopesTenant === true)
+
 	// FROM clause
 	let fromFragment
+	// Whether the row source is itself tenant-confined. A query reading only from
+	// a scoped subquery cannot see another tenant's rows even with no WHERE of
+	// its own — that is the `SELECT sum(total) FROM (scoped UNION scoped)` shape.
+	let fromSourceScope: TenantScope = "cross-org"
 	if (state.fromQuery) {
 		// Compile the inner query lazily
 		const innerCompiled = compileCH(state.fromQuery, params, { skipFormat: true })
+		fromSourceScope = innerCompiled.tenantScope
 		fromFragment = raw(`(${innerCompiled.sql}) AS ${state.fromQueryAlias}`)
 	} else if (state.fromUnion) {
 		// Compile the inner union without an outer FORMAT — the outer query
 		// owns formatting. Strips a trailing `\nFORMAT <fmt>` defensively.
 		const innerCompiled = compileUnion(state.fromUnion, params)
+		fromSourceScope = innerCompiled.tenantScope
 		const innerSql = innerCompiled.sql.replace(/\nFORMAT \w+$/, "")
 		fromFragment = raw(`(\n${innerSql}\n) AS ${state.fromQueryAlias}`)
 	} else if (state.tableAlias) {
@@ -183,15 +221,29 @@ export function compileCH<
 		fromFragment = ident(state.tableName)
 	}
 
+	// A FROM that names a CTE inherits whatever scope the CTE was declared with.
+	// The CTE body is an opaque pre-compiled string, so the declaration is the
+	// only thing that can carry this — see `withCTE`.
+	if (!state.fromQuery && !state.fromUnion) {
+		const cte = state.ctes.find((c) => c.name === state.tableName)
+		if (cte?.tenantScope === "org") fromSourceScope = "org"
+	}
+
 	// JOINs
+	// Every joined source is another set of rows that can reach the output, so
+	// each must be tenant-confined for the join result to be. A bare table join
+	// is unconfined unless the outer query pins the tenant itself.
+	let allJoinSourcesScoped = true
 	const joins =
 		state.typedJoins.length > 0
 			? state.typedJoins.map((j) => {
 					let tableSql: string
 					if (j.innerQuery) {
 						const compiled = compileCH(j.innerQuery, params, { skipFormat: true })
+						if (compiled.tenantScope !== "org") allJoinSourcesScoped = false
 						tableSql = `(${compiled.sql})`
 					} else if (j.tableName) {
+						allJoinSourcesScoped = false
 						tableSql = j.tableName
 					} else {
 						throw new QueryBuilderError({
@@ -236,8 +288,17 @@ export function compileCH<
 		sql = sql.replaceAll(placeholder, resolved)
 	}
 
+	// Scoped when this query pins the tenant itself, or when every row source it
+	// reads from — the FROM and each join — is already confined to one tenant.
+	const tenantScope: TenantScope =
+		state.crossOrg === true
+			? "cross-org"
+			: hasOwnTenantPredicate || (fromSourceScope === "org" && allJoinSourcesScoped)
+				? "org"
+				: "cross-org"
+
 	return {
-		...makeCompiledQuery<Output>(sql, options?.rowSchema, state.routingValue),
+		...makeCompiledQuery<Output>(sql, tenantScope, options?.rowSchema, state.routingValue),
 	}
 }
 
@@ -253,9 +314,14 @@ export function compileUnion<Output extends Record<string, any>, Params extends 
 	const state = union._state
 
 	// Compile each sub-query without FORMAT
-	const subSqls = state.queries.map((q) => compileCH(q, params, { skipFormat: true }).sql)
+	const subQueries = state.queries.map((q) => compileCH(q, params, { skipFormat: true }))
 
-	let sql = subSqls.join("\nUNION ALL\n")
+	// UNION ALL is a disjunction: one unscoped branch leaks every tenant into the
+	// result regardless of how tightly the others are filtered.
+	const tenantScope: TenantScope =
+		subQueries.length > 0 && subQueries.every((q) => q.tenantScope === "org") ? "org" : "cross-org"
+
+	let sql = subQueries.map((q) => q.sql).join("\nUNION ALL\n")
 
 	// Wrap in outer SELECT if ordering/pagination is needed
 	const hasOuter =
@@ -279,7 +345,7 @@ export function compileUnion<Output extends Record<string, any>, Params extends 
 	}
 
 	return {
-		...makeCompiledQuery<Output>(sql, options?.rowSchema),
+		...makeCompiledQuery<Output>(sql, tenantScope, options?.rowSchema),
 	}
 }
 

--- a/lib/clickhouse-builder/src/ch/expr.ts
+++ b/lib/clickhouse-builder/src/ch/expr.ts
@@ -52,6 +52,14 @@ export interface ColumnRef<Name extends string, ColType extends CHType<string, a
 
 export interface Condition {
 	readonly _brand: "Condition"
+	/**
+	 * Set only by an equality/membership test on the tenant column
+	 * (`TENANT_COLUMN`). `compile` reads it off the top-level `where` list to
+	 * decide whether a query is tenant-scoped, so it deliberately does NOT
+	 * propagate through `and`/`or`: `OrgId.eq(x).or(y)` is not a scoping
+	 * predicate, and treating it as one is the bug this marker exists to catch.
+	 */
+	readonly scopesTenant?: boolean
 	toFragment(): SqlFragment
 	and(other: Condition): Condition
 	or(other: Condition): Condition
@@ -128,27 +136,62 @@ export function makeExpr<T>(fragment: SqlFragment): Expr<T> {
 // ColumnRef implementation
 // ---------------------------------------------------------------------------
 
+/**
+ * The column carrying row-level tenancy. An equality or membership test on it
+ * is what marks a query as tenant-scoped (`CompiledQuery.tenantScope`).
+ *
+ * Row-per-tenant is the usual ClickHouse multi-tenancy shape, but the column's
+ * name is a schema decision — this is the single place to change it.
+ */
+export const TENANT_COLUMN = "OrgId"
+
 export function makeColumnRef<Name extends string, ColType extends CHType<string, any>>(
 	name: Name,
+	/**
+	 * Unqualified column name. Differs from `name` for joined accessors, where
+	 * `name` is `alias.Column` — so `$.p.OrgId.eq(…)` still marks the query as
+	 * scoped.  Defaults to `name` for the unqualified case.
+	 */
+	columnName?: string,
 ): ColumnRef<Name, ColType> {
 	const fragment = raw(name)
 	const base = makeExpr<InferTS<ColType>>(fragment)
-	return Object.assign(base, {
-		columnName: name as Name,
-		get(key: string): Expr<string> {
-			return makeExpr<string>(raw(`${name}[${compile(str(key))}]`))
+	const isTenantColumn = (columnName ?? name) === TENANT_COLUMN
+	// Captured before `Object.assign` mutates `base` — the overrides below reuse
+	// these to emit byte-identical SQL, and reading them off `base` afterwards
+	// would just call the override again.
+	const baseEq = base.eq
+	const baseIn = base.in_
+	return Object.assign(
+		base,
+		// Only `eq`/`in_` scope a query. `neq`/`notIn`/`like` on the tenant column
+		// narrow nothing, and marking them would let `OrgId != 'x'` pass as scoped.
+		isTenantColumn
+			? {
+					eq: (other: any) => makeCond(baseEq(other).toFragment(), true),
+					in_: (...values: ReadonlyArray<any>) =>
+						makeCond((baseIn as any)(...values).toFragment(), true),
+				}
+			: {},
+		{
+			columnName: name as Name,
+			get(key: string): Expr<string> {
+				return makeExpr<string>(raw(`${name}[${compile(str(key))}]`))
+			},
 		},
-	}) as ColumnRef<Name, ColType>
+	) as ColumnRef<Name, ColType>
 }
 
 // ---------------------------------------------------------------------------
 // Condition implementation
 // ---------------------------------------------------------------------------
 
-export function makeCond(fragment: SqlFragment): Condition {
+export function makeCond(fragment: SqlFragment, scopesTenant?: boolean): Condition {
 	return {
 		_brand: "Condition" as const,
+		...(scopesTenant === true ? { scopesTenant: true as const } : {}),
 		toFragment: () => fragment,
+		// Composition drops the marker on purpose — see `Condition.scopesTenant`.
 		and: (other) => makeCond(raw(`(${compile(fragment)} AND ${compile(other.toFragment())})`)),
 		or: (other) => makeCond(raw(`(${compile(fragment)} OR ${compile(other.toFragment())})`)),
 	}

--- a/lib/clickhouse-builder/src/ch/index.ts
+++ b/lib/clickhouse-builder/src/ch/index.ts
@@ -162,6 +162,7 @@ export {
 	unsafeCompiledQuery,
 	type CompiledQuery,
 	type CompiledQueryRowSchema,
+	type TenantScope,
 	QueryBuilderError,
 	CompiledQueryDecodeError,
 } from "./compile"

--- a/lib/clickhouse-builder/src/ch/query.ts
+++ b/lib/clickhouse-builder/src/ch/query.ts
@@ -30,6 +30,7 @@ import type { ColumnDefs, CHType, InferTS, OutputToColumnDefs, NullableColumnDef
 import type { Table } from "./table"
 import type { Expr, Condition, ColumnRef } from "./expr"
 import { makeColumnRef } from "./expr"
+import type { TenantScope } from "./compile"
 
 // ---------------------------------------------------------------------------
 // Type utilities
@@ -89,6 +90,8 @@ interface CHQueryState {
 	readonly formatValue?: string
 	/** Execution-routing metadata carried onto the CompiledQuery (see compile.ts). */
 	readonly routingValue?: "ingest"
+	/** Set by `.crossOrg()`. Forces `tenantScope: "cross-org"` (see compile.ts). */
+	readonly crossOrg?: boolean
 	/** Typed FROM subquery. Compiled lazily at compileCH time. */
 	readonly fromQuery?: CHQuery<any, any, any>
 	readonly fromQueryAlias?: string
@@ -97,7 +100,7 @@ interface CHQueryState {
 	/** Typed joins (compiled lazily at compileCH time). */
 	readonly typedJoins: TypedJoinClause[]
 	/** CTE definitions prepended as WITH clauses. */
-	readonly ctes: Array<{ name: string; sql: string }>
+	readonly ctes: Array<{ name: string; sql: string; tenantScope?: TenantScope }>
 }
 
 // ---------------------------------------------------------------------------
@@ -145,6 +148,17 @@ export interface CHQuery<
 	 * ingest backend instead of a per-org read override.
 	 */
 	routing(route: "ingest"): CHQuery<Cols, Output, Joins>
+
+	/**
+	 * Declare that this query deliberately reads across every tenant, forcing
+	 * `tenantScope: "cross-org"` on the compiled result.
+	 *
+	 * Opting in explicitly rather than relying on the absence of a tenant
+	 * predicate is the whole point: "no `OrgId` filter" is indistinguishable
+	 * from "someone forgot the `OrgId` filter" until an author says which.
+	 * Executors are expected to refuse these on the ordinary read path.
+	 */
+	crossOrg(): CHQuery<Cols, Output, Joins>
 
 	// ---------------------------------------------------------------------------
 	// Type-safe joins with Table
@@ -211,7 +225,19 @@ export interface CHQuery<
 	 * Add a CTE (WITH clause). The CTE SQL is prepended to the compiled query.
 	 * The CTE name can then be used as a table name via `from()` or in raw expressions.
 	 */
-	withCTE(name: string, sql: string): CHQuery<Cols, Output, Joins>
+	/**
+	 * Attach a CTE from pre-compiled SQL.
+	 *
+	 * `tenantScope` describes the SQL being passed in. It cannot be inferred —
+	 * the CTE arrives as an opaque string — so a caller splicing in a query it
+	 * compiled itself should pass the scope through, otherwise a query whose only
+	 * row source is a scoped CTE reads as cross-org.
+	 */
+	withCTE(
+		name: string,
+		sql: string,
+		options?: { readonly tenantScope?: TenantScope },
+	): CHQuery<Cols, Output, Joins>
 }
 
 // ---------------------------------------------------------------------------
@@ -253,7 +279,7 @@ function createQualifiedColumnAccessor(alias: string): ColumnAccessor<any> {
 			if (typeof prop !== "string") return undefined
 			let ref = cache.get(prop)
 			if (!ref) {
-				ref = makeColumnRef(`${alias}.${prop}`)
+				ref = makeColumnRef(`${alias}.${prop}`, prop)
 				cache.set(prop, ref)
 			}
 			return ref
@@ -288,7 +314,7 @@ export function createJoinedColumnAccessor<Cols extends ColumnDefs, Joins extend
 
 			// Main table column — qualify with alias when joins are present
 			const qualifiedName = mainAlias ? `${mainAlias}.${prop}` : prop
-			cached = makeColumnRef(qualifiedName)
+			cached = makeColumnRef(qualifiedName, prop)
 			cache.set(prop, cached)
 			return cached
 		},
@@ -350,6 +376,10 @@ function makeQuery<
 
 		routing(route) {
 			return makeQuery({ ...state, routingValue: route })
+		},
+
+		crossOrg() {
+			return makeQuery({ ...state, crossOrg: true })
 		},
 
 		// -----------------------------------------------------------------------
@@ -428,10 +458,10 @@ function makeQuery<
 			}) as any
 		},
 
-		withCTE(name, sql) {
+		withCTE(name, sql, options) {
 			return makeQuery({
 				...state,
-				ctes: [...state.ctes, { name, sql }],
+				ctes: [...state.ctes, { name, sql, tenantScope: options?.tenantScope }],
 			})
 		},
 	}

--- a/packages/query-engine/src/__sql_baseline__/catalog.sql
+++ b/packages/query-engine/src/__sql_baseline__/catalog.sql
@@ -1,0 +1,6521 @@
+-- builder:activity:activeOrgsByErrorEventsQuery:default  [eae8a088]
+SELECT
+          OrgId AS orgId
+        FROM error_events_by_time
+        WHERE Timestamp >= '2026-01-01 10:30:00'
+        GROUP BY orgId
+        FORMAT JSON
+
+-- builder:activity:activeOrgsByLogsQuery:default  [8c4b87f8]
+SELECT
+          OrgId AS orgId
+        FROM logs_aggregates_hourly
+        WHERE Hour >= '2026-01-01 10:30:00'
+        GROUP BY orgId
+        FORMAT JSON
+
+-- builder:activity:activeOrgsByTracesQuery:default  [80107423]
+SELECT
+          OrgId AS orgId
+        FROM traces_aggregates_hourly
+        WHERE Hour >= '2026-01-01 10:30:00'
+        GROUP BY orgId
+        FORMAT JSON
+
+-- builder:cloudflare-infra-breakdowns:cloudflareZoneBreakdownTimeseriesSQL:default  [d70e5294]
+SELECT
+          formatDateTime(toStartOfInterval(TimeUnix, INTERVAL 300 SECOND), '%Y-%m-%dT%H:%i:%S.%fZ') AS bucket,
+          if(Attributes['url.path'] IN ('/api/v2/traces'), Attributes['url.path'], 'other') AS key,
+          sum(Value) AS requests
+        FROM metrics_sum
+        WHERE OrgId = 'org_sql_catalog'
+          AND ServiceName = 'cloudflare-zone-example-com'
+          AND MetricName = 'cloudflare.http.requests.by_path'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY bucket, key
+        ORDER BY bucket ASC, key ASC
+        FORMAT JSON
+
+-- builder:cloudflare-infra-extended:cloudflareQueueGaugesSQL:default  [5214441e]
+SELECT
+          ServiceName AS serviceName,
+          if(countIf(MetricName = 'cloudflare.queue.backlog.messages') > 0, avgIf(Value, MetricName = 'cloudflare.queue.backlog.messages'), 0) AS backlogMessages,
+          maxIf(Value, MetricName = 'cloudflare.queue.backlog.messages') AS backlogMessagesMax,
+          if(countIf(MetricName = 'cloudflare.queue.backlog.bytes') > 0, avgIf(Value, MetricName = 'cloudflare.queue.backlog.bytes'), 0) AS backlogBytes,
+          if(countIf(MetricName = 'cloudflare.queue.consumer.concurrency') > 0, avgIf(Value, MetricName = 'cloudflare.queue.consumer.concurrency'), 0) AS consumerConcurrency
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName IN ('cloudflare.queue.backlog.messages', 'cloudflare.queue.backlog.bytes', 'cloudflare.queue.consumer.concurrency')
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY serviceName
+        ORDER BY backlogMessagesMax DESC
+        LIMIT 500
+        FORMAT JSON
+
+-- builder:cloudflare-infra:cloudflareZoneLatencySQL:default  [1b6f80d9]
+SELECT
+          ServiceName AS serviceName,
+          if(countIf((MetricName = 'cloudflare.http.edge.ttfb' AND Attributes['quantile'] = '0.5')) > 0, avgIf(Value, (MetricName = 'cloudflare.http.edge.ttfb' AND Attributes['quantile'] = '0.5')), 0) AS ttfbP50Ms,
+          if(countIf((MetricName = 'cloudflare.http.edge.ttfb' AND Attributes['quantile'] = '0.95')) > 0, avgIf(Value, (MetricName = 'cloudflare.http.edge.ttfb' AND Attributes['quantile'] = '0.95')), 0) AS ttfbP95Ms,
+          if(countIf((MetricName = 'cloudflare.http.edge.ttfb' AND Attributes['quantile'] = '0.99')) > 0, avgIf(Value, (MetricName = 'cloudflare.http.edge.ttfb' AND Attributes['quantile'] = '0.99')), 0) AS ttfbP99Ms,
+          if(countIf((MetricName = 'cloudflare.http.origin.duration' AND Attributes['quantile'] = '0.5')) > 0, avgIf(Value, (MetricName = 'cloudflare.http.origin.duration' AND Attributes['quantile'] = '0.5')), 0) AS originP50Ms,
+          if(countIf((MetricName = 'cloudflare.http.origin.duration' AND Attributes['quantile'] = '0.95')) > 0, avgIf(Value, (MetricName = 'cloudflare.http.origin.duration' AND Attributes['quantile'] = '0.95')), 0) AS originP95Ms,
+          if(countIf((MetricName = 'cloudflare.http.origin.duration' AND Attributes['quantile'] = '0.99')) > 0, avgIf(Value, (MetricName = 'cloudflare.http.origin.duration' AND Attributes['quantile'] = '0.99')), 0) AS originP99Ms
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName IN ('cloudflare.http.edge.ttfb', 'cloudflare.http.origin.duration')
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY serviceName
+        LIMIT 500
+        FORMAT JSON
+
+-- builder:cloudflare-infra:cloudflareZoneTimeseriesSQL:default  [792c6b0c]
+SELECT
+          ServiceName AS serviceName,
+          formatDateTime(toStartOfInterval(TimeUnix, INTERVAL 300 SECOND), '%Y-%m-%dT%H:%i:%S.%fZ') AS bucket,
+          sumIf(Value, MetricName = 'cloudflare.http.requests') AS requests,
+          sumIf(Value, (MetricName = 'cloudflare.http.requests' AND Attributes['http.status_class'] = '5xx')) AS errors5xx,
+          sumIf(Value, (MetricName = 'cloudflare.http.requests' AND Attributes['cache.status'] IN ('hit', 'stale', 'revalidated', 'updating'))) AS cacheHits,
+          sumIf(Value, MetricName = 'cloudflare.http.bytes') AS bytes,
+          sumIf(Value, MetricName = 'cloudflare.http.visits') AS visits
+        FROM metrics_sum
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName IN ('cloudflare.http.requests', 'cloudflare.http.bytes', 'cloudflare.http.visits')
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY serviceName, bucket
+        ORDER BY serviceName ASC, bucket ASC
+        FORMAT JSON
+
+-- builder:cloudflare-infra:cloudflareZoneTimeseriesSQL:filtered  [5072f801]
+SELECT
+          ServiceName AS serviceName,
+          formatDateTime(toStartOfInterval(TimeUnix, INTERVAL 300 SECOND), '%Y-%m-%dT%H:%i:%S.%fZ') AS bucket,
+          sumIf(Value, MetricName = 'cloudflare.http.requests') AS requests,
+          sumIf(Value, (MetricName = 'cloudflare.http.requests' AND Attributes['http.status_class'] = '5xx')) AS errors5xx,
+          sumIf(Value, (MetricName = 'cloudflare.http.requests' AND Attributes['cache.status'] IN ('hit', 'stale', 'revalidated', 'updating'))) AS cacheHits,
+          sumIf(Value, MetricName = 'cloudflare.http.bytes') AS bytes,
+          sumIf(Value, MetricName = 'cloudflare.http.visits') AS visits
+        FROM metrics_sum
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName IN ('cloudflare.http.requests', 'cloudflare.http.bytes', 'cloudflare.http.visits')
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND if(Attributes['server.address'] != '', Attributes['server.address'], Attributes['http.host']) IN ('example.com')
+          AND Attributes['http.status_class'] IN ('5xx')
+        GROUP BY serviceName, bucket
+        ORDER BY serviceName ASC, bucket ASC
+        FORMAT JSON
+
+-- builder:cloudflare-map:cloudflareServiceLatencySQL:default  [46672bf1]
+SELECT
+          ServiceName AS serviceName,
+          if(countIf((MetricName = 'cloudflare.worker.duration' AND Attributes['quantile'] = '0.99')) > 0, avgIf(Value, (MetricName = 'cloudflare.worker.duration' AND Attributes['quantile'] = '0.99')), 0) AS latencyP99Ms,
+          if(countIf((MetricName = 'cloudflare.worker.cpu_time' AND Attributes['quantile'] = '0.99')) > 0, avgIf(Value, (MetricName = 'cloudflare.worker.cpu_time' AND Attributes['quantile'] = '0.99')), 0) AS cpuP99Ms
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName IN ('cloudflare.worker.duration', 'cloudflare.worker.cpu_time')
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY serviceName
+        LIMIT 500
+        FORMAT JSON
+
+-- builder:cloudflare-usage:cloudflareUsageQuery:default  [2a4b1f46]
+SELECT
+          ServiceName AS serviceName,
+          formatDateTime(toStartOfInterval(TimeUnix, INTERVAL 3600 SECOND), '%Y-%m-%dT%H:%i:%S.%fZ') AS bucket,
+          sum(Value) AS requests,
+          count() AS datapoints,
+          formatDateTime(max(TimeUnix), '%Y-%m-%dT%H:%i:%S.%fZ') AS lastTimeUnix
+        FROM metrics_sum
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName IN ('cloudflare.http.requests', 'cloudflare.worker.requests')
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY serviceName, bucket
+        ORDER BY serviceName ASC, bucket ASC
+        FORMAT JSON
+
+-- builder:errors:errorFingerprintsQuery:envFiltered  [f1269c9f]
+SELECT
+          toString(FingerprintHash) AS fingerprintHash
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName IN ('api')
+          AND DeploymentEnv IN ('production')
+        GROUP BY fingerprintHash
+        LIMIT 1000
+        FORMAT JSON
+
+-- builder:errors:errorIssueSampleTracesQuery:default  [165204e4]
+SELECT
+          TraceId AS traceId,
+          SpanId AS spanId,
+          ServiceName AS serviceName,
+          Timestamp AS timestamp,
+          ExceptionMessage AS exceptionMessage,
+          intDiv(Duration, 1000) AS durationMicros
+        FROM error_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND FingerprintHash = toUInt64('11640393269246331608')
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        ORDER BY timestamp DESC
+        LIMIT 5
+        FORMAT JSON
+
+-- builder:errors:errorIssuesQuery:scan  [ce76d415]
+SELECT
+          toString(FingerprintHash) AS fingerprintHash,
+          any(ServiceName) AS serviceName,
+          any(ExceptionType) AS exceptionType,
+          any(ExceptionMessage) AS exceptionMessage,
+          any(ErrorLabel) AS errorLabel,
+          any(TopFrame) AS topFrame,
+          count() AS count,
+          uniq(ServiceName) AS affectedServicesCount,
+          min(Timestamp) AS firstSeen,
+          max(Timestamp) AS lastSeen
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY fingerprintHash
+        ORDER BY count DESC
+        LIMIT 500
+        FORMAT JSON
+
+-- builder:errors:errorIssueTimeseriesQuery:default  [8ea53a5e]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 300 SECOND) AS bucket,
+          count() AS count
+        FROM error_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND FingerprintHash = toUInt64('11640393269246331608')
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY bucket
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- builder:errors:spanDetailQuery:default  [64ddf7c1]
+SELECT
+          TraceId AS traceId,
+          SpanId AS spanId,
+          ParentSpanId AS parentSpanId,
+          if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) AS spanName,
+          ServiceName AS serviceName,
+          SpanKind AS spanKind,
+          Duration / 1000000 AS durationMs,
+          Timestamp AS startTime,
+          StatusCode AS statusCode,
+          StatusMessage AS statusMessage,
+          toJSONString(SpanAttributes) AS spanAttributes,
+          toJSONString(ResourceAttributes) AS resourceAttributes
+        FROM trace_detail_spans
+        WHERE TraceId = '0af7651916cd43dd8448eb211c80319c'
+          AND SpanId = 'b7ad6b7169203331'
+          AND OrgId = 'org_sql_catalog'
+        LIMIT 1
+        FORMAT JSON
+
+-- builder:errors:spanDetailQuery:narrowByTime  [b78705cd]
+SELECT
+          TraceId AS traceId,
+          SpanId AS spanId,
+          ParentSpanId AS parentSpanId,
+          if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) AS spanName,
+          ServiceName AS serviceName,
+          SpanKind AS spanKind,
+          Duration / 1000000 AS durationMs,
+          Timestamp AS startTime,
+          StatusCode AS statusCode,
+          StatusMessage AS statusMessage,
+          toJSONString(SpanAttributes) AS spanAttributes,
+          toJSONString(ResourceAttributes) AS resourceAttributes
+        FROM trace_detail_spans
+        WHERE TraceId = '0af7651916cd43dd8448eb211c80319c'
+          AND SpanId = 'b7ad6b7169203331'
+          AND OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        LIMIT 1
+        FORMAT JSON
+
+-- builder:infra:hostGaugeTimeseriesQuery:default  [7d9ca740]
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 300 SECOND) AS bucket,
+          '' AS attributeValue,
+          avg(Value) AS avgValue
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['host.name'] = 'ip-10-0-1-42'
+          AND MetricName = 'system.cpu.utilization'
+        GROUP BY bucket
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- builder:infra:hostGaugeTimeseriesQuery:grouped  [bc031666]
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 300 SECOND) AS bucket,
+          Attributes['cpu'] AS attributeValue,
+          avg(Value) AS avgValue
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['host.name'] = 'ip-10-0-1-42'
+          AND MetricName = 'system.cpu.utilization'
+        GROUP BY bucket, attributeValue
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- builder:infra:nodeFacetsQuery:default  [ecfd3ec1]
+SELECT
+          ResourceAttributes['k8s.node.name'] AS name,
+          uniq(ResourceAttributes['k8s.node.name']) AS count,
+          'node' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.node.name'] != ''
+          AND ResourceAttributes['k8s.pod.name'] = ''
+          AND MetricName IN ('k8s.node.cpu.usage')
+          AND ResourceAttributes['k8s.node.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 200
+UNION ALL
+SELECT
+          ResourceAttributes['k8s.cluster.name'] AS name,
+          uniq(ResourceAttributes['k8s.node.name']) AS count,
+          'cluster' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.node.name'] != ''
+          AND ResourceAttributes['k8s.pod.name'] = ''
+          AND MetricName IN ('k8s.node.cpu.usage')
+          AND ResourceAttributes['k8s.cluster.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          ResourceAttributes['deployment.environment.name'] AS name,
+          uniq(ResourceAttributes['k8s.node.name']) AS count,
+          'environment' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.node.name'] != ''
+          AND ResourceAttributes['k8s.pod.name'] = ''
+          AND MetricName IN ('k8s.node.cpu.usage')
+          AND ResourceAttributes['deployment.environment.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+FORMAT JSON
+
+-- builder:infra:nodeGaugeTimeseriesQuery:default  [6a0ebdb5]
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 300 SECOND) AS bucket,
+          '' AS attributeValue,
+          avg(Value) AS avgValue
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.node.name'] = 'ip-10-0-1-42.ec2.internal'
+          AND ResourceAttributes['k8s.pod.name'] = ''
+          AND MetricName = 'k8s.node.cpu.utilization'
+        GROUP BY bucket
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- builder:infra:podFacetsQuery:default  [b49456ea]
+SELECT
+          ResourceAttributes['k8s.pod.name'] AS name,
+          uniq(ResourceAttributes['k8s.pod.uid']) AS count,
+          'pod' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.pod.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 200
+UNION ALL
+SELECT
+          ResourceAttributes['k8s.namespace.name'] AS name,
+          uniq(ResourceAttributes['k8s.pod.uid']) AS count,
+          'namespace' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.namespace.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          ResourceAttributes['k8s.node.name'] AS name,
+          uniq(ResourceAttributes['k8s.pod.uid']) AS count,
+          'node' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.node.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          ResourceAttributes['k8s.cluster.name'] AS name,
+          uniq(ResourceAttributes['k8s.pod.uid']) AS count,
+          'cluster' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.cluster.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          ResourceAttributes['k8s.deployment.name'] AS name,
+          uniq(ResourceAttributes['k8s.pod.uid']) AS count,
+          'deployment' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.deployment.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          ResourceAttributes['k8s.statefulset.name'] AS name,
+          uniq(ResourceAttributes['k8s.pod.uid']) AS count,
+          'statefulset' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.statefulset.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          ResourceAttributes['k8s.daemonset.name'] AS name,
+          uniq(ResourceAttributes['k8s.pod.uid']) AS count,
+          'daemonset' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.daemonset.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          ResourceAttributes['k8s.job.name'] AS name,
+          uniq(ResourceAttributes['k8s.pod.uid']) AS count,
+          'job' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.job.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          ResourceAttributes['deployment.environment.name'] AS name,
+          uniq(ResourceAttributes['k8s.pod.uid']) AS count,
+          'environment' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['deployment.environment.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          ResourceAttributes['eks.amazonaws.com/compute-type'] AS name,
+          uniq(ResourceAttributes['k8s.pod.uid']) AS count,
+          'computeType' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['eks.amazonaws.com/compute-type'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+FORMAT JSON
+
+-- builder:infra:podGaugeTimeseriesQuery:default  [6a0ebdb5]
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 300 SECOND) AS bucket,
+          '' AS attributeValue,
+          avg(Value) AS avgValue
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.pod.name'] = 'api-7d9f8b6c5-x2n4k'
+          AND ResourceAttributes['k8s.namespace.name'] = 'backend'
+          AND MetricName = 'k8s.pod.cpu.utilization'
+        GROUP BY bucket
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- builder:infra:workloadFacetsQuery:default  [e1f768b0]
+SELECT
+          ResourceAttributes['k8s.deployment.name'] AS name,
+          uniq(ResourceAttributes['k8s.deployment.name']) AS count,
+          'workload' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.deployment.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.deployment.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 200
+UNION ALL
+SELECT
+          ResourceAttributes['k8s.namespace.name'] AS name,
+          uniq(ResourceAttributes['k8s.deployment.name']) AS count,
+          'namespace' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.deployment.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.namespace.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          ResourceAttributes['k8s.cluster.name'] AS name,
+          uniq(ResourceAttributes['k8s.deployment.name']) AS count,
+          'cluster' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.deployment.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['k8s.cluster.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          ResourceAttributes['deployment.environment.name'] AS name,
+          uniq(ResourceAttributes['k8s.deployment.name']) AS count,
+          'environment' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.deployment.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['deployment.environment.name'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          ResourceAttributes['eks.amazonaws.com/compute-type'] AS name,
+          uniq(ResourceAttributes['k8s.deployment.name']) AS count,
+          'computeType' AS facetType
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.deployment.name'] != ''
+          AND MetricName IN ('k8s.pod.cpu.usage')
+          AND ResourceAttributes['eks.amazonaws.com/compute-type'] != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+FORMAT JSON
+
+-- builder:infra:workloadGaugeTimeseriesQuery:default  [6a0ebdb5]
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 300 SECOND) AS bucket,
+          '' AS attributeValue,
+          avg(Value) AS avgValue
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.deployment.name'] = 'api'
+          AND ResourceAttributes['k8s.namespace.name'] = 'backend'
+          AND MetricName = 'k8s.pod.cpu.utilization'
+        GROUP BY bucket
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- builder:infra:workloadGaugeTimeseriesQuery:groupedByPod  [ceff2e1f]
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 300 SECOND) AS bucket,
+          ResourceAttributes['k8s.pod.name'] AS attributeValue,
+          avg(Value) AS avgValue
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ResourceAttributes['k8s.statefulset.name'] = 'clickhouse'
+          AND ResourceAttributes['k8s.namespace.name'] = 'data'
+          AND MetricName = 'k8s.pod.memory.usage'
+        GROUP BY bucket, attributeValue
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- builder:planetscale-map:planetscaleGaugesSQL:default  [c3acc181]
+SELECT
+          coalesce(nullIf(Attributes['planetscale_database_name'], ''), Attributes['planetscale_database']) AS database,
+          maxIf(Value, MetricName IN ('planetscale_pods_cpu_util_percentages')) AS cpuMaxPercent,
+          maxIf(Value, MetricName IN ('planetscale_pods_mem_util_percentages')) AS memMaxPercent,
+          maxIf(Value, MetricName IN ('planetscale_mysql_replica_lag_seconds', 'planetscale_vttablet_replication_lag', 'planetscale_postgres_replica_lag_seconds')) AS replicaLagMaxSeconds
+        FROM metrics_gauge
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName IN ('planetscale_pods_cpu_util_percentages', 'planetscale_pods_mem_util_percentages', 'planetscale_mysql_replica_lag_seconds', 'planetscale_vttablet_replication_lag', 'planetscale_postgres_replica_lag_seconds')
+          AND coalesce(nullIf(Attributes['planetscale_database_name'], ''), Attributes['planetscale_database']) != ''
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY database
+        LIMIT 500
+        FORMAT JSON
+
+-- builder:service-operations:serviceOperationsSummaryQuery:default  [6845b233]
+SELECT
+          bSpanName AS spanName,
+          sum(bSpanCount) AS spanCount,
+          sum(bEstimatedSpanCount) AS estimatedSpanCount,
+          sum(bErrorCount) AS errorCount,
+          sum(bEstimatedErrorCount) AS estimatedErrorCount,
+          if(sum(bEstimatedSpanCount) > 0, sum(bEstimatedErrorCount) / sum(bEstimatedSpanCount), 0) AS errorRate,
+          if(sum(bSpanCount) > 0, sum(bDurationSum) / sum(bSpanCount) / 1000000, 0) AS avgDurationMs,
+          if(sum(bSpanCount) > 0, arrayElement(quantilesTDigestMerge(0.5, 0.95)(bDurationQuantiles), 1) / 1000000, 0) AS p50DurationMs,
+          if(sum(bSpanCount) > 0, arrayElement(quantilesTDigestMerge(0.5, 0.95)(bDurationQuantiles), 2) / 1000000, 0) AS p95DurationMs
+        FROM (
+SELECT
+          if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) AS bSpanName,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95)(Duration) AS bDurationQuantiles
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 MINUTE) OR Timestamp >= toStartOfMinute(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bSpanName
+UNION ALL
+SELECT
+          SpanName AS bSpanName,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95)(DurationQuantiles) AS bDurationQuantiles
+        FROM service_operations_minutely
+        WHERE OrgId = 'org_sql_catalog'
+          AND ServiceName = 'api'
+          AND Minute >= if(toDateTime('2026-01-01 10:30:00') = toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 MINUTE)
+          AND Minute < toStartOfMinute(toDateTime('2026-01-03 14:15:00'))
+          AND (Minute < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Minute >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bSpanName
+UNION ALL
+SELECT
+          SpanName AS bSpanName,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95)(DurationQuantiles) AS bDurationQuantiles
+        FROM service_operations_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND ServiceName = 'api'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bSpanName
+) AS operation_windows
+        GROUP BY spanName
+        ORDER BY estimatedSpanCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- builder:service-operations:serviceOperationsSummaryQuery:envFiltered  [66a9f885]
+SELECT
+          bSpanName AS spanName,
+          sum(bSpanCount) AS spanCount,
+          sum(bEstimatedSpanCount) AS estimatedSpanCount,
+          sum(bErrorCount) AS errorCount,
+          sum(bEstimatedErrorCount) AS estimatedErrorCount,
+          if(sum(bEstimatedSpanCount) > 0, sum(bEstimatedErrorCount) / sum(bEstimatedSpanCount), 0) AS errorRate,
+          if(sum(bSpanCount) > 0, sum(bDurationSum) / sum(bSpanCount) / 1000000, 0) AS avgDurationMs,
+          if(sum(bSpanCount) > 0, arrayElement(quantilesTDigestMerge(0.5, 0.95)(bDurationQuantiles), 1) / 1000000, 0) AS p50DurationMs,
+          if(sum(bSpanCount) > 0, arrayElement(quantilesTDigestMerge(0.5, 0.95)(bDurationQuantiles), 2) / 1000000, 0) AS p95DurationMs
+        FROM (
+SELECT
+          if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) AS bSpanName,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95)(Duration) AS bDurationQuantiles
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 MINUTE) OR Timestamp >= toStartOfMinute(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bSpanName
+UNION ALL
+SELECT
+          SpanName AS bSpanName,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95)(DurationQuantiles) AS bDurationQuantiles
+        FROM service_operations_minutely
+        WHERE OrgId = 'org_sql_catalog'
+          AND ServiceName = 'api'
+          AND DeploymentEnv IN ('production')
+          AND Minute >= if(toDateTime('2026-01-01 10:30:00') = toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 MINUTE)
+          AND Minute < toStartOfMinute(toDateTime('2026-01-03 14:15:00'))
+          AND (Minute < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Minute >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bSpanName
+UNION ALL
+SELECT
+          SpanName AS bSpanName,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95)(DurationQuantiles) AS bDurationQuantiles
+        FROM service_operations_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND ServiceName = 'api'
+          AND DeploymentEnv IN ('production')
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bSpanName
+) AS operation_windows
+        GROUP BY spanName
+        ORDER BY estimatedSpanCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- builder:service-operations:serviceOperationsTimeseriesQuery:default  [aa8bcdc7]
+SELECT
+          bucket AS bucket,
+          spanName AS spanName,
+          sum(count) AS count
+        FROM (
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 300 SECOND) AS bucket,
+          if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) AS spanName,
+          sum(SampleRate) AS count
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 MINUTE) OR Timestamp >= toStartOfMinute(toDateTime('2026-01-03 14:15:00')))
+          AND if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) IN ('GET /v2/services', 'POST /v2/alerts')
+        GROUP BY bucket, spanName
+UNION ALL
+SELECT
+          toStartOfInterval(Minute, INTERVAL 300 SECOND) AS bucket,
+          SpanName AS spanName,
+          sum(EstimatedSpanCount) AS count
+        FROM service_operations_minutely
+        WHERE OrgId = 'org_sql_catalog'
+          AND ServiceName = 'api'
+          AND Minute >= if(toDateTime('2026-01-01 10:30:00') = toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')), toStartOfMinute(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 MINUTE)
+          AND Minute < toStartOfMinute(toDateTime('2026-01-03 14:15:00'))
+          AND SpanName IN ('GET /v2/services', 'POST /v2/alerts')
+        GROUP BY bucket, spanName
+) AS operation_buckets
+        GROUP BY bucket, spanName
+        ORDER BY bucket ASC
+        LIMIT 10000
+        FORMAT JSON
+
+-- builder:services:serviceCatalogQuery:default  [d5bf26ae]
+SELECT
+          bServiceName AS serviceName,
+          arraySort(arrayFilter(x -> x != '', arrayDistinct(groupArray(bServiceNamespace)))) AS serviceNamespaces,
+          arraySort(arrayFilter(x -> x != '', arrayDistinct(groupArray(bEnvironment)))) AS deploymentEnvironments,
+          sum(bSpanCount) AS spanCount,
+          sum(bErrorCount) AS errorCount,
+          sum(bEstimatedErrorCount) AS estimatedErrorCount,
+          sum(bEstimatedSpanCount) AS estimatedSpanCount,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 1) / 1000000 AS p50LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 2) / 1000000 AS p95LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 3) / 1000000 AS p99LatencyMs
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        GROUP BY serviceName
+        ORDER BY estimatedSpanCount DESC, serviceName ASC
+        LIMIT 50
+        OFFSET 0
+        FORMAT JSON
+
+-- builder:services:serviceCatalogQuery:filtered  [fc879e14]
+SELECT
+          bServiceName AS serviceName,
+          arraySort(arrayFilter(x -> x != '', arrayDistinct(groupArray(bServiceNamespace)))) AS serviceNamespaces,
+          arraySort(arrayFilter(x -> x != '', arrayDistinct(groupArray(bEnvironment)))) AS deploymentEnvironments,
+          sum(bSpanCount) AS spanCount,
+          sum(bErrorCount) AS errorCount,
+          sum(bEstimatedErrorCount) AS estimatedErrorCount,
+          sum(bEstimatedSpanCount) AS estimatedSpanCount,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 1) / 1000000 AS p50LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 2) / 1000000 AS p95LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 3) / 1000000 AS p99LatencyMs
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv IN ('production')
+          AND ServiceNamespace IN ('backend')
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+          AND DeploymentEnv IN ('production')
+          AND ServiceNamespace IN ('backend')
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        GROUP BY serviceName
+        ORDER BY estimatedSpanCount DESC, serviceName ASC
+        LIMIT 50
+        OFFSET 0
+        FORMAT JSON
+
+-- builder:session-events:sessionActivityQuery:default  [daf1704b]
+SELECT
+          sessionId AS sessionId,
+          sumIf(gapMs, (gapMs > 0 AND gapMs <= 15000)) AS activeTimeMs,
+          sumIf(gapMs, gapMs > 15000) AS idleTimeMs,
+          count() AS eventCount
+        FROM (SELECT
+          SessionId AS sessionId,
+          toFloat64(toUnixTimestamp64Nano(Timestamp) - toUnixTimestamp64Nano(lagInFrame(Timestamp, 1, Timestamp) OVER (PARTITION BY SessionId ORDER BY Timestamp ASC, Seq ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW))) / 1000000 AS gapMs
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND SessionId = 'sess_0af7651916cd43dd'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00') AS g
+        GROUP BY sessionId
+        LIMIT 1
+        FORMAT JSON
+
+-- builder:session-events:sessionTranscriptQuery:default  [ac53e184]
+SELECT
+          Timestamp AS timestamp,
+          Seq AS seq,
+          Type AS type,
+          Url AS url,
+          TraceId AS traceId,
+          Level AS level,
+          Message AS message,
+          TargetSelector AS targetSelector,
+          TargetText AS targetText,
+          NetMethod AS netMethod,
+          NetUrl AS netUrl,
+          NetStatus AS netStatus,
+          NetDurationMs AS netDurationMs,
+          ErrorStack AS errorStack
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND SessionId = 'sess_0af7651916cd43dd'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        ORDER BY timestamp ASC, seq ASC
+        LIMIT 100
+        OFFSET 0
+        FORMAT JSON
+
+-- builder:session-replays:getSessionReplayQuery:default  [c277ac48]
+SELECT
+          Version AS version,
+          SessionId AS sessionId,
+          StartTime AS startTime,
+          EndTime AS endTime,
+          DurationMs AS durationMs,
+          Status AS status,
+          UserId AS userId,
+          UrlInitial AS urlInitial,
+          UserAgent AS userAgent,
+          BrowserName AS browserName,
+          OsName AS osName,
+          DeviceType AS deviceType,
+          Country AS country,
+          ServiceName AS serviceName,
+          PageViews AS pageViews,
+          ClickCount AS clickCount,
+          ErrorCount AS errorCount,
+          TraceIds AS traceIds,
+          toJSONString(ResourceAttributes) AS resourceAttributes
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND SessionId = 'sess_0af7651916cd43dd'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+        ORDER BY version DESC
+        LIMIT 1
+        FORMAT JSON
+
+-- builder:session-replays:sessionReplayEventsQuery:default  [42cce486]
+SELECT
+          ChunkSeq AS chunkSeq,
+          Timestamp AS timestamp,
+          DurationMs AS durationMs,
+          EventCount AS eventCount,
+          ByteSize AS byteSize,
+          Events AS events,
+          IsCheckpoint AS isCheckpoint
+        FROM session_replay_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND SessionId = 'sess_0af7651916cd43dd'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        ORDER BY chunkSeq ASC
+        FORMAT JSON
+
+-- builder:session-replays:sessionReplaysFacetsQuery:default  [896379cc]
+SELECT
+          ServiceName AS name,
+          uniq(SessionId) AS count,
+          'service' AS facetType
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND ServiceName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          BrowserName AS name,
+          uniq(SessionId) AS count,
+          'browser' AS facetType
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND BrowserName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          Country AS name,
+          uniq(SessionId) AS count,
+          'country' AS facetType
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND Country != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          DeviceType AS name,
+          uniq(SessionId) AS count,
+          'device' AS facetType
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND DeviceType != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          toString(toUInt64(round(pow(2, floor(log2(greatest(DurationMs, 1000) / 1000) * 2) / 2) * 1000))) AS name,
+          uniq(SessionId) AS count,
+          'durationBucket' AS facetType
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND DurationMs > 0
+        GROUP BY name
+        LIMIT 40
+UNION ALL
+SELECT
+          'p50' AS name,
+          toUInt64(ifNotFinite(round(quantile(0.5)(assumeNotNull(DurationMs))), 0)) AS count,
+          'durationStat' AS facetType
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND DurationMs > 0
+UNION ALL
+SELECT
+          'p95' AS name,
+          toUInt64(ifNotFinite(round(quantile(0.95)(assumeNotNull(DurationMs))), 0)) AS count,
+          'durationStat' AS facetType
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND DurationMs > 0
+UNION ALL
+SELECT
+          'error' AS name,
+          uniq(SessionId) AS count,
+          'error' AS facetType
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND ErrorCount > 0
+FORMAT JSON
+
+-- builder:session-replays:sessionReplaysListQuery:default  [6631a4ef]
+SELECT
+          SessionId AS sessionId,
+          argMax(StartTime, Version) AS startTime,
+          argMax(EndTime, Version) AS endTime,
+          argMax(DurationMs, Version) AS durationMs,
+          argMax(Status, Version) AS status,
+          argMax(UserId, Version) AS userId,
+          argMax(UrlInitial, Version) AS urlInitial,
+          argMax(BrowserName, Version) AS browserName,
+          argMax(OsName, Version) AS osName,
+          argMax(DeviceType, Version) AS deviceType,
+          argMax(Country, Version) AS country,
+          argMax(ServiceName, Version) AS serviceName,
+          argMax(PageViews, Version) AS pageViews,
+          argMax(ClickCount, Version) AS clickCount,
+          argMax(ErrorCount, Version) AS errorCount,
+          length(argMax(TraceIds, Version)) AS traceCount,
+          argMax(ResourceAttributes['maple.session.recorded'], Version) AS recorded
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+        GROUP BY sessionId
+        ORDER BY startTime DESC, sessionId DESC
+        LIMIT 50
+        OFFSET 0
+        FORMAT JSON
+
+-- builder:session-replays:sessionReplaysListQuery:filtered  [e21452a7]
+SELECT
+          s.sessionId AS sessionId,
+          s.startTime AS startTime,
+          s.endTime AS endTime,
+          s.durationMs AS durationMs,
+          s.status AS status,
+          s.userId AS userId,
+          s.urlInitial AS urlInitial,
+          s.browserName AS browserName,
+          s.osName AS osName,
+          s.deviceType AS deviceType,
+          s.country AS country,
+          s.serviceName AS serviceName,
+          s.pageViews AS pageViews,
+          s.clickCount AS clickCount,
+          s.errorCount AS errorCount,
+          s.traceCount AS traceCount,
+          s.recorded AS recorded
+        FROM (SELECT
+          SessionId AS sessionId,
+          argMax(StartTime, Version) AS startTime,
+          argMax(EndTime, Version) AS endTime,
+          argMax(DurationMs, Version) AS durationMs,
+          argMax(Status, Version) AS status,
+          argMax(UserId, Version) AS userId,
+          argMax(UrlInitial, Version) AS urlInitial,
+          argMax(BrowserName, Version) AS browserName,
+          argMax(OsName, Version) AS osName,
+          argMax(DeviceType, Version) AS deviceType,
+          argMax(Country, Version) AS country,
+          argMax(ServiceName, Version) AS serviceName,
+          argMax(PageViews, Version) AS pageViews,
+          argMax(ClickCount, Version) AS clickCount,
+          argMax(ErrorCount, Version) AS errorCount,
+          length(argMax(TraceIds, Version)) AS traceCount,
+          argMax(ResourceAttributes['maple.session.recorded'], Version) AS recorded
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND ServiceName = 'web'
+          AND ErrorCount > 0
+          AND UrlInitial ILIKE '%checkout%'
+        GROUP BY sessionId) AS s
+        LEFT JOIN (SELECT
+          sessionId AS sessionId,
+          sumIf(gapMs, (gapMs > 0 AND gapMs <= 15000)) AS activeTimeMs,
+          sumIf(gapMs, gapMs > 15000) AS idleTimeMs,
+          count() AS eventCount
+        FROM (SELECT
+          SessionId AS sessionId,
+          toFloat64(toUnixTimestamp64Nano(Timestamp) - toUnixTimestamp64Nano(lagInFrame(Timestamp, 1, Timestamp) OVER (PARTITION BY SessionId ORDER BY Timestamp ASC, Seq ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW))) / 1000000 AS gapMs
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00') AS g
+        GROUP BY sessionId) AS a ON s.sessionId = a.sessionId
+        WHERE s.durationMs >= 1000
+          AND coalesce(a.activeTimeMs, 0) >= 500
+        ORDER BY startTime DESC, sessionId DESC
+        LIMIT 50
+        OFFSET 0
+        FORMAT JSON
+
+-- builder:session-replays:sessionsForTraceQuery:default  [279e957f]
+SELECT
+          SessionId AS sessionId,
+          argMax(StartTime, Version) AS startTime,
+          argMax(DurationMs, Version) AS durationMs
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND has(TraceIds, '0af7651916cd43dd8448eb211c80319c')
+        GROUP BY sessionId
+        ORDER BY startTime DESC, sessionId DESC
+        LIMIT 10
+        OFFSET 0
+        FORMAT JSON
+
+-- builder:session-replays:sessionTraceSummariesQuery:default  [cd6dac42]
+SELECT
+          TraceId AS traceId,
+          min(Timestamp) AS startTime,
+          if(maxIf(Duration, ParentSpanId = '') / 1000000 > 0, maxIf(Duration, ParentSpanId = '') / 1000000, max(Duration) / 1000000) AS durationMs,
+          coalesce(nullIf(anyIf(SpanName, ParentSpanId = ''), ''), any(SpanName)) AS rootSpanName,
+          coalesce(nullIf(anyIf(ServiceName, ParentSpanId = ''), ''), any(ServiceName)) AS rootServiceName,
+          anyIf(SpanKind, ParentSpanId = '') AS rootSpanKind,
+          anyIf(toJSONString(SpanAttributes), ParentSpanId = '') AS rootSpanAttributes,
+          count() AS spanCount,
+          if(countIf(StatusCode = 'Error') > 0, 1, 0) AS hasError
+        FROM trace_detail_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND TraceId IN ('0af7651916cd43dd8448eb211c80319c')
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY traceId
+        ORDER BY startTime ASC
+        LIMIT 200
+        FORMAT JSON
+
+-- pipe:custom_traces_breakdown:by-attribute:baseline  [169e0040]
+SELECT
+          SpanAttributes['http.route'] AS name,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- pipe:custom_traces_breakdown:by-attribute:bloom  [169e0040]
+SELECT
+          SpanAttributes['http.route'] AS name,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- pipe:custom_traces_breakdown:by-attribute:text  [169e0040]
+SELECT
+          SpanAttributes['http.route'] AS name,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- pipe:custom_traces_breakdown:by-service:baseline  [327fa1f0]
+SELECT
+          ServiceName AS name,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- pipe:custom_traces_timeseries:errors-only:baseline  [8def6b38]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 3600 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          sum(SampleRate) AS estimatedSpanCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode = 'Error'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- pipe:custom_traces_timeseries:grouped-by-attribute:baseline  [f7a51146]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 300 SECOND) AS bucket,
+          coalesce(nullIf(arrayStringConcat([toString(SpanAttributes['http.route']), toString(SpanAttributes['http.method'])], ' · '), ''), 'all') AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          sum(SampleRate) AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- pipe:custom_traces_timeseries:grouped-by-attribute:bloom  [f7a51146]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 300 SECOND) AS bucket,
+          coalesce(nullIf(arrayStringConcat([toString(SpanAttributes['http.route']), toString(SpanAttributes['http.method'])], ' · '), ''), 'all') AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          sum(SampleRate) AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- pipe:custom_traces_timeseries:grouped-by-attribute:text  [f7a51146]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 300 SECOND) AS bucket,
+          coalesce(nullIf(arrayStringConcat([toString(SpanAttributes['http.route']), toString(SpanAttributes['http.method'])], ' · '), ''), 'all') AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          sum(SampleRate) AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- pipe:custom_traces_timeseries:grouped-by-service:baseline  [60857539]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 60 SECOND) AS bucket,
+          coalesce(nullIf(toString(ServiceName), ''), 'all') AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          sum(SampleRate) AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- pipe:custom_traces_timeseries:grouped-by-service:bloom  [60857539]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 60 SECOND) AS bucket,
+          coalesce(nullIf(toString(ServiceName), ''), 'all') AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          sum(SampleRate) AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- pipe:custom_traces_timeseries:grouped-by-service:text  [60857539]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 60 SECOND) AS bucket,
+          coalesce(nullIf(toString(ServiceName), ''), 'all') AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          sum(SampleRate) AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- pipe:custom_traces_timeseries:root-only:baseline  [056b7b95]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 3600 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          sum(SampleRate) AS estimatedSpanCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- pipe:custom_traces_timeseries:ungrouped:baseline  [13bf30de]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 3600 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          sum(SampleRate) AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- pipe:error_detail_traces:default:baseline  [365ebaf7]
+SELECT
+          TraceId AS traceId,
+          min(Timestamp) AS startTime,
+          intDiv(max(Duration), 1000) AS durationMicros,
+          count() AS spanCount,
+          groupUniqArray(ServiceName) AS services,
+          anyIf(SpanName, ParentSpanId = '') AS rootSpanName,
+          any(StatusMessage) AS errorMessage
+        FROM trace_detail_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND TraceId IN (SELECT TraceId FROM (SELECT
+          TraceId AS TraceId,
+          max(Timestamp) AS lastErrorSeen
+        FROM error_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND FingerprintHash = toUInt64('11640393269246331608')
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY TraceId
+        ORDER BY lastErrorSeen DESC
+        LIMIT 10))
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY traceId
+        ORDER BY startTime DESC
+        FORMAT JSON
+
+-- pipe:error_issue_sample_traces:default:baseline  [165204e4]
+SELECT
+          TraceId AS traceId,
+          SpanId AS spanId,
+          ServiceName AS serviceName,
+          Timestamp AS timestamp,
+          ExceptionMessage AS exceptionMessage,
+          intDiv(Duration, 1000) AS durationMicros
+        FROM error_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND FingerprintHash = toUInt64('11640393269246331608')
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        ORDER BY timestamp DESC
+        LIMIT 25
+        FORMAT JSON
+
+-- pipe:error_issue_timeseries:default:baseline  [8ea53a5e]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 3600 SECOND) AS bucket,
+          count() AS count
+        FROM error_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND FingerprintHash = toUInt64('11640393269246331608')
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY bucket
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- pipe:error_issues:default:baseline  [ce76d415]
+SELECT
+          toString(FingerprintHash) AS fingerprintHash,
+          any(ServiceName) AS serviceName,
+          any(ExceptionType) AS exceptionType,
+          any(ExceptionMessage) AS exceptionMessage,
+          any(ErrorLabel) AS errorLabel,
+          any(TopFrame) AS topFrame,
+          count() AS count,
+          uniq(ServiceName) AS affectedServicesCount,
+          min(Timestamp) AS firstSeen,
+          max(Timestamp) AS lastSeen
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY fingerprintHash
+        ORDER BY count DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:error_rate_by_service:default:baseline  [915de03d]
+SELECT
+          serviceName AS serviceName,
+          sum(bucketTotalLogs) AS totalLogs,
+          sum(bucketErrorLogs) AS errorLogs,
+          round(sum(bucketErrorLogs) / sum(bucketTotalLogs), 6) AS errorRate
+        FROM (
+SELECT
+          ServiceName AS serviceName,
+          count() AS bucketTotalLogs,
+          countIf(SeverityText IN ('ERROR', 'FATAL')) AS bucketErrorLogs,
+          0 AS errorRate
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (TimestampTime < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR TimestampTime >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY serviceName
+UNION ALL
+SELECT
+          ServiceName AS serviceName,
+          sum(Count) AS bucketTotalLogs,
+          sumIf(Count, SeverityText IN ('ERROR', 'FATAL')) AS bucketErrorLogs,
+          0 AS errorRate
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY serviceName
+) AS rates
+        GROUP BY serviceName
+        ORDER BY errorRate DESC
+        FORMAT JSON
+
+-- pipe:errors_by_type:default:baseline  [155d011e]
+SELECT
+          toString(FingerprintHash) AS fingerprintHash,
+          any(ErrorLabel) AS errorLabel,
+          any(StatusMessage) AS sampleMessage,
+          count() AS count,
+          uniq(ServiceName) AS affectedServicesCount,
+          min(Timestamp) AS firstSeen,
+          max(Timestamp) AS lastSeen
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY fingerprintHash
+        ORDER BY count DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:errors_facets:default:baseline  [d5afc6d2]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'environment' AS facetType
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          ErrorLabel AS name,
+          count() AS count,
+          'error_type' AS facetType
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+FORMAT JSON
+
+-- pipe:errors_summary:default:baseline  [e28ab64c]
+SELECT
+          e.totalErrors AS totalErrors,
+          s.totalSpans AS totalSpans,
+          if(s.totalSpans > 0, round(e.totalErrors / s.totalSpans, 6), 0) AS errorRate,
+          e.affectedServicesCount AS affectedServicesCount,
+          e.affectedTracesCount AS affectedTracesCount
+        FROM (SELECT
+          count() AS totalErrors,
+          uniq(ServiceName) AS affectedServicesCount,
+          uniq(TraceId) AS affectedTracesCount
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00') AS e
+        CROSS JOIN (SELECT
+          sum(TraceCount) AS totalSpans
+        FROM service_usage
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00') AS s
+        FORMAT JSON
+
+-- pipe:errors_timeseries:default:baseline  [8ea53a5e]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 3600 SECOND) AS bucket,
+          count() AS count
+        FROM error_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND FingerprintHash = toUInt64('11640393269246331608')
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY bucket
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- pipe:get_service_usage_compare:default:baseline  [2d4d90c6]
+SELECT 'current' AS period, * FROM (
+SELECT
+          ServiceName AS serviceName,
+          sum(LogCount) AS totalLogCount,
+          sum(LogSizeBytes) AS totalLogSizeBytes,
+          sum(TraceCount) AS totalTraceCount,
+          sum(TraceSizeBytes) AS totalTraceSizeBytes,
+          sum(SumMetricCount) AS totalSumMetricCount,
+          sum(SumMetricSizeBytes) AS totalSumMetricSizeBytes,
+          sum(GaugeMetricCount) AS totalGaugeMetricCount,
+          sum(GaugeMetricSizeBytes) AS totalGaugeMetricSizeBytes,
+          sum(HistogramMetricCount) AS totalHistogramMetricCount,
+          sum(HistogramMetricSizeBytes) AS totalHistogramMetricSizeBytes,
+          sum(ExpHistogramMetricCount) AS totalExpHistogramMetricCount,
+          sum(ExpHistogramMetricSizeBytes) AS totalExpHistogramMetricSizeBytes,
+          sum(LogSizeBytes) + sum(TraceSizeBytes) + sum(SumMetricSizeBytes) + sum(GaugeMetricSizeBytes) + sum(HistogramMetricSizeBytes) + sum(ExpHistogramMetricSizeBytes) AS totalSizeBytes
+        FROM service_usage
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= toStartOfHour(toDateTime('2026-01-01 10:30:00'))
+          AND Hour <= toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+        GROUP BY serviceName
+        ORDER BY totalSizeBytes DESC
+)
+UNION ALL
+SELECT 'previous' AS period, * FROM (
+SELECT
+          ServiceName AS serviceName,
+          sum(LogCount) AS totalLogCount,
+          sum(LogSizeBytes) AS totalLogSizeBytes,
+          sum(TraceCount) AS totalTraceCount,
+          sum(TraceSizeBytes) AS totalTraceSizeBytes,
+          sum(SumMetricCount) AS totalSumMetricCount,
+          sum(SumMetricSizeBytes) AS totalSumMetricSizeBytes,
+          sum(GaugeMetricCount) AS totalGaugeMetricCount,
+          sum(GaugeMetricSizeBytes) AS totalGaugeMetricSizeBytes,
+          sum(HistogramMetricCount) AS totalHistogramMetricCount,
+          sum(HistogramMetricSizeBytes) AS totalHistogramMetricSizeBytes,
+          sum(ExpHistogramMetricCount) AS totalExpHistogramMetricCount,
+          sum(ExpHistogramMetricSizeBytes) AS totalExpHistogramMetricSizeBytes,
+          sum(LogSizeBytes) + sum(TraceSizeBytes) + sum(SumMetricSizeBytes) + sum(GaugeMetricSizeBytes) + sum(HistogramMetricSizeBytes) + sum(ExpHistogramMetricSizeBytes) AS totalSizeBytes
+        FROM service_usage
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= toStartOfHour(toDateTime('2025-12-30 10:30:00'))
+          AND Hour <= toStartOfHour(toDateTime('2026-01-01 14:15:00'))
+          AND ServiceName = 'api'
+        GROUP BY serviceName
+        ORDER BY totalSizeBytes DESC
+)
+FORMAT JSON
+
+-- pipe:get_service_usage:default:baseline  [9baa30ad]
+SELECT
+          ServiceName AS serviceName,
+          sum(LogCount) AS totalLogCount,
+          sum(LogSizeBytes) AS totalLogSizeBytes,
+          sum(TraceCount) AS totalTraceCount,
+          sum(TraceSizeBytes) AS totalTraceSizeBytes,
+          sum(SumMetricCount) AS totalSumMetricCount,
+          sum(SumMetricSizeBytes) AS totalSumMetricSizeBytes,
+          sum(GaugeMetricCount) AS totalGaugeMetricCount,
+          sum(GaugeMetricSizeBytes) AS totalGaugeMetricSizeBytes,
+          sum(HistogramMetricCount) AS totalHistogramMetricCount,
+          sum(HistogramMetricSizeBytes) AS totalHistogramMetricSizeBytes,
+          sum(ExpHistogramMetricCount) AS totalExpHistogramMetricCount,
+          sum(ExpHistogramMetricSizeBytes) AS totalExpHistogramMetricSizeBytes,
+          sum(LogSizeBytes) + sum(TraceSizeBytes) + sum(SumMetricSizeBytes) + sum(GaugeMetricSizeBytes) + sum(HistogramMetricSizeBytes) + sum(ExpHistogramMetricSizeBytes) AS totalSizeBytes
+        FROM service_usage
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= toStartOfHour(toDateTime('2026-01-01 10:30:00'))
+          AND Hour <= toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+        GROUP BY serviceName
+        ORDER BY totalSizeBytes DESC
+        FORMAT JSON
+
+-- pipe:list_logs:default:baseline  [2122d9b9]
+SELECT
+          Timestamp AS timestamp,
+          SeverityText AS severityText,
+          SeverityNumber AS severityNumber,
+          ServiceName AS serviceName,
+          Body AS body,
+          TraceId AS traceId,
+          SpanId AS spanId,
+          hex(MD5(toJSONString(tuple(Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber, ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl, ScopeName, ScopeVersion, ScopeAttributes, LogAttributes)))) AS recordIdentity,
+          toJSONString(LogAttributes) AS logAttributes,
+          toJSONString(ResourceAttributes) AS resourceAttributes
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        ORDER BY ts DESC
+        LIMIT 50))
+        ORDER BY timestamp DESC, serviceName ASC, traceId ASC, spanId ASC, recordIdentity ASC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:list_logs:default:bloom  [2122d9b9]
+SELECT
+          Timestamp AS timestamp,
+          SeverityText AS severityText,
+          SeverityNumber AS severityNumber,
+          ServiceName AS serviceName,
+          Body AS body,
+          TraceId AS traceId,
+          SpanId AS spanId,
+          hex(MD5(toJSONString(tuple(Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber, ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl, ScopeName, ScopeVersion, ScopeAttributes, LogAttributes)))) AS recordIdentity,
+          toJSONString(LogAttributes) AS logAttributes,
+          toJSONString(ResourceAttributes) AS resourceAttributes
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        ORDER BY ts DESC
+        LIMIT 50))
+        ORDER BY timestamp DESC, serviceName ASC, traceId ASC, spanId ASC, recordIdentity ASC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:list_logs:default:text  [2122d9b9]
+SELECT
+          Timestamp AS timestamp,
+          SeverityText AS severityText,
+          SeverityNumber AS severityNumber,
+          ServiceName AS serviceName,
+          Body AS body,
+          TraceId AS traceId,
+          SpanId AS spanId,
+          hex(MD5(toJSONString(tuple(Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber, ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl, ScopeName, ScopeVersion, ScopeAttributes, LogAttributes)))) AS recordIdentity,
+          toJSONString(LogAttributes) AS logAttributes,
+          toJSONString(ResourceAttributes) AS resourceAttributes
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        ORDER BY ts DESC
+        LIMIT 50))
+        ORDER BY timestamp DESC, serviceName ASC, traceId ASC, spanId ASC, recordIdentity ASC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:list_logs:searched:baseline  [f4e5cc5d]
+SELECT
+          Timestamp AS timestamp,
+          SeverityText AS severityText,
+          SeverityNumber AS severityNumber,
+          ServiceName AS serviceName,
+          Body AS body,
+          TraceId AS traceId,
+          SpanId AS spanId,
+          hex(MD5(toJSONString(tuple(Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber, ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl, ScopeName, ScopeVersion, ScopeAttributes, LogAttributes)))) AS recordIdentity,
+          toJSONString(LogAttributes) AS logAttributes,
+          toJSONString(ResourceAttributes) AS resourceAttributes
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND SeverityText = 'ERROR'
+          AND TraceId = '0af7651916cd43dd8448eb211c80319c'
+          AND Body ILIKE '%connection refused%'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND SeverityText = 'ERROR'
+          AND TraceId = '0af7651916cd43dd8448eb211c80319c'
+          AND Body ILIKE '%connection refused%'
+        ORDER BY ts DESC
+        LIMIT 50))
+        ORDER BY timestamp DESC, serviceName ASC, traceId ASC, spanId ASC, recordIdentity ASC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:list_logs:searched:bloom  [efc50db5]
+SELECT
+          Timestamp AS timestamp,
+          SeverityText AS severityText,
+          SeverityNumber AS severityNumber,
+          ServiceName AS serviceName,
+          Body AS body,
+          TraceId AS traceId,
+          SpanId AS spanId,
+          hex(MD5(toJSONString(tuple(Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber, ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl, ScopeName, ScopeVersion, ScopeAttributes, LogAttributes)))) AS recordIdentity,
+          toJSONString(LogAttributes) AS logAttributes,
+          toJSONString(ResourceAttributes) AS resourceAttributes
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND SeverityText = 'ERROR'
+          AND TraceId = '0af7651916cd43dd8448eb211c80319c'
+          AND ((hasToken(lower(Body), 'connection') AND hasToken(lower(Body), 'refused')) AND Body ILIKE '%connection refused%')
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND SeverityText = 'ERROR'
+          AND TraceId = '0af7651916cd43dd8448eb211c80319c'
+          AND ((hasToken(lower(Body), 'connection') AND hasToken(lower(Body), 'refused')) AND Body ILIKE '%connection refused%')
+        ORDER BY ts DESC
+        LIMIT 50))
+        ORDER BY timestamp DESC, serviceName ASC, traceId ASC, spanId ASC, recordIdentity ASC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:list_logs:searched:text  [fad2e4f1]
+SELECT
+          Timestamp AS timestamp,
+          SeverityText AS severityText,
+          SeverityNumber AS severityNumber,
+          ServiceName AS serviceName,
+          Body AS body,
+          TraceId AS traceId,
+          SpanId AS spanId,
+          hex(MD5(toJSONString(tuple(Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber, ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl, ScopeName, ScopeVersion, ScopeAttributes, LogAttributes)))) AS recordIdentity,
+          toJSONString(LogAttributes) AS logAttributes,
+          toJSONString(ResourceAttributes) AS resourceAttributes
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND SeverityText = 'ERROR'
+          AND TraceId = '0af7651916cd43dd8448eb211c80319c'
+          AND (hasAllTokens(lower(Body), 'connection refused') AND Body ILIKE '%connection refused%')
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND SeverityText = 'ERROR'
+          AND TraceId = '0af7651916cd43dd8448eb211c80319c'
+          AND (hasAllTokens(lower(Body), 'connection refused') AND Body ILIKE '%connection refused%')
+        ORDER BY ts DESC
+        LIMIT 50))
+        ORDER BY timestamp DESC, serviceName ASC, traceId ASC, spanId ASC, recordIdentity ASC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:list_metrics:default:baseline  [024f8bd8]
+SELECT
+          MetricName AS metricName,
+          MetricType AS metricType,
+          ServiceName AS serviceName,
+          any(MetricDescription) AS metricDescription,
+          any(MetricUnit) AS metricUnit,
+          sum(DataPointCount) AS dataPointCount,
+          min(FirstSeen) AS firstSeen,
+          max(LastSeen) AS lastSeen,
+          any(IsMonotonic) AS isMonotonic
+        FROM metric_catalog
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= toStartOfInterval(toDateTime('2026-01-01 10:30:00'), INTERVAL 3600 SECOND)
+          AND Hour <= '2026-01-03 14:15:00'
+        GROUP BY metricName, metricType, serviceName
+        ORDER BY lastSeen DESC, metricName ASC, metricType ASC, serviceName ASC
+        LIMIT 100
+        OFFSET 0
+        FORMAT JSON
+
+-- pipe:list_traces:contains-match:baseline  [608a1075]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS startTime,
+          Timestamp AS endTime,
+          intDiv(Duration, 1000) AS durationMicros,
+          toUInt64(1) AS spanCount,
+          [ServiceName] AS services,
+          SpanName AS rootSpanName,
+          SpanKind AS rootSpanKind,
+          StatusCode AS rootSpanStatusCode,
+          SpanAttributes['http.method'] AS rootHttpMethod,
+          SpanAttributes['http.route'] AS rootHttpRoute,
+          SpanAttributes['http.status_code'] AS rootHttpStatusCode,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'http.url', SpanAttributes['http.url'], 'url.full', SpanAttributes['url.full'], 'url.path', SpanAttributes['url.path'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'])) AS rootSpanAttributes,
+          if(StatusCode = 'Error', 1, 0) AS hasError
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(ServiceName, 'ap') > 0
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(ServiceName, 'ap') > 0
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+        ORDER BY ts DESC
+        LIMIT 100))
+        ORDER BY startTime DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- pipe:list_traces:contains-match:bloom  [608a1075]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS startTime,
+          Timestamp AS endTime,
+          intDiv(Duration, 1000) AS durationMicros,
+          toUInt64(1) AS spanCount,
+          [ServiceName] AS services,
+          SpanName AS rootSpanName,
+          SpanKind AS rootSpanKind,
+          StatusCode AS rootSpanStatusCode,
+          SpanAttributes['http.method'] AS rootHttpMethod,
+          SpanAttributes['http.route'] AS rootHttpRoute,
+          SpanAttributes['http.status_code'] AS rootHttpStatusCode,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'http.url', SpanAttributes['http.url'], 'url.full', SpanAttributes['url.full'], 'url.path', SpanAttributes['url.path'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'])) AS rootSpanAttributes,
+          if(StatusCode = 'Error', 1, 0) AS hasError
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(ServiceName, 'ap') > 0
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(ServiceName, 'ap') > 0
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+        ORDER BY ts DESC
+        LIMIT 100))
+        ORDER BY startTime DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- pipe:list_traces:contains-match:text  [608a1075]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS startTime,
+          Timestamp AS endTime,
+          intDiv(Duration, 1000) AS durationMicros,
+          toUInt64(1) AS spanCount,
+          [ServiceName] AS services,
+          SpanName AS rootSpanName,
+          SpanKind AS rootSpanKind,
+          StatusCode AS rootSpanStatusCode,
+          SpanAttributes['http.method'] AS rootHttpMethod,
+          SpanAttributes['http.route'] AS rootHttpRoute,
+          SpanAttributes['http.status_code'] AS rootHttpStatusCode,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'http.url', SpanAttributes['http.url'], 'url.full', SpanAttributes['url.full'], 'url.path', SpanAttributes['url.path'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'])) AS rootSpanAttributes,
+          if(StatusCode = 'Error', 1, 0) AS hasError
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(ServiceName, 'ap') > 0
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(ServiceName, 'ap') > 0
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+        ORDER BY ts DESC
+        LIMIT 100))
+        ORDER BY startTime DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- pipe:list_traces:default:baseline  [62bbe0b9]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS startTime,
+          Timestamp AS endTime,
+          intDiv(Duration, 1000) AS durationMicros,
+          toUInt64(1) AS spanCount,
+          [ServiceName] AS services,
+          SpanName AS rootSpanName,
+          SpanKind AS rootSpanKind,
+          StatusCode AS rootSpanStatusCode,
+          SpanAttributes['http.method'] AS rootHttpMethod,
+          SpanAttributes['http.route'] AS rootHttpRoute,
+          SpanAttributes['http.status_code'] AS rootHttpStatusCode,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'http.url', SpanAttributes['http.url'], 'url.full', SpanAttributes['url.full'], 'url.path', SpanAttributes['url.path'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'])) AS rootSpanAttributes,
+          if(StatusCode = 'Error', 1, 0) AS hasError
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+        ORDER BY ts DESC
+        LIMIT 100))
+        ORDER BY startTime DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- pipe:list_traces:default:bloom  [62bbe0b9]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS startTime,
+          Timestamp AS endTime,
+          intDiv(Duration, 1000) AS durationMicros,
+          toUInt64(1) AS spanCount,
+          [ServiceName] AS services,
+          SpanName AS rootSpanName,
+          SpanKind AS rootSpanKind,
+          StatusCode AS rootSpanStatusCode,
+          SpanAttributes['http.method'] AS rootHttpMethod,
+          SpanAttributes['http.route'] AS rootHttpRoute,
+          SpanAttributes['http.status_code'] AS rootHttpStatusCode,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'http.url', SpanAttributes['http.url'], 'url.full', SpanAttributes['url.full'], 'url.path', SpanAttributes['url.path'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'])) AS rootSpanAttributes,
+          if(StatusCode = 'Error', 1, 0) AS hasError
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+        ORDER BY ts DESC
+        LIMIT 100))
+        ORDER BY startTime DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- pipe:list_traces:default:text  [62bbe0b9]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS startTime,
+          Timestamp AS endTime,
+          intDiv(Duration, 1000) AS durationMicros,
+          toUInt64(1) AS spanCount,
+          [ServiceName] AS services,
+          SpanName AS rootSpanName,
+          SpanKind AS rootSpanKind,
+          StatusCode AS rootSpanStatusCode,
+          SpanAttributes['http.method'] AS rootHttpMethod,
+          SpanAttributes['http.route'] AS rootHttpRoute,
+          SpanAttributes['http.status_code'] AS rootHttpStatusCode,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'http.url', SpanAttributes['http.url'], 'url.full', SpanAttributes['url.full'], 'url.path', SpanAttributes['url.path'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'])) AS rootSpanAttributes,
+          if(StatusCode = 'Error', 1, 0) AS hasError
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode != 'Error'
+        ORDER BY ts DESC
+        LIMIT 100))
+        ORDER BY startTime DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- pipe:list_traces:filtered:baseline  [b1aaf6f5]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS startTime,
+          Timestamp AS endTime,
+          intDiv(Duration, 1000) AS durationMicros,
+          toUInt64(1) AS spanCount,
+          [ServiceName] AS services,
+          SpanName AS rootSpanName,
+          SpanKind AS rootSpanKind,
+          StatusCode AS rootSpanStatusCode,
+          SpanAttributes['http.method'] AS rootHttpMethod,
+          SpanAttributes['http.route'] AS rootHttpRoute,
+          SpanAttributes['http.status_code'] AS rootHttpStatusCode,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'http.url', SpanAttributes['http.url'], 'url.full', SpanAttributes['url.full'], 'url.path', SpanAttributes['url.path'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'])) AS rootSpanAttributes,
+          if(StatusCode = 'Error', 1, 0) AS hasError
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND (SpanName = 'GET /v1/x' OR if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) = 'GET /v1/x')
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode = 'Error'
+          AND Duration >= 5000000
+          AND Duration <= 5000000000
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND if(SpanAttributes['http.method'] != '', SpanAttributes['http.method'], SpanAttributes['http.request.method']) = 'GET'
+          AND ResourceAttributes['service.namespace'] = 'core'
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND (SpanName = 'GET /v1/x' OR if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) = 'GET /v1/x')
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode = 'Error'
+          AND Duration >= 5000000
+          AND Duration <= 5000000000
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND if(SpanAttributes['http.method'] != '', SpanAttributes['http.method'], SpanAttributes['http.request.method']) = 'GET'
+          AND ResourceAttributes['service.namespace'] = 'core'
+        ORDER BY ts DESC
+        LIMIT 25))
+        ORDER BY startTime DESC
+        LIMIT 25
+        FORMAT JSON
+
+-- pipe:list_traces:filtered:bloom  [5d0533fd]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS startTime,
+          Timestamp AS endTime,
+          intDiv(Duration, 1000) AS durationMicros,
+          toUInt64(1) AS spanCount,
+          [ServiceName] AS services,
+          SpanName AS rootSpanName,
+          SpanKind AS rootSpanKind,
+          StatusCode AS rootSpanStatusCode,
+          SpanAttributes['http.method'] AS rootHttpMethod,
+          SpanAttributes['http.route'] AS rootHttpRoute,
+          SpanAttributes['http.status_code'] AS rootHttpStatusCode,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'http.url', SpanAttributes['http.url'], 'url.full', SpanAttributes['url.full'], 'url.path', SpanAttributes['url.path'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'])) AS rootSpanAttributes,
+          if(StatusCode = 'Error', 1, 0) AS hasError
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND (SpanName = 'GET /v1/x' OR if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) = 'GET /v1/x')
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode = 'Error'
+          AND Duration >= 5000000
+          AND Duration <= 5000000000
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND (((has(mapKeys(SpanAttributes), 'http.method') OR has(mapKeys(SpanAttributes), 'http.request.method')) AND has(mapValues(SpanAttributes), 'GET')) AND if(SpanAttributes['http.method'] != '', SpanAttributes['http.method'], SpanAttributes['http.request.method']) = 'GET')
+          AND ((has(mapKeys(ResourceAttributes), 'service.namespace') AND has(mapValues(ResourceAttributes), 'core')) AND ResourceAttributes['service.namespace'] = 'core')
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND (SpanName = 'GET /v1/x' OR if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) = 'GET /v1/x')
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode = 'Error'
+          AND Duration >= 5000000
+          AND Duration <= 5000000000
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND (((has(mapKeys(SpanAttributes), 'http.method') OR has(mapKeys(SpanAttributes), 'http.request.method')) AND has(mapValues(SpanAttributes), 'GET')) AND if(SpanAttributes['http.method'] != '', SpanAttributes['http.method'], SpanAttributes['http.request.method']) = 'GET')
+          AND ((has(mapKeys(ResourceAttributes), 'service.namespace') AND has(mapValues(ResourceAttributes), 'core')) AND ResourceAttributes['service.namespace'] = 'core')
+        ORDER BY ts DESC
+        LIMIT 25))
+        ORDER BY startTime DESC
+        LIMIT 25
+        FORMAT JSON
+
+-- pipe:list_traces:filtered:text  [e5d9f1cd]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS startTime,
+          Timestamp AS endTime,
+          intDiv(Duration, 1000) AS durationMicros,
+          toUInt64(1) AS spanCount,
+          [ServiceName] AS services,
+          SpanName AS rootSpanName,
+          SpanKind AS rootSpanKind,
+          StatusCode AS rootSpanStatusCode,
+          SpanAttributes['http.method'] AS rootHttpMethod,
+          SpanAttributes['http.route'] AS rootHttpRoute,
+          SpanAttributes['http.status_code'] AS rootHttpStatusCode,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'http.url', SpanAttributes['http.url'], 'url.full', SpanAttributes['url.full'], 'url.path', SpanAttributes['url.path'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'])) AS rootSpanAttributes,
+          if(StatusCode = 'Error', 1, 0) AS hasError
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND (SpanName = 'GET /v1/x' OR if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) = 'GET /v1/x')
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode = 'Error'
+          AND Duration >= 5000000
+          AND Duration <= 5000000000
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND ((has(SpanAttributeItems, concat('http.method', char(31), 'GET')) OR has(SpanAttributeItems, concat('http.request.method', char(31), 'GET'))) AND if(SpanAttributes['http.method'] != '', SpanAttributes['http.method'], SpanAttributes['http.request.method']) = 'GET')
+          AND (has(ResourceAttributeItems, concat('service.namespace', char(31), 'core')) AND ResourceAttributes['service.namespace'] = 'core')
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND (SpanName = 'GET /v1/x' OR if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) = 'GET /v1/x')
+          AND (SpanKind IN ('Server', 'Consumer') OR ParentSpanId = '')
+          AND StatusCode = 'Error'
+          AND Duration >= 5000000
+          AND Duration <= 5000000000
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND ((has(SpanAttributeItems, concat('http.method', char(31), 'GET')) OR has(SpanAttributeItems, concat('http.request.method', char(31), 'GET'))) AND if(SpanAttributes['http.method'] != '', SpanAttributes['http.method'], SpanAttributes['http.request.method']) = 'GET')
+          AND (has(ResourceAttributeItems, concat('service.namespace', char(31), 'core')) AND ResourceAttributes['service.namespace'] = 'core')
+        ORDER BY ts DESC
+        LIMIT 25))
+        ORDER BY startTime DESC
+        LIMIT 25
+        FORMAT JSON
+
+-- pipe:logs_count:default:baseline  [96214c48]
+SELECT
+          sum(total) AS total
+        FROM (
+SELECT
+          count() AS total
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (TimestampTime < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR TimestampTime >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+UNION ALL
+SELECT
+          sum(Count) AS total
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+) AS counts
+        FORMAT JSON
+
+-- pipe:logs_count:default:bloom  [96214c48]
+SELECT
+          sum(total) AS total
+        FROM (
+SELECT
+          count() AS total
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (TimestampTime < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR TimestampTime >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+UNION ALL
+SELECT
+          sum(Count) AS total
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+) AS counts
+        FORMAT JSON
+
+-- pipe:logs_count:default:text  [96214c48]
+SELECT
+          sum(total) AS total
+        FROM (
+SELECT
+          count() AS total
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (TimestampTime < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR TimestampTime >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+UNION ALL
+SELECT
+          sum(Count) AS total
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+) AS counts
+        FORMAT JSON
+
+-- pipe:logs_count:searched:baseline  [6c5b910d]
+SELECT
+          count() AS total
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Body ILIKE '%timeout%'
+        FORMAT JSON
+
+-- pipe:logs_count:searched:bloom  [6c5b910d]
+SELECT
+          count() AS total
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Body ILIKE '%timeout%'
+        FORMAT JSON
+
+-- pipe:logs_count:searched:text  [6c5b910d]
+SELECT
+          count() AS total
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Body ILIKE '%timeout%'
+        FORMAT JSON
+
+-- pipe:logs_facets:default:baseline  [14a32e81]
+SELECT * FROM (
+SELECT
+          SeverityText AS severityText,
+          '' AS serviceName,
+          '' AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'severity' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+        GROUP BY severityText
+UNION ALL
+SELECT
+          '' AS severityText,
+          ServiceName AS serviceName,
+          '' AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'service' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+        GROUP BY serviceName
+UNION ALL
+SELECT
+          '' AS severityText,
+          '' AS serviceName,
+          DeploymentEnv AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'deploymentEnv' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND DeploymentEnv != ''
+        GROUP BY deploymentEnv
+UNION ALL
+SELECT
+          '' AS severityText,
+          '' AS serviceName,
+          '' AS deploymentEnv,
+          ServiceNamespace AS namespace,
+          sum(Count) AS count,
+          'namespace' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND ServiceNamespace != ''
+        GROUP BY namespace
+)
+ORDER BY count DESC
+LIMIT 500
+FORMAT JSON
+
+-- pipe:logs_facets:default:bloom  [14a32e81]
+SELECT * FROM (
+SELECT
+          SeverityText AS severityText,
+          '' AS serviceName,
+          '' AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'severity' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+        GROUP BY severityText
+UNION ALL
+SELECT
+          '' AS severityText,
+          ServiceName AS serviceName,
+          '' AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'service' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+        GROUP BY serviceName
+UNION ALL
+SELECT
+          '' AS severityText,
+          '' AS serviceName,
+          DeploymentEnv AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'deploymentEnv' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND DeploymentEnv != ''
+        GROUP BY deploymentEnv
+UNION ALL
+SELECT
+          '' AS severityText,
+          '' AS serviceName,
+          '' AS deploymentEnv,
+          ServiceNamespace AS namespace,
+          sum(Count) AS count,
+          'namespace' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND ServiceNamespace != ''
+        GROUP BY namespace
+)
+ORDER BY count DESC
+LIMIT 500
+FORMAT JSON
+
+-- pipe:logs_facets:default:text  [14a32e81]
+SELECT * FROM (
+SELECT
+          SeverityText AS severityText,
+          '' AS serviceName,
+          '' AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'severity' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+        GROUP BY severityText
+UNION ALL
+SELECT
+          '' AS severityText,
+          ServiceName AS serviceName,
+          '' AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'service' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+        GROUP BY serviceName
+UNION ALL
+SELECT
+          '' AS severityText,
+          '' AS serviceName,
+          DeploymentEnv AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'deploymentEnv' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND DeploymentEnv != ''
+        GROUP BY deploymentEnv
+UNION ALL
+SELECT
+          '' AS severityText,
+          '' AS serviceName,
+          '' AS deploymentEnv,
+          ServiceNamespace AS namespace,
+          sum(Count) AS count,
+          'namespace' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND ServiceNamespace != ''
+        GROUP BY namespace
+)
+ORDER BY count DESC
+LIMIT 500
+FORMAT JSON
+
+-- pipe:metric_attribute_keys:default:baseline  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'metric'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- pipe:metric_attribute_keys:metric-scoped:baseline  [67ceada2]
+SELECT
+          arrayJoin(mapKeys(Attributes)) AS attributeKey,
+          count() AS usageCount
+        FROM metrics_histogram
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName = 'http.server.duration'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- pipe:metric_attribute_values:default:baseline  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'metric'
+          AND AttributeKey = 'http.route'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:metric_attribute_values:metric-scoped:baseline  [7110579a]
+SELECT
+          Attributes['http.route'] AS attributeValue,
+          count() AS usageCount
+        FROM metrics_histogram
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName = 'http.server.duration'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND Attributes['http.route'] != ''
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:metrics_summary:default:baseline  [d5f7c1e5]
+SELECT
+          MetricType AS metricType,
+          uniq(MetricName) AS metricCount,
+          sum(DataPointCount) AS dataPointCount
+        FROM metric_catalog
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= toStartOfInterval(toDateTime('2026-01-01 10:30:00'), INTERVAL 3600 SECOND)
+          AND Hour <= '2026-01-03 14:15:00'
+        GROUP BY metricType
+        FORMAT JSON
+
+-- pipe:resource_attribute_keys:default:baseline  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'resource'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- pipe:resource_attribute_keys:default:bloom  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'resource'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- pipe:resource_attribute_keys:default:text  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'resource'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- pipe:resource_attribute_values:default:baseline  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'resource'
+          AND AttributeKey = 'service.namespace'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:resource_attribute_values:default:bloom  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'resource'
+          AND AttributeKey = 'service.namespace'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:resource_attribute_values:default:text  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'resource'
+          AND AttributeKey = 'service.namespace'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:service_apdex_time_series:custom-threshold:baseline  [b27c4edd]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 3600 SECOND) AS bucket,
+          count() AS totalCount,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 250)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 250 AND Duration / 1000000 < 1000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 250)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 250 AND Duration / 1000000 < 1000))) * 0.5 / count(), 4), 0) AS apdexScore
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+        GROUP BY bucket
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- pipe:service_apdex_time_series:default:baseline  [cc0b4d44]
+SELECT
+          toStartOfInterval(bHour, INTERVAL 60 SECOND) AS bucket,
+          sum(bSpanCount) AS totalCount,
+          sum(bApdexSatisfiedCount) AS satisfiedCount,
+          sum(bApdexToleratingCount) AS toleratingCount,
+          if(sum(bSpanCount) > 0, round(sum(bApdexSatisfiedCount) / sum(bSpanCount) + sum(bApdexToleratingCount) * 0.5 / sum(bSpanCount), 4), 0) AS apdexScore
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        GROUP BY bucket
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- pipe:service_dependencies:default:baseline  [8cda870b]
+SELECT
+  sourceService,
+  targetService,
+  sum(bucketCallCount) AS callCount,
+  sum(bucketErrorCount) AS errorCount,
+  sum(bucketDurationSumMs) / nullIf(sum(bucketCallCount), 0) AS avgDurationMs,
+  max(bucketMaxDurationMs) AS p95DurationMs,
+  sum(bucketEstimatedSpanCount) AS estimatedSpanCount
+FROM (
+  SELECT
+      SourceService AS sourceService,
+      TargetService AS targetService,
+      sum(CallCount) AS bucketCallCount,
+      sum(ErrorCount) AS bucketErrorCount,
+      sum(DurationSumMs) AS bucketDurationSumMs,
+      max(MaxDurationMs) AS bucketMaxDurationMs,
+      sum(if(SampleRateSum > 0, SampleRateSum, toFloat64(CallCount))) AS bucketEstimatedSpanCount
+    FROM service_map_edges_hourly
+    WHERE OrgId = 'org_sql_catalog'
+	  AND Hour >= least(toDateTime('2026-01-03 14:15:00'), if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toDateTime('2026-01-01 10:30:00'), addHours(toStartOfHour(toDateTime('2026-01-01 10:30:00')), 1)))
+	  AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+      AND DeploymentEnv = 'production'
+    GROUP BY sourceService, targetService
+  UNION ALL
+  SELECT
+      SourceService AS sourceService,
+      TargetService AS targetService,
+      sum(CallCount) AS bucketCallCount,
+      sum(ErrorCount) AS bucketErrorCount,
+      sum(DurationSumMs) AS bucketDurationSumMs,
+      max(MaxDurationMs) AS bucketMaxDurationMs,
+      sum(SampleRateSum) AS bucketEstimatedSpanCount
+    FROM (
+      SELECT
+      p.OrgId AS OrgId,
+      toStartOfHour(p.Timestamp) AS Hour,
+      p.ServiceName AS SourceService,
+      c.ServiceName AS TargetService,
+      p.DeploymentEnv AS DeploymentEnv,
+      count() AS CallCount,
+      countIf(c.StatusCode = 'Error') AS ErrorCount,
+      sum(c.Duration / 1000000) AS DurationSumMs,
+      max(c.Duration / 1000000) AS MaxDurationMs,
+      countIf(match(c.TraceState, 'th:[0-9a-f]+')) AS SampledSpanCount,
+      countIf(NOT match(c.TraceState, 'th:[0-9a-f]+')) AS UnsampledSpanCount,
+      sum(multiIf(
+        match(c.TraceState, 'th:[0-9a-f]+'),
+        1.0 / greatest(1.0 - reinterpretAsUInt64(reverse(unhex(rightPad(extract(c.TraceState, 'th:([0-9a-f]+)'), 16, '0')))) / pow(2.0, 64), 0.0001),
+        1.0
+      )) AS SampleRateSum
+    FROM (
+      SELECT OrgId, Timestamp, TraceId, SpanId, ServiceName, DeploymentEnv
+      FROM service_map_spans
+      WHERE SpanKind IN ('Client', 'Producer')
+        AND Timestamp >= toDateTime('2026-01-01 10:30:00')
+        AND Timestamp < least(toDateTime('2026-01-03 14:15:00'), if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toDateTime('2026-01-01 10:30:00'), addHours(toStartOfHour(toDateTime('2026-01-01 10:30:00')), 1)))
+        AND OrgId = 'org_sql_catalog'
+        AND DeploymentEnv = 'production'
+        
+    ) AS p
+    INNER JOIN (
+      SELECT TraceId, ParentSpanId, ServiceName, Duration, StatusCode, TraceState
+      FROM service_map_children
+      WHERE Timestamp >= toDateTime('2026-01-01 10:30:00')
+        AND Timestamp < least(toDateTime('2026-01-03 14:15:00'), if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toDateTime('2026-01-01 10:30:00'), addHours(toStartOfHour(toDateTime('2026-01-01 10:30:00')), 1)))
+        AND OrgId = 'org_sql_catalog'
+        AND DeploymentEnv = 'production'
+    ) AS c
+    ON p.SpanId = c.ParentSpanId AND p.TraceId = c.TraceId
+    WHERE p.ServiceName != c.ServiceName
+    GROUP BY OrgId, Hour, SourceService, TargetService, DeploymentEnv
+    )
+    GROUP BY sourceService, targetService
+  UNION ALL
+  SELECT
+      SourceService AS sourceService,
+      TargetService AS targetService,
+      sum(CallCount) AS bucketCallCount,
+      sum(ErrorCount) AS bucketErrorCount,
+      sum(DurationSumMs) AS bucketDurationSumMs,
+      max(MaxDurationMs) AS bucketMaxDurationMs,
+      sum(SampleRateSum) AS bucketEstimatedSpanCount
+    FROM (
+      SELECT
+      p.OrgId AS OrgId,
+      toStartOfHour(p.Timestamp) AS Hour,
+      p.ServiceName AS SourceService,
+      c.ServiceName AS TargetService,
+      p.DeploymentEnv AS DeploymentEnv,
+      count() AS CallCount,
+      countIf(c.StatusCode = 'Error') AS ErrorCount,
+      sum(c.Duration / 1000000) AS DurationSumMs,
+      max(c.Duration / 1000000) AS MaxDurationMs,
+      countIf(match(c.TraceState, 'th:[0-9a-f]+')) AS SampledSpanCount,
+      countIf(NOT match(c.TraceState, 'th:[0-9a-f]+')) AS UnsampledSpanCount,
+      sum(multiIf(
+        match(c.TraceState, 'th:[0-9a-f]+'),
+        1.0 / greatest(1.0 - reinterpretAsUInt64(reverse(unhex(rightPad(extract(c.TraceState, 'th:([0-9a-f]+)'), 16, '0')))) / pow(2.0, 64), 0.0001),
+        1.0
+      )) AS SampleRateSum
+    FROM (
+      SELECT OrgId, Timestamp, TraceId, SpanId, ServiceName, DeploymentEnv
+      FROM service_map_spans
+      WHERE SpanKind IN ('Client', 'Producer')
+        AND Timestamp >= greatest(least(toDateTime('2026-01-03 14:15:00'), if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toDateTime('2026-01-01 10:30:00'), addHours(toStartOfHour(toDateTime('2026-01-01 10:30:00')), 1))), toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        AND Timestamp < toDateTime('2026-01-03 14:15:00')
+        AND OrgId = 'org_sql_catalog'
+        AND DeploymentEnv = 'production'
+        
+    ) AS p
+    INNER JOIN (
+      SELECT TraceId, ParentSpanId, ServiceName, Duration, StatusCode, TraceState
+      FROM service_map_children
+      WHERE Timestamp >= greatest(least(toDateTime('2026-01-03 14:15:00'), if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toDateTime('2026-01-01 10:30:00'), addHours(toStartOfHour(toDateTime('2026-01-01 10:30:00')), 1))), toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        AND Timestamp < toDateTime('2026-01-03 14:15:00')
+        AND OrgId = 'org_sql_catalog'
+        AND DeploymentEnv = 'production'
+    ) AS c
+    ON p.SpanId = c.ParentSpanId AND p.TraceId = c.TraceId
+    WHERE p.ServiceName != c.ServiceName
+    GROUP BY OrgId, Hour, SourceService, TargetService, DeploymentEnv
+    )
+    GROUP BY sourceService, targetService
+)
+GROUP BY sourceService, targetService
+ORDER BY callCount DESC
+LIMIT 200
+FORMAT JSON
+
+-- pipe:service_overview_compare:default:baseline  [ae5f3c76]
+SELECT 'current' AS period, * FROM (
+SELECT
+          bServiceName AS serviceName,
+          bServiceNamespace AS serviceNamespace,
+          bEnvironment AS environment,
+          bCommitSha AS commitSha,
+          sum(bSpanCount) AS throughput,
+          sum(bErrorCount) AS errorCount,
+          sum(bEstimatedErrorCount) AS estimatedErrorCount,
+          sum(bSpanCount) AS spanCount,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 1) / 1000000 AS p50LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 2) / 1000000 AS p95LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 3) / 1000000 AS p99LatencyMs,
+          sum(bEstimatedSpanCount) AS estimatedSpanCount,
+          min(bFirstSeen) AS firstSeen
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        GROUP BY serviceName, serviceNamespace, environment, commitSha
+        ORDER BY throughput DESC
+        LIMIT 100
+)
+UNION ALL
+SELECT 'previous' AS period, * FROM (
+SELECT
+          bServiceName AS serviceName,
+          bServiceNamespace AS serviceNamespace,
+          bEnvironment AS environment,
+          bCommitSha AS commitSha,
+          sum(bSpanCount) AS throughput,
+          sum(bErrorCount) AS errorCount,
+          sum(bEstimatedErrorCount) AS estimatedErrorCount,
+          sum(bSpanCount) AS spanCount,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 1) / 1000000 AS p50LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 2) / 1000000 AS p95LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 3) / 1000000 AS p99LatencyMs,
+          sum(bEstimatedSpanCount) AS estimatedSpanCount,
+          min(bFirstSeen) AS firstSeen
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2025-12-30 10:30:00'
+          AND Timestamp <= '2026-01-01 14:15:00'
+          AND (Timestamp < if(toDateTime('2025-12-30 10:30:00') = toStartOfHour(toDateTime('2025-12-30 10:30:00')), toStartOfHour(toDateTime('2025-12-30 10:30:00')), toStartOfHour(toDateTime('2025-12-30 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-01 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2025-12-30 10:30:00') = toStartOfHour(toDateTime('2025-12-30 10:30:00')), toStartOfHour(toDateTime('2025-12-30 10:30:00')), toStartOfHour(toDateTime('2025-12-30 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-01 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        GROUP BY serviceName, serviceNamespace, environment, commitSha
+        ORDER BY throughput DESC
+        LIMIT 100
+)
+FORMAT JSON
+
+-- pipe:service_overview:default:baseline  [0c02cf5d]
+SELECT
+          bServiceName AS serviceName,
+          bServiceNamespace AS serviceNamespace,
+          bEnvironment AS environment,
+          bCommitSha AS commitSha,
+          sum(bSpanCount) AS throughput,
+          sum(bErrorCount) AS errorCount,
+          sum(bEstimatedErrorCount) AS estimatedErrorCount,
+          sum(bSpanCount) AS spanCount,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 1) / 1000000 AS p50LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 2) / 1000000 AS p95LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 3) / 1000000 AS p99LatencyMs,
+          sum(bEstimatedSpanCount) AS estimatedSpanCount,
+          min(bFirstSeen) AS firstSeen
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        GROUP BY serviceName, serviceNamespace, environment, commitSha
+        ORDER BY throughput DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- pipe:service_overview:filtered:baseline  [e9509b63]
+SELECT
+          bServiceName AS serviceName,
+          bServiceNamespace AS serviceNamespace,
+          bEnvironment AS environment,
+          bCommitSha AS commitSha,
+          sum(bSpanCount) AS throughput,
+          sum(bErrorCount) AS errorCount,
+          sum(bEstimatedErrorCount) AS estimatedErrorCount,
+          sum(bSpanCount) AS spanCount,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 1) / 1000000 AS p50LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 2) / 1000000 AS p95LatencyMs,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 3) / 1000000 AS p99LatencyMs,
+          sum(bEstimatedSpanCount) AS estimatedSpanCount,
+          min(bFirstSeen) AS firstSeen
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND DeploymentEnv IN ('production', 'staging')
+          AND CommitSha IN ('abc123', 'def456')
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND DeploymentEnv IN ('production', 'staging')
+          AND CommitSha IN ('abc123', 'def456')
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        GROUP BY serviceName, serviceNamespace, environment, commitSha
+        ORDER BY throughput DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- pipe:service_releases_timeline:default:baseline  [d6b94f27]
+SELECT
+          toStartOfInterval(bHour, INTERVAL 300 SECOND) AS bucket,
+          bCommitSha AS commitSha,
+          sum(bSpanCount) AS count,
+          sum(bErrorCount) AS errorCount
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        WHERE bCommitSha != ''
+        GROUP BY bucket, commitSha
+        ORDER BY bucket ASC
+        LIMIT 1000
+        FORMAT JSON
+
+-- pipe:services_facets:default:baseline  [ced46564]
+SELECT
+          bEnvironment AS name,
+          sum(bSpanCount) AS count,
+          'environment' AS facetType
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        WHERE bEnvironment != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          bServiceNamespace AS name,
+          sum(bSpanCount) AS count,
+          'namespace' AS facetType
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        WHERE bServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          bCommitSha AS name,
+          sum(bSpanCount) AS count,
+          'commit_sha' AS facetType
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        WHERE bCommitSha != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          bServiceName AS name,
+          sum(bSpanCount) AS count,
+          'service' AS facetType
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        WHERE bServiceName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+FORMAT JSON
+
+-- pipe:slow_traces:default:baseline  [6d14854f]
+SELECT
+          TraceId AS traceId,
+          SpanName AS spanName,
+          ServiceName AS serviceName,
+          Duration / 1000000 AS durationMs,
+          StatusCode AS statusCode,
+          toString(Timestamp) AS timestamp
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+        ORDER BY durationMs DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- pipe:span_attribute_keys:default:baseline  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- pipe:span_attribute_keys:default:bloom  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- pipe:span_attribute_keys:default:text  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- pipe:span_attribute_values:default:baseline  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+          AND AttributeKey = 'http.method'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:span_attribute_values:default:bloom  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+          AND AttributeKey = 'http.method'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:span_attribute_values:default:text  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+          AND AttributeKey = 'http.method'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- pipe:span_hierarchy:unwindowed:baseline  [29ddf75d]
+SELECT
+          TraceId AS traceId,
+          SpanId AS spanId,
+          ParentSpanId AS parentSpanId,
+          if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) AS spanName,
+          ServiceName AS serviceName,
+          SpanKind AS spanKind,
+          Duration / 1000000 AS durationMs,
+          Timestamp AS startTime,
+          StatusCode AS statusCode,
+          StatusMessage AS statusMessage,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'url.full', SpanAttributes['url.full'], 'http.url', SpanAttributes['http.url'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'], 'url.path', SpanAttributes['url.path'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'cache.system', SpanAttributes['cache.system'], 'cache.result', SpanAttributes['cache.result'], 'cache.name', SpanAttributes['cache.name'], 'cache.operation', SpanAttributes['cache.operation'], 'cache.lookup_performed', SpanAttributes['cache.lookup_performed'], 'db.system.name', SpanAttributes['db.system.name'], 'db.system', SpanAttributes['db.system'], 'cloud.platform', SpanAttributes['cloud.platform'], 'cloudflare.colo', SpanAttributes['cloudflare.colo'], 'faas.invoked_region', SpanAttributes['faas.invoked_region'], 'cloudflare.outcome', SpanAttributes['cloudflare.outcome'])) AS spanAttributes,
+          toJSONString(map('deployment.environment', ResourceAttributes['deployment.environment'], 'deployment.commit_sha', ResourceAttributes['deployment.commit_sha'])) AS resourceAttributes,
+          'related' AS relationship
+        FROM trace_detail_spans
+        WHERE TraceId = '0af7651916cd43dd8448eb211c80319c'
+          AND OrgId = 'org_sql_catalog'
+        ORDER BY startTime ASC
+        LIMIT 5000
+        FORMAT JSON
+
+-- pipe:span_hierarchy:windowed:baseline  [58d61ffb]
+SELECT
+          TraceId AS traceId,
+          SpanId AS spanId,
+          ParentSpanId AS parentSpanId,
+          if(((SpanName LIKE 'http.server %' OR SpanName IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')) AND (SpanAttributes['http.route'] != '' OR SpanAttributes['url.path'] != '')), concat(if(SpanName LIKE 'http.server %', replaceOne(SpanName, 'http.server ', ''), SpanName), ' ', if(SpanAttributes['http.route'] != '', SpanAttributes['http.route'], SpanAttributes['url.path'])), SpanName) AS spanName,
+          ServiceName AS serviceName,
+          SpanKind AS spanKind,
+          Duration / 1000000 AS durationMs,
+          Timestamp AS startTime,
+          StatusCode AS statusCode,
+          StatusMessage AS statusMessage,
+          toJSONString(map('http.method', SpanAttributes['http.method'], 'http.request.method', SpanAttributes['http.request.method'], 'http.route', SpanAttributes['http.route'], 'url.full', SpanAttributes['url.full'], 'http.url', SpanAttributes['http.url'], 'server.address', SpanAttributes['server.address'], 'net.peer.name', SpanAttributes['net.peer.name'], 'url.path', SpanAttributes['url.path'], 'http.target', SpanAttributes['http.target'], 'http.status_code', SpanAttributes['http.status_code'], 'http.response.status_code', SpanAttributes['http.response.status_code'], 'cache.system', SpanAttributes['cache.system'], 'cache.result', SpanAttributes['cache.result'], 'cache.name', SpanAttributes['cache.name'], 'cache.operation', SpanAttributes['cache.operation'], 'cache.lookup_performed', SpanAttributes['cache.lookup_performed'], 'db.system.name', SpanAttributes['db.system.name'], 'db.system', SpanAttributes['db.system'], 'cloud.platform', SpanAttributes['cloud.platform'], 'cloudflare.colo', SpanAttributes['cloudflare.colo'], 'faas.invoked_region', SpanAttributes['faas.invoked_region'], 'cloudflare.outcome', SpanAttributes['cloudflare.outcome'])) AS spanAttributes,
+          toJSONString(map('deployment.environment', ResourceAttributes['deployment.environment'], 'deployment.commit_sha', ResourceAttributes['deployment.commit_sha'])) AS resourceAttributes,
+          if(SpanId = '00f067aa0ba902b7', 'target', 'related') AS relationship
+        FROM trace_detail_spans
+        WHERE TraceId = '0af7651916cd43dd8448eb211c80319c'
+          AND OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        ORDER BY startTime ASC
+        LIMIT 5000
+        FORMAT JSON
+
+-- pipe:span_search:default:baseline  [d4e4a298]
+SELECT
+          TraceId AS traceId,
+          SpanId AS spanId,
+          SpanName AS spanName,
+          ServiceName AS serviceName,
+          Duration / 1000000 AS durationMs,
+          StatusCode AS statusCode,
+          StatusMessage AS statusMessage,
+          SpanAttributes AS spanAttributes,
+          ResourceAttributes AS resourceAttributes,
+          toString(Timestamp) AS timestamp
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        ORDER BY timestamp DESC
+        LIMIT 20
+        FORMAT JSON
+
+-- pipe:span_search:default:bloom  [d4e4a298]
+SELECT
+          TraceId AS traceId,
+          SpanId AS spanId,
+          SpanName AS spanName,
+          ServiceName AS serviceName,
+          Duration / 1000000 AS durationMs,
+          StatusCode AS statusCode,
+          StatusMessage AS statusMessage,
+          SpanAttributes AS spanAttributes,
+          ResourceAttributes AS resourceAttributes,
+          toString(Timestamp) AS timestamp
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        ORDER BY timestamp DESC
+        LIMIT 20
+        FORMAT JSON
+
+-- pipe:span_search:default:text  [d4e4a298]
+SELECT
+          TraceId AS traceId,
+          SpanId AS spanId,
+          SpanName AS spanName,
+          ServiceName AS serviceName,
+          Duration / 1000000 AS durationMs,
+          StatusCode AS statusCode,
+          StatusMessage AS statusMessage,
+          SpanAttributes AS spanAttributes,
+          ResourceAttributes AS resourceAttributes,
+          toString(Timestamp) AS timestamp
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND StatusCode != 'Error'
+        ORDER BY timestamp DESC
+        LIMIT 20
+        FORMAT JSON
+
+-- pipe:top_operations:default:baseline  [af24600b]
+SELECT
+          SpanName AS name,
+          quantile(0.95)(Duration) / 1000000 AS value
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND ServiceName = 'api'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY name
+        ORDER BY value DESC
+        LIMIT 20
+        FORMAT JSON
+
+-- pipe:traces_duration_stats:default:baseline  [cc9afeb5]
+SELECT
+          min(Duration) / 1000000 AS minDurationMs,
+          max(Duration) / 1000000 AS maxDurationMs,
+          quantile(0.5)(Duration) / 1000000 AS p50DurationMs,
+          quantile(0.95)(Duration) / 1000000 AS p95DurationMs
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        FORMAT JSON
+
+-- pipe:traces_facets:attribute-filtered:baseline  [952a9803]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          SpanName AS name,
+          count() AS count,
+          'spanName' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND SpanName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpMethod AS name,
+          count() AS count,
+          'httpMethod' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND HttpMethod != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpStatusCode AS name,
+          count() AS count,
+          'httpStatus' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND HttpStatusCode != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'deploymentEnv' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          ServiceNamespace AS name,
+          count() AS count,
+          'serviceNamespace' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND ServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          'error' AS name,
+          count() AS count,
+          'errorCount' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND HasError = 1
+FORMAT JSON
+
+-- pipe:traces_facets:attribute-filtered:bloom  [952a9803]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          SpanName AS name,
+          count() AS count,
+          'spanName' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND SpanName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpMethod AS name,
+          count() AS count,
+          'httpMethod' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND HttpMethod != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpStatusCode AS name,
+          count() AS count,
+          'httpStatus' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND HttpStatusCode != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'deploymentEnv' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          ServiceNamespace AS name,
+          count() AS count,
+          'serviceNamespace' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND ServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          'error' AS name,
+          count() AS count,
+          'errorCount' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND HasError = 1
+FORMAT JSON
+
+-- pipe:traces_facets:attribute-filtered:text  [952a9803]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          SpanName AS name,
+          count() AS count,
+          'spanName' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND SpanName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpMethod AS name,
+          count() AS count,
+          'httpMethod' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND HttpMethod != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpStatusCode AS name,
+          count() AS count,
+          'httpStatus' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND HttpStatusCode != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'deploymentEnv' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          ServiceNamespace AS name,
+          count() AS count,
+          'serviceNamespace' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND ServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          'error' AS name,
+          count() AS count,
+          'errorCount' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_attr
+        WHERE t_attr.TraceId = TraceId
+          AND t_attr.OrgId = 'org_sql_catalog'
+          AND t_attr.Timestamp >= '2026-01-01 10:30:00'
+          AND t_attr.Timestamp <= '2026-01-03 14:15:00'
+          AND positionCaseInsensitive(t_attr.SpanAttributes['http.method'], 'GE') > 0)
+          AND EXISTS (SELECT
+          1 AS _
+        FROM traces AS t_res
+        WHERE t_res.TraceId = TraceId
+          AND t_res.OrgId = 'org_sql_catalog'
+          AND t_res.Timestamp >= '2026-01-01 10:30:00'
+          AND t_res.Timestamp <= '2026-01-03 14:15:00'
+          AND t_res.ResourceAttributes['host.name'] = 'web')
+          AND HasError = 1
+FORMAT JSON
+
+-- pipe:traces_facets:default:baseline  [3a9bffe8]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          SpanName AS name,
+          count() AS count,
+          'spanName' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND SpanName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpMethod AS name,
+          count() AS count,
+          'httpMethod' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND HttpMethod != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpStatusCode AS name,
+          count() AS count,
+          'httpStatus' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND HttpStatusCode != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'deploymentEnv' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          ServiceNamespace AS name,
+          count() AS count,
+          'serviceNamespace' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          'error' AS name,
+          count() AS count,
+          'errorCount' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND HasError = 1
+FORMAT JSON
+
+-- pipe:traces_facets:default:bloom  [3a9bffe8]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          SpanName AS name,
+          count() AS count,
+          'spanName' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND SpanName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpMethod AS name,
+          count() AS count,
+          'httpMethod' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND HttpMethod != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpStatusCode AS name,
+          count() AS count,
+          'httpStatus' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND HttpStatusCode != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'deploymentEnv' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          ServiceNamespace AS name,
+          count() AS count,
+          'serviceNamespace' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          'error' AS name,
+          count() AS count,
+          'errorCount' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND HasError = 1
+FORMAT JSON
+
+-- pipe:traces_facets:default:text  [3a9bffe8]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          SpanName AS name,
+          count() AS count,
+          'spanName' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND SpanName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpMethod AS name,
+          count() AS count,
+          'httpMethod' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND HttpMethod != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpStatusCode AS name,
+          count() AS count,
+          'httpStatus' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND HttpStatusCode != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'deploymentEnv' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          ServiceNamespace AS name,
+          count() AS count,
+          'serviceNamespace' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          'error' AS name,
+          count() AS count,
+          'errorCount' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND HasError = 1
+FORMAT JSON
+
+-- spec:attribute-keys-logs:baseline  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'log'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- spec:attribute-keys-metrics-scoped:baseline  [83346ccb]
+SELECT
+          arrayJoin(mapKeys(Attributes)) AS attributeKey,
+          count() AS usageCount
+        FROM metrics_sum
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName = 'http.server.requests'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- spec:attribute-keys-metrics:baseline  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'metric'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- spec:attribute-keys-resource:baseline  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'resource'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- spec:attribute-keys-span:baseline  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- spec:attribute-keys-span:bloom  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- spec:attribute-keys-span:text  [f2e10453]
+SELECT
+          AttributeKey AS attributeKey,
+          sum(UsageCount) AS usageCount
+        FROM attribute_keys_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+        GROUP BY attributeKey
+        ORDER BY usageCount DESC
+        LIMIT 200
+        FORMAT JSON
+
+-- spec:attribute-values-log:baseline  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'log'
+          AND AttributeKey = 'log.level'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- spec:attribute-values-metrics-scoped:baseline  [47cae3b9]
+SELECT
+          Attributes['http.route'] AS attributeValue,
+          count() AS usageCount
+        FROM metrics_sum
+        WHERE OrgId = 'org_sql_catalog'
+          AND MetricName = 'http.server.requests'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND Attributes['http.route'] != ''
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- spec:attribute-values-metrics:baseline  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'metric'
+          AND AttributeKey = 'http.route'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- spec:attribute-values-span:baseline  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+          AND AttributeKey = 'http.method'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- spec:attribute-values-span:bloom  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+          AND AttributeKey = 'http.method'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- spec:attribute-values-span:text  [522791bf]
+SELECT
+          AttributeValue AS attributeValue,
+          sum(UsageCount) AS usageCount
+        FROM attribute_values_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND AttributeScope = 'span'
+          AND AttributeKey = 'http.method'
+        GROUP BY attributeValue
+        ORDER BY usageCount DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- spec:errors-facets:baseline  [d5afc6d2]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'environment' AS facetType
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 100
+UNION ALL
+SELECT
+          ErrorLabel AS name,
+          count() AS count,
+          'error_type' AS facetType
+        FROM error_events_by_time
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+FORMAT JSON
+
+-- spec:logs-breakdown:baseline  [17d3173d]
+SELECT
+          name AS name,
+          sum(count) AS count
+        FROM (
+SELECT
+          SeverityText AS name,
+          count() AS count
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (TimestampTime < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR TimestampTime >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+          AND ServiceName = 'api'
+        GROUP BY name
+UNION ALL
+SELECT
+          SeverityText AS name,
+          sum(Count) AS count
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+        GROUP BY name
+) AS breakdown
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- spec:logs-count:baseline  [8e66dc08]
+SELECT
+          sum(total) AS total
+        FROM (
+SELECT
+          count() AS total
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (TimestampTime < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR TimestampTime >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+          AND ServiceName = 'api'
+UNION ALL
+SELECT
+          sum(Count) AS total
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+) AS counts
+        FORMAT JSON
+
+-- spec:logs-count:bloom  [8e66dc08]
+SELECT
+          sum(total) AS total
+        FROM (
+SELECT
+          count() AS total
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (TimestampTime < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR TimestampTime >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+          AND ServiceName = 'api'
+UNION ALL
+SELECT
+          sum(Count) AS total
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+) AS counts
+        FORMAT JSON
+
+-- spec:logs-count:text  [8e66dc08]
+SELECT
+          sum(total) AS total
+        FROM (
+SELECT
+          count() AS total
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-01 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (TimestampTime < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR TimestampTime >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+          AND ServiceName = 'api'
+UNION ALL
+SELECT
+          sum(Count) AS total
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+) AS counts
+        FORMAT JSON
+
+-- spec:logs-facets-single-dimension:baseline  [51dbd2d0]
+SELECT * FROM (
+SELECT
+          SeverityText AS severityText,
+          '' AS serviceName,
+          '' AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'severity' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+        GROUP BY severityText
+)
+ORDER BY count DESC
+LIMIT 500
+FORMAT JSON
+
+-- spec:logs-facets:baseline  [1b88491f]
+SELECT * FROM (
+SELECT
+          SeverityText AS severityText,
+          '' AS serviceName,
+          '' AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'severity' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+        GROUP BY severityText
+UNION ALL
+SELECT
+          '' AS severityText,
+          ServiceName AS serviceName,
+          '' AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'service' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+        GROUP BY serviceName
+UNION ALL
+SELECT
+          '' AS severityText,
+          '' AS serviceName,
+          DeploymentEnv AS deploymentEnv,
+          '' AS namespace,
+          sum(Count) AS count,
+          'deploymentEnv' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv != ''
+        GROUP BY deploymentEnv
+UNION ALL
+SELECT
+          '' AS severityText,
+          '' AS serviceName,
+          '' AS deploymentEnv,
+          ServiceNamespace AS namespace,
+          sum(Count) AS count,
+          'namespace' AS facetType
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ServiceNamespace != ''
+        GROUP BY namespace
+)
+ORDER BY count DESC
+LIMIT 500
+FORMAT JSON
+
+-- spec:logs-timeseries-grouped:baseline  [a6200cf2]
+WITH __series_base AS (
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 60 SECOND) AS bucket,
+          coalesce(nullIf(toString(SeverityText), ''), 'all') AS groupName,
+          count() AS count
+        FROM logs
+        WHERE OrgId = 'org_sql_catalog'
+          AND TimestampTime >= '2026-01-03 10:30:00'
+          AND TimestampTime <= '2026-01-03 14:15:00'
+          AND Timestamp >= '2026-01-03 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+)
+SELECT
+          bucket AS bucket,
+          groupName AS groupName,
+          count AS count
+        FROM __series_base
+        WHERE groupName IN (SELECT groupName FROM (SELECT
+          groupName AS groupName,
+          max(count) AS rank
+        FROM __series_base
+        GROUP BY groupName
+        ORDER BY rank DESC
+        LIMIT 5))
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:logs-timeseries:baseline  [ea443f9a]
+SELECT
+          toStartOfInterval(Hour, INTERVAL 3600 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(Count) AS count
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:logs-timeseries:bloom  [ea443f9a]
+SELECT
+          toStartOfInterval(Hour, INTERVAL 3600 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(Count) AS count
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:logs-timeseries:text  [ea443f9a]
+SELECT
+          toStartOfInterval(Hour, INTERVAL 3600 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(Count) AS count
+        FROM logs_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= '2026-01-01 10:30:00'
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:metrics-breakdown:baseline  [35b2dc2d]
+SELECT
+          ServiceName AS name,
+          if(sum(Count) > 0, sum(Sum) / sum(Count), 0) AS avgValue,
+          sum(Sum) AS sumValue,
+          sum(Count) AS count
+        FROM metrics_histogram
+        WHERE MetricName = 'http.server.request.duration'
+          AND OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- spec:metrics-sparklines:baseline  [377afd48]
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 3600 SECOND) AS bucket,
+          MetricName AS metricName,
+          avg(Value) AS avgValue,
+          sum(Value) AS sumValue,
+          count() AS dataPointCount
+        FROM metrics_sum
+        WHERE MetricName IN ('http.server.requests', 'rpc.server.duration')
+          AND OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+        GROUP BY bucket, metricName
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- spec:metrics-timeseries-grouped-by-attribute:baseline  [8b63032e]
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 300 SECOND) AS bucket,
+          ServiceName AS serviceName,
+          Attributes['http.route'] AS attributeValue,
+          Attributes['http.route'] AS groupName,
+          if(sum(Count) > 0, sum(Sum) / sum(Count), 0) AS avgValue,
+          min(Min) AS minValue,
+          max(Max) AS maxValue,
+          sum(Sum) AS sumValue,
+          sum(Count) AS dataPointCount
+        FROM metrics_histogram
+        WHERE MetricName = 'http.server.request.duration'
+          AND OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+        GROUP BY bucket, serviceName, attributeValue
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- spec:metrics-timeseries-grouped-by-resource:baseline  [b9a2d4d6]
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 300 SECOND) AS bucket,
+          ServiceName AS serviceName,
+          ResourceAttributes['host.name'] AS attributeValue,
+          ResourceAttributes['host.name'] AS groupName,
+          if(sum(Count) > 0, sum(Sum) / sum(Count), 0) AS avgValue,
+          min(Min) AS minValue,
+          max(Max) AS maxValue,
+          sum(Sum) AS sumValue,
+          sum(Count) AS dataPointCount
+        FROM metrics_histogram
+        WHERE MetricName = 'http.server.request.duration'
+          AND OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+        GROUP BY bucket, serviceName, attributeValue
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- spec:metrics-timeseries-rate:baseline  [bc6c3438]
+WITH with_deltas AS (
+SELECT
+          TimeUnix AS TimeUnix,
+          ServiceName AS ServiceName,
+          Attributes AS Attributes,
+          '' AS resourceAttributeValue,
+          Value AS Value,
+          Value - lagInFrame(Value, 1, Value) OVER (PARTITION BY ServiceName, MetricName, cityHash64(mapKeys(Attributes), mapValues(Attributes)), cityHash64(mapKeys(ResourceAttributes), mapValues(ResourceAttributes)), StartTimeUnix ORDER BY TimeUnix ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS delta,
+          toFloat64(toUnixTimestamp64Nano(TimeUnix) - toUnixTimestamp64Nano(lagInFrame(TimeUnix, 1, TimeUnix) OVER (PARTITION BY ServiceName, MetricName, cityHash64(mapKeys(Attributes), mapValues(Attributes)), cityHash64(mapKeys(ResourceAttributes), mapValues(ResourceAttributes)), StartTimeUnix ORDER BY TimeUnix ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW))) / 1000000000 AS time_delta
+        FROM metrics_sum
+        WHERE MetricName = 'http.server.requests'
+          AND OrgId = 'org_sql_catalog'
+          AND IsMonotonic = 1
+          AND TimeUnix >= '2026-01-01 10:30:00' - INTERVAL 3600 SECOND
+          AND TimeUnix <= '2026-01-03 14:15:00'
+)
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 3600 SECOND) AS bucket,
+          ServiceName AS serviceName,
+          '' AS attributeValue,
+          ServiceName AS groupName,
+          sumIf(delta / time_delta, (delta >= 0 AND time_delta > 0)) AS rateValue,
+          sumIf(delta, delta >= 0) AS increaseValue,
+          count() AS dataPointCount
+        FROM with_deltas
+        WHERE TimeUnix >= '2026-01-01 10:30:00'
+        GROUP BY bucket, serviceName
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- spec:metrics-timeseries:baseline  [e6156cc2]
+SELECT
+          toStartOfInterval(TimeUnix, INTERVAL 3600 SECOND) AS bucket,
+          ServiceName AS serviceName,
+          '' AS attributeValue,
+          ServiceName AS groupName,
+          if(sum(Count) > 0, sum(Sum) / sum(Count), 0) AS avgValue,
+          min(Min) AS minValue,
+          max(Max) AS maxValue,
+          sum(Sum) AS sumValue,
+          sum(Count) AS dataPointCount
+        FROM metrics_histogram
+        WHERE MetricName = 'http.server.request.duration'
+          AND OrgId = 'org_sql_catalog'
+          AND TimeUnix >= '2026-01-01 10:30:00'
+          AND TimeUnix <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+        GROUP BY bucket, serviceName
+        ORDER BY bucket ASC
+        FORMAT JSON
+
+-- spec:services-facets:baseline  [ced46564]
+SELECT
+          bEnvironment AS name,
+          sum(bSpanCount) AS count,
+          'environment' AS facetType
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        WHERE bEnvironment != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          bServiceNamespace AS name,
+          sum(bSpanCount) AS count,
+          'namespace' AS facetType
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        WHERE bServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          bCommitSha AS name,
+          sum(bSpanCount) AS count,
+          'commit_sha' AS facetType
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        WHERE bCommitSha != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          bServiceName AS name,
+          sum(bSpanCount) AS count,
+          'service' AS facetType
+        FROM (
+SELECT
+          toStartOfHour(Timestamp) AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          count() AS bSpanCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sumIf(SampleRate, StatusCode = 'Error') AS bEstimatedErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          min(Timestamp) AS bFirstSeen,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bApdexSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bApdexToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+UNION ALL
+SELECT
+          Hour AS bHour,
+          ServiceName AS bServiceName,
+          ServiceNamespace AS bServiceNamespace,
+          DeploymentEnv AS bEnvironment,
+          CommitSha AS bCommitSha,
+          sum(SpanCount) AS bSpanCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(EstimatedErrorCount) AS bEstimatedErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          min(FirstSeen) AS bFirstSeen,
+          sum(ApdexSatisfiedCount) AS bApdexSatisfiedCount,
+          sum(ApdexToleratingCount) AS bApdexToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+        GROUP BY bHour, bServiceName, bServiceNamespace, bEnvironment, bCommitSha
+) AS service_windows
+        WHERE bServiceName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+FORMAT JSON
+
+-- spec:traces-breakdown-by-attribute:baseline  [647b92c0]
+SELECT
+          SpanAttributes['http.route'] AS name,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          0 AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- spec:traces-breakdown-by-attribute:bloom  [647b92c0]
+SELECT
+          SpanAttributes['http.route'] AS name,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          0 AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- spec:traces-breakdown-by-attribute:text  [647b92c0]
+SELECT
+          SpanAttributes['http.route'] AS name,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          0 AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- spec:traces-breakdown:baseline  [35f449b0]
+SELECT
+          ServiceName AS name,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          0 AS p50Duration,
+          0 AS p95Duration,
+          0 AS p99Duration,
+          0 AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 10
+        FORMAT JSON
+
+-- spec:traces-facets-single-dimension:baseline  [a277cb3c]
+SELECT
+          SpanName AS name,
+          count() AS count,
+          'spanName' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND SpanName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+FORMAT JSON
+
+-- spec:traces-facets:baseline  [eabfe99e]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          SpanName AS name,
+          count() AS count,
+          'spanName' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND SpanName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpMethod AS name,
+          count() AS count,
+          'httpMethod' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND HttpMethod != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpStatusCode AS name,
+          count() AS count,
+          'httpStatus' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND HttpStatusCode != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'deploymentEnv' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          ServiceNamespace AS name,
+          count() AS count,
+          'serviceNamespace' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND ServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          'error' AS name,
+          count() AS count,
+          'errorCount' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND HasError = 1
+FORMAT JSON
+
+-- spec:traces-facets:bloom  [eabfe99e]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          SpanName AS name,
+          count() AS count,
+          'spanName' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND SpanName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpMethod AS name,
+          count() AS count,
+          'httpMethod' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND HttpMethod != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpStatusCode AS name,
+          count() AS count,
+          'httpStatus' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND HttpStatusCode != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'deploymentEnv' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          ServiceNamespace AS name,
+          count() AS count,
+          'serviceNamespace' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND ServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          'error' AS name,
+          count() AS count,
+          'errorCount' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND HasError = 1
+FORMAT JSON
+
+-- spec:traces-facets:text  [eabfe99e]
+SELECT
+          ServiceName AS name,
+          count() AS count,
+          'service' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 50
+UNION ALL
+SELECT
+          SpanName AS name,
+          count() AS count,
+          'spanName' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND SpanName != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpMethod AS name,
+          count() AS count,
+          'httpMethod' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND HttpMethod != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          HttpStatusCode AS name,
+          count() AS count,
+          'httpStatus' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND HttpStatusCode != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          DeploymentEnv AS name,
+          count() AS count,
+          'deploymentEnv' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND DeploymentEnv != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          ServiceNamespace AS name,
+          count() AS count,
+          'serviceNamespace' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND ServiceNamespace != ''
+        GROUP BY name
+        ORDER BY count DESC
+        LIMIT 20
+UNION ALL
+SELECT
+          'error' AS name,
+          count() AS count,
+          'errorCount' AS facetType
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+          AND HasError = 1
+FORMAT JSON
+
+-- spec:traces-list:baseline  [ec86c957]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS timestamp,
+          SpanId AS spanId,
+          ServiceName AS serviceName,
+          SpanName AS spanName,
+          Duration / 1000000 AS durationMs,
+          StatusCode AS statusCode,
+          SpanKind AS spanKind,
+          if(StatusCode = 'Error', 1, 0) AS hasError,
+          SpanAttributes AS spanAttributes,
+          ResourceAttributes AS resourceAttributes
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        ORDER BY ts DESC
+        LIMIT 50))
+        ORDER BY timestamp DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- spec:traces-list:bloom  [ec86c957]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS timestamp,
+          SpanId AS spanId,
+          ServiceName AS serviceName,
+          SpanName AS spanName,
+          Duration / 1000000 AS durationMs,
+          StatusCode AS statusCode,
+          SpanKind AS spanKind,
+          if(StatusCode = 'Error', 1, 0) AS hasError,
+          SpanAttributes AS spanAttributes,
+          ResourceAttributes AS resourceAttributes
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        ORDER BY ts DESC
+        LIMIT 50))
+        ORDER BY timestamp DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- spec:traces-list:text  [ec86c957]
+SELECT
+          TraceId AS traceId,
+          Timestamp AS timestamp,
+          SpanId AS spanId,
+          ServiceName AS serviceName,
+          SpanName AS spanName,
+          Duration / 1000000 AS durationMs,
+          StatusCode AS statusCode,
+          SpanKind AS spanKind,
+          if(StatusCode = 'Error', 1, 0) AS hasError,
+          SpanAttributes AS spanAttributes,
+          ResourceAttributes AS resourceAttributes
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND Timestamp >= (SELECT min(ts) FROM (SELECT
+          Timestamp AS ts
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        ORDER BY ts DESC
+        LIMIT 50))
+        ORDER BY timestamp DESC
+        LIMIT 50
+        FORMAT JSON
+
+-- spec:traces-stats:baseline  [e90761b3]
+SELECT
+          min(Duration) / 1000000 AS minDurationMs,
+          max(Duration) / 1000000 AS maxDurationMs,
+          quantile(0.5)(Duration) / 1000000 AS p50DurationMs,
+          quantile(0.95)(Duration) / 1000000 AS p95DurationMs
+        FROM trace_list_mv
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv = 'production'
+        FORMAT JSON
+
+-- spec:traces-timeseries-aggregates-mv:baseline  [0cf473e6]
+SELECT
+          bucket AS bucket,
+          groupName AS groupName,
+          sum(bWeightedCount) AS count,
+          sum(bSpanCount) AS spanCount,
+          0 AS avgDuration,
+          0 AS p50Duration,
+          0 AS p95Duration,
+          0 AS p99Duration,
+          0 AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore,
+          0 AS estimatedSpanCount
+        FROM (
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 3600 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS bWeightedCount,
+          toFloat64(count()) AS bSpanCount,
+          sum(toFloat64(Duration) * SampleRate) AS bWeightedDurationSum,
+          sumIf(SampleRate, StatusCode = 'Error') AS bWeightedErrorCount,
+          '' AS bDurationQuantiles
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bucket, groupName
+UNION ALL
+SELECT
+          toStartOfInterval(Hour, INTERVAL 3600 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(WeightedCount) AS bWeightedCount,
+          sum(WeightedCount) AS bSpanCount,
+          sum(WeightedDurationSum) AS bWeightedDurationSum,
+          sum(WeightedErrorCount) AS bWeightedErrorCount,
+          '' AS bDurationQuantiles
+        FROM traces_aggregates_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+          AND DeploymentEnv IN ('production')
+        GROUP BY bucket, groupName
+) AS traces_metric_windows
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-all-metrics-grouped:baseline  [800b31cb]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 3600 SECOND) AS bucket,
+          coalesce(nullIf(toString(ServiceName), ''), 'all') AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          avg(Duration) / 1000000 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 500)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 500 AND Duration / 1000000 < 2000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          sum(SampleRate) AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-annual-daily-buckets:baseline  [a17db3e2]
+SELECT
+          bucket AS bucket,
+          'all' AS groupName,
+          if(sum(bEstimatedSpanCount) > 0, sum(bEstimatedSpanCount), toFloat64(sum(bCount))) AS count,
+          sum(bCount) AS spanCount,
+          if(sum(bCount) > 0, sum(bDurationSum) / sum(bCount) / 1000000, 0) AS avgDuration,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 1) / 1000000 AS p50Duration,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 2) / 1000000 AS p95Duration,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 3) / 1000000 AS p99Duration,
+          if(sum(bCount) > 0, sum(bErrorCount) / sum(bCount), 0) AS errorRate,
+          sum(bSatisfiedCount) AS satisfiedCount,
+          sum(bToleratingCount) AS toleratingCount,
+          if(sum(bCount) > 0, round(sum(bSatisfiedCount) / sum(bCount) + sum(bToleratingCount) * 0.5 / sum(bCount), 4), 0) AS apdexScore,
+          if(sum(bEstimatedSpanCount) > 0, sum(bEstimatedSpanCount), toFloat64(sum(bCount))) AS estimatedSpanCount
+        FROM (
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 86400 SECOND) AS bucket,
+          count() AS bCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2025-11-01 00:00:00'
+          AND Timestamp <= '2025-11-25 00:00:00'
+          AND (Timestamp < if(toDateTime('2025-11-01 00:00:00') = toStartOfHour(toDateTime('2025-11-01 00:00:00')), toStartOfHour(toDateTime('2025-11-01 00:00:00')), toStartOfHour(toDateTime('2025-11-01 00:00:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2025-11-25 00:00:00')))
+        GROUP BY bucket
+UNION ALL
+SELECT
+          toStartOfInterval(Hour, INTERVAL 86400 SECOND) AS bucket,
+          sum(SpanCount) AS bCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          sum(ApdexSatisfiedCount) AS bSatisfiedCount,
+          sum(ApdexToleratingCount) AS bToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2025-11-01 00:00:00') = toStartOfHour(toDateTime('2025-11-01 00:00:00')), toStartOfHour(toDateTime('2025-11-01 00:00:00')), toStartOfHour(toDateTime('2025-11-01 00:00:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2025-11-25 00:00:00'))
+        GROUP BY bucket
+) AS service_metric_windows
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-annual:baseline  [85a5b7ae]
+SELECT
+          bucket AS bucket,
+          'all' AS groupName,
+          if(sum(bEstimatedSpanCount) > 0, sum(bEstimatedSpanCount), toFloat64(sum(bCount))) AS count,
+          sum(bCount) AS spanCount,
+          if(sum(bCount) > 0, sum(bDurationSum) / sum(bCount) / 1000000, 0) AS avgDuration,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 1) / 1000000 AS p50Duration,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 2) / 1000000 AS p95Duration,
+          arrayElement(quantilesTDigestMerge(0.5, 0.95, 0.99)(bDurationQuantiles), 3) / 1000000 AS p99Duration,
+          if(sum(bCount) > 0, sum(bErrorCount) / sum(bCount), 0) AS errorRate,
+          sum(bSatisfiedCount) AS satisfiedCount,
+          sum(bToleratingCount) AS toleratingCount,
+          if(sum(bCount) > 0, round(sum(bSatisfiedCount) / sum(bCount) + sum(bToleratingCount) * 0.5 / sum(bCount), 4), 0) AS apdexScore,
+          if(sum(bEstimatedSpanCount) > 0, sum(bEstimatedSpanCount), toFloat64(sum(bCount))) AS estimatedSpanCount
+        FROM (
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 3600 SECOND) AS bucket,
+          count() AS bCount,
+          sum(SampleRate) AS bEstimatedSpanCount,
+          countIf(StatusCode = 'Error') AS bErrorCount,
+          sum(toFloat64(Duration)) AS bDurationSum,
+          quantilesTDigestState(0.5, 0.95, 0.99)(Duration) AS bDurationQuantiles,
+          countIf((StatusCode != 'Error' AND Duration < 500000000)) AS bSatisfiedCount,
+          countIf(((StatusCode != 'Error' AND Duration >= 500000000) AND Duration < 2000000000)) AS bToleratingCount
+        FROM service_overview_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND DeploymentEnv IN ('production')
+          AND (Timestamp < if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR) OR Timestamp >= toStartOfHour(toDateTime('2026-01-03 14:15:00')))
+        GROUP BY bucket
+UNION ALL
+SELECT
+          toStartOfInterval(Hour, INTERVAL 3600 SECOND) AS bucket,
+          sum(SpanCount) AS bCount,
+          sum(EstimatedSpanCount) AS bEstimatedSpanCount,
+          sum(ErrorCount) AS bErrorCount,
+          sum(DurationSum) AS bDurationSum,
+          quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles) AS bDurationQuantiles,
+          sum(ApdexSatisfiedCount) AS bSatisfiedCount,
+          sum(ApdexToleratingCount) AS bToleratingCount
+        FROM service_overview_hourly
+        WHERE OrgId = 'org_sql_catalog'
+          AND Hour >= if(toDateTime('2026-01-01 10:30:00') = toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')), toStartOfHour(toDateTime('2026-01-01 10:30:00')) + INTERVAL 1 HOUR)
+          AND Hour < toStartOfHour(toDateTime('2026-01-03 14:15:00'))
+          AND ServiceName = 'api'
+          AND DeploymentEnv IN ('production')
+        GROUP BY bucket
+) AS service_metric_windows
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-apdex:baseline  [7368a4c9]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 300 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          0 AS p50Duration,
+          0 AS p95Duration,
+          0 AS p99Duration,
+          0 AS errorRate,
+          countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 250)) AS satisfiedCount,
+          countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 250 AND Duration / 1000000 < 1000))) AS toleratingCount,
+          if(count() > 0, round(countIf((NOT (StatusCode = 'Error') AND Duration / 1000000 < 250)) / count() + countIf((NOT (StatusCode = 'Error') AND (Duration / 1000000 >= 250 AND Duration / 1000000 < 1000))) * 0.5 / count(), 4), 0) AS apdexScore,
+          0 AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-attribute-filtered:baseline  [b89f03f1]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 300 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          0 AS p50Duration,
+          0 AS p95Duration,
+          0 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore,
+          0 AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND if(SpanAttributes['http.method'] != '', SpanAttributes['http.method'], SpanAttributes['http.request.method']) = 'GET'
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-attribute-filtered:bloom  [0ed9323f]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 300 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          0 AS p50Duration,
+          0 AS p95Duration,
+          0 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore,
+          0 AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND (((has(mapKeys(SpanAttributes), 'http.method') OR has(mapKeys(SpanAttributes), 'http.request.method')) AND has(mapValues(SpanAttributes), 'GET')) AND if(SpanAttributes['http.method'] != '', SpanAttributes['http.method'], SpanAttributes['http.request.method']) = 'GET')
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-attribute-filtered:text  [c4e0b61b]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 300 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          0 AS p50Duration,
+          0 AS p95Duration,
+          0 AS p99Duration,
+          if(sum(SampleRate) > 0, sumIf(SampleRate, StatusCode = 'Error') / sum(SampleRate), 0) AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore,
+          0 AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+          AND ((has(SpanAttributeItems, concat('http.method', char(31), 'GET')) OR has(SpanAttributeItems, concat('http.request.method', char(31), 'GET'))) AND if(SpanAttributes['http.method'] != '', SpanAttributes['http.method'], SpanAttributes['http.request.method']) = 'GET')
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-raw:baseline  [ebfaf7db]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 60 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          0 AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore,
+          0 AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-03 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-raw:bloom  [ebfaf7db]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 60 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          0 AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore,
+          0 AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-03 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-raw:text  [ebfaf7db]
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 60 SECOND) AS bucket,
+          'all' AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          quantile(0.5)(Duration) / 1000000 AS p50Duration,
+          quantile(0.95)(Duration) / 1000000 AS p95Duration,
+          quantile(0.99)(Duration) / 1000000 AS p99Duration,
+          0 AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore,
+          0 AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-03 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON
+
+-- spec:traces-timeseries-series-cap:baseline  [6cd85f46]
+WITH __series_base AS (
+SELECT
+          toStartOfInterval(Timestamp, INTERVAL 300 SECOND) AS bucket,
+          coalesce(nullIf(toString(SpanName), ''), 'all') AS groupName,
+          sum(SampleRate) AS count,
+          count() AS spanCount,
+          0 AS avgDuration,
+          0 AS p50Duration,
+          0 AS p95Duration,
+          0 AS p99Duration,
+          0 AS errorRate,
+          0 AS satisfiedCount,
+          0 AS toleratingCount,
+          0 AS apdexScore,
+          0 AS estimatedSpanCount
+        FROM traces
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND ServiceName = 'api'
+          AND ResourceAttributes['deployment.environment'] IN ('production')
+        GROUP BY bucket, groupName
+        ORDER BY bucket ASC, groupName ASC
+)
+SELECT
+          bucket AS bucket,
+          groupName AS groupName,
+          count AS count,
+          spanCount AS spanCount,
+          avgDuration AS avgDuration,
+          p50Duration AS p50Duration,
+          p95Duration AS p95Duration,
+          p99Duration AS p99Duration,
+          errorRate AS errorRate,
+          satisfiedCount AS satisfiedCount,
+          toleratingCount AS toleratingCount,
+          apdexScore AS apdexScore,
+          estimatedSpanCount AS estimatedSpanCount
+        FROM __series_base
+        WHERE groupName IN (SELECT groupName FROM (SELECT
+          groupName AS groupName,
+          max(count) AS rank
+        FROM __series_base
+        GROUP BY groupName
+        ORDER BY rank DESC
+        LIMIT 10))
+        ORDER BY bucket ASC, groupName ASC
+        FORMAT JSON

--- a/packages/query-engine/src/ch/builder-fixtures.ts
+++ b/packages/query-engine/src/ch/builder-fixtures.ts
@@ -147,7 +147,10 @@ export const builderFixtures: ReadonlyArray<BuilderFixture> = [
 		name: "spanDetailQuery",
 		label: "narrowByTime",
 		compile: () =>
-			CH.compile(CH.spanDetailQuery({ traceId: TRACE_ID, spanId: SPAN_ID, narrowByTime: true }), window),
+			CH.compile(
+				CH.spanDetailQuery({ traceId: TRACE_ID, spanId: SPAN_ID, narrowByTime: true }),
+				window,
+			),
 	},
 	{
 		// ErrorsService errorIssuesScan (the scheduled sweep)
@@ -187,5 +190,268 @@ export const builderFixtures: ReadonlyArray<BuilderFixture> = [
 				...window,
 				fingerprintHash: FINGERPRINT,
 			}),
+	},
+
+	// -------------------------------------------------------------------------
+	// Batch ④ — the modules the query-engine refactor touches. These exist so a
+	// refactor that claims "no SQL changed" is actually checkable: without a
+	// fixture, a builder contributes nothing to `__sql_baseline__/catalog.sql`
+	// and its SQL can drift silently.
+	// -------------------------------------------------------------------------
+
+	// ----- service-operations: the three-tier raw/minutely/hourly splice -----
+	{
+		// routes/v2/services.http.ts — service detail "Operations" tab.
+		module: "service-operations",
+		name: "serviceOperationsSummaryQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(CH.serviceOperationsSummaryQuery({ serviceName: "api", limit: 50 }), window),
+	},
+	{
+		// Env filter exercises the extra predicate on every tier of the splice.
+		module: "service-operations",
+		name: "serviceOperationsSummaryQuery",
+		label: "envFiltered",
+		compile: () =>
+			CH.compile(
+				CH.serviceOperationsSummaryQuery({
+					serviceName: "api",
+					environments: ["production"],
+					limit: 50,
+				}),
+				window,
+			),
+	},
+	{
+		module: "service-operations",
+		name: "serviceOperationsTimeseriesQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(
+				CH.serviceOperationsTimeseriesQuery({
+					serviceName: "api",
+					spanNames: ["GET /v2/services", "POST /v2/alerts"],
+				}),
+				{ ...window, bucketSeconds: 300 },
+			),
+	},
+
+	// ----- services: the hourly-rollup splice behind the service catalog -----
+	{
+		// routes/v2/services.http.ts — the services list.
+		module: "services",
+		name: "serviceCatalogQuery",
+		label: "default",
+		compile: () => CH.compile(CH.serviceCatalogQuery({ limit: 50 }), window),
+	},
+	{
+		module: "services",
+		name: "serviceCatalogQuery",
+		label: "filtered",
+		compile: () =>
+			CH.compile(
+				CH.serviceCatalogQuery({
+					serviceName: "api",
+					deploymentEnvironment: "production",
+					serviceNamespace: "backend",
+					limit: 50,
+				}),
+				window,
+			),
+	},
+
+	// ----- infra: the four gauge-timeseries shapes and three facet unions -----
+	{
+		module: "infra",
+		name: "hostGaugeTimeseriesQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(
+				CH.hostGaugeTimeseriesQuery({
+					hostName: "ip-10-0-1-42",
+					metricName: "system.cpu.utilization",
+				}),
+				{ ...window, bucketSeconds: 300 },
+			),
+	},
+	{
+		// `groupByAttributeKey` switches the projected column off the `lit("")` default.
+		module: "infra",
+		name: "hostGaugeTimeseriesQuery",
+		label: "grouped",
+		compile: () =>
+			CH.compile(
+				CH.hostGaugeTimeseriesQuery({
+					hostName: "ip-10-0-1-42",
+					metricName: "system.cpu.utilization",
+					groupByAttributeKey: "cpu",
+				}),
+				{ ...window, bucketSeconds: 300 },
+			),
+	},
+	{
+		module: "infra",
+		name: "podGaugeTimeseriesQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(
+				CH.podGaugeTimeseriesQuery({
+					podName: "api-7d9f8b6c5-x2n4k",
+					namespace: "backend",
+					metricName: "k8s.pod.cpu.utilization",
+				}),
+				{ ...window, bucketSeconds: 300 },
+			),
+	},
+	{
+		module: "infra",
+		name: "nodeGaugeTimeseriesQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(
+				CH.nodeGaugeTimeseriesQuery({
+					nodeName: "ip-10-0-1-42.ec2.internal",
+					metricName: "k8s.node.cpu.utilization",
+				}),
+				{ ...window, bucketSeconds: 300 },
+			),
+	},
+	{
+		module: "infra",
+		name: "workloadGaugeTimeseriesQuery",
+		label: "default",
+		compile: () =>
+			CH.compile(
+				CH.workloadGaugeTimeseriesQuery({
+					kind: "deployment",
+					workloadName: "api",
+					namespace: "backend",
+					metricName: "k8s.pod.cpu.utilization",
+				}),
+				{ ...window, bucketSeconds: 300 },
+			),
+	},
+	{
+		// `groupByPod` fans the workload series out per pod.
+		module: "infra",
+		name: "workloadGaugeTimeseriesQuery",
+		label: "groupedByPod",
+		compile: () =>
+			CH.compile(
+				CH.workloadGaugeTimeseriesQuery({
+					kind: "statefulset",
+					workloadName: "clickhouse",
+					namespace: "data",
+					metricName: "k8s.pod.memory.usage",
+					groupByPod: true,
+				}),
+				{ ...window, bucketSeconds: 300 },
+			),
+	},
+	{
+		module: "infra",
+		name: "podFacetsQuery",
+		label: "default",
+		compile: () => CH.compileUnion(CH.podFacetsQuery(), window),
+	},
+	{
+		module: "infra",
+		name: "nodeFacetsQuery",
+		label: "default",
+		compile: () => CH.compileUnion(CH.nodeFacetsQuery(), window),
+	},
+	{
+		module: "infra",
+		name: "workloadFacetsQuery",
+		label: "default",
+		compile: () => CH.compileUnion(CH.workloadFacetsQuery({ kind: "deployment" }), window),
+	},
+
+	// ----- activity: the only deliberately cross-org builders in the product.
+	// ----- Fixtured so the catalog's tenant-scope test actually exercises the
+	// ----- cross-org branch, rather than asserting a rule nothing exemplifies.
+	{
+		module: "activity",
+		name: "activeOrgsByErrorEventsQuery",
+		label: "default",
+		compile: () => CH.compile(CH.activeOrgsByErrorEventsQuery(), { startTime: START_TIME }),
+	},
+	{
+		module: "activity",
+		name: "activeOrgsByTracesQuery",
+		label: "default",
+		compile: () => CH.compile(CH.activeOrgsByTracesQuery(), { startTime: START_TIME }),
+	},
+	{
+		module: "activity",
+		name: "activeOrgsByLogsQuery",
+		label: "default",
+		compile: () => CH.compile(CH.activeOrgsByLogsQuery(), { startTime: START_TIME }),
+	},
+
+	// ----- cloudflare / planetscale: one shape per module, so the extraction
+	// ----- in phase 8 can be proven byte-identical.
+	{
+		module: "cloudflare-infra",
+		name: "cloudflareZoneLatencySQL",
+		label: "default",
+		compile: () => CH.compile(CH.cloudflareZoneLatencySQL(), window),
+	},
+	{
+		module: "cloudflare-infra",
+		name: "cloudflareZoneTimeseriesSQL",
+		label: "default",
+		compile: () => CH.compile(CH.cloudflareZoneTimeseriesSQL(), { ...window, bucketSeconds: 300 }),
+	},
+	{
+		// Filters exercise the zone-slice predicates the /infra/cloudflare page sends.
+		module: "cloudflare-infra",
+		name: "cloudflareZoneTimeseriesSQL",
+		label: "filtered",
+		compile: () =>
+			CH.compile(
+				CH.cloudflareZoneTimeseriesSQL({
+					hosts: ["example.com"],
+					statusClasses: ["5xx"],
+					methods: ["GET"],
+				}),
+				{ ...window, bucketSeconds: 300 },
+			),
+	},
+	{
+		module: "cloudflare-infra-extended",
+		name: "cloudflareQueueGaugesSQL",
+		label: "default",
+		compile: () => CH.compile(CH.cloudflareQueueGaugesSQL(), window),
+	},
+	{
+		module: "cloudflare-infra-breakdowns",
+		name: "cloudflareZoneBreakdownTimeseriesSQL",
+		label: "default",
+		compile: () =>
+			CH.compile(CH.cloudflareZoneBreakdownTimeseriesSQL("path", {}, ["/api/v2/traces"]), {
+				...window,
+				serviceName: "cloudflare-zone-example-com",
+				bucketSeconds: 300,
+			}),
+	},
+	{
+		module: "cloudflare-usage",
+		name: "cloudflareUsageQuery",
+		label: "default",
+		compile: () => CH.compile(CH.cloudflareUsageQuery(), { ...window, bucketSeconds: 3600 }),
+	},
+	{
+		module: "cloudflare-map",
+		name: "cloudflareServiceLatencySQL",
+		label: "default",
+		compile: () => CH.compile(CH.cloudflareServiceLatencySQL(), window),
+	},
+	{
+		module: "planetscale-map",
+		name: "planetscaleGaugesSQL",
+		label: "default",
+		compile: () => CH.compile(CH.planetscaleGaugesSQL(), window),
 	},
 ]

--- a/packages/query-engine/src/ch/index.ts
+++ b/packages/query-engine/src/ch/index.ts
@@ -187,6 +187,7 @@ export {
 export {
 	serviceOverviewQuery,
 	serviceOverviewRowSchema,
+	serviceUsageRowSchema,
 	serviceCatalogQuery,
 	serviceHealthSnapshotQuery,
 	serviceHealthSnapshotRowSchema,

--- a/packages/query-engine/src/ch/pipe-dispatch.ts
+++ b/packages/query-engine/src/ch/pipe-dispatch.ts
@@ -96,8 +96,15 @@ export function compilePipeQuery(
 			// union is scoped exactly when the branch is.
 			tenantScope:
 				current.tenantScope === "org" && previous.tenantScope === "org" ? "org" : "cross-org",
+			// `period` is typed as a plain String, not a `"current" | "previous"`
+			// literal union. The value is produced by our own SELECT so it is
+			// always one of the two at runtime — but the row schema describes the
+			// WIRE type, and ClickHouse reports the column as String. The SQL
+			// catalog's analyzer sweep decodes a synthetic zero-value row built
+			// from DESCRIBE output, where a String column is `""`; a literal union
+			// rejects that and fails the gate.
 			rowSchema: rowSchema
-				? Schema.Struct({ period: Schema.Literals(["current", "previous"]), ...rowSchema.fields })
+				? Schema.Struct({ period: Schema.String, ...rowSchema.fields })
 				: undefined,
 		})
 	}

--- a/packages/query-engine/src/ch/pipe-dispatch.ts
+++ b/packages/query-engine/src/ch/pipe-dispatch.ts
@@ -18,7 +18,7 @@ import * as CH from "./index"
 import type { TracesMetric, AttributeFilter, MetricType } from "../query-engine"
 import type { OrgId } from "@maple/domain"
 import { unsafeCompiledQuery, type CompiledQuery } from "@maple-dev/clickhouse-builder"
-import { Array as A, Match, Result } from "effect"
+import { Array as A, Match, Result, Schema } from "effect"
 import {
 	attributeIndexMode,
 	baselineWarehouseCapabilities,
@@ -59,7 +59,7 @@ export function compilePipeQuery(
 	const int = (key: string, def?: number) => (params[key] != null ? Number(params[key]) : def)
 	const bool = (key: string) => params[key] === true || params[key] === "1" || params[key] === "true"
 
-	const compileCompare = (
+	const compileCompare = <Fields extends Schema.Struct.Fields>(
 		query: CompileTarget,
 		ranges: {
 			currentStart: string
@@ -67,23 +67,38 @@ export function compilePipeQuery(
 			previousStart: string
 			previousEnd: string
 		},
+		/**
+		 * The branch query's row schema. Taking a `Schema.Struct` rather than a
+		 * bare `Schema` is what makes the `period` field spreadable below — and
+		 * every `*RowSchema` export already is one. Without this the union
+		 * decoded nothing, so on a backend that quotes 64-bit integers every
+		 * count came back as a string. See ../schema.ts.
+		 */
+		rowSchema?: Schema.Struct<Fields>,
 	): PipeCompiledQuery => {
-		const currentSql = CH.compile(
+		const current = CH.compile(
 			query,
 			{ orgId, startTime: ranges.currentStart, endTime: ranges.currentEnd },
 			{ skipFormat: true },
-		).sql
-		const previousSql = CH.compile(
+		)
+		const previous = CH.compile(
 			query,
 			{ orgId, startTime: ranges.previousStart, endTime: ranges.previousEnd },
 			{ skipFormat: true },
-		).sql
+		)
 		return unsafeCompiledQuery({
 			sql:
-				`SELECT 'current' AS period, * FROM (\n${currentSql}\n)\n` +
+				`SELECT 'current' AS period, * FROM (\n${current.sql}\n)\n` +
 				`UNION ALL\n` +
-				`SELECT 'previous' AS period, * FROM (\n${previousSql}\n)\n` +
+				`SELECT 'previous' AS period, * FROM (\n${previous.sql}\n)\n` +
 				`FORMAT JSON`,
+			// Both branches are the same builder over different windows, so the
+			// union is scoped exactly when the branch is.
+			tenantScope:
+				current.tenantScope === "org" && previous.tenantScope === "org" ? "org" : "cross-org",
+			rowSchema: rowSchema
+				? Schema.Struct({ period: Schema.Literals(["current", "previous"]), ...rowSchema.fields })
+				: undefined,
 		})
 	}
 
@@ -301,6 +316,7 @@ export function compilePipeQuery(
 						previousStart: str("previous_start_time") ?? startTime,
 						previousEnd: str("previous_end_time") ?? endTime,
 					},
+					CH.serviceOverviewRowSchema,
 				),
 			),
 			Match.when("services_facets", () =>
@@ -342,7 +358,9 @@ export function compilePipeQuery(
 					currentEnd: str("current_end_time") ?? endTime,
 					previousStart: str("previous_start_time") ?? startTime,
 					previousEnd: str("previous_end_time") ?? endTime,
-				}),
+				},
+				CH.serviceUsageRowSchema,
+				),
 			),
 			Match.when("service_dependencies", () =>
 				eraseType(

--- a/packages/query-engine/src/ch/queries/activity.ts
+++ b/packages/query-engine/src/ch/queries/activity.ts
@@ -8,11 +8,12 @@
 //
 // They are deliberately CROSS-ORG: there is no `OrgId.eq(...)` predicate, so a
 // single cheap scan of the small recent window / hourly MVs enumerates active
-// orgs at once. `OrgId` still appears in SELECT/GROUP BY, which satisfies the
-// WarehouseQueryService `sql.includes("OrgId")` guard. `.routing("ingest")`
-// routes them to the managed Tinybird workspace (where all managed orgs' data
-// lives); BYO-ClickHouse orgs are invisible here and are gated separately by
-// the caller (always processed).
+// orgs at once. Each declares `.crossOrg()`, which is what lets them through
+// `WarehouseQueryService.crossOrgQuery` — the ordinary read path rejects a
+// query with no top-level tenant predicate. `.routing("ingest")` routes them to
+// the managed Tinybird workspace (where all managed orgs' data lives);
+// BYO-ClickHouse orgs are invisible here and are gated separately by the caller
+// (always processed).
 //
 // The discovery window must be a SUPERSET of the per-org scan window so no
 // active org is missed for the tick.
@@ -33,6 +34,7 @@ export function activeOrgsByErrorEventsQuery() {
 		.groupBy("orgId")
 		.format("JSON")
 		.routing("ingest")
+		.crossOrg()
 }
 
 /** Orgs with any span aggregates since `startTime` (gates the anomaly detector). */
@@ -43,6 +45,7 @@ export function activeOrgsByTracesQuery() {
 		.groupBy("orgId")
 		.format("JSON")
 		.routing("ingest")
+		.crossOrg()
 }
 
 /** Orgs with any log aggregates since `startTime` (gates the anomaly detector). */
@@ -53,4 +56,5 @@ export function activeOrgsByLogsQuery() {
 		.groupBy("orgId")
 		.format("JSON")
 		.routing("ingest")
+		.crossOrg()
 }

--- a/packages/query-engine/src/ch/queries/metrics.ts
+++ b/packages/query-engine/src/ch/queries/metrics.ts
@@ -213,7 +213,7 @@ function metricsTimeseriesRateFromSpanMetricsCallsHourly(
 		param.int("bucketSeconds"),
 	)
 
-	const hourlySql = compileCH(
+	const hourlyCompiled = compileCH(
 		from(SpanMetricsCallsHourly)
 			.select(($) => ({
 				Hour: $.Hour,
@@ -246,7 +246,8 @@ function metricsTimeseriesRateFromSpanMetricsCallsHourly(
 			),
 		{},
 		{ skipFormat: true },
-	).sql
+	)
+	const hourlySql = hourlyCompiled.sql
 
 	const hourlyValues = table("hourly_values", {
 		Hour: T.dateTime,
@@ -295,8 +296,10 @@ function metricsTimeseriesRateFromSpanMetricsCallsHourly(
 	})
 
 	const q = from(deltas)
-		.withCTE("hourly_values", hourlySql)
-		.withCTE("with_deltas", deltasSql)
+		// Both CTEs descend from `hourlySql`, so the outer query is confined to
+		// whatever that was — the compiled CTE strings can't carry it themselves.
+		.withCTE("hourly_values", hourlySql, { tenantScope: hourlyCompiled.tenantScope })
+		.withCTE("with_deltas", deltasSql, { tenantScope: hourlyCompiled.tenantScope })
 		.select(($) => ({
 			bucket: CH.toStartOfInterval($.Hour, param.int("bucketSeconds")),
 			serviceName: $.ServiceName,
@@ -405,7 +408,7 @@ export function metricsTimeseriesRateQuery(
 	})
 
 	const q = from(cteTable)
-		.withCTE("with_deltas", cteSql.sql)
+		.withCTE("with_deltas", cteSql.sql, { tenantScope: cteSql.tenantScope })
 		.select(($) => ({
 			bucket: CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
 			serviceName: $.ServiceName,

--- a/packages/query-engine/src/ch/queries/series-cap.ts
+++ b/packages/query-engine/src/ch/queries/series-cap.ts
@@ -56,7 +56,8 @@ export function finalizeTimeseries<Output extends Record<string, unknown>>(
 	// Compile the inner query with placeholders intact ({} params, skipFormat) so
 	// the outer `CH.compile()` substitutes them once — same pattern as the
 	// list-query cutoff and the metrics-rate CTE.
-	const innerSql = compileCH(inner, {}, { skipFormat: true }).sql
+	const innerCompiled = compileCH(inner, {}, { skipFormat: true })
+	const innerSql = innerCompiled.sql
 	const baseTable = table(SERIES_BASE_ALIAS, outputColumns)
 
 	// Top-N group names, ranked by the max of `rankColumn` across all buckets.
@@ -80,7 +81,9 @@ export function finalizeTimeseries<Output extends Record<string, unknown>>(
 	}
 
 	const capped = from(baseTable)
-		.withCTE(SERIES_BASE_ALIAS, innerSql)
+		// The capped query reads only from this CTE, so it inherits the inner
+		// query's tenant scope — which the opaque SQL string can't carry.
+		.withCTE(SERIES_BASE_ALIAS, innerSql, { tenantScope: innerCompiled.tenantScope })
 		.select(() => passthrough)
 		.where(() => [CH.inSubquery(CH.dynamicColumn<string>("groupName"), topGroupsSql)])
 		.orderBy(["bucket", "asc"], ["groupName", "asc"])

--- a/packages/query-engine/src/ch/queries/service-infra.ts
+++ b/packages/query-engine/src/ch/queries/service-infra.ts
@@ -81,7 +81,13 @@ export function serviceWorkloadsSQL(
 	params: { orgId: string; startTime: string; endTime: string },
 ): CompiledQuery<ServiceWorkloadsOutput> {
 	if (opts.services.length === 0) {
-		return unsafeCompiledQuery({ sql: EMPTY_WORKLOADS_SQL, rowSchema: ServiceWorkloadsOutputSchema })
+		// Reads no table at all (`WHERE 0`), so it cannot cross tenants; it stands
+		// in for a scoped call whose service list was empty.
+		return unsafeCompiledQuery({
+			sql: EMPTY_WORKLOADS_SQL,
+			tenantScope: "org",
+			rowSchema: ServiceWorkloadsOutputSchema,
+		})
 	}
 
 	// Per-service workload identity from the pre-aggregated MV. `max()` over the
@@ -212,5 +218,5 @@ export function serviceWorkloadsSQL(
 		endTime: params.endTime,
 	})
 
-	return unsafeCompiledQuery({ sql, rowSchema: ServiceWorkloadsOutputSchema })
+	return unsafeCompiledQuery({ sql, tenantScope: "org", rowSchema: ServiceWorkloadsOutputSchema })
 }

--- a/packages/query-engine/src/ch/queries/service-map-rollup.ts
+++ b/packages/query-engine/src/ch/queries/service-map-rollup.ts
@@ -106,6 +106,7 @@ export function serviceMapEdgesExistingHoursSQL(params: {
 
 	return unsafeCompiledQuery({
 		sql,
+		tenantScope: "org",
 		rowSchema: ServiceMapEdgesExistingHourSchema,
 	})
 }
@@ -128,6 +129,7 @@ FORMAT JSON`
 
 	return unsafeCompiledQuery({
 		sql,
+		tenantScope: "org",
 		rowSchema: ServiceMapEdgesHourlyOutputSchema,
 	})
 }
@@ -235,6 +237,7 @@ export function serviceMapResolutionsRollupSQL(
 
 	return unsafeCompiledQuery({
 		sql,
+		tenantScope: "org",
 		rowSchema: ServiceAddressResolutionsHourlyOutputSchema,
 	})
 }

--- a/packages/query-engine/src/ch/queries/service-map.ts
+++ b/packages/query-engine/src/ch/queries/service-map.ts
@@ -103,12 +103,18 @@ const ServiceDependenciesOutputSchema: CompiledQueryRowSchema<ServiceDependencie
  * `startExpr` / `endExpr` are raw SQL datetime expressions — the caller is
  * responsible for quoting any literals (e.g. `toDateTime('2026-05-16 09:00:00')`).
  *
- * `orgId` scopes the join to one org. Omit it only for the all-orgs backfill
- * script, which connects to ClickHouse directly; every in-app caller (the
- * rollup and `serviceDependenciesSQL`) must pass it so the query is tenant-scoped.
+ * `orgId` scopes the join to one org and is REQUIRED.
+ *
+ * It used to be optional "for the all-orgs backfill script", degrading to an
+ * empty filter — i.e. a join across every tenant's spans. That is now actively
+ * dangerous rather than merely unchecked: both callers wrap this string in
+ * `unsafeCompiledQuery({ tenantScope: "org" })`, so an omitted org id would be
+ * positively ASSERTED as tenant-scoped and sail through the executor's gate. A
+ * cross-org backfill needs its own explicitly-named entry point, not a
+ * parameter someone can forget.
  */
 export function serviceMapEdgeJoinSQL(params: {
-	orgId?: string
+	orgId: string
 	startExpr: string
 	endExpr: string
 	deploymentEnv?: string
@@ -123,7 +129,7 @@ export function serviceMapEdgeJoinSQL(params: {
 	parentServiceName?: string
 }): string {
 	const esc = escapeClickHouseString
-	const orgFilter = params.orgId ? `AND OrgId = '${esc(params.orgId)}'` : ""
+	const orgFilter = `AND OrgId = '${esc(params.orgId)}'`
 	const envFilter = params.deploymentEnv ? `AND DeploymentEnv = '${esc(params.deploymentEnv)}'` : ""
 	const parentServiceFilter = params.parentServiceName
 		? `AND ServiceName = '${esc(params.parentServiceName)}'`

--- a/packages/query-engine/src/ch/queries/service-map.ts
+++ b/packages/query-engine/src/ch/queries/service-map.ts
@@ -30,6 +30,8 @@ import * as CH from "@maple-dev/clickhouse-builder/expr"
 import { param } from "@maple-dev/clickhouse-builder"
 import { from, fromQuery, fromUnion } from "@maple-dev/clickhouse-builder"
 import {
+	ServiceAddressResolutionsHourly,
+	ServiceExternalEdgesHourly,
 	ServiceMapChildren,
 	ServiceMapDbEdgesHourly,
 	ServiceMapDbQueryShapesHourly,
@@ -145,7 +147,7 @@ export function serviceMapEdgeJoinSQL(params: {
       )) AS SampleRateSum
     FROM (
       SELECT OrgId, Timestamp, TraceId, SpanId, ServiceName, DeploymentEnv
-      FROM service_map_spans
+      FROM ${ServiceMapSpans.name}
       WHERE SpanKind IN ('Client', 'Producer')
         AND Timestamp >= ${params.startExpr}
         AND Timestamp < ${params.endExpr}
@@ -155,7 +157,7 @@ export function serviceMapEdgeJoinSQL(params: {
     ) AS p
     INNER JOIN (
       SELECT TraceId, ParentSpanId, ServiceName, Duration, StatusCode, TraceState
-      FROM service_map_children
+      FROM ${ServiceMapChildren.name}
       WHERE Timestamp >= ${params.startExpr}
         AND Timestamp < ${params.endExpr}
         ${orgFilter}
@@ -203,7 +205,7 @@ export function serviceDependenciesSQL(
       sum(DurationSumMs) AS bucketDurationSumMs,
       max(MaxDurationMs) AS bucketMaxDurationMs,
       sum(if(SampleRateSum > 0, SampleRateSum, toFloat64(CallCount))) AS bucketEstimatedSpanCount
-    FROM service_map_edges_hourly
+    FROM ${ServiceMapEdgesHourly.name}
     WHERE OrgId = '${esc(params.orgId)}'
 	  AND Hour >= ${startEdgeEnd}
 	  AND Hour < ${endHour}
@@ -254,6 +256,7 @@ FORMAT JSON`
 
 	return unsafeCompiledQuery({
 		sql,
+		tenantScope: "org",
 		rowSchema: ServiceDependenciesOutputSchema,
 	})
 }
@@ -1100,7 +1103,7 @@ export function serviceExternalEdgesSQL(
       sum(DurationSumMs) AS bucketDurationSumMs,
       max(MaxDurationMs) AS bucketMaxDurationMs,
       sum(if(SampleRateSum > 0, SampleRateSum, toFloat64(CallCount))) AS bucketEstimatedSpanCount
-    FROM service_external_edges_hourly
+    FROM ${ServiceExternalEdgesHourly.name}
     WHERE OrgId = '${esc(params.orgId)}'
       AND ServiceName = '${esc(opts.serviceName)}'
       AND Hour >= toStartOfHour(toDateTime('${esc(params.startTime)}'))
@@ -1140,7 +1143,7 @@ export function serviceExternalEdgesSQL(
       sum(Duration / 1000000) AS bucketDurationSumMs,
       max(Duration / 1000000) AS bucketMaxDurationMs,
       sum(SampleRate) AS bucketEstimatedSpanCount
-    FROM traces
+    FROM ${Traces.name}
     WHERE OrgId = '${esc(params.orgId)}'
       AND ServiceName = '${esc(opts.serviceName)}'
       AND Timestamp >= toStartOfHour(toDateTime('${esc(params.endTime)}'))
@@ -1184,7 +1187,7 @@ WHERE NOT (
   targetType = 'http'
   AND targetName IN (
     SELECT DISTINCT ParentServerAddress
-    FROM service_address_resolutions_hourly
+    FROM ${ServiceAddressResolutionsHourly.name}
     WHERE OrgId = '${esc(params.orgId)}'
       AND SourceService = '${esc(opts.serviceName)}'
       AND Hour >= toStartOfHour(toDateTime('${esc(params.startTime)}'))
@@ -1200,6 +1203,7 @@ FORMAT JSON`
 
 	return unsafeCompiledQuery({
 		sql,
+		tenantScope: "org",
 		rowSchema: ServiceExternalEdgesOutputSchema,
 	})
 }
@@ -1287,6 +1291,7 @@ export function servicePlatformsSQL(
 
 	return unsafeCompiledQuery({
 		sql,
+		tenantScope: "org",
 		rowSchema: ServicePlatformsOutputSchema,
 	})
 }

--- a/packages/query-engine/src/ch/queries/services.ts
+++ b/packages/query-engine/src/ch/queries/services.ts
@@ -126,7 +126,7 @@ export interface ServiceOverviewOutput {
 	readonly firstSeen: string
 }
 
-export const serviceOverviewRowSchema: CompiledQueryRowSchema<ServiceOverviewOutput> = Schema.Struct({
+export const serviceOverviewRowSchema = Schema.Struct({
 	serviceName: Schema.String,
 	serviceNamespace: Schema.String,
 	environment: Schema.String,
@@ -140,7 +140,7 @@ export const serviceOverviewRowSchema: CompiledQueryRowSchema<ServiceOverviewOut
 	p99LatencyMs: CHNumber,
 	estimatedSpanCount: CHNumber,
 	firstSeen: Schema.String,
-})
+}) satisfies CompiledQueryRowSchema<ServiceOverviewOutput>
 
 export interface ServiceCatalogOpts {
 	serviceName?: string
@@ -505,6 +505,23 @@ export interface ServiceUsageOutput {
 	readonly totalExpHistogramMetricSizeBytes: number
 	readonly totalSizeBytes: number
 }
+
+export const serviceUsageRowSchema = Schema.Struct({
+	serviceName: Schema.String,
+	totalLogCount: CHNumber,
+	totalLogSizeBytes: CHNumber,
+	totalTraceCount: CHNumber,
+	totalTraceSizeBytes: CHNumber,
+	totalSumMetricCount: CHNumber,
+	totalSumMetricSizeBytes: CHNumber,
+	totalGaugeMetricCount: CHNumber,
+	totalGaugeMetricSizeBytes: CHNumber,
+	totalHistogramMetricCount: CHNumber,
+	totalHistogramMetricSizeBytes: CHNumber,
+	totalExpHistogramMetricCount: CHNumber,
+	totalExpHistogramMetricSizeBytes: CHNumber,
+	totalSizeBytes: CHNumber,
+}) satisfies CompiledQueryRowSchema<ServiceUsageOutput>
 
 export function serviceUsageQuery(opts: ServiceUsageOpts) {
 	return from(ServiceUsage)

--- a/packages/query-engine/src/ch/queries/setup-audit.ts
+++ b/packages/query-engine/src/ch/queries/setup-audit.ts
@@ -550,7 +550,7 @@ export function auditOrphanSpansSQL(params: AuditTraceWindowParams): CompiledQue
     LIMIT 200
     FORMAT JSON`
 
-	return unsafeCompiledQuery({ sql, rowSchema: auditOrphanSpanRowSchema })
+	return unsafeCompiledQuery({ sql, tenantScope: "org", rowSchema: auditOrphanSpanRowSchema })
 }
 
 export interface AuditRootlessTraceRow {
@@ -618,5 +618,5 @@ export function auditRootlessTracesSQL(params: AuditTraceWindowParams): Compiled
     LIMIT 200
     FORMAT JSON`
 
-	return unsafeCompiledQuery({ sql, rowSchema: auditRootlessTraceRowSchema })
+	return unsafeCompiledQuery({ sql, tenantScope: "org", rowSchema: auditRootlessTraceRowSchema })
 }

--- a/packages/query-engine/src/ch/tables.ts
+++ b/packages/query-engine/src/ch/tables.ts
@@ -387,6 +387,34 @@ export const ServiceMapEdgesHourly = table("service_map_edges_hourly", {
 	SampleRateSum: T.float64,
 })
 
+// Reached only from the raw-SQL builders in queries/service-map.ts, which
+// interpolate `.name` rather than going through the DSL — the `multiIf` ladders
+// they emit are what the DSL can't express. Declared here anyway so
+// tables.test.ts drift-checks the columns those builders read.
+export const ServiceExternalEdgesHourly = table("service_external_edges_hourly", {
+	OrgId: T.string,
+	Hour: T.dateTime,
+	ServiceName: T.string,
+	TargetType: T.string,
+	TargetSystem: T.string,
+	TargetName: T.string,
+	DeploymentEnv: T.string,
+	CallCount: T.uint64,
+	ErrorCount: T.uint64,
+	DurationSumMs: T.float64,
+	MaxDurationMs: T.float64,
+	SampleRateSum: T.float64,
+})
+
+export const ServiceAddressResolutionsHourly = table("service_address_resolutions_hourly", {
+	OrgId: T.string,
+	Hour: T.dateTime,
+	SourceService: T.string,
+	ParentServerAddress: T.string,
+	ResolvedTargetService: T.string,
+	DeploymentEnv: T.string,
+})
+
 export const ServiceMapDbEdgesHourly = table("service_map_db_edges_hourly", {
 	OrgId: T.string,
 	Hour: T.dateTime,

--- a/packages/query-engine/src/execution/executor.test.ts
+++ b/packages/query-engine/src/execution/executor.test.ts
@@ -62,9 +62,16 @@ const compiled = compile(listRuleChecksQuery({ limit: 1 }), {
 	ruleId: "rule_test",
 })
 
+// The old `sqlQuery(tenant, sql)` entry point took a raw string; scope now
+// travels on the compiled query, so these execution/span/retry tests wrap their
+// SQL in a compiled value that declares it.
+const scoped = (sql: string) =>
+	unsafeCompiledQuery<Record<string, unknown>>({ sql, tenantScope: "org" })
+
 // A plain query with no routing declaration follows the default read route.
 const untaggedCompiled = unsafeCompiledQuery<{ readonly c: number }>({
 	sql: "SELECT count() AS c FROM traces WHERE OrgId = 'org_test'\nFORMAT JSON",
+	tenantScope: "org",
 })
 
 // Records the backend each constructed client was wired to, so a test can assert
@@ -114,7 +121,7 @@ describe("makeWarehouseExecutor ingest routing", () => {
 		Effect.gen(function* () {
 			const created: Array<ResolvedWarehouseConfig["kind"]> = []
 			const executor = makeWarehouseExecutor(makeDeps(created))
-			yield* executor.sqlQuery(tenant, "SELECT 1 WHERE OrgId = 'org_test'", {
+			yield* executor.compiledQuery(tenant, scoped("SELECT 1 WHERE OrgId = 'org_test'"), {
 				context: "test",
 				route: "ingest",
 			})
@@ -130,7 +137,7 @@ describe("makeWarehouseExecutor span instrumentation", () => {
 			const executor = makeWarehouseExecutor(makeDeps([]))
 
 			yield* executor
-				.sqlQuery(tenant, "SELECT 1 WHERE OrgId = 'org_test'", {
+				.compiledQuery(tenant, scoped("SELECT 1 WHERE OrgId = 'org_test'"), {
 					profile: "list",
 					context: "spanContract",
 				})
@@ -162,7 +169,7 @@ describe("makeWarehouseExecutor span instrumentation", () => {
 			)
 
 			yield* executor
-				.sqlQuery(tenant, "SELECT 1 WHERE OrgId = 'org_test'", { context: "localSpan" })
+				.compiledQuery(tenant, scoped("SELECT 1 WHERE OrgId = 'org_test'"), { context: "localSpan" })
 				.pipe(Effect.withTracer(tracer))
 
 			const span = spans.find((candidate) => candidate.name === "WarehouseQueryService.executeSql")
@@ -204,6 +211,7 @@ describe("makeWarehouseExecutor span instrumentation", () => {
 					() =>
 						unsafeCompiledQuery<{ readonly c: number }>({
 							sql: "SELECT count() AS c FROM logs WHERE OrgId = 'org_test' FORMAT JSON",
+							tenantScope: "org",
 						}),
 					{ context: "capabilitySpan" },
 				)
@@ -237,7 +245,7 @@ describe("makeWarehouseExecutor span instrumentation", () => {
 			})
 
 			const exit = yield* executor
-				.sqlQuery(tenant, "SELECT 1 WHERE OrgId = 'org_test'", { context: "retrySpan" })
+				.compiledQuery(tenant, scoped("SELECT 1 WHERE OrgId = 'org_test'"), { context: "retrySpan" })
 				.pipe(Effect.withTracer(tracer), Effect.exit)
 
 			assert.strictEqual(exit._tag, "Failure")
@@ -315,6 +323,7 @@ describe("makeWarehouseExecutor compiled-query defaults", () => {
 			}
 			const withSchema = unsafeCompiledQuery<{ readonly c: number }>({
 				sql: "SELECT count() AS c FROM traces WHERE OrgId = 'org_test'\nFORMAT JSON",
+				tenantScope: "org",
 				rowSchema: Schema.Struct({ c: Schema.Number }),
 			})
 			const executor = makeWarehouseExecutor(badRowDeps)
@@ -431,6 +440,7 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 			const factory = (capabilities: WarehouseCapabilities) =>
 				unsafeCompiledQuery<{ readonly c: number }>({
 					sql: `SELECT count() AS c FROM logs WHERE OrgId = 'org_test' AND '${logBodySearchMode(capabilities)}' = 'text' FORMAT JSON`,
+					tenantScope: "org",
 				})
 
 			yield* executor.compiledQuery(tenant, factory, { context: "capability-test" })
@@ -484,6 +494,7 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 					() =>
 						unsafeCompiledQuery<{ readonly c: number }>({
 							sql: "SELECT count() AS c FROM logs WHERE OrgId = 'org_test' FORMAT JSON",
+							tenantScope: "org",
 						}),
 					{ context: "capability-request-local" },
 				)
@@ -527,6 +538,7 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 				(capabilities) =>
 					unsafeCompiledQuery<{ readonly c: number }>({
 						sql: `SELECT count() AS c FROM logs WHERE OrgId = 'org_test' AND '${logBodySearchMode(capabilities)}' = 'scan' FORMAT JSON`,
+						tenantScope: "org",
 					}),
 				{ context: "capability-fallback-test" },
 			)
@@ -577,6 +589,7 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 				(capabilities) =>
 					unsafeCompiledQuery<{ readonly c: number }>({
 						sql: `SELECT count() AS c FROM logs WHERE OrgId = 'org_test' AND '${logBodySearchMode(capabilities)}' = 'scan' FORMAT JSON`,
+						tenantScope: "org",
 					}),
 				{ context: "tinybird-gateway-capabilities" },
 			)
@@ -618,6 +631,7 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 						(capabilities) =>
 							unsafeCompiledQuery<{ readonly c: number }>({
 								sql: `SELECT count() AS c FROM logs WHERE OrgId = 'org_test' AND '${logBodySearchMode(capabilities)}' = 'scan' FORMAT JSON`,
+								tenantScope: "org",
 							}),
 						{ context: "hung-capability-probe" },
 					)
@@ -784,10 +798,10 @@ describe("makeWarehouseExecutor client cache partitions", () => {
 					}),
 			})
 
-			yield* executor.sqlQuery(tenant, "SELECT 1 WHERE OrgId = 'org_test'")
+			yield* executor.compiledQuery(tenant, scoped("SELECT 1 WHERE OrgId = 'org_test'"))
 			yield* executor.rawSqlQuery(tenant, "SELECT 1 WHERE OrgId = 'org_test'")
 			yield* executor.ingest(tenant, "traces", [{ TraceId: "trace" }])
-			yield* executor.sqlQuery(tenant, "SELECT 2 WHERE OrgId = 'org_test'")
+			yield* executor.compiledQuery(tenant, scoped("SELECT 2 WHERE OrgId = 'org_test'"))
 
 			assert.strictEqual(nextClientId, 3)
 			assert.deepStrictEqual(calls, [

--- a/packages/query-engine/src/execution/executor.ts
+++ b/packages/query-engine/src/execution/executor.ts
@@ -10,7 +10,7 @@ import {
 	WarehouseValidationError,
 } from "@maple/domain/http"
 import type { WarehouseQueryName } from "@maple/domain/warehouse-queries"
-import { compilePipeQuery, type CompiledQuery } from "../ch"
+import { compilePipeQuery, type CompiledQuery, type TenantScope } from "../ch"
 import type { WarehouseExecutorShape } from "../observability"
 import {
 	appendSettings,
@@ -585,9 +585,13 @@ WHERE name = 'enable_full_text_index'`,
 			})
 		}
 
-		const rows = yield* executeTrustedSql(
+		// The pipe path used to call `executeTrustedSql` directly, with no scope
+		// assertion of any kind — it relied on `compilePipeQuery` always threading
+		// `org_id`. Same gate as the compiled path now.
+		const rows = yield* executeScopedSql(
 			tenant,
 			compiled.sql,
+			compiled.tenantScope,
 			payload.pipeName,
 			withCapabilitySettings(capabilities, options),
 		)
@@ -608,24 +612,37 @@ WHERE name = 'enable_full_text_index'`,
 		})
 	})
 
-	const sqlQuery = Effect.fn("WarehouseQueryService.sqlQuery")(function* (
+	/**
+	 * Run SQL that a `CompiledQuery` has already vouched for.
+	 *
+	 * Callers must pass the compiled query's `tenantScope`, not a string they
+	 * assembled themselves. The old gate here was `sql.includes("OrgId")`, which
+	 * `SELECT count() AS OrgId …` and `WHERE OrgId = 'x' OR 1=1` both satisfy —
+	 * so scoping is now decided by the builder when it sees an `OrgId` predicate
+	 * in a top-level WHERE, and this only enforces the decision.
+	 */
+	const executeScopedSql = Effect.fn("WarehouseQueryService.executeScopedSql")(function* (
 		tenant: ExecutionTenant,
 		sql: string,
+		tenantScope: TenantScope,
+		context: string,
 		options?: SqlQueryOptions,
 	) {
 		if (!tenant.orgId || tenant.orgId.trim() === "") {
 			return yield* new WarehouseValidationError({
-				pipeName: "sqlQuery",
-				message: "org_id must not be empty (sqlQuery)",
+				pipeName: context,
+				message: `org_id must not be empty (${context})`,
 			})
 		}
-		if (!sql.includes("OrgId")) {
+		if (tenantScope !== "org") {
 			return yield* new WarehouseValidationError({
-				pipeName: "sqlQuery",
-				message: "SQL query must contain OrgId filter (sqlQuery)",
+				pipeName: context,
+				message:
+					`compiled query is not tenant-scoped: no top-level OrgId predicate (${context}). ` +
+					`Deliberate cross-tenant reads must declare .crossOrg() and run through crossOrgQuery.`,
 			})
 		}
-		return yield* executeTrustedSql(tenant, sql, "sqlQuery", options)
+		return yield* executeTrustedSql(tenant, sql, context, options)
 	})
 
 	const rawSqlQuery = Effect.fn("WarehouseQueryService.rawSqlQuery")(function* (
@@ -633,12 +650,12 @@ WHERE name = 'enable_full_text_index'`,
 		sql: string,
 		options?: Pick<SqlQueryOptions, "profile" | "context">,
 	) {
-		if (!sql.includes("OrgId")) {
-			return yield* new RawSqlValidationError({
-				code: "MissingOrgFilter",
-				message: "Raw SQL must contain the expanded OrgId filter",
-			})
-		}
+		// No OrgId assertion here on purpose. This path runs user-authored SQL,
+		// whose isolation is enforced upstream at the credential layer — a
+		// per-org datasource-scoped JWT on managed Tinybird, the org's own
+		// cluster credentials on BYO ClickHouse. `prepareRawSql` has already
+		// expanded and validated `$__orgFilter`; a substring check on top of that
+		// asserts nothing and invites the belief that it does.
 		return yield* executeSql(tenant, sql, "rawSqlQuery", options, "raw")
 	})
 
@@ -676,7 +693,13 @@ WHERE name = 'enable_full_text_index'`,
 			"query.optimization.capabilityAware",
 			typeof compiled === "function",
 		)
-		const rows = yield* sqlQuery(tenant, selected.sql, withCompiledRouting(selected, executionOptions))
+		const rows = yield* executeScopedSql(
+			tenant,
+			selected.sql,
+			selected.tenantScope,
+			options.context ?? "compiledQuery",
+			withCompiledRouting(selected, executionOptions),
+		)
 		return yield* selected.decodeRows(rows).pipe(
 			Effect.mapError(
 				(error) =>
@@ -702,6 +725,53 @@ WHERE name = 'enable_full_text_index'`,
 		options?: SqlQueryOptions,
 	) => executeCompiledQuery(tenant, compile, options)
 
+	/**
+	 * Deliberately read across every tenant.
+	 *
+	 * A separate method rather than a flag on `compiledQuery`, so that grepping
+	 * for cross-tenant reads returns a finite, reviewable list. The compiled
+	 * query must have declared `.crossOrg()`; a scoped query arriving here is
+	 * just as much a bug as an unscoped one on the normal path, so both
+	 * directions are rejected.
+	 */
+	const crossOrgQuery = Effect.fn("WarehouseQueryService.crossOrgQuery")(function* <T>(
+		tenant: ExecutionTenant,
+		compiled: CompiledQuery<T>,
+		rawOptions: SqlQueryOptions & { readonly justification: string },
+	) {
+		const options = withDefaultProfile(rawOptions)
+		const context = options.context ?? "crossOrgQuery"
+		if (compiled.tenantScope !== "cross-org") {
+			return yield* new WarehouseValidationError({
+				pipeName: context,
+				message:
+					`tenant-scoped query routed through crossOrgQuery (${context}). ` +
+					`Use compiledQuery — the cross-org path skips scope enforcement.`,
+			})
+		}
+		// Annotated so "who reads across tenants, and why" is answerable from the
+		// traces themselves rather than from code review alone.
+		yield* Effect.annotateCurrentSpan("tenant.scope", "cross-org")
+		yield* Effect.annotateCurrentSpan("tenant.crossOrg.justification", rawOptions.justification)
+		const rows = yield* executeTrustedSql(
+			tenant,
+			compiled.sql,
+			context,
+			withCompiledRouting(compiled, options),
+		)
+		return yield* compiled.decodeRows(rows).pipe(
+			Effect.mapError(
+				(error) =>
+					new WarehouseSchemaDriftError({
+						pipeName: context,
+						message: error.message,
+						kind: "decode",
+						cause: error,
+					}),
+			),
+		)
+	})
+
 	const compiledQueryFirst = Effect.fn("WarehouseQueryService.compiledQueryFirst")(function* <T>(
 		tenant: ExecutionTenant,
 		compiled: CompiledQuery<T> | ((capabilities: WarehouseCapabilities) => CompiledQuery<T>),
@@ -717,7 +787,13 @@ WHERE name = 'enable_full_text_index'`,
 			"query.optimization.capabilityAware",
 			typeof compiled === "function",
 		)
-		const rows = yield* sqlQuery(tenant, selected.sql, withCompiledRouting(selected, executionOptions))
+		const rows = yield* executeScopedSql(
+			tenant,
+			selected.sql,
+			selected.tenantScope,
+			options.context ?? "compiledQueryFirst",
+			withCompiledRouting(selected, executionOptions),
+		)
 		return yield* selected.decodeFirstRow(rows).pipe(
 			Effect.mapError(
 				(error) =>
@@ -829,10 +905,6 @@ WHERE name = 'enable_full_text_index'`,
 			query(tenant, { pipeName: pipe, params }, { context: `pipe:${pipe}`, ...options }).pipe(
 				Effect.map((response) => ({ data: response.data as unknown as ReadonlyArray<T> })),
 			),
-		sqlQuery: <T>(sql: string, options?: SqlQueryOptions) =>
-			sqlQuery(tenant, sql, { context: "warehouseExecutor.sqlQuery", ...options }).pipe(
-				Effect.map((rows) => rows as unknown as ReadonlyArray<T>),
-			),
 		compiledQuery: <T>(compiled: CompiledQuery<T>, options?: SqlQueryOptions) =>
 			compiledQuery(tenant, compiled, { context: "warehouseExecutor.compiledQuery", ...options }),
 		compiledQueryFirst: <T>(compiled: CompiledQuery<T>, options?: SqlQueryOptions) =>
@@ -844,7 +916,7 @@ WHERE name = 'enable_full_text_index'`,
 
 	return {
 		query,
-		sqlQuery,
+		crossOrgQuery,
 		rawSqlQuery,
 		compiledQuery,
 		compiledQueryWithCapabilities,

--- a/packages/query-engine/src/execution/ports.ts
+++ b/packages/query-engine/src/execution/ports.ts
@@ -5,6 +5,7 @@ import type {
 	WarehouseQueryRequest,
 	WarehouseQueryResponse,
 	WarehouseValidationError,
+	WarehouseSchemaDriftError,
 } from "@maple/domain/http"
 import type { ResolvedWarehouseConfig } from "./backend"
 import type { CompiledQuery } from "../ch"
@@ -86,11 +87,20 @@ export interface WarehouseQueryServiceShape {
 		payload: WarehouseQueryRequest,
 		options?: SqlQueryOptions,
 	) => Effect.Effect<WarehouseQueryResponse, WarehouseSqlError | WarehouseValidationError>
-	readonly sqlQuery: (
+	/**
+	 * Execute a query that deliberately spans every tenant. The compiled query
+	 * must declare `.crossOrg()`, and `justification` is recorded on the span so
+	 * cross-tenant reads are auditable from the traces.
+	 *
+	 * There is deliberately no general `sqlQuery(tenant, sql)` on this shape:
+	 * arbitrary strings cannot carry a `tenantScope`, so accepting them would
+	 * reintroduce the substring guard this replaced.
+	 */
+	readonly crossOrgQuery: <T>(
 		tenant: ExecutionTenant,
-		sql: string,
-		options?: SqlQueryOptions,
-	) => Effect.Effect<ReadonlyArray<Record<string, unknown>>, WarehouseSqlError | WarehouseValidationError>
+		compiled: CompiledQuery<T>,
+		options: SqlQueryOptions & { readonly justification: string },
+	) => Effect.Effect<ReadonlyArray<T>, WarehouseSqlError | WarehouseValidationError | WarehouseSchemaDriftError>
 	/** Execute validated user-authored SQL with tenant-scoped credentials and hard response limits. */
 	readonly rawSqlQuery: (
 		tenant: ExecutionTenant,

--- a/packages/query-engine/src/observability/WarehouseExecutor.ts
+++ b/packages/query-engine/src/observability/WarehouseExecutor.ts
@@ -23,11 +23,6 @@ export interface WarehouseExecutorShape {
 	) => Effect.Effect<{ data: ReadonlyArray<T> }, WarehouseExecutorError>
 
 	/** Execute raw ClickHouse SQL. The SQL MUST include an OrgId filter. */
-	readonly sqlQuery: <T = Record<string, unknown>>(
-		sql: string,
-		options?: SqlQueryOptions,
-	) => Effect.Effect<ReadonlyArray<T>, WarehouseExecutorError>
-
 	readonly compiledQuery: <T>(
 		compiled: CompiledQuery<T>,
 		options?: SqlQueryOptions,

--- a/packages/query-engine/src/observability/error-detail.test.ts
+++ b/packages/query-engine/src/observability/error-detail.test.ts
@@ -23,7 +23,6 @@ const makeMockExecutor = (
 	tracesData: ReadonlyArray<unknown>,
 ): WarehouseExecutorShape => ({
 	orgId: "org_test",
-	sqlQuery: () => Effect.succeed([] as ReadonlyArray<never>),
 	compiledQuery: (compiled) => compiled.decodeRows([]).pipe(Effect.orDie),
 	compiledQueryFirst: (compiled) => compiled.decodeFirstRow([]).pipe(Effect.orDie),
 	query: (pipe: string, params: Record<string, unknown>) => {

--- a/packages/query-engine/src/observability/explore-attributes.test.ts
+++ b/packages/query-engine/src/observability/explore-attributes.test.ts
@@ -10,7 +10,6 @@ interface CapturedCalls {
 
 const makeMockExecutor = (captured: CapturedCalls): WarehouseExecutorShape => ({
 	orgId: "org_test",
-	sqlQuery: () => Effect.succeed([] as ReadonlyArray<never>),
 	compiledQuery: (compiled) => compiled.decodeRows([]).pipe(Effect.orDie),
 	compiledQueryFirst: (compiled) => compiled.decodeFirstRow([]).pipe(Effect.orDie),
 	query: (pipe: string, params: Record<string, unknown>) => {

--- a/packages/query-engine/src/observability/find-slow-traces.test.ts
+++ b/packages/query-engine/src/observability/find-slow-traces.test.ts
@@ -15,7 +15,6 @@ const makeMockExecutor = (
 	statsRows: ReadonlyArray<Record<string, unknown>> = [],
 ): WarehouseExecutorShape => ({
 	orgId: "org_test",
-	sqlQuery: () => Effect.succeed([] as ReadonlyArray<never>),
 	compiledQuery: (compiled) => compiled.decodeRows([]).pipe(Effect.orDie),
 	compiledQueryFirst: (compiled) => compiled.decodeFirstRow([]).pipe(Effect.orDie),
 	query: (pipe: string, params: Record<string, unknown>) => {
@@ -128,7 +127,6 @@ describe("findSlowTraces", () => {
 		Effect.gen(function* () {
 			const failingExecutor: WarehouseExecutorShape = {
 				orgId: "org_test",
-				sqlQuery: () => Effect.succeed([]),
 				compiledQuery: (compiled) => compiled.decodeRows([]).pipe(Effect.orDie),
 				compiledQueryFirst: (compiled) => compiled.decodeFirstRow([]).pipe(Effect.orDie),
 				query: () =>

--- a/packages/query-engine/src/observability/search-logs.test.ts
+++ b/packages/query-engine/src/observability/search-logs.test.ts
@@ -18,7 +18,6 @@ interface CapturedCalls {
 
 const makeMockExecutor = (captured: CapturedCalls): WarehouseExecutorShape => ({
 	orgId: "org_test",
-	sqlQuery: () => Effect.succeed([] as ReadonlyArray<never>),
 	compiledQuery: (compiled) => compiled.decodeRows([]).pipe(Effect.orDie),
 	compiledQueryFirst: (compiled) => compiled.decodeFirstRow([]).pipe(Effect.orDie),
 	query: (

--- a/packages/query-engine/src/observability/session-replays.test.ts
+++ b/packages/query-engine/src/observability/session-replays.test.ts
@@ -30,10 +30,6 @@ const makeExecutor = (captured: Captured, responses: MockResponses): WarehouseEx
 	return {
 		orgId: "org_test",
 		query: () => Effect.succeed({ data: [] as ReadonlyArray<never> }),
-		sqlQuery: ((sql: string) => {
-			captured.sqls.push(sql)
-			return Effect.succeed(rowsFor(sql) as ReadonlyArray<never>)
-		}) as WarehouseExecutorShape["sqlQuery"],
 		compiledQuery: ((compiled) => {
 			captured.sqls.push(compiled.sql)
 			return compiled.decodeRows(rowsFor(compiled.sql)).pipe(Effect.orDie)
@@ -145,14 +141,6 @@ describe("getSessionTraces", () => {
 			const failing: WarehouseExecutorShape = {
 				orgId: "org_test",
 				query: () => Effect.succeed({ data: [] }),
-				sqlQuery: () =>
-					Effect.fail(
-						new WarehouseUpstreamError({
-							pipeName: "session_traces",
-							message: "ClickHouse exploded",
-							upstreamStatus: 503,
-						}),
-					),
 				compiledQuery: () =>
 					Effect.fail(
 						new WarehouseUpstreamError({

--- a/packages/query-engine/src/runtime/metrics-alert-evaluation.test.ts
+++ b/packages/query-engine/src/runtime/metrics-alert-evaluation.test.ts
@@ -22,7 +22,6 @@ const makeWarehouse = (
 	rows: ReadonlyArray<Record<string, unknown>>,
 	onCompiled: (sql: string, context: string | undefined) => void = () => undefined,
 ): QueryEngineWarehouse => ({
-	sqlQuery: () => Effect.die("unexpected sqlQuery"),
 	rawSqlQuery: () => Effect.die("unexpected rawSqlQuery"),
 	compiledQuery(_tenant, compiled, options) {
 		onCompiled(compiled.sql, options?.context)

--- a/packages/query-engine/src/runtime/query-engine.ts
+++ b/packages/query-engine/src/runtime/query-engine.ts
@@ -80,11 +80,6 @@ export interface QueryTenant {
  * `WarehouseQueryService` and `T` is inferred as that concrete tenant.
  */
 export interface QueryEngineWarehouse<T extends QueryTenant = QueryTenant> {
-	readonly sqlQuery: (
-		tenant: T,
-		sql: string,
-		options?: SqlQueryOptions,
-	) => Effect.Effect<ReadonlyArray<Record<string, unknown>>, WarehouseError>
 	readonly rawSqlQuery: (
 		tenant: T,
 		sql: string,

--- a/packages/query-engine/src/sql-catalog.baseline.test.ts
+++ b/packages/query-engine/src/sql-catalog.baseline.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { collectSqlCatalog } from "./sql-catalog"
+
+// ---------------------------------------------------------------------------
+// A verbatim record of every SQL string the product can emit.
+//
+// `sql-catalog.test.ts` asserts *properties* of the catalog (it compiles, it
+// covers every pipe, it scopes to an org). This file asserts the bytes. It
+// exists so a refactor that claims "no SQL changed" is checkable by reading one
+// file's diff instead of by reasoning about the builders.
+//
+// Regenerate with `vitest -u` ONLY when a SQL change is intended, and treat the
+// resulting diff as part of the review. An unexplained diff means the refactor
+// is wrong.
+// ---------------------------------------------------------------------------
+
+describe("sql catalog baseline", () => {
+	it("emits the same SQL as the recorded baseline", async () => {
+		const rendered = [...collectSqlCatalog()]
+			.sort((a, b) => a.id.localeCompare(b.id))
+			.map((entry) => `-- ${entry.id}  [${entry.fingerprint}]\n${entry.sql}`)
+			.join("\n\n")
+
+		await expect(rendered).toMatchFileSnapshot("__sql_baseline__/catalog.sql")
+	})
+})

--- a/packages/query-engine/src/sql-catalog.test.ts
+++ b/packages/query-engine/src/sql-catalog.test.ts
@@ -65,9 +65,25 @@ describe("sql catalog", () => {
 		expect(uncoveredPipes(pipeEntries)).toEqual([])
 	})
 
+	// Builders that read across every tenant on purpose. Each must declare
+	// `.crossOrg()` and run through `WarehouseQueryService.crossOrgQuery`, which
+	// records a justification on the span. This list should stay tiny — it is the
+	// complete inventory of cross-tenant reads in the product.
+	const CROSS_ORG_BUILDERS: ReadonlySet<string> = new Set([
+		"activeOrgsByErrorEventsQuery",
+		"activeOrgsByTracesQuery",
+		"activeOrgsByLogsQuery",
+	])
+
+	// The predecessor of this test asserted `entry.sql.toContain("OrgId")`, which
+	// `SELECT count() AS OrgId ...` and `WHERE OrgId = 'x' OR 1=1` both satisfy.
+	// Scope is now derived by the compiler from a top-level OrgId predicate, so
+	// this asserts the derived fact rather than the presence of a substring.
 	it("scopes every query to an org", () => {
 		for (const entry of entries) {
-			expect(entry.sql, `${entry.id} must filter OrgId`).toContain("OrgId")
+			if (entry.compiled === undefined) continue
+			const expected = CROSS_ORG_BUILDERS.has(entry.name) ? "cross-org" : "org"
+			expect(entry.compiled.tenantScope, `${entry.id} tenant scope`).toBe(expected)
 		}
 	})
 
@@ -231,9 +247,6 @@ const EXEMPT_BUILDERS: ReadonlySet<string> = new Set([
 	"errors/traceTimeProbeQuery",
 
 	// todo batch ② — alerting correctness (anomaly, alert-checks, setup-audit, activity, liveness, internal)
-	"activity/activeOrgsByErrorEventsQuery",
-	"activity/activeOrgsByTracesQuery",
-	"activity/activeOrgsByLogsQuery",
 	"alert-checks/listRuleChecksQuery",
 	"alert-checks/alertCheckGroupTotalsQuery",
 	"alert-checks/alertChecksSummaryQuery",
@@ -262,24 +275,16 @@ const EXEMPT_BUILDERS: ReadonlySet<string> = new Set([
 	// todo batch ③ — infra + integrations (infra, cloudflare-*, planetscale-*, service-map, rollups)
 	"infra/listHostsQuery",
 	"infra/hostDetailSummaryQuery",
-	"infra/hostGaugeTimeseriesQuery",
 	"infra/fleetUtilizationTimeseriesQuery",
 	"infra/hostNetworkTimeseriesQuery",
 	"infra/listPodsQuery",
 	"infra/listPodsSummaryQuery",
 	"infra/podDetailSummaryQuery",
-	"infra/podGaugeTimeseriesQuery",
 	"infra/listNodesQuery",
 	"infra/nodeDetailSummaryQuery",
-	"infra/nodeGaugeTimeseriesQuery",
 	"infra/listWorkloadsQuery",
 	"infra/workloadDetailSummaryQuery",
-	"infra/workloadGaugeTimeseriesQuery",
-	"infra/podFacetsQuery",
-	"infra/nodeFacetsQuery",
-	"infra/workloadFacetsQuery",
 	"cloudflare-infra-breakdowns/cloudflareZoneBreakdownTotalsSQL",
-	"cloudflare-infra-breakdowns/cloudflareZoneBreakdownTimeseriesSQL",
 	"cloudflare-infra-breakdowns/cloudflareZoneBreakdownCoverageSQL",
 	"cloudflare-infra-breakdowns/cloudflareZoneFacetsQuery",
 	"cloudflare-infra-extended/cloudflareZoneHostBreakdownSQL",
@@ -288,11 +293,8 @@ const EXEMPT_BUILDERS: ReadonlySet<string> = new Set([
 	"cloudflare-infra-extended/cloudflareZoneFirewallTopSQL",
 	"cloudflare-infra-extended/cloudflareZoneDnsTimeseriesSQL",
 	"cloudflare-infra-extended/cloudflareZoneDnsBreakdownSQL",
-	"cloudflare-infra-extended/cloudflareQueueGaugesSQL",
 	"cloudflare-infra-extended/cloudflareDurableObjectCountersSQL",
 	"cloudflare-infra/cloudflareZoneCountersSQL",
-	"cloudflare-infra/cloudflareZoneLatencySQL",
-	"cloudflare-infra/cloudflareZoneTimeseriesSQL",
 	"cloudflare-infra/cloudflareZoneStatusTimeseriesSQL",
 	"cloudflare-infra/cloudflareZoneCacheTimeseriesSQL",
 	"cloudflare-infra/cloudflareZoneLatencyTimeseriesSQL",
@@ -300,10 +302,8 @@ const EXEMPT_BUILDERS: ReadonlySet<string> = new Set([
 	"cloudflare-infra/cloudflareWorkerLatencySQL",
 	"cloudflare-infra/cloudflareWorkerTimeseriesSQL",
 	"cloudflare-map/cloudflareServiceCountersSQL",
-	"cloudflare-map/cloudflareServiceLatencySQL",
 	"planetscale-infra/planetscaleInfraTimeseriesSQL",
 	"planetscale-infra/planetscaleBranchInfraTimeseriesSQL",
-	"planetscale-map/planetscaleGaugesSQL",
 	"planetscale-map/planetscaleBranchGaugesSQL",
 	"planetscale-map/planetscaleStorageSQL",
 	"planetscale-map/planetscaleBranchStorageSQL",
@@ -327,13 +327,9 @@ const EXEMPT_BUILDERS: ReadonlySet<string> = new Set([
 	"billing-usage/dailySignalVolumeQuery",
 	"billing-usage/dailySessionCountQuery",
 	"cloudflare-usage/cloudflareUsageStatsQuery",
-	"cloudflare-usage/cloudflareUsageQuery",
 	"logs/getLogByKeyQuery",
 	"service-operations/serviceOperationsSummaryRawQuery",
-	"service-operations/serviceOperationsSummaryQuery",
 	"service-operations/serviceOperationsTimeseriesRawQuery",
-	"service-operations/serviceOperationsTimeseriesQuery",
-	"services/serviceCatalogQuery",
 	"services/serviceHealthSnapshotQuery",
 	"services/serviceHealthBaselineQuery",
 	"services/serviceEnvironmentsQuery",
@@ -357,10 +353,9 @@ describe("builder coverage", () => {
 		for (const fixture of builderFixtures) {
 			const module = QUERY_MODULES[fixture.module]
 			expect(module, `unknown module ${fixture.module}`).toBeDefined()
-			expect(
-				typeof module?.[fixture.name],
-				`${fixture.module} does not export ${fixture.name}`,
-			).toBe("function")
+			expect(typeof module?.[fixture.name], `${fixture.module} does not export ${fixture.name}`).toBe(
+				"function",
+			)
 		}
 	})
 

--- a/packages/query-engine/src/sql-catalog.ts
+++ b/packages/query-engine/src/sql-catalog.ts
@@ -730,10 +730,6 @@ function makeCapturingWarehouse(capabilities: WarehouseCapabilities): {
 	const captured: Array<CapturedSql> = []
 	const empty = Effect.succeed([] as ReadonlyArray<never>)
 	const warehouse: QueryEngineWarehouse<QueryTenant> = {
-		sqlQuery: (_tenant, sql) => {
-			captured.push({ sql })
-			return empty
-		},
 		rawSqlQuery: (_tenant, sql) => {
 			captured.push({ sql })
 			return empty


### PR DESCRIPTION
## Why

Tenant isolation on the **typed query path** rested on `sql.includes("OrgId")` (`execution/executor.ts`). That passes for any SQL merely *mentioning* the token — `SELECT count() AS OrgId FROM traces`, `WHERE OrgId = 'x' OR 1=1` — and the pipe path (`query()`) had no assertion at all. Two places rode the hole on purpose: `activity.ts` documented doing so, and `serviceMapEdgeJoinSQL` took an **optional** `orgId` that built an all-tenant join when omitted.

The raw-SQL path is isolated at the credential layer by a per-org datasource-scoped Tinybird JWT (BYO orgs run on their own cluster; the shared self-hosted endpoint is single-org), so `$__orgFilter` is ergonomics, not a control.

**Correction:** an earlier version of this description said that path was "unchanged". That was wrong — `rawSqlQuery`'s `sql.includes("OrgId")` check *is* deleted here, deliberately: it asserted nothing (see the substring examples above) and its presence implied a guarantee it never provided. See the open item at the bottom.

## What changed

**Scope is derived, then enforced.**

- `Condition.scopesTenant` is minted by `eq`/`in_` on the tenant column and deliberately does *not* survive `and`/`or` — a disjoined predicate no longer reads as scoping.
- `CompiledQuery.tenantScope` is `"org"` when the query pins the tenant itself, or when every row source it reads (the FROM and each join) already did. That second clause matters: `SELECT sum(total) FROM (scoped UNION scoped)` is exactly what the rollup-splice queries compile to.
- `withCTE` gained an optional `tenantScope` — a pre-compiled CTE arrives as an opaque string, so `series-cap.ts` and `metrics.ts` forward it.
- `unsafeCompiledQuery` **requires** `tenantScope`. Handwritten SQL can't compile until an author has stated it; all 11 sites annotated.
- `.crossOrg()` is an explicit opt-in, because "no OrgId filter" and "someone forgot the OrgId filter" are otherwise indistinguishable.

**Executor.** `sqlQuery` deleted (zero production callers — only tests). `compiledQuery` / `compiledQueryFirst` / `query()` all gate on `tenantScope`. Deliberate cross-tenant reads go through a separate `crossOrgQuery` requiring a `justification` string that lands on the span, so "who reads across tenants, and why" is answerable from traces. The three `activity.ts` builders are the only users.

**`serviceMapEdgeJoinSQL`** no longer takes an optional `orgId`.

## The gate this needed

Half the modules here had no SQL-level regression test — `EXEMPT_BUILDERS` held ~70 entries and there were no snapshots anywhere.

- `sql-catalog.baseline.test.ts` snapshots every SQL string the product can emit, so "this changed no SQL" is a one-file `git diff`.
- 22 builder fixtures; builder-covered shapes go 15 → 37 and `EXEMPT_BUILDERS` shrinks.
- `service_external_edges_hourly` / `service_address_resolutions_hourly` added to the table catalog so `tables.test.ts` drift-checks them; the six bare table literals in `service-map.ts` now interpolate `Table.name`.
- Compare-mode pipes carry their branch `rowSchema` again — they built a UNION via `unsafeCompiledQuery` with none, so counts decoded as strings on any backend that quotes 64-bit integers.

`sql-catalog.test.ts` now asserts `tenantScope` instead of the substring, with a three-entry cross-org allowlist that is genuinely exercised (the `activity.ts` builders are fixtured, so the rule has examples on both sides).

## Verification

- **The SQL baseline is byte-identical throughout** — none of this changed a single byte of emitted SQL.
- Every SQL shape in the catalog is `tenantScope: "org"`, except the three declared cross-org builders.
- 85 clickhouse-builder tests, 1080 query-engine tests, 34 `WarehouseQueryService` tests, 41 `ErrorsService` tests, 3 CLI executor tests.
- Full monorepo `bun typecheck`: 33/33.

Tests were also re-run against this branch's `main` base, not just the working tree they were written on.

## Notes for review

- `TENANT_COLUMN` lives in the builder as a single named constant rather than a hardcoded string at the marker site.
- The derivation was tightened twice during implementation, both times because the new baseline flagged a legitimate query as cross-org (`logsCountQuery`, then `errorsSummaryQuery`). Both cases are covered by tests in `compile.test.ts`, along with the shapes that must *stay* cross-org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788343477&installation_model_id=427786&pr_number=320&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F320&signature=e0f644562511493d9557addc622ed37fadab5f308b4017e26d7ad19e7ee4e570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


---

## Review follow-ups

**Fixed — `serviceMapEdgeJoinSQL` optional `orgId`** (Devin, `service-map.ts:150`). The finding was correct and the description was wrong: I claimed the parameter had been made required and it had not. It mattered more than a stale doc line, because both callers wrap the output in `unsafeCompiledQuery({ tenantScope: "org" })` — so an omitted org id would have been *positively asserted* as tenant-scoped and passed `executeScopedSql`, where before it was merely unchecked. Now required; both in-app callers already passed it, so no SQL changed.

**Open — `rawSqlQuery` takes a bare `string`** (Devin, `executor.ts:653-658`). The security framing doesn't hold: every backend this path reaches is single-tenant (per-org JWT on managed Tinybird, the org's own cluster on BYO, single-org on shared self-hosted), so restoring `sql.includes("OrgId")` would restore theatre — the exact thing this PR argues against. But the *contract* point is right: `rawSqlQuery` is public on `WarehouseQueryServiceShape` with nothing tying it to `prepareRawSql`, so the precondition lives in convention rather than in types.

The right fix is Devin's second suggestion — have `rawSqlQuery` accept the value `prepareRawSql` returns rather than a `string`, making it unreachable without validation. That is exactly the move this PR makes for compiled queries. It touches ~15 call sites (mostly tests) and changes a public method, so I've left it out rather than expanding an already-large PR; happy to do it here or as a follow-up.
