### PR TITLE
refactor(query-engine): derive rollup-splice boundaries from one definition

### DIFF
--- a/packages/query-engine/src/ch/queries/logs.ts
+++ b/packages/query-engine/src/ch/queries/logs.ts
@@ -16,6 +16,7 @@ import { finalizeTimeseries } from "./series-cap"
 import type { AttributeFilter } from "../../query-engine"
 import { buildAttrFilterCondition } from "../../traces-shared"
 import type { AttributeIndexMode, LogBodySearchMode } from "../../capabilities"
+import { edgeCondition, interiorConditions } from "./rollup-splice"
 
 // ---------------------------------------------------------------------------
 // Shared options
@@ -135,11 +136,6 @@ function namespaceCondition(
 	return CH.inList(nsAttr, opts.namespaces)
 }
 
-const START_DT = "toDateTime(__PARAM_startTime__)"
-const END_DT = "toDateTime(__PARAM_endTime__)"
-const START_HOUR = `toStartOfHour(${START_DT})`
-const END_HOUR = `toStartOfHour(${END_DT})`
-const FIRST_FULL_HOUR = `if(${START_DT} = ${START_HOUR}, ${START_HOUR}, ${START_HOUR} + INTERVAL 1 HOUR)`
 
 function rawLogsTimeRange($: ColumnAccessor<typeof Logs.columns>): Array<CH.Condition | undefined> {
 	return [
@@ -153,7 +149,7 @@ function rawLogsTimeRange($: ColumnAccessor<typeof Logs.columns>): Array<CH.Cond
 }
 
 function rawLogEdgeCondition(): CH.Condition {
-	return CH.rawCond(`(TimestampTime < ${FIRST_FULL_HOUR} OR TimestampTime >= ${END_HOUR})`)
+	return edgeCondition("TimestampTime")
 }
 
 function canUseLogsAggregateInterior(opts: LogsQueryOpts): boolean {
@@ -415,8 +411,7 @@ export function logsBreakdownQuery(opts: LogsBreakdownOpts): CHQuery<ColumnDefs,
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(CH.rawExpr<string>(FIRST_FULL_HOUR)),
-			$.Hour.lt(CH.rawExpr<string>(END_HOUR)),
+			...interiorConditions($.Hour),
 			CH.when(opts.serviceName, (v: string) => $.ServiceName.eq(v)),
 			CH.when(opts.severity, (v: string) => $.SeverityText.eq(v)),
 			mvEnvironmentCondition($, opts),
@@ -487,8 +482,7 @@ export function logsCountQuery(opts: LogsQueryOpts): CHQuery<ColumnDefs, LogsCou
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(CH.rawExpr<string>(FIRST_FULL_HOUR)),
-			$.Hour.lt(CH.rawExpr<string>(END_HOUR)),
+			...interiorConditions($.Hour),
 			CH.when(opts.serviceName, (v: string) => $.ServiceName.eq(v)),
 			CH.when(opts.severity, (v: string) => $.SeverityText.eq(v)),
 			mvEnvironmentCondition($, opts),
@@ -704,8 +698,7 @@ export function errorRateByServiceQuery() {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(CH.rawExpr<string>(FIRST_FULL_HOUR)),
-			$.Hour.lt(CH.rawExpr<string>(END_HOUR)),
+			...interiorConditions($.Hour),
 		])
 		.groupBy("serviceName")
 

--- a/packages/query-engine/src/ch/queries/rollup-splice.test.ts
+++ b/packages/query-engine/src/ch/queries/rollup-splice.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import { compile } from "../index"
+import { compile as compileFragment } from "@maple-dev/clickhouse-builder/sql"
+import * as CH from "../index"
+import {
+	edgeCondition,
+	hourGrain,
+	interiorBounds,
+	interiorConditions,
+	minuteGrain,
+} from "./rollup-splice"
+
+// ---------------------------------------------------------------------------
+// These pin the tiling invariant: the raw edge and the aggregate interior must
+// cover the window exactly once. Getting it wrong does not raise — it inflates
+// or deflates counts — so the boundary is asserted directly rather than
+// inferred from a query's output.
+//
+// What this can and cannot prove: it proves both halves are built from ONE
+// boundary definition, which is the failure mode five hand-copied definitions
+// had. It does NOT prove the tiers tile against real data; that needs a live
+// ClickHouse (insert spans straddling a boundary, assert raw-only total ==
+// spliced total) and belongs with the apps/api DESCRIBE sweep.
+// ---------------------------------------------------------------------------
+
+const sqlOf = (cond: CH.Condition) => compileFragment(cond.toFragment())
+
+/** Compile a trivial query carrying `conds` so the WHERE text can be inspected. */
+const whereSql = (conds: ReadonlyArray<CH.Condition>) => {
+	const t = CH.table("t", { OrgId: CH.string, Hour: CH.dateTime, Minute: CH.dateTime })
+	return compile(
+		CH.from(t)
+			.select(($) => ({ c: $.OrgId }))
+			.where(($) => [$.OrgId.eq("org"), ...conds]),
+		{ startTime: "2026-01-01 10:30:00", endTime: "2026-01-03 14:15:00" },
+	).sql
+}
+
+describe("rollup splice boundaries", () => {
+	describe("half-open interior", () => {
+		// A `<=` on the upper bound would include the trailing partial bucket that
+		// the raw edge also covers — the silent double-count.
+		it("bounds the interior with >= lower and strictly < upper", () => {
+			const [lower, upper] = interiorConditions(CH.rawExpr<string>("Hour"))
+			expect(sqlOf(lower)).toContain(">=")
+			expect(sqlOf(upper)).toContain("<")
+			expect(sqlOf(upper)).not.toContain("<=")
+		})
+
+		it("uses the same bounds in interiorBounds as in interiorConditions", () => {
+			const bounds = interiorBounds()
+			expect(bounds.gte).toBe(hourGrain.firstFullBucket)
+			expect(bounds.lt).toBe(hourGrain.endFloor)
+		})
+	})
+
+	describe("aligned start", () => {
+		// When the window begins exactly on a boundary, startFloor IS the first
+		// whole bucket. Advancing unconditionally would drop it entirely.
+		it("guards firstFullBucket against advancing past an aligned start", () => {
+			expect(hourGrain.firstFullBucket).toBe(
+				`if(${hourGrain.startDt} = ${hourGrain.startFloor}, ${hourGrain.startFloor}, ${hourGrain.startFloor} + INTERVAL 1 HOUR)`,
+			)
+			expect(minuteGrain.firstFullBucket).toContain("INTERVAL 1 MINUTE")
+		})
+	})
+
+	describe("complementarity", () => {
+		// The edge is the exact complement of the interior: same two boundary
+		// expressions, opposite inequalities. This is what makes the two tiers
+		// tile rather than gap or overlap.
+		it.each([
+			["hour", hourGrain],
+			["minute", minuteGrain],
+		])("edge and interior share one boundary definition (%s grain)", (_label, grain) => {
+			const edge = sqlOf(edgeCondition("Timestamp", grain))
+			expect(edge).toBe(
+				`(Timestamp < ${grain.firstFullBucket} OR Timestamp >= ${grain.endFloor})`,
+			)
+
+			const [lower, upper] = interiorConditions(CH.rawExpr<string>("Hour"), grain)
+			// The edge excludes exactly what the interior includes.
+			expect(sqlOf(lower)).toContain(grain.firstFullBucket)
+			expect(sqlOf(upper)).toContain(grain.endFloor)
+		})
+
+		it("lets the edge take a different physical column than the interior", () => {
+			// The three-tier service-operations splice reads its minutely tier with
+			// the HOUR grain, so column and grain vary independently.
+			expect(sqlOf(edgeCondition("Minute", hourGrain))).toBe(
+				`(Minute < ${hourGrain.firstFullBucket} OR Minute >= ${hourGrain.endFloor})`,
+			)
+		})
+	})
+
+	it("emits placeholders that survive to compile time", () => {
+		// The fragments embed __PARAM_*__ rather than literals, so a compiled
+		// query resolves them once at the outer compile() call.
+		expect(hourGrain.startDt).toContain("__PARAM_startTime__")
+		const sql = whereSql([edgeCondition("Hour")])
+		expect(sql).not.toContain("__PARAM_")
+		expect(sql).toContain("2026-01-01 10:30:00")
+	})
+})

--- a/packages/query-engine/src/ch/queries/rollup-splice.ts
+++ b/packages/query-engine/src/ch/queries/rollup-splice.ts
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------
+// Rollup splice boundaries
+//
+// Several queries reconstruct a time window from two tiers: exact raw rows for
+// the partial buckets at each end, plus pre-aggregated rows for every whole
+// bucket in between. Correctness rests entirely on the two tiers tiling the
+// window — covering it exactly once, with no gap and no overlap.
+//
+// That boundary was previously written out five separate times (traces ×2,
+// logs, services, service-operations) as byte-identical template strings. Every
+// copy was a place to get an inequality backwards, and the failure mode is
+// silent: a `<=` where a `<` belongs double-counts the trailing bucket, so
+// counts inflate rather than error.
+//
+// The invariants, in one place:
+//
+//   - The interior is HALF-OPEN: `>= firstFullBucket` and strictly
+//     `< endFloor`. The edge predicate is its exact complement.
+//   - `firstFullBucket` guards against an aligned start. When the window begins
+//     exactly on a boundary, `startFloor` IS the first whole bucket; advancing
+//     unconditionally would drop it.
+//
+// The expressions are SQL strings rather than DSL nodes because they embed
+// `__PARAM_*__` placeholders that `compile()` substitutes later.
+// ---------------------------------------------------------------------------
+
+import * as CH from "@maple-dev/clickhouse-builder/expr"
+
+/**
+ * One tier boundary of a splice. `unit` names the bucket size; the rest are
+ * the SQL fragments derived from it.
+ */
+export interface SpliceGrain {
+	readonly unit: "HOUR" | "MINUTE"
+	/** `toDateTime(__PARAM_startTime__)` — the window start, unrounded. */
+	readonly startDt: string
+	readonly endDt: string
+	/** The window start rounded DOWN to a bucket boundary. */
+	readonly startFloor: string
+	readonly endFloor: string
+	/** First bucket wholly inside the window (see the aligned-start note above). */
+	readonly firstFullBucket: string
+}
+
+const makeGrain = (unit: "HOUR" | "MINUTE"): SpliceGrain => {
+	const floorFn = unit === "HOUR" ? "toStartOfHour" : "toStartOfMinute"
+	const startDt = "toDateTime(__PARAM_startTime__)"
+	const endDt = "toDateTime(__PARAM_endTime__)"
+	const startFloor = `${floorFn}(${startDt})`
+	const endFloor = `${floorFn}(${endDt})`
+	return {
+		unit,
+		startDt,
+		endDt,
+		startFloor,
+		endFloor,
+		firstFullBucket: `if(${startDt} = ${startFloor}, ${startFloor}, ${startFloor} + INTERVAL 1 ${unit})`,
+	}
+}
+
+export const hourGrain: SpliceGrain = makeGrain("HOUR")
+export const minuteGrain: SpliceGrain = makeGrain("MINUTE")
+
+/**
+ * The finer tier's predicate: rows outside the whole-bucket interior, i.e. the
+ * two partial buckets at the ends of the window.
+ *
+ * `tsColumn` is the PHYSICAL column on the finer table and varies per table
+ * (`Timestamp`, `TimestampTime`, `Minute`) — it is not inferable from the
+ * grain. The three-tier service-operations splice reads its minutely tier with
+ * the hour grain (`edgeCondition("Minute", hourGrain)`), which is why the
+ * column and the grain are separate arguments.
+ */
+export function edgeCondition(tsColumn: string, grain: SpliceGrain = hourGrain): CH.Condition {
+	return CH.rawCond(`(${tsColumn} < ${grain.firstFullBucket} OR ${tsColumn} >= ${grain.endFloor})`)
+}
+
+/** The interior bounds as raw SQL, for builders that take a `{ gte, lt }` pair. */
+export function interiorBounds(grain: SpliceGrain = hourGrain): {
+	readonly gte: string
+	readonly lt: string
+} {
+	return { gte: grain.firstFullBucket, lt: grain.endFloor }
+}
+
+/**
+ * The aggregate tier's predicate on its bucket column — half-open, so it is the
+ * exact complement of `edgeCondition` at the same grain.
+ */
+export function interiorConditions(
+	bucketColumn: CH.Expr<string>,
+	grain: SpliceGrain = hourGrain,
+): readonly [CH.Condition, CH.Condition] {
+	return [
+		bucketColumn.gte(CH.rawExpr<string>(grain.firstFullBucket)),
+		bucketColumn.lt(CH.rawExpr<string>(grain.endFloor)),
+	]
+}

--- a/packages/query-engine/src/ch/queries/service-operations.ts
+++ b/packages/query-engine/src/ch/queries/service-operations.ts
@@ -23,6 +23,7 @@ import { httpDisplaySpanName } from "../../traces-shared"
 import { CHNumber } from "../schema"
 import { ServiceOperationsHourly, ServiceOperationsMinutely, Traces } from "../tables"
 import { tracesBaseWhereConditions } from "./query-helpers"
+import { edgeCondition, hourGrain, interiorConditions, minuteGrain } from "./rollup-splice"
 
 export interface ServiceOperationsSummaryOpts {
 	serviceName: string
@@ -61,16 +62,6 @@ export const serviceOperationsSummaryRowSchema = Schema.Struct({
 const displaySpanName = ($: ColumnAccessor<typeof Traces.columns>) =>
 	httpDisplaySpanName($.SpanName, $.SpanAttributes.get("http.route"), $.SpanAttributes.get("url.path"))
 
-const START_DT = "toDateTime(__PARAM_startTime__)"
-const END_DT = "toDateTime(__PARAM_endTime__)"
-const START_MINUTE = `toStartOfMinute(${START_DT})`
-const END_MINUTE = `toStartOfMinute(${END_DT})`
-const FIRST_FULL_MINUTE = `if(${START_DT} = ${START_MINUTE}, ${START_MINUTE}, ${START_MINUTE} + INTERVAL 1 MINUTE)`
-const RAW_EDGE_CONDITION = `(Timestamp < ${FIRST_FULL_MINUTE} OR Timestamp >= ${END_MINUTE})`
-const START_HOUR = `toStartOfHour(${START_DT})`
-const END_HOUR = `toStartOfHour(${END_DT})`
-const FIRST_FULL_HOUR = `if(${START_DT} = ${START_HOUR}, ${START_HOUR}, ${START_HOUR} + INTERVAL 1 HOUR)`
-const MINUTELY_EDGE_CONDITION = `(Minute < ${FIRST_FULL_HOUR} OR Minute >= ${END_HOUR})`
 const RAW_DURATION_STATE = "quantilesTDigestState(0.5, 0.95)(Duration)"
 const ROLLUP_DURATION_STATE = "quantilesTDigestMergeState(0.5, 0.95)(DurationQuantiles)"
 
@@ -142,7 +133,7 @@ export function serviceOperationsSummaryQuery(opts: ServiceOperationsSummaryOpts
 				serviceName: opts.serviceName,
 				environments: opts.environments,
 			}),
-			CH.rawCond(RAW_EDGE_CONDITION),
+			edgeCondition("Timestamp", minuteGrain),
 		])
 		.groupBy("bSpanName")
 
@@ -160,9 +151,8 @@ export function serviceOperationsSummaryQuery(opts: ServiceOperationsSummaryOpts
 			$.OrgId.eq(param.string("orgId")),
 			$.ServiceName.eq(opts.serviceName),
 			rollupEnvironmentCondition($, opts.environments),
-			$.Minute.gte(CH.rawExpr<string>(FIRST_FULL_MINUTE)),
-			$.Minute.lt(CH.rawExpr<string>(END_MINUTE)),
-			CH.rawCond(MINUTELY_EDGE_CONDITION),
+			...interiorConditions($.Minute, minuteGrain),
+			edgeCondition("Minute", hourGrain),
 		])
 		.groupBy("bSpanName")
 
@@ -180,8 +170,7 @@ export function serviceOperationsSummaryQuery(opts: ServiceOperationsSummaryOpts
 			$.OrgId.eq(param.string("orgId")),
 			$.ServiceName.eq(opts.serviceName),
 			hourlyEnvironmentCondition($, opts.environments),
-			$.Hour.gte(CH.rawExpr<string>(FIRST_FULL_HOUR)),
-			$.Hour.lt(CH.rawExpr<string>(END_HOUR)),
+			...interiorConditions($.Hour, hourGrain),
 		])
 		.groupBy("bSpanName")
 
@@ -274,7 +263,7 @@ export function serviceOperationsTimeseriesQuery(opts: ServiceOperationsTimeseri
 				serviceName: opts.serviceName,
 				environments: opts.environments,
 			}),
-			CH.rawCond(RAW_EDGE_CONDITION),
+			edgeCondition("Timestamp", minuteGrain),
 			CH.inList(displaySpanName($), opts.spanNames),
 		])
 		.groupBy("bucket", "spanName")
@@ -289,10 +278,9 @@ export function serviceOperationsTimeseriesQuery(opts: ServiceOperationsTimeseri
 			$.OrgId.eq(param.string("orgId")),
 			$.ServiceName.eq(opts.serviceName),
 			rollupEnvironmentCondition($, opts.environments),
-			$.Minute.gte(CH.rawExpr<string>(FIRST_FULL_MINUTE)),
-			$.Minute.lt(CH.rawExpr<string>(END_MINUTE)),
+			...interiorConditions($.Minute, minuteGrain),
 			opts.bucketSeconds != null && opts.bucketSeconds >= 3600
-				? CH.rawCond(MINUTELY_EDGE_CONDITION)
+				? edgeCondition("Minute", hourGrain)
 				: undefined,
 			CH.inList($.SpanName, opts.spanNames),
 		])
@@ -308,8 +296,7 @@ export function serviceOperationsTimeseriesQuery(opts: ServiceOperationsTimeseri
 			$.OrgId.eq(param.string("orgId")),
 			$.ServiceName.eq(opts.serviceName),
 			hourlyEnvironmentCondition($, opts.environments),
-			$.Hour.gte(CH.rawExpr<string>(FIRST_FULL_HOUR)),
-			$.Hour.lt(CH.rawExpr<string>(END_HOUR)),
+			...interiorConditions($.Hour, hourGrain),
 			CH.inList($.SpanName, opts.spanNames),
 		])
 		.groupBy("bucket", "spanName")

--- a/packages/query-engine/src/ch/queries/services.ts
+++ b/packages/query-engine/src/ch/queries/services.ts
@@ -19,18 +19,13 @@ import type { ColumnDefs } from "@maple-dev/clickhouse-builder/types"
 import { ServiceOverviewHourly, ServiceOverviewSpans, ServiceUsage, TracesAggregatesHourly } from "../tables"
 import { CHNumber } from "../schema"
 import { apdexExprs, serviceOverviewWhereConditions } from "./query-helpers"
+import { edgeCondition, interiorConditions } from "./rollup-splice"
 
 // ---------------------------------------------------------------------------
 // Service overview
 // ---------------------------------------------------------------------------
 
 const hourFloor = (name: string) => CH.toStartOfHour(CH.toDateTime(param.dateTime(name)))
-const SERVICE_START_DT = "toDateTime(__PARAM_startTime__)"
-const SERVICE_END_DT = "toDateTime(__PARAM_endTime__)"
-const SERVICE_START_HOUR = `toStartOfHour(${SERVICE_START_DT})`
-const SERVICE_END_HOUR = `toStartOfHour(${SERVICE_END_DT})`
-const SERVICE_FIRST_FULL_HOUR = `if(${SERVICE_START_DT} = ${SERVICE_START_HOUR}, ${SERVICE_START_HOUR}, ${SERVICE_START_HOUR} + INTERVAL 1 HOUR)`
-const SERVICE_RAW_EDGE_CONDITION = `(Timestamp < ${SERVICE_FIRST_FULL_HOUR} OR Timestamp >= ${SERVICE_END_HOUR})`
 const SERVICE_RAW_DURATION_STATE = "quantilesTDigestState(0.5, 0.95, 0.99)(Duration)"
 const SERVICE_ROLLUP_DURATION_STATE = "quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles)"
 
@@ -68,7 +63,7 @@ function serviceOverviewWindows(filters: ServiceWindowFilters) {
 				$.StatusCode.neq("Error").and($.Duration.gte(500_000_000)).and($.Duration.lt(2_000_000_000)),
 			),
 		}))
-		.where(($) => [...serviceOverviewWhereConditions($, filters), CH.rawCond(SERVICE_RAW_EDGE_CONDITION)])
+		.where(($) => [...serviceOverviewWhereConditions($, filters), edgeCondition("Timestamp")])
 		.groupBy("bHour", "bServiceName", "bServiceNamespace", "bEnvironment", "bCommitSha")
 
 	const hourlyInterior = from(ServiceOverviewHourly)
@@ -90,8 +85,7 @@ function serviceOverviewWindows(filters: ServiceWindowFilters) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(CH.rawExpr<string>(SERVICE_FIRST_FULL_HOUR)),
-			$.Hour.lt(CH.rawExpr<string>(SERVICE_END_HOUR)),
+			...interiorConditions($.Hour),
 			CH.when(filters.serviceName, (value: string) => $.ServiceName.eq(value)),
 			filters.environments?.length ? CH.inList($.DeploymentEnv, filters.environments) : undefined,
 			filters.namespaces?.length ? CH.inList($.ServiceNamespace, filters.namespaces) : undefined,

--- a/packages/query-engine/src/ch/queries/traces.ts
+++ b/packages/query-engine/src/ch/queries/traces.ts
@@ -22,6 +22,7 @@ import { METRIC_NEEDS } from "../../traces-shared"
 import type { ColumnDefs } from "@maple-dev/clickhouse-builder/types"
 import * as T from "@maple-dev/clickhouse-builder/types"
 import { finalizeTimeseries } from "./series-cap"
+import { edgeCondition, interiorBounds, interiorConditions } from "./rollup-splice"
 import {
 	apdexExprs,
 	buildProjectedMapExpr,
@@ -393,9 +394,6 @@ export function tracesTimeseriesQuery(
 	const apdexThresholdMs = opts.apdexThresholdMs ?? 500
 
 	if (canUseAnnualServiceOverview(opts)) {
-		const startHour = "toStartOfHour(toDateTime(__PARAM_startTime__))"
-		const endHour = "toStartOfHour(toDateTime(__PARAM_endTime__))"
-		const firstFullHour = `if(toDateTime(__PARAM_startTime__) = ${startHour}, ${startHour}, ${startHour} + INTERVAL 1 HOUR)`
 		const rawEdges = from(ServiceOverviewSpans)
 			.select(($) => ({
 				bucket: CH.toStartOfInterval($.Timestamp, param.int("bucketSeconds")),
@@ -413,7 +411,7 @@ export function tracesTimeseriesQuery(
 			}))
 			.where(($) => [
 				...serviceOverviewWhereConditions($, opts),
-				CH.rawCond(`(Timestamp < ${firstFullHour} OR Timestamp >= ${endHour})`),
+				edgeCondition("Timestamp"),
 			])
 			.groupBy("bucket")
 
@@ -432,8 +430,7 @@ export function tracesTimeseriesQuery(
 			}))
 			.where(($) => [
 				$.OrgId.eq(param.string("orgId")),
-				$.Hour.gte(CH.rawExpr<string>(firstFullHour)),
-				$.Hour.lt(CH.rawExpr<string>(endHour)),
+				...interiorConditions($.Hour),
 				opts.serviceName ? $.ServiceName.eq(opts.serviceName) : undefined,
 				opts.environments?.length ? CH.inList($.DeploymentEnv, opts.environments) : undefined,
 				opts.namespaces?.length ? CH.inList($.ServiceNamespace, opts.namespaces) : undefined,
@@ -518,9 +515,6 @@ export function tracesTimeseriesQuery(
 		// hour of traffic. Instead: raw `traces` covers the two partial edge hours,
 		// the MV covers the whole-hour interior, and the two tile the window
 		// exactly. Same shape as the annual service-overview branch above.
-		const startHour = "toStartOfHour(toDateTime(__PARAM_startTime__))"
-		const endHour = "toStartOfHour(toDateTime(__PARAM_endTime__))"
-		const firstFullHour = `if(toDateTime(__PARAM_startTime__) = ${startHour}, ${startHour}, ${startHour} + INTERVAL 1 HOUR)`
 
 		// The union's branches must agree on aggregate-state types, so the raw side
 		// emits `quantilesTDigestWeightedState(…)(Duration, toUInt32(…))` to match
@@ -562,7 +556,7 @@ export function tracesTimeseriesQuery(
 						? CH.positionCaseInsensitive($.SpanName, CH.lit(v[0]!)).gt(0)
 						: inclusionCondition($.SpanName, v),
 				),
-				CH.rawCond(`(Timestamp < ${firstFullHour} OR Timestamp >= ${endHour})`),
+				edgeCondition("Timestamp"),
 			])
 			.groupBy("bucket", "groupName")
 
@@ -580,7 +574,7 @@ export function tracesTimeseriesQuery(
 				bWeightedErrorCount: CH.sum($.WeightedErrorCount),
 				bDurationQuantiles: CH.rawExpr<string>(mvQuantileState),
 			}))
-			.where(($) => tracesAggregatesWhereConditions($, opts, { gte: firstFullHour, lt: endHour }))
+			.where(($) => tracesAggregatesWhereConditions($, opts, interiorBounds()))
 			.groupBy("bucket", "groupName")
 
 		const weightedCount = CH.rawExpr<number>("sum(bWeightedCount)")


### PR DESCRIPTION
> Stacked on #320.

## Why

Several queries reconstruct a time window from two tiers: exact raw rows for the partial buckets at each end, plus pre-aggregated rows for every whole bucket between. Correctness rests entirely on the two tiers **tiling** the window — covering it exactly once, no gap, no overlap.

That boundary was written out **five separate times** as byte-identical template strings:

| file | |
|---|---|
| `traces.ts:396` | inline |
| `traces.ts:521` | inline, second copy in the same file |
| `logs.ts:138` | `START_DT` / `FIRST_FULL_HOUR` / … |
| `services.ts:28` | same, `SERVICE_`-prefixed |
| `service-operations.ts:64` | same, plus a minute grain |

Every copy is a place to get an inequality backwards, and **the failure mode is silent**: a `<=` where a `<` belongs double-counts the trailing bucket, so counts inflate rather than error. This is the one duplication in the package where divergence produces wrong numbers rather than a crash.

## What changed

`ch/queries/rollup-splice.ts` owns the two invariants:

- the interior is **half-open** — `>= firstFullBucket`, strictly `< endFloor` — and the edge predicate is its exact complement;
- `firstFullBucket` guards an **aligned start**, where `startFloor` already *is* the first whole bucket and advancing unconditionally would drop it.

Grain and physical column are separate arguments because they vary independently: the three-tier `service-operations` splice reads its minutely tier with the **hour** grain — `edgeCondition("Minute", hourGrain)` — which the old constants expressed only by naming convention.

```ts
edgeCondition(tsColumn: string, grain?: SpliceGrain): CH.Condition
interiorConditions(bucketColumn: CH.Expr<string>, grain?: SpliceGrain): readonly [CH.Condition, CH.Condition]
interiorBounds(grain?: SpliceGrain): { gte: string; lt: string }
```

**No `splice()` combinator.** It would replace one legible line with an opaque one, save zero lines, and hide the branch count at the one site — the three-tier splice — where a reader most needs to see it.

## Tests

`rollup-splice.test.ts` pins half-openness, the aligned-start guard, and complementarity (edge and interior reference the *same* two boundary expressions).

**Scope, honestly:** this proves both halves are built from **one** definition — the failure mode five hand-copied ones had. It does **not** prove the tiers tile against real data; that needs a live ClickHouse (insert spans straddling a boundary, assert `raw-only total == spliced total`) and belongs with the `apps/api` DESCRIBE sweep. The test file says so rather than implying more.

I mutation-checked it: injecting `<=` in place of `<` fails exactly one test.

## Verification

- **SQL baseline byte-identical** — all five call sites migrated with zero change to emitted SQL.
- 1087 query-engine tests pass (58 files).
- Typecheck clean.
- **54 lines of duplicated boundary logic → 22.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)