### PR TITLE
refactor(query-engine): collapse duplicated filter and formatting helpers

### DIFF
--- a/packages/query-engine/src/ch/queries/alert-checks.ts
+++ b/packages/query-engine/src/ch/queries/alert-checks.ts
@@ -9,8 +9,8 @@ import * as CH from "@maple-dev/clickhouse-builder/expr"
 import { param } from "@maple-dev/clickhouse-builder"
 import { from } from "@maple-dev/clickhouse-builder"
 import { AlertChecks } from "../tables"
+import { ISO_Z_FORMAT } from "./format"
 
-const ISO_Z_FORMAT = "%Y-%m-%dT%H:%i:%S.%fZ"
 
 export interface ListRuleChecksOpts {
 	readonly groupKey?: string

--- a/packages/query-engine/src/ch/queries/billing-usage.ts
+++ b/packages/query-engine/src/ch/queries/billing-usage.ts
@@ -25,6 +25,7 @@ import * as CH from "@maple-dev/clickhouse-builder/expr"
 import { from, param, type CompiledQueryRowSchema } from "@maple-dev/clickhouse-builder"
 import { ServiceUsage, SessionReplays } from "../tables"
 import { CHNumber } from "../schema"
+import { hourFloor } from "./query-helpers"
 
 const DAY_SECONDS = 86_400
 
@@ -55,7 +56,6 @@ export const dailySignalVolumeRowSchema: CompiledQueryRowSchema<DailySignalVolum
  * the customer is never billed for separately.
  */
 export function dailySignalVolumeQuery() {
-	const hourFloor = (name: string) => CH.toStartOfHour(CH.toDateTime(param.dateTime(name)))
 
 	return from(ServiceUsage)
 		.select(($) => ({

--- a/packages/query-engine/src/ch/queries/cloudflare-infra-breakdowns.ts
+++ b/packages/query-engine/src/ch/queries/cloudflare-infra-breakdowns.ts
@@ -22,6 +22,7 @@ import {
 } from "@maple-dev/clickhouse-builder"
 import { CHNumber } from "../schema"
 import { MetricsSum } from "../tables"
+import { ISO_Z_FORMAT, isoBucket } from "./format"
 import {
 	CF_ATTR,
 	CF_FILTERABLE,
@@ -33,7 +34,6 @@ import {
 	type CloudflareMetricsAccessor,
 } from "./cloudflare-infra-filters"
 
-const ISO_Z_FORMAT = "%Y-%m-%dT%H:%i:%S.%fZ"
 
 export type CloudflareBreakdownDimension =
 	| "path"
@@ -247,10 +247,7 @@ export function cloudflareZoneBreakdownTimeseriesSQL(
 	}
 	return from(MetricsSum)
 		.select(($) => ({
-			bucket: CH.formatDateTime(
-				CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-				ISO_Z_FORMAT,
-			),
+			bucket: isoBucket($.TimeUnix),
 			key: seriesKey($),
 			requests: CH.sum($.Value),
 		}))

--- a/packages/query-engine/src/ch/queries/cloudflare-infra-extended.ts
+++ b/packages/query-engine/src/ch/queries/cloudflare-infra-extended.ts
@@ -19,6 +19,7 @@ import * as CH from "@maple-dev/clickhouse-builder/expr"
 import { from, param, type ColumnAccessor, type CompiledQueryRowSchema } from "@maple-dev/clickhouse-builder"
 import { CHNumber } from "../schema"
 import { MetricsGauge, MetricsSum } from "../tables"
+import { avgWhere, isoBucket } from "./format"
 import {
 	CF_FILTERABLE,
 	CF_METRIC,
@@ -27,11 +28,8 @@ import {
 	type CloudflareFilterOpts,
 } from "./cloudflare-infra-filters"
 
-const ISO_Z_FORMAT = "%Y-%m-%dT%H:%i:%S.%fZ"
 
 // Same NaN guard as cloudflare-infra.ts.
-const avgWhere = (value: CH.Expr<number>, cond: CH.Condition) =>
-	CH.if_(CH.countIf(cond).gt(0), CH.avgIf(value, cond), CH.lit(0))
 
 // ---------------------------------------------------------------------------
 // Per-host HTTP breakdown (single zone)
@@ -109,10 +107,7 @@ export function cloudflareZoneHostBreakdownSQL(opts: CloudflareFilterOpts = {}) 
 export function cloudflareZoneHostTimeseriesSQL(opts: CloudflareFilterOpts = {}) {
 	return from(MetricsSum)
 		.select(($) => ({
-			bucket: CH.formatDateTime(
-				CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-				ISO_Z_FORMAT,
-			),
+			bucket: isoBucket($.TimeUnix),
 			host: cloudflareHostAttr($),
 			requests: CH.sum($.Value),
 		}))
@@ -168,10 +163,7 @@ export const cloudflareZoneFirewallTopRowSchema: CompiledQueryRowSchema<Cloudfla
 export function cloudflareZoneFirewallTimeseriesSQL(opts: CloudflareFilterOpts = {}) {
 	return from(MetricsSum)
 		.select(($) => ({
-			bucket: CH.formatDateTime(
-				CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-				ISO_Z_FORMAT,
-			),
+			bucket: isoBucket($.TimeUnix),
 			action: $.Attributes.get("firewall.action"),
 			events: CH.sum($.Value),
 		}))
@@ -248,10 +240,7 @@ export const cloudflareZoneDnsBreakdownRowSchema: CompiledQueryRowSchema<Cloudfl
 export function cloudflareZoneDnsTimeseriesSQL(opts: CloudflareFilterOpts = {}) {
 	return from(MetricsSum)
 		.select(($) => ({
-			bucket: CH.formatDateTime(
-				CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-				ISO_Z_FORMAT,
-			),
+			bucket: isoBucket($.TimeUnix),
 			responseCode: $.Attributes.get("dns.response_code"),
 			queries: CH.sum($.Value),
 		}))

--- a/packages/query-engine/src/ch/queries/cloudflare-infra.ts
+++ b/packages/query-engine/src/ch/queries/cloudflare-infra.ts
@@ -19,6 +19,7 @@ import * as CH from "@maple-dev/clickhouse-builder/expr"
 import { from, param, type ColumnAccessor, type CompiledQueryRowSchema } from "@maple-dev/clickhouse-builder"
 import { CHNumber } from "../schema"
 import { MetricsGauge, MetricsSum } from "../tables"
+import { avgWhere, isoBucket } from "./format"
 import {
 	CF_FILTERABLE,
 	CF_METRIC,
@@ -26,7 +27,6 @@ import {
 	type CloudflareFilterOpts,
 } from "./cloudflare-infra-filters"
 
-const ISO_Z_FORMAT = "%Y-%m-%dT%H:%i:%S.%fZ"
 
 /** Counter metrics the poller emits for zone HTTP analytics (all in `metrics_sum`). */
 const ZONE_COUNTER_METRIC_NAMES = [
@@ -59,8 +59,6 @@ const CACHE_SERVED_STATUSES = ["hit", "stale", "revalidated", "updating"] as con
 // `avgIf` over a metric with no matching rows is NaN, which serializes to
 // JSON `null` and would break row decoding — so guard each with
 // `if(countIf > 0, avgIf, 0)`. (Same guard as cloudflare-map.ts.)
-const avgWhere = (value: CH.Expr<number>, cond: CH.Condition) =>
-	CH.if_(CH.countIf(cond).gt(0), CH.avgIf(value, cond), CH.lit(0))
 
 // ---------------------------------------------------------------------------
 // Zones
@@ -225,10 +223,7 @@ export function cloudflareZoneTimeseriesSQL(opts: CloudflareFilterOpts = {}) {
 	return from(MetricsSum)
 		.select(($) => ({
 			serviceName: $.ServiceName,
-			bucket: CH.formatDateTime(
-				CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-				ISO_Z_FORMAT,
-			),
+			bucket: isoBucket($.TimeUnix),
 			...zoneCounterColumns($),
 		}))
 		.where(($) => [
@@ -308,10 +303,7 @@ export const cloudflareZoneLatencyTimeseriesRowSchema: CompiledQueryRowSchema<Cl
 export function cloudflareZoneStatusTimeseriesSQL(opts: CloudflareFilterOpts = {}) {
 	return from(MetricsSum)
 		.select(($) => ({
-			bucket: CH.formatDateTime(
-				CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-				ISO_Z_FORMAT,
-			),
+			bucket: isoBucket($.TimeUnix),
 			statusClass: $.Attributes.get("http.status_class"),
 			requests: CH.sum($.Value),
 		}))
@@ -332,10 +324,7 @@ export function cloudflareZoneStatusTimeseriesSQL(opts: CloudflareFilterOpts = {
 export function cloudflareZoneCacheTimeseriesSQL(opts: CloudflareFilterOpts = {}) {
 	return from(MetricsSum)
 		.select(($) => ({
-			bucket: CH.formatDateTime(
-				CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-				ISO_Z_FORMAT,
-			),
+			bucket: isoBucket($.TimeUnix),
 			cacheStatus: $.Attributes.get("cache.status"),
 			requests: CH.sum($.Value),
 		}))
@@ -364,10 +353,7 @@ export function cloudflareZoneLatencyTimeseriesSQL() {
 			avgWhere($.Value, $.MetricName.eq(metricName).and($.Attributes.get("quantile").eq(quantile)))
 	return from(MetricsGauge)
 		.select(($) => ({
-			bucket: CH.formatDateTime(
-				CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-				ISO_Z_FORMAT,
-			),
+			bucket: isoBucket($.TimeUnix),
 			ttfbP50Ms: quantileAvg("cloudflare.http.edge.ttfb", "0.5")($),
 			ttfbP95Ms: quantileAvg("cloudflare.http.edge.ttfb", "0.95")($),
 			ttfbP99Ms: quantileAvg("cloudflare.http.edge.ttfb", "0.99")($),
@@ -508,10 +494,7 @@ export function cloudflareWorkerTimeseriesSQL() {
 	return from(MetricsSum)
 		.select(($) => ({
 			serviceName: $.ServiceName,
-			bucket: CH.formatDateTime(
-				CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-				ISO_Z_FORMAT,
-			),
+			bucket: isoBucket($.TimeUnix),
 			requests: CH.sumIf($.Value, $.MetricName.eq("cloudflare.worker.requests")),
 			errors: CH.sumIf($.Value, $.MetricName.eq("cloudflare.worker.errors")),
 		}))

--- a/packages/query-engine/src/ch/queries/cloudflare-map.ts
+++ b/packages/query-engine/src/ch/queries/cloudflare-map.ts
@@ -21,6 +21,7 @@ import * as CH from "@maple-dev/clickhouse-builder/expr"
 import { from, param, type CompiledQueryRowSchema } from "@maple-dev/clickhouse-builder"
 import { CHNumber } from "../schema"
 import { MetricsGauge, MetricsSum } from "../tables"
+import { avgWhere } from "./format"
 
 /** Counter metrics the poller emits for Workers (all in `metrics_sum`). */
 const COUNTER_METRIC_NAMES = ["cloudflare.worker.requests", "cloudflare.worker.errors"] as const
@@ -100,8 +101,6 @@ export function cloudflareServiceLatencySQL() {
 	// `avgIf` over a metric with no matching rows is NaN, which serializes to
 	// JSON `null` and would break row decoding — so guard each with
 	// `if(countIf > 0, avgIf, 0)`.
-	const avgWhere = (value: CH.Expr<number>, cond: CH.Condition) =>
-		CH.if_(CH.countIf(cond).gt(0), CH.avgIf(value, cond), CH.lit(0))
 	return from(MetricsGauge)
 		.select(($) => ({
 			serviceName: $.ServiceName,

--- a/packages/query-engine/src/ch/queries/cloudflare-usage.ts
+++ b/packages/query-engine/src/ch/queries/cloudflare-usage.ts
@@ -12,8 +12,8 @@ import * as CH from "@maple-dev/clickhouse-builder/expr"
 import { from, param, type CompiledQueryRowSchema } from "@maple-dev/clickhouse-builder"
 import { CHNumber } from "../schema"
 import { MetricsSum } from "../tables"
+import { ISO_Z_FORMAT, isoBucket } from "./format"
 
-const ISO_Z_FORMAT = "%Y-%m-%dT%H:%i:%S.%fZ"
 
 /**
  * The only metric names the poller emits as monotonic request counters — the
@@ -103,10 +103,7 @@ export function cloudflareUsageQuery() {
 	return from(MetricsSum)
 		.select(($) => ({
 			serviceName: $.ServiceName,
-			bucket: CH.formatDateTime(
-				CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-				ISO_Z_FORMAT,
-			),
+			bucket: isoBucket($.TimeUnix),
 			requests: CH.sum($.Value),
 			datapoints: CH.count(),
 			lastTimeUnix: CH.formatDateTime(CH.max_($.TimeUnix), ISO_Z_FORMAT),

--- a/packages/query-engine/src/ch/queries/errors.ts
+++ b/packages/query-engine/src/ch/queries/errors.ts
@@ -18,7 +18,7 @@ import {
 	TraceListMv,
 	Traces,
 } from "../tables"
-import { buildProjectedMapExpr, inclusionValues, inclusionCondition } from "./query-helpers"
+import { buildProjectedMapExpr, inclusionValues, inclusionCondition, matchOrIn , type FacetOutput} from "./query-helpers"
 import { httpDisplaySpanName } from "../../traces-shared"
 
 function errorEventsTableForRecentScan(opts: {
@@ -426,14 +426,10 @@ export function tracesDurationStatsQuery(opts: TracesDurationStatsOpts) {
 			$.Timestamp.gte(param.dateTime("startTime")),
 			$.Timestamp.lte(param.dateTime("endTime")),
 			CH.when(services, (v: readonly string[]) =>
-				mm?.serviceName === "contains" && v.length === 1
-					? CH.positionCaseInsensitive($.ServiceName, CH.lit(v[0]!)).gt(0)
-					: inclusionCondition($.ServiceName, v),
+				matchOrIn($.ServiceName, v, mm?.serviceName === "contains"),
 			),
 			CH.when(spanNames, (v: readonly string[]) =>
-				mm?.spanName === "contains" && v.length === 1
-					? CH.positionCaseInsensitive($.SpanName, CH.lit(v[0]!)).gt(0)
-					: inclusionCondition($.SpanName, v),
+				matchOrIn($.SpanName, v, mm?.spanName === "contains"),
 			),
 			CH.whenTrue(!!opts.hasError, () => $.HasError.eq(1)),
 			CH.when(opts.minDurationMs, (v: number) => $.Duration.gte(v * 1000000)),
@@ -441,14 +437,10 @@ export function tracesDurationStatsQuery(opts: TracesDurationStatsOpts) {
 			CH.when(httpMethods, (v: readonly string[]) => inclusionCondition($.HttpMethod, v)),
 			CH.when(httpStatusCodes, (v: readonly string[]) => inclusionCondition($.HttpStatusCode, v)),
 			CH.when(envs, (v: readonly string[]) =>
-				mm?.deploymentEnv === "contains" && v.length === 1
-					? CH.positionCaseInsensitive($.DeploymentEnv, CH.lit(v[0]!)).gt(0)
-					: inclusionCondition($.DeploymentEnv, v),
+				matchOrIn($.DeploymentEnv, v, mm?.deploymentEnv === "contains"),
 			),
 			CH.when(namespaces, (v: readonly string[]) =>
-				mm?.serviceNamespace === "contains" && v.length === 1
-					? CH.positionCaseInsensitive($.ServiceNamespace, CH.lit(v[0]!)).gt(0)
-					: inclusionCondition($.ServiceNamespace, v),
+				matchOrIn($.ServiceNamespace, v, mm?.serviceNamespace === "contains"),
 			),
 		])
 		.format("JSON")
@@ -502,11 +494,7 @@ export interface TracesFacetsOpts {
 	facet?: TracesFacetDimension
 }
 
-export interface TracesFacetsOutput {
-	readonly name: string
-	readonly count: number
-	readonly facetType: string
-}
+export type TracesFacetsOutput = FacetOutput
 
 export function tracesFacetsQuery(opts: TracesFacetsOpts): CHUnionQuery<TracesFacetsOutput> {
 	const baseWhere = ($: ColumnAccessor<typeof TraceListMv.columns>): Array<CH.Condition | undefined> => {
@@ -524,18 +512,10 @@ export function tracesFacetsQuery(opts: TracesFacetsOpts): CHUnionQuery<TracesFa
 		const namespaces = inclusionValues(opts.namespace, opts.namespaces)
 
 		if (services) {
-			conditions.push(
-				opts.matchModes?.serviceName === "contains" && services.length === 1
-					? CH.positionCaseInsensitive($.ServiceName, CH.lit(services[0]!)).gt(0)
-					: inclusionCondition($.ServiceName, services),
-			)
+			conditions.push(matchOrIn($.ServiceName, services, opts.matchModes?.serviceName === "contains"))
 		}
 		if (spanNames) {
-			conditions.push(
-				opts.matchModes?.spanName === "contains" && spanNames.length === 1
-					? CH.positionCaseInsensitive($.SpanName, CH.lit(spanNames[0]!)).gt(0)
-					: inclusionCondition($.SpanName, spanNames),
-			)
+			conditions.push(matchOrIn($.SpanName, spanNames, opts.matchModes?.spanName === "contains"))
 		}
 		if (opts.hasError) conditions.push($.HasError.eq(1))
 		if (opts.minDurationMs != null) conditions.push($.Duration.gte(opts.minDurationMs * 1000000))
@@ -543,18 +523,10 @@ export function tracesFacetsQuery(opts: TracesFacetsOpts): CHUnionQuery<TracesFa
 		if (httpMethods) conditions.push(inclusionCondition($.HttpMethod, httpMethods))
 		if (httpStatusCodes) conditions.push(inclusionCondition($.HttpStatusCode, httpStatusCodes))
 		if (envs) {
-			conditions.push(
-				opts.matchModes?.deploymentEnv === "contains" && envs.length === 1
-					? CH.positionCaseInsensitive($.DeploymentEnv, CH.lit(envs[0]!)).gt(0)
-					: inclusionCondition($.DeploymentEnv, envs),
-			)
+			conditions.push(matchOrIn($.DeploymentEnv, envs, opts.matchModes?.deploymentEnv === "contains"))
 		}
 		if (namespaces) {
-			conditions.push(
-				opts.matchModes?.serviceNamespace === "contains" && namespaces.length === 1
-					? CH.positionCaseInsensitive($.ServiceNamespace, CH.lit(namespaces[0]!)).gt(0)
-					: inclusionCondition($.ServiceNamespace, namespaces),
-			)
+			conditions.push(matchOrIn($.ServiceNamespace, namespaces, opts.matchModes?.serviceNamespace === "contains"))
 		}
 
 		// Attribute filter EXISTS subqueries (correlated — references outer TraceId)
@@ -670,11 +642,7 @@ export interface ErrorsFacetsOpts {
 	fingerprintHashes?: readonly string[]
 }
 
-export interface ErrorsFacetsOutput {
-	readonly name: string
-	readonly count: number
-	readonly facetType: string
-}
+export type ErrorsFacetsOutput = FacetOutput
 
 export function errorsFacetsQuery(opts: ErrorsFacetsOpts): CHUnionQuery<ErrorsFacetsOutput> {
 	const table = errorEventsTableForRecentScan(opts)

--- a/packages/query-engine/src/ch/queries/format.ts
+++ b/packages/query-engine/src/ch/queries/format.ts
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------
+// Shared output-shaping helpers for timeseries queries.
+//
+// These are not Cloudflare-specific despite most of the callers living there —
+// PlanetScale, usage and alert-check queries format buckets the same way, and
+// the format string has to match what the frontend parses.
+// ---------------------------------------------------------------------------
+
+import * as CH from "@maple-dev/clickhouse-builder/expr"
+import { param } from "@maple-dev/clickhouse-builder"
+
+/**
+ * ISO-8601 with a literal `Z`. ClickHouse `DateTime` has no zone, so the suffix
+ * is asserted rather than converted — every warehouse timestamp is already UTC,
+ * and without it `new Date(...)` on the client reads the value as local time.
+ */
+export const ISO_Z_FORMAT = "%Y-%m-%dT%H:%i:%S.%fZ"
+
+/**
+ * The bucket column every timeseries query selects: the timestamp snapped down
+ * to the caller's interval, rendered as an ISO-Z string.
+ */
+export function isoBucket(column: CH.Expr<string>): CH.Expr<string> {
+	return CH.formatDateTime(CH.toStartOfInterval(column, param.int("bucketSeconds")), ISO_Z_FORMAT)
+}
+
+/**
+ * Average of `value` over rows matching `cond`, or 0 when none match.
+ *
+ * `avgIf` over an empty set is NaN, which serializes to JSON `null` and breaks
+ * row decoding — the guard is the reason this exists rather than a bare
+ * `CH.avgIf`.
+ */
+export function avgWhere(value: CH.Expr<number>, cond: CH.Condition): CH.Expr<number> {
+	return CH.if_(CH.countIf(cond).gt(0), CH.avgIf(value, cond), CH.lit(0))
+}

--- a/packages/query-engine/src/ch/queries/infra.ts
+++ b/packages/query-engine/src/ch/queries/infra.ts
@@ -20,6 +20,7 @@ import { from, fromQuery, type ColumnAccessor } from "@maple-dev/clickhouse-buil
 import { unionAll, type CHUnionQuery, type CompiledQueryRowSchema } from "@maple-dev/clickhouse-builder"
 import { MetricsGauge, MetricsSum } from "../tables"
 import { CHNumber } from "../schema"
+import type { FacetOutput } from "./query-helpers"
 
 const HOSTMETRIC_NAMES = [
 	"system.cpu.utilization",
@@ -999,11 +1000,7 @@ export function workloadGaugeTimeseriesQuery(opts: WorkloadGaugeTimeseriesOpts) 
 // facet counts reflect the *current* filtered set.
 // ---------------------------------------------------------------------------
 
-export interface PodFacetsOutput {
-	readonly name: string
-	readonly count: number
-	readonly facetType: string
-}
+export type PodFacetsOutput = FacetOutput
 
 const makePodFacet = (opts: ListPodsOpts, attrKey: string, facetType: string, perFacetLimit: number) =>
 	from(MetricsGauge)
@@ -1036,11 +1033,7 @@ export function podFacetsQuery(opts: ListPodsOpts = {}): CHUnionQuery<PodFacetsO
 	).format("JSON")
 }
 
-export interface NodeFacetsOutput {
-	readonly name: string
-	readonly count: number
-	readonly facetType: string
-}
+export type NodeFacetsOutput = FacetOutput
 
 const makeNodeFacet = (opts: ListNodesOpts, attrKey: string, facetType: string, perFacetLimit: number) =>
 	from(MetricsGauge)
@@ -1066,11 +1059,7 @@ export function nodeFacetsQuery(opts: ListNodesOpts = {}): CHUnionQuery<NodeFace
 	).format("JSON")
 }
 
-export interface WorkloadFacetsOutput {
-	readonly name: string
-	readonly count: number
-	readonly facetType: string
-}
+export type WorkloadFacetsOutput = FacetOutput
 
 const makeWorkloadFacet = (
 	opts: ListWorkloadsOpts,

--- a/packages/query-engine/src/ch/queries/query-helpers.ts
+++ b/packages/query-engine/src/ch/queries/query-helpers.ts
@@ -140,8 +140,48 @@ export function inclusionValues(
  * the overwhelmingly common case, and `=` is what the captured `db.query.text`
  * span attribute and every query fingerprint carried before multi-select.
  */
+/**
+ * A time param floored to its hour, for querying hourly rollup tables. Four
+ * files defined this identically; the expression has to agree with the MV's
+ * `Hour` column or the join silently misses.
+ */
+export function hourFloor(name: string): CH.Expr<string> {
+	return CH.toStartOfHour(CH.toDateTime(param.dateTime(name)))
+}
+
+/**
+ * The row shape every facet-sidebar query returns: one distinct value, how many
+ * rows carry it, and which dimension it belongs to. Declared once and aliased
+ * per query, so the seven callers keep their descriptive names (they are public
+ * API) without seven structurally identical declarations.
+ */
+export interface FacetOutput {
+	readonly name: string
+	readonly count: number
+	readonly facetType: string
+}
+
 export function inclusionCondition(col: CH.Expr<string>, values: readonly string[]): CH.Condition {
 	return values.length === 1 ? col.eq(values[0]!) : CH.inList(col, values)
+}
+
+/**
+ * The filter form behind every "type to narrow" text box: a single value under
+ * `contains` mode becomes a case-insensitive substring match, anything else
+ * falls back to `inclusionCondition`.
+ *
+ * `contains` only applies to a single value on purpose — a substring match
+ * across several needles would have to OR them, which is not what the UI's
+ * multi-select means (there it is set membership, not fuzzy matching).
+ */
+export function matchOrIn(
+	col: CH.Expr<string>,
+	values: readonly string[],
+	contains: boolean,
+): CH.Condition {
+	return contains && values.length === 1
+		? CH.positionCaseInsensitive(col, CH.lit(values[0]!)).gt(0)
+		: inclusionCondition(col, values)
 }
 
 /**
@@ -193,9 +233,7 @@ export function tracesBaseWhereConditions(
 		$.Timestamp.gte(param.dateTime("startTime")),
 		$.Timestamp.lte(param.dateTime("endTime")),
 		CH.when(services, (v: readonly string[]) =>
-			mm?.serviceName === "contains" && v.length === 1
-				? CH.positionCaseInsensitive($.ServiceName, CH.lit(v[0]!)).gt(0)
-				: inclusionCondition($.ServiceName, v),
+			matchOrIn($.ServiceName, v, mm?.serviceName === "contains"),
 		),
 		CH.when(spanNames, (v: readonly string[]) => {
 			// The "Root Span" facet and trace_list_mv expose the *display* name
@@ -344,9 +382,7 @@ export function serviceOverviewWhereConditions(
 		$.Timestamp.gte(param.dateTime("startTime")),
 		$.Timestamp.lte(param.dateTime("endTime")),
 		CH.when(services, (v: readonly string[]) =>
-			mm?.serviceName === "contains" && v.length === 1
-				? CH.positionCaseInsensitive($.ServiceName, CH.lit(v[0]!)).gt(0)
-				: inclusionCondition($.ServiceName, v),
+			matchOrIn($.ServiceName, v, mm?.serviceName === "contains"),
 		),
 		errorsOnlyCondition($.StatusCode, opts.errorsOnly),
 	]
@@ -448,9 +484,7 @@ export function tracesAggregatesWhereConditions(
 		hourBounds ? $.Hour.gte(CH.rawExpr<string>(hourBounds.gte)) : $.Hour.gte(param.dateTime("startTime")),
 		hourBounds ? $.Hour.lt(CH.rawExpr<string>(hourBounds.lt)) : $.Hour.lte(param.dateTime("endTime")),
 		CH.when(services, (v: readonly string[]) =>
-			mm?.serviceName === "contains" && v.length === 1
-				? CH.positionCaseInsensitive($.ServiceName, CH.lit(v[0]!)).gt(0)
-				: inclusionCondition($.ServiceName, v),
+			matchOrIn($.ServiceName, v, mm?.serviceName === "contains"),
 		),
 		CH.when(spanNames, (v: readonly string[]) =>
 			mm?.spanName === "contains" && v.length === 1

--- a/packages/query-engine/src/ch/queries/service-infra.ts
+++ b/packages/query-engine/src/ch/queries/service-infra.ts
@@ -37,8 +37,8 @@ import * as CH from "@maple-dev/clickhouse-builder/expr"
 import { param } from "@maple-dev/clickhouse-builder"
 import { from, fromQuery } from "@maple-dev/clickhouse-builder"
 import { MetricsGauge, ServicePlatformsHourly } from "../tables"
+import { CHNumber } from "../schema"
 
-const CHNumber = Schema.Union([Schema.Finite, Schema.FiniteFromString])
 
 export interface ServiceWorkloadsOpts {
 	services: ReadonlyArray<string>

--- a/packages/query-engine/src/ch/queries/service-map-rollup.ts
+++ b/packages/query-engine/src/ch/queries/service-map-rollup.ts
@@ -22,8 +22,8 @@ import { from, fromQuery } from "@maple-dev/clickhouse-builder"
 import { escapeClickHouseString } from "@maple-dev/clickhouse-builder/sql"
 import { ServiceMapEdgesHourly, Traces } from "../tables"
 import { serviceMapEdgeJoinSQL } from "./service-map"
+import { CHNumber } from "../schema"
 
-const CHNumber = Schema.Union([Schema.Finite, Schema.FiniteFromString])
 
 /** One pre-aggregated service-to-service edge bucket — mirrors the columns of
  * the `service_map_edges_hourly` ClickHouse table. */

--- a/packages/query-engine/src/ch/queries/services.ts
+++ b/packages/query-engine/src/ch/queries/services.ts
@@ -18,14 +18,13 @@ import { unionAll, type CHUnionQuery } from "@maple-dev/clickhouse-builder"
 import type { ColumnDefs } from "@maple-dev/clickhouse-builder/types"
 import { ServiceOverviewHourly, ServiceOverviewSpans, ServiceUsage, TracesAggregatesHourly } from "../tables"
 import { CHNumber } from "../schema"
-import { apdexExprs, serviceOverviewWhereConditions } from "./query-helpers"
+import { apdexExprs, serviceOverviewWhereConditions , hourFloor, type FacetOutput} from "./query-helpers"
 import { edgeCondition, interiorConditions } from "./rollup-splice"
 
 // ---------------------------------------------------------------------------
 // Service overview
 // ---------------------------------------------------------------------------
 
-const hourFloor = (name: string) => CH.toStartOfHour(CH.toDateTime(param.dateTime(name)))
 const SERVICE_RAW_DURATION_STATE = "quantilesTDigestState(0.5, 0.95, 0.99)(Duration)"
 const SERVICE_ROLLUP_DURATION_STATE = "quantilesTDigestMergeState(0.5, 0.95, 0.99)(DurationQuantiles)"
 
@@ -578,7 +577,6 @@ export interface ServiceUsageWithPreviousOutput extends ServiceUsageOutput {
  * delta chips consume.
  */
 export function serviceUsageWithPreviousQuery(opts: ServiceUsageOpts) {
-	const hourFloor = (p: string) => CH.toStartOfHour(CH.toDateTime(param.dateTime(p)))
 	const inCurrent = ($: ColumnAccessor<typeof ServiceUsage.columns>) =>
 		$.Hour.gte(hourFloor("startTime")).and($.Hour.lte(hourFloor("endTime")))
 	const inPrevious = ($: ColumnAccessor<typeof ServiceUsage.columns>) =>
@@ -635,11 +633,7 @@ export function serviceUsageWithPreviousQuery(opts: ServiceUsageOpts) {
 // Services facets (UNION ALL — environment + commit_sha facets)
 // ---------------------------------------------------------------------------
 
-export interface ServicesFacetsOutput {
-	readonly name: string
-	readonly count: number
-	readonly facetType: string
-}
+export type ServicesFacetsOutput = FacetOutput
 
 // NOTE: kept as a 4-way UNION ALL on purpose. A single-scan rewrite (ARRAY JOIN
 // of (facetType, value) pairs, or GROUP BY GROUPING SETS) reads ~3× fewer rows

--- a/packages/query-engine/src/ch/queries/session-replays.ts
+++ b/packages/query-engine/src/ch/queries/session-replays.ts
@@ -25,6 +25,7 @@ import { from, fromQuery, type ColumnAccessor, type CHQuery } from "@maple-dev/c
 import { unionAll, type CHUnionQuery } from "@maple-dev/clickhouse-builder"
 import { SessionReplays, SessionReplayEvents, TraceDetailSpans } from "../tables"
 import { sessionActivityAggregateQuery, sessionEventMatchQuery } from "./session-events"
+import type { FacetOutput } from "./query-helpers"
 
 // argMax(value, ordering) — finalize a ReplacingMergeTree column to its latest
 // version. Generic per call site, so declared here rather than via defineFn.
@@ -392,11 +393,7 @@ export interface SessionReplaysFacetsOpts {
 	search?: string
 }
 
-export interface SessionReplaysFacetsOutput {
-	readonly name: string
-	readonly count: number
-	readonly facetType: string
-}
+export type SessionReplaysFacetsOutput = FacetOutput
 
 type SessionFacetKey = "service" | "browser" | "country" | "device"
 

--- a/packages/query-engine/src/ch/queries/setup-audit.ts
+++ b/packages/query-engine/src/ch/queries/setup-audit.ts
@@ -34,9 +34,9 @@ import {
 	TracesAggregatesHourly,
 } from "../tables"
 import { CHNumber } from "../schema"
+import { hourFloor } from "./query-helpers"
 
 /** Snaps a window bound to its hour floor so any overlapping hour of an hourly MV contributes. */
-const hourFloor = (name: string) => CH.toStartOfHour(CH.toDateTime(param.dateTime(name)))
 
 /** Span kinds and status codes Maple stores; anything else is an SDK emitting the wrong casing. */
 const VALID_SPAN_KINDS = ["Server", "Client", "Producer", "Consumer", "Internal", ""]

--- a/packages/query-engine/src/ch/queries/traces.ts
+++ b/packages/query-engine/src/ch/queries/traces.ts
@@ -34,6 +34,7 @@ import {
 	tracesAggregatesWhereConditions,
 	tracesBaseWhereConditions,
 	type TracesBaseWhereOpts,
+	matchOrIn,
 } from "./query-helpers"
 
 // ---------------------------------------------------------------------------
@@ -552,9 +553,7 @@ export function tracesTimeseriesQuery(
 				// which is the same class of bug this union exists to close.
 				...tracesBaseWhereConditions($, { ...opts, spanName: undefined, spanNames: undefined }),
 				CH.when(spanNames, (v: readonly string[]) =>
-					opts.matchModes?.spanName === "contains" && v.length === 1
-						? CH.positionCaseInsensitive($.SpanName, CH.lit(v[0]!)).gt(0)
-						: inclusionCondition($.SpanName, v),
+					matchOrIn($.SpanName, v, opts.matchModes?.spanName === "contains"),
 				),
 				edgeCondition("Timestamp"),
 			])

--- a/packages/query-engine/src/ch/queries/traces.ts
+++ b/packages/query-engine/src/ch/queries/traces.ts
@@ -28,7 +28,6 @@ import {
 	buildProjectedMapExpr,
 	canUseServiceOverviewMv,
 	canUseTracesAggregatesMv,
-	inclusionCondition,
 	inclusionValues,
 	serviceOverviewWhereConditions,
 	tracesAggregatesWhereConditions,


### PR DESCRIPTION
> Stacked on #321.

## Why

Six sets of identical definitions, each one a place for a copy to drift:

| duplication | copies | now |
|---|---|---|
| contains-vs-inList ternary | 10 | `matchOrIn` |
| `CHNumber` local redefinition | 2 | import the canonical one |
| `hourFloor` | 4 | one export |
| facet row `{name, count, facetType}` | 7 interfaces | `FacetOutput` + aliases |
| `ISO_Z_FORMAT` | 5 | `queries/format.ts` |
| `avgWhere` | 3 | `queries/format.ts` |
| `formatDateTime(toStartOfInterval(…), ISO_Z)` | 10 | `isoBucket(col)` |

The ternary is the interesting one: the **same filter set was written twice in two different styles** — a declarative `CH.when` chain in `tracesDurationStatsQuery` and an imperative `if/push` chain in `tracesFacetsQuery`. That's the worst shape for duplication, because a fix applied to one won't be pattern-matched into the other.

`hourFloor` had four copies including two in the same file — one at module scope and one shadowing it inside a function.

`format.ts` is deliberately **not** named `cloudflare-*`: PlanetScale, usage and alert-check queries format buckets identically, and the format string has to agree with what the frontend parses.

## Two things deliberately NOT unified

- **`inclusionCondition` vs `CH.inList`.** The imperative sites fall back to `CH.inList`, which emits `col IN ('x')` for a single value; the declarative ones use `inclusionCondition`, which emits `col = 'x'`. Semantically identical, textually not — collapsing them would have changed emitted SQL and broken the zero-diff property. `matchOrIn` mirrors `inclusionCondition`, and only the sites that already used it moved. The rest stay as they are.
- **The two attribute-value matchers in `errors.ts`** look like the same ternary but take a scalar and fall back to `.eq`, not set membership.

Both were caught by the baseline rather than by reading — which is the argument for having added it in #320.

## Verification

- **SQL baseline byte-identical.**
- 1087 query-engine tests pass.
- Typecheck clean.
- **138 lines deleted, 84 added** across 16 files.

## Not in this PR

The larger `SpanFilterColumns` refactor from the plan — one filter builder parameterized by a per-table column map, with an `ignore` set that throws when a table is handed an option it cannot serve. That one changes behaviour (it turns a silent population swap into a loud failure) and deserves its own review rather than riding along with mechanical dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)