### PR TITLE
fix(api): normalize telemetry query bounds for ClickHouse DateTime

### DIFF
--- a/apps/api/src/routes/v2/telemetry.http.test.ts
+++ b/apps/api/src/routes/v2/telemetry.http.test.ts
@@ -459,7 +459,7 @@ describe("v2 telemetry reads over HTTP", () => {
 		await harness.dispose()
 	})
 
-	it("preserves fractional bounds and reads complete traces by their sorting-key identity", async () => {
+	it("normalizes warehouse bounds to second precision and reads complete traces by sorting-key identity", async () => {
 		const observedSql: string[] = []
 		const observingWarehouse: WarehouseQueryServiceShape = {
 			...warehouseStub,
@@ -481,8 +481,8 @@ describe("v2 telemetry reads over HTTP", () => {
 		})
 		expect(logs.status).toBe(200)
 		const logSql = observedSql.find((sql) => sql.includes("FROM logs"))
-		expect(logSql).toContain("'2026-07-15 12:00:00.900'")
-		expect(logSql).toContain("'2026-07-15 12:00:01.100'")
+		expect(logSql).toContain("'2026-07-15 12:00:00'")
+		expect(logSql).toContain("'2026-07-15 12:00:01'")
 
 		observedSql.length = 0
 		const trace = await harness.request("GET", `/v2/traces/${TRACE_ID}`, key.secret)

--- a/apps/api/src/routes/v2/telemetry.http.ts
+++ b/apps/api/src/routes/v2/telemetry.http.ts
@@ -81,7 +81,7 @@ const toWarehouseDateTime = (value: string, param: string) => {
 	const ms = Date.parse(value)
 	return Number.isNaN(ms)
 		? Effect.fail(invalidRequest("parameter_invalid", `Invalid ISO-8601 timestamp for ${param}.`, param))
-		: Effect.succeed(formatWarehouseDateTimeMs(ms))
+		: Effect.succeed(formatWarehouseDateTime(ms))
 }
 
 const parseWindow = (


### PR DESCRIPTION
## Summary

- Normalize telemetry query bounds to second precision for ClickHouse DateTime columns.
- Keep the v2 API contract unchanged; no schema migration.

## Validation

- `bun test apps/api/src/routes/v2/telemetry.http.test.ts`
- 8 tests passed locally.

This branch is maintained in the pminds organization fork for Railway deployment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788423212&installation_model_id=427786&pr_number=330&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F330&signature=5196cfd754b6ac2f165d0b5f1708ab51e1d06b96dfc986bef4e7694e8826840b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->