### PR TITLE
feat(clickhouse-builder): require a typed reason for every handwritten query

### DIFF
--- a/.agents/skills/maple-telemetry-conventions/SKILL.md
+++ b/.agents/skills/maple-telemetry-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maple-telemetry-conventions
-description: Maple's OpenTelemetry conventions — custom span attribute keys (`maple.*` vendor namespace, `query.context`, `db.query.*`, `result.*`, `cache.*`, `tenant.*`), Title Case status codes (`Ok`/`Error`/`Unset`), resource attribute dual-emit (`deployment.environment` + `deployment.environment.name`), span kinds, Tinybird MV pre-extracted columns, loop-prevention filters, and sampling. Use whenever writing or reviewing instrumentation code in any language (TypeScript, Rust, Python) in this repo — adding `setAttribute`/`setAttributes`/`record`/`#[instrument(fields(...))]` calls, setting span status, configuring an OTLP exporter, defining a new resource attribute, or wiring a new query through `WarehouseQueryService.sqlQuery()`.
+description: Maple's OpenTelemetry conventions — custom span attribute keys (`maple.*` vendor namespace, `query.context`, `db.query.*`, `result.*`, `cache.*`, `tenant.*`), Title Case status codes (`Ok`/`Error`/`Unset`), resource attribute dual-emit (`deployment.environment` + `deployment.environment.name`), span kinds, Tinybird MV pre-extracted columns, loop-prevention filters, and sampling. Use whenever writing or reviewing instrumentation code in any language (TypeScript, Rust, Python) in this repo — adding `setAttribute`/`setAttributes`/`record`/`#[instrument(fields(...))]` calls, setting span status, configuring an OTLP exporter, defining a new resource attribute, or wiring a new query through `WarehouseQueryService.compiledQuery()`.
 version: "1.0.0"
 ---
 
@@ -12,7 +12,7 @@ Reference for the **language-agnostic** OpenTelemetry conventions Maple uses acr
 
 - Adding `setAttribute` / `Effect.annotateCurrentSpan` / `Span::current().record(...)` / `#[instrument(fields(...))]` to any code path
 - Setting span status (Ok / Error / Unset)
-- Wiring a new query through `WarehouseQueryService.sqlQuery()` (the `context` and `profile` options become span attributes)
+- Wiring a new query through `WarehouseQueryService.compiledQuery()` (the `context` and `profile` options become span attributes)
 - Configuring an OTLP exporter, tracer provider, or resource builder
 - Introducing a new pre-extracted MV column or a new vendor attribute under `maple.*`
 - Reviewing a PR that touches `apps/api/src/services/WarehouseQueryService.ts`, `apps/ingest/src/main.rs`, `apps/api/src/app.ts`, `packages/effect-sdk/src/cloudflare/`, or `packages/domain/src/tinybird/materializations.ts`

--- a/.agents/skills/maple-telemetry-conventions/rules/span-attributes.md
+++ b/.agents/skills/maple-telemetry-conventions/rules/span-attributes.md
@@ -31,7 +31,7 @@ Source: `packages/query-engine/src/execution/executor.ts` (`executeSql`)
 | `db.duration_ms` | int | `executor.ts` | Execution time in ms (emitted on both success and error tap) |
 | `db.total_duration_ms` | int | `executor.ts` | Total execution-span duration including config resolution and client setup |
 | `db.retry.attempts` | int | `executor.ts` | Retries actually performed (not total attempts) |
-| `query.pipe` | string | `executor.ts` | Original pipe name passed to `sqlQuery()` |
+| `query.pipe` | string | `executor.ts` | Original pipe name resolved by `query()` |
 | `query.context` | string | `executor.ts` | Semantic call-site label (e.g. `"errorsByType"`, `"spanHierarchy"`). Set via `SqlQueryOptions.context`. |
 | `query.profile` | string | `executor.ts` | Execution profile (e.g. `"list"`, `"analytics"`). Set via `SqlQueryOptions.profile`. |
 | `ch.settings` | string (JSON) | `executor.ts` | JSON-encoded ClickHouse settings applied to the query |

--- a/.deepsec/data/maple/INFO.md
+++ b/.deepsec/data/maple/INFO.md
@@ -28,7 +28,7 @@ API for AI-agent access; a Cloudflare Workers chat agent
   `"org:admin"` in `routes/integrations.http.ts`,
   `OrganizationService`, `OrgOpenRouterSettingsService`. There is no
   central middleware for this — every admin route opts in.
-- **Warehouse scoping:** `WarehouseQueryService.sqlQuery` refuses any
+- **Warehouse scoping:** `WarehouseQueryService.compiledQuery` refuses any
   SQL that does not literally contain `"OrgId"`. This is the only
   tenant guard between the API and the warehouse — bypassing it
   bypasses tenancy.
@@ -44,7 +44,7 @@ API for AI-agent access; a Cloudflare Workers chat agent
 ## Threat model
 
 Highest impact: **cross-tenant data leakage** through warehouse queries
-that skip `WarehouseQueryService.sqlQuery` or build SQL without an
+that skip `WarehouseQueryService.compiledQuery` or build SQL without an
 `OrgId` filter. **Self-hosted mode** is unusual — the root password
 doubles as the JWT signing key, so password disclosure = unlimited
 session forgery. Ingest-key disclosure (especially private keys) lets
@@ -54,7 +54,7 @@ in `resolveMcpTenant` or in the api-key lookup are critical.
 
 ## Project-specific patterns to flag
 
-- Warehouse access that **bypasses `WarehouseQueryService.sqlQuery`** —
+- Warehouse access that **bypasses `WarehouseQueryService.compiledQuery`** —
   raw `fetch()` to `/v0/sql`, direct `createClickHouseClient` /
   `Tinybird` SDK calls, or `executeSql` callers that omit an `OrgId`
   filter in the compiled SQL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ upgrading a runtime (keep `bun` in sync with `packageManager`).
 ## Warehouse queries
 
 **No Tinybird pipes/endpoints exist.** All backend queries use the ClickHouse DSL in
-`@maple/query-engine` and run through `WarehouseQueryService.sqlQuery()`, which routes to the
+`@maple/query-engine` and run through `WarehouseQueryService.compiledQuery()`, which routes to the
 Tinybird SDK or ClickHouse per org config. Never `fetch()` `/v0/sql` directly.
 
 Subpath exports: `./ch` (DSL + `compile`), `./runtime` (dashboard/alert lowering, `evaluate`,
@@ -59,7 +59,7 @@ To add a query: define it in `packages/query-engine/src/ch/queries/*.ts` with
 
 ```typescript
 const compiled = CH.compile(CH.myQuery({ limit: 50 }), { orgId, startTime, endTime })
-const rows = yield* warehouse.compiledQuery(tenant, compiled, { profile: "list", context: "myQuery" })
+const rows = yield * warehouse.compiledQuery(tenant, compiled, { profile: "list", context: "myQuery" })
 ```
 
 `compiledQuery` runs the SQL and decodes rows through the query's `rowSchema` (if declared);

--- a/apps/api/src/services/warehouse/WarehouseQueryService.test.ts
+++ b/apps/api/src/services/warehouse/WarehouseQueryService.test.ts
@@ -86,7 +86,13 @@ const makeTenant = (): TenantContext => ({
 // A scoped stand-in for the removed `sqlQuery(tenant, sql)` entry point: these
 // tests exercise retry/routing/caching, not scope, so the SQL travels wrapped in
 // a compiled query that declares it.
-const scopedSql = (sql: string) => unsafeCompiledQuery<Record<string, unknown>>({ sql, tenantScope: "org" })
+const scopedSql = (sql: string) =>
+	unsafeCompiledQuery<Record<string, unknown>>({
+		sql,
+		tenantScope: "org",
+		reason: "test-fixture",
+		note: "Synthetic SQL asserting executor behaviour, not a product query.",
+	})
 
 const transient503 = () => new Error("HTTP status 503 service temporarily unavailable")
 
@@ -388,6 +394,8 @@ describe("WarehouseQueryService.compiledQuery", () => {
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
 		const compiled = unsafeCompiledQuery<{ readonly serviceName: string; readonly count: number }>({
+			reason: "test-fixture",
+			note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 			tenantScope: "org",
 			sql: "SELECT ServiceName AS serviceName, count() AS count FROM traces WHERE OrgId = 'org_test'",
 			rowSchema: Schema.Struct({ serviceName: Schema.String, count: RowNumber }),
@@ -411,6 +419,8 @@ describe("WarehouseQueryService.compiledQuery", () => {
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
 		const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+			reason: "test-fixture",
+			note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 			tenantScope: "org",
 			sql: "SELECT count() AS count FROM traces WHERE OrgId = 'org_test'",
 			rowSchema: Schema.Struct({ count: RowNumber }),
@@ -439,6 +449,8 @@ describe("WarehouseQueryService.compiledQuery", () => {
 		// substring "OrgId"; scope is now a property of the compiled query, so a
 		// query that merely mentions the column can no longer sneak through.
 		const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+			reason: "test-fixture",
+			note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 			sql: "SELECT count() AS count, 'x' AS OrgId FROM traces",
 			tenantScope: "cross-org",
 			rowSchema: Schema.Struct({ count: RowNumber }),
@@ -477,6 +489,8 @@ describe("WarehouseQueryService.compiledQueryFirst", () => {
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
 		const compiled = unsafeCompiledQuery<{ readonly serviceName: string; readonly count: number }>({
+			reason: "test-fixture",
+			note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 			tenantScope: "org",
 			sql: "SELECT ServiceName AS serviceName, count() AS count FROM traces WHERE OrgId = 'org_test'",
 			rowSchema: Schema.Struct({ serviceName: Schema.String, count: RowNumber }),
@@ -503,6 +517,8 @@ describe("WarehouseQueryService.compiledQueryFirst", () => {
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
 		const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+			reason: "test-fixture",
+			note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 			tenantScope: "org",
 			sql: "SELECT count() AS count FROM traces WHERE OrgId = 'org_test'",
 			rowSchema: Schema.Struct({ count: RowNumber }),
@@ -526,6 +542,8 @@ describe("WarehouseQueryService.compiledQueryFirst", () => {
 		const layer = buildLayer(createTestDb(trackedDbs))
 		const tenant = makeTenant()
 		const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+			reason: "test-fixture",
+			note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 			tenantScope: "org",
 			sql: "SELECT count() AS count FROM traces WHERE OrgId = 'org_test'",
 			rowSchema: Schema.Struct({ count: RowNumber }),

--- a/apps/cli/src/core/executor.test.ts
+++ b/apps/cli/src/core/executor.test.ts
@@ -37,6 +37,8 @@ describe("makeLocalWarehouseExecutorShape", () => {
 			const requests = stubLocalServer([{ c: 1 }])
 			const shape = makeLocalWarehouseExecutorShape("http://127.0.0.1:4318")
 			const compiled = unsafeCompiledQuery<{ readonly c: number }>({
+				reason: "test-fixture",
+				note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 				tenantScope: "org",
 				sql: "SELECT count() AS c FROM traces WHERE OrgId = 'local'\nFORMAT JSON",
 			})
@@ -61,7 +63,14 @@ describe("makeLocalWarehouseExecutorShape", () => {
 			// Scope now rides on the compiled query rather than being sniffed out
 			// of the SQL string, so an unscoped one is rejected before execution.
 			const exit = yield* shape
-				.compiledQuery(unsafeCompiledQuery({ sql: "SELECT 1", tenantScope: "cross-org" }))
+				.compiledQuery(
+					unsafeCompiledQuery({
+						reason: "test-fixture",
+						note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
+						sql: "SELECT 1",
+						tenantScope: "cross-org",
+					}),
+				)
 				.pipe(Effect.exit)
 
 			expect(Exit.isFailure(exit)).toBe(true)
@@ -80,6 +89,8 @@ describe("makeLocalWarehouseExecutorShape", () => {
 			const exit = yield* shape
 				.compiledQuery(
 					unsafeCompiledQuery({
+						reason: "test-fixture",
+						note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 						sql: "SELECT nope FROM traces WHERE OrgId = 'local'",
 						tenantScope: "org",
 					}),

--- a/lib/clickhouse-builder/docs/extending.md
+++ b/lib/clickhouse-builder/docs/extending.md
@@ -19,7 +19,7 @@ CH.from(Events)
 Arguments are compiled through the same escaping path as everything else, so raw values are
 safe to pass. This is the right tool almost every time.
 
-*(Backed by `docs/extending.md > defineFn declares a missing function`.)*
+_(Backed by `docs/extending.md > defineFn declares a missing function`.)_
 
 ### `defineCondFn` — for predicates
 
@@ -28,11 +28,11 @@ Same, but returning a `Condition` so it can go straight into `where`:
 ```ts
 const matchesRegex = CH.defineCondFn<[CH.Expr<string>, string]>("match")
 
-.where(($) => [$.OrgId.eq("org_123"), matchesRegex($.Name, "^checkout")])
+	.where(($) => [$.OrgId.eq("org_123"), matchesRegex($.Name, "^checkout")])
 // match(Name, '^checkout')
 ```
 
-*(Backed by `docs/extending.md > defineCondFn declares a predicate`.)*
+_(Backed by `docs/extending.md > defineCondFn declares a predicate`.)_
 
 ## `compileFnCall` — variadic or generic shapes
 
@@ -79,7 +79,7 @@ CH.from(Events)
 `dynamicColumn<T>(name)` (on the `/expr` subpath) is the same idea for a column name only known
 at runtime.
 
-*(Backed by `docs/extending.md > rawExpr and rawCond are the last resort`.)*
+_(Backed by `docs/extending.md > rawExpr and rawCond are the last resort`.)_
 
 ## Handwritten queries: `unsafeCompiledQuery`
 
@@ -90,16 +90,35 @@ sees a uniform `CompiledQuery`:
 const compiled = CH.unsafeCompiledQuery<{ readonly name: string }>({
 	sql: "SELECT Name AS name FROM events WHERE OrgId = 'org_123'",
 	tenantScope: "org",
+	reason: "user-authored-sql",
+	note: "The SQL came from a user; there is no AST to build.",
 	rowSchema: Schema.Struct({ name: Schema.String }),
 })
 ```
 
 `tenantScope` is **required** — it cannot be inferred from a string, and whatever you assert is
-taken at face value. Supply a `rowSchema` too: handwritten SQL is exactly where schema drift
-goes unnoticed, and without one `decodeRows` validates nothing. See
-[Decoding results](./decoding-results.md).
+taken at face value. That is the whole hazard: this is the one place tenant scope is asserted
+rather than derived, so a query that forgot its tenant predicate would be positively *claimed*
+as scoped and sail through an executor's gate.
 
-*(Backed by `docs/extending.md > unsafeCompiledQuery wraps handwritten SQL`.)*
+`reason` is therefore required too, and its type — `RawSqlReason` — **is** the boundary between
+legitimate raw SQL and raw SQL nobody got round to converting:
+
+| reason | when |
+| --- | --- |
+| `"user-authored-sql"` | The SQL came from a user. There is no AST to build; isolation comes from the credential layer. |
+| `"empty-result-stub"` | A constant zero-row result reading no table (`SELECT … WHERE 0`). The builder always emits a FROM. |
+| `"param-varied-union"` | A `UNION ALL` of one builder over two parameter sets. Params substitute once per compile, so one `CHQuery` cannot carry both. Derive the scope from the compiled branches. |
+| `"test-fixture"` | A test asserting executor behaviour on synthetic SQL. |
+
+Adding a member is the review gate — a one-line diff in `compile.ts` that a reviewer cannot
+miss. There is deliberately no `"legacy"` or `"todo"` member: with one, the gate is decorative.
+If your query doesn't fit a member, the answer is almost always to express it in the builder.
+
+Supply a `rowSchema` too: handwritten SQL is exactly where schema drift goes unnoticed, and
+without one `decodeRows` validates nothing. See [Decoding results](./decoding-results.md).
+
+_(Backed by `docs/extending.md > unsafeCompiledQuery wraps handwritten SQL`.)_
 
 ## The fragment AST
 

--- a/lib/clickhouse-builder/docs/reference.md
+++ b/lib/clickhouse-builder/docs/reference.md
@@ -8,22 +8,22 @@ Everything on this page is exported from the root entry point
 Some ClickHouse functions collide with JavaScript reserved words or globals. The source defines
 those with a trailing underscore, and the root barrel renames **some but not all** of them:
 
-| Root barrel name | Also on `/expr` as | Note |
-| --- | --- | --- |
-| `min` | `min_` | renamed |
-| `max` | `max_` | renamed |
-| `any` | `any_` | renamed |
-| `toString` | `toString_` | renamed |
-| `position` | `position_` | renamed |
-| `left` | `left_` | renamed |
-| `length` | `length_` | renamed |
-| `extract` | `extract_` | renamed |
-| `least` | `least_` | renamed |
-| `greatest` | `greatest_` | renamed |
-| `if_` | `if_` | **not** renamed |
-| `lower_` | `lower_` | **not** renamed |
-| `round_` | `round_` | **not** renamed |
-| `in_` / `notIn` | — | `Expr` methods; `in` is reserved |
+| Root barrel name | Also on `/expr` as | Note                             |
+| ---------------- | ------------------ | -------------------------------- |
+| `min`            | `min_`             | renamed                          |
+| `max`            | `max_`             | renamed                          |
+| `any`            | `any_`             | renamed                          |
+| `toString`       | `toString_`        | renamed                          |
+| `position`       | `position_`        | renamed                          |
+| `left`           | `left_`            | renamed                          |
+| `length`         | `length_`          | renamed                          |
+| `extract`        | `extract_`         | renamed                          |
+| `least`          | `least_`           | renamed                          |
+| `greatest`       | `greatest_`        | renamed                          |
+| `if_`            | `if_`              | **not** renamed                  |
+| `lower_`         | `lower_`           | **not** renamed                  |
+| `round_`         | `round_`           | **not** renamed                  |
+| `in_` / `notIn`  | —                  | `Expr` methods; `in` is reserved |
 
 There is no rule to infer here — check the table. Importing the kitchen-sink namespace
 (`import * as CH from "@maple-dev/clickhouse-builder/expr"`) gives you the raw names uniformly,
@@ -33,13 +33,13 @@ which some codebases prefer for exactly this reason.
 
 The root barrel is curated. These are exported by the package but not from it:
 
-| Symbol | Subpath |
-| --- | --- |
-| `uint16`, `uint32`, `int32`, `bool` | `/types` |
-| `not`, `notInList`, `dynamicColumn` | `/expr` |
-| `TENANT_COLUMN`, `makeColumnRef`, `aliased`, `toFragment` | `/expr` |
-| `raw`, `str`, `ident`, `int`, `join`, `as_`, `when`, `compile`, `escapeClickHouseString` | `/sql` |
-| `SqlQuery`, `compileQuery` | `/sql` |
+| Symbol                                                                                   | Subpath  |
+| ---------------------------------------------------------------------------------------- | -------- |
+| `uint16`, `uint32`, `int32`, `bool`                                                      | `/types` |
+| `not`, `notInList`, `dynamicColumn`                                                      | `/expr`  |
+| `TENANT_COLUMN`, `makeColumnRef`, `aliased`, `toFragment`                                | `/expr`  |
+| `raw`, `str`, `ident`, `int`, `join`, `as_`, `when`, `compile`, `escapeClickHouseString` | `/sql`   |
+| `SqlQuery`, `compileQuery`                                                               | `/sql`   |
 
 Note `/sql` exports a `compile` (fragment → string) distinct from the root `compile`
 (query → `CompiledQuery`), and a `when` distinct from the root `when` (optional conditions).
@@ -50,39 +50,39 @@ Note `/sql` exports a `compile` (fragment → string) distinct from the root `co
 
 ### Query construction
 
-| Export | Signature |
-| --- | --- |
-| `table` | `(name, columns) => Table` |
-| `from` | `(table, alias?) => CHQuery` |
-| `fromQuery` | `(query, alias) => CHQuery` |
-| `fromUnion` | `(union, alias) => CHQuery` |
-| `unionAll` | `(...queries) => CHUnionQuery` |
+| Export      | Signature                      |
+| ----------- | ------------------------------ |
+| `table`     | `(name, columns) => Table`     |
+| `from`      | `(table, alias?) => CHQuery`   |
+| `fromQuery` | `(query, alias) => CHQuery`    |
+| `fromUnion` | `(union, alias) => CHQuery`    |
+| `unionAll`  | `(...queries) => CHUnionQuery` |
 
 ### `CHQuery` methods
 
-| Method | Notes |
-| --- | --- |
-| `select(...names)` / `select(fn)` | Required before compiling |
-| `where(fn)` | Returns `Array<Condition \| undefined>`; AND-joined |
-| `groupBy(...outputKeys)` | Takes select aliases, not column names |
-| `orderBy(...[col, dir])` | **Tuples**, not two strings |
-| `limit(n)` / `offset(n)` | Rounded before emission |
-| `format(fmt)` | `"JSON"` \| `"JSONEachRow"` |
-| `innerJoin` / `leftJoin` / `crossJoin` | `(table, alias, on?)` |
-| `innerJoinQuery` / `leftJoinQuery` / `crossJoinQuery` | `(query, alias, on?)` |
-| `withCTE(name, sql, options?)` | `options.tenantScope` |
-| `routing("ingest")` | Metadata only |
-| `crossOrg()` | Forces `tenantScope: "cross-org"` |
+| Method                                                | Notes                                               |
+| ----------------------------------------------------- | --------------------------------------------------- |
+| `select(...names)` / `select(fn)`                     | Required before compiling                           |
+| `where(fn)`                                           | Returns `Array<Condition \| undefined>`; AND-joined |
+| `groupBy(...outputKeys)`                              | Takes select aliases, not column names              |
+| `orderBy(...[col, dir])`                              | **Tuples**, not two strings                         |
+| `limit(n)` / `offset(n)`                              | Rounded before emission                             |
+| `format(fmt)`                                         | `"JSON"` \| `"JSONEachRow"`                         |
+| `innerJoin` / `leftJoin` / `crossJoin`                | `(table, alias, on?)`                               |
+| `innerJoinQuery` / `leftJoinQuery` / `crossJoinQuery` | `(query, alias, on?)`                               |
+| `withCTE(name, sql, options?)`                        | `options.tenantScope`                               |
+| `routing("ingest")`                                   | Metadata only                                       |
+| `crossOrg()`                                          | Forces `tenantScope: "cross-org"`                   |
 
 `CHUnionQuery` offers only `orderBy`, `limit`, `offset`, `format`.
 
 ### Compilation
 
-| Export | Signature |
-| --- | --- |
-| `compile` / `compileCH` | `(query, params, options?) => CompiledQuery<Output>` |
-| `compileUnion` | `(union, params, options?) => CompiledQuery<Output>` |
-| `unsafeCompiledQuery` | `({ sql, tenantScope, rowSchema?, routing? }) => CompiledQuery` |
+| Export                  | Signature                                                       |
+| ----------------------- | --------------------------------------------------------------- |
+| `compile` / `compileCH` | `(query, params, options?) => CompiledQuery<Output>`            |
+| `compileUnion`          | `(union, params, options?) => CompiledQuery<Output>`            |
+| `unsafeCompiledQuery`   | `({ sql, tenantScope, reason, note, rowSchema?, routing? }) => CompiledQuery` |
 
 ### Params
 
@@ -92,18 +92,18 @@ Note `/sql` exports a `compile` (fragment → string) distinct from the root `co
 
 ## Expressions
 
-| Export | Purpose |
-| --- | --- |
-| `lit(value)` | Literal `Expr` from a `string` or `number` |
-| `rawExpr<T>(sql)` | Unescaped `Expr` from SQL text |
-| `rawCond(sql)` | Unescaped `Condition` from SQL text |
-| `when(value, fn)` | `Condition \| undefined`; skips `undefined`/`null`/`false` |
-| `whenTrue(flag, fn)` | Boolean-gated variant |
-| `inList(expr, values)` | `expr IN ('a', 'b')` |
-| `inExprList(expr, exprs)` | Same for expression lists |
-| `exists(sql)` | `EXISTS (…)` from pre-compiled SQL |
-| `inSubquery(expr, sql)` | `expr IN (…)` from pre-compiled SQL |
-| `outerRef<T>(name)` | Reference an outer column in a correlated subquery |
+| Export                    | Purpose                                                    |
+| ------------------------- | ---------------------------------------------------------- |
+| `lit(value)`              | Literal `Expr` from a `string` or `number`                 |
+| `rawExpr<T>(sql)`         | Unescaped `Expr` from SQL text                             |
+| `rawCond(sql)`            | Unescaped `Condition` from SQL text                        |
+| `when(value, fn)`         | `Condition \| undefined`; skips `undefined`/`null`/`false` |
+| `whenTrue(flag, fn)`      | Boolean-gated variant                                      |
+| `inList(expr, values)`    | `expr IN ('a', 'b')`                                       |
+| `inExprList(expr, exprs)` | Same for expression lists                                  |
+| `exists(sql)`             | `EXISTS (…)` from pre-compiled SQL                         |
+| `inSubquery(expr, sql)`   | `expr IN (…)` from pre-compiled SQL                        |
+| `outerRef<T>(name)`       | Reference an outer column in a correlated subquery         |
 
 `Expr<T>` methods: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in_`, `notIn`, `like`, `notLike`,
 `ilike` (string-only), and `add`, `sub`, `mul`, `div` (number-only, **no parentheses**).
@@ -114,14 +114,14 @@ Note `/sql` exports a `compile` (fragment → string) distinct from the root `co
 
 ## Extensibility
 
-| Export | Purpose |
-| --- | --- |
-| `defineFn<Args, R>(name)` | Declare a standard `fn(args…)` returning `Expr<R>` |
-| `defineCondFn<Args>(name)` | Same, returning `Condition` |
-| `compileFnCall<R>(name, ...args)` | Variadic/generic wrapper |
-| `compileFnCallCond(name, ...args)` | Same, returning `Condition` |
-| `makeExpr<T>(fragment)` | Build an `Expr` from a fragment |
-| `makeCond(fragment)` | Build a `Condition` from a fragment |
+| Export                             | Purpose                                            |
+| ---------------------------------- | -------------------------------------------------- |
+| `defineFn<Args, R>(name)`          | Declare a standard `fn(args…)` returning `Expr<R>` |
+| `defineCondFn<Args>(name)`         | Same, returning `Condition`                        |
+| `compileFnCall<R>(name, ...args)`  | Variadic/generic wrapper                           |
+| `compileFnCallCond(name, ...args)` | Same, returning `Condition`                        |
+| `makeExpr<T>(fragment)`            | Build an `Expr` from a fragment                    |
+| `makeCond(fragment)`               | Build a `Condition` from a fragment                |
 
 ---
 
@@ -131,7 +131,7 @@ Note `/sql` exports a `compile` (fragment → string) distinct from the root `co
 
 `count()`, `countIf(cond)`, `avg(e)`, `sum(e)`, `min(e)`, `max(e)`, `any(e)`, `uniq(e)`,
 `sumIf(e, cond)`, `avgIf(e, cond)`, `minIf(e, cond)`, `maxIf(e, cond)`, `anyIf(e, cond)`,
-`groupUniqArray(e)`, `argMaxMerge(e)`, `quantile(q)(e)` *(curried)*.
+`groupUniqArray(e)`, `argMaxMerge(e)`, `quantile(q)(e)` _(curried)_.
 
 `min`/`max` return `Expr<NonNullable<T>>`; `groupUniqArray` returns `Expr<ReadonlyArray<T>>`.
 
@@ -178,8 +178,8 @@ Note `/sql` exports a `compile` (fragment → string) distinct from the root `co
 ### Window
 
 `over(expr, spec)`, `windowSpec({ partitionBy?, orderBy?, frame? })`,
-`rowsBetween(start, end)`, `lagInFrame(expr, offset, defaultValue)` *(all three arguments
-required)*, and the frame bounds `currentRow`, `unboundedPreceding`, `unboundedFollowing`,
+`rowsBetween(start, end)`, `lagInFrame(expr, offset, defaultValue)` _(all three arguments
+required)_, and the frame bounds `currentRow`, `unboundedPreceding`, `unboundedFollowing`,
 `preceding(n)`, `following(n)`.
 
 ```ts
@@ -215,11 +215,11 @@ Both are Effect `Schema.TaggedErrorClass`es, catchable by tag.
 Tag `"@maple-dev/clickhouse-builder/QueryBuilderError"`. Thrown **synchronously** during
 compilation.
 
-| `code` | Cause |
-| --- | --- |
-| `SelectRequired` | Compiling a query with no `select()` |
-| `UnresolvedParam` | Calling a comparison on a param before compilation resolved it |
-| `InvalidOrderBySpec` | An `orderBy` entry that is not a `[column, direction]` tuple |
+| `code`               | Cause                                                          |
+| -------------------- | -------------------------------------------------------------- |
+| `SelectRequired`     | Compiling a query with no `select()`                           |
+| `UnresolvedParam`    | Calling a comparison on a param before compilation resolved it |
+| `InvalidOrderBySpec` | An `orderBy` entry that is not a `[column, direction]` tuple   |
 
 ### `CompiledQueryDecodeError`
 

--- a/lib/clickhouse-builder/docs/tenant-scoping.md
+++ b/lib/clickhouse-builder/docs/tenant-scoping.md
@@ -7,7 +7,7 @@ compiled.tenantScope // "org" | "cross-org"
 ```
 
 `"org"` means the query pins itself to a single tenant. `"cross-org"` means it reads whatever
-the credentials can see. The builder only *computes and reports* this — it never blocks a
+the credentials can see. The builder only _computes and reports_ this — it never blocks a
 query. The intended use is that your executor refuses `"cross-org"` on its ordinary read path,
 so a forgotten tenant filter fails loudly instead of quietly returning another tenant's rows.
 
@@ -28,7 +28,7 @@ CH.from(Events)
 // tenantScope: "org"
 ```
 
-*(Backed by `docs/tenant-scoping.md > An OrgId equality scopes the query`.)*
+_(Backed by `docs/tenant-scoping.md > An OrgId equality scopes the query`.)_
 
 ## The tenant column is `OrgId`, and that is hardcoded
 
@@ -49,21 +49,21 @@ field carries no signal for you. Conversely, a column named `OrgId` that is not 
 tenant key will mark queries as scoped when they are not. Know which case you are in before
 building an authorization decision on top of this.
 
-*(Backed by `docs/tenant-scoping.md > A column named anything else does not scope`.)*
+_(Backed by `docs/tenant-scoping.md > A column named anything else does not scope`.)_
 
 ## Only `eq` and `in_` count
 
 ```ts
-$.OrgId.eq("org_123")        // scopes
+$.OrgId.eq("org_123") // scopes
 $.OrgId.in_("org_a", "org_b") // scopes
-$.OrgId.neq("org_123")       // does NOT scope
-$.OrgId.like("org_%")        // does NOT scope
+$.OrgId.neq("org_123") // does NOT scope
+$.OrgId.like("org_%") // does NOT scope
 ```
 
 `!=` and `LIKE` on the tenant column narrow nothing meaningful, and treating them as scoping
 would be worse than useless.
 
-*(Backed by `docs/tenant-scoping.md > in_ also scopes; neq does not`.)*
+_(Backed by `docs/tenant-scoping.md > in_ also scopes; neq does not`.)\_
 
 ## The marker does not survive `and` / `or`
 
@@ -77,7 +77,7 @@ tenants. Composition drops the marker deliberately, and it applies to `.and()` t
 tenant predicates as their own top-level entry in the `where` array rather than folding them
 into a compound condition.
 
-*(Backed by `docs/tenant-scoping.md > The marker does not survive or()`.)*
+_(Backed by `docs/tenant-scoping.md > The marker does not survive or()`.)_
 
 ## Inherited scope
 
@@ -93,7 +93,7 @@ CH.fromQuery(inner, "sub").select(($) => ({ name: $.name }))
 ```
 
 For joins, **every** joined source must be scoped — one unscoped table drags the result to
-`"cross-org"`. A CTE contributes only if the query's `FROM` names it *and* it was declared with
+`"cross-org"`. A CTE contributes only if the query's `FROM` names it _and_ it was declared with
 `{ tenantScope: "org" }`; see [Unions and CTEs](./unions-and-ctes.md#declare-the-ctes-scope).
 
 ## `crossOrg()` — the explicit opt-out
@@ -111,7 +111,7 @@ else. The point is to distinguish "this query deliberately spans tenants" from "
 the filter" — two states that are otherwise identical from the outside. Use it for admin and
 internal-rollup queries so that reviewers, and your executor, can tell them apart.
 
-*(Backed by `docs/tenant-scoping.md > crossOrg() is the explicit opt-out`.)*
+_(Backed by `docs/tenant-scoping.md > crossOrg() is the explicit opt-out`.)_
 
 ## `routing("ingest")`
 
@@ -124,9 +124,11 @@ no SQL and means nothing on its own — it exists so a query definition can decl
 backend it must be read from, and an executor that understands the convention can honour it.
 If you have no such executor, ignore it.
 
-*(Backed by `docs/tenant-scoping.md > routing is carried onto the compiled query`.)*
+_(Backed by `docs/tenant-scoping.md > routing is carried onto the compiled query`.)_
 
 ## Handwritten SQL
 
 `unsafeCompiledQuery` requires `tenantScope` explicitly, since a raw string cannot be
-inspected. Whatever you pass is taken at face value.
+inspected. Whatever you pass is taken at face value — which is why it also requires a
+`reason` naming why the query isn't a builder query at all. See
+[Extending](./extending.md#handwritten-queries-unsafecompiledquery).

--- a/lib/clickhouse-builder/src/ch/compile.test.ts
+++ b/lib/clickhouse-builder/src/ch/compile.test.ts
@@ -25,6 +25,8 @@ describe("CompiledQuery.decodeRows", () => {
 	it.effect("decodes rows with the declared schema for handwritten SQL", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly name: string; readonly count: number }>({
+				reason: "test-fixture",
+				note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 				tenantScope: "org",
 				sql: "SELECT name, count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ name: Schema.String, count: RowNumber }),
@@ -39,6 +41,8 @@ describe("CompiledQuery.decodeRows", () => {
 	it.effect("fails with CompiledQueryDecodeError when a row does not match its schema", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+				reason: "test-fixture",
+				note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 				tenantScope: "org",
 				sql: "SELECT count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ count: RowNumber }),
@@ -60,6 +64,8 @@ describe("CompiledQuery.decodeFirstRow", () => {
 	it.effect("returns Some with the first decoded row", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly name: string; readonly count: number }>({
+				reason: "test-fixture",
+				note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 				tenantScope: "org",
 				sql: "SELECT name, count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ name: Schema.String, count: RowNumber }),
@@ -80,6 +86,8 @@ describe("CompiledQuery.decodeFirstRow", () => {
 	it.effect("returns None when the result set is empty", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+				reason: "test-fixture",
+				note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 				tenantScope: "org",
 				sql: "SELECT count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ count: RowNumber }),
@@ -94,6 +102,8 @@ describe("CompiledQuery.decodeFirstRow", () => {
 	it.effect("fails when the first row does not match the declared schema", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+				reason: "test-fixture",
+				note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 				tenantScope: "org",
 				sql: "SELECT count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ count: RowNumber }),
@@ -113,6 +123,8 @@ describe("CompiledQuery.decodeFirstRow", () => {
 	it.effect("does not decode later rows when only the first row is requested", () =>
 		Effect.gen(function* () {
 			const compiled = unsafeCompiledQuery<{ readonly count: number }>({
+				reason: "test-fixture",
+				note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 				tenantScope: "org",
 				sql: "SELECT count FROM events WHERE OrgId = 'org'",
 				rowSchema: Schema.Struct({ count: RowNumber }),
@@ -273,8 +285,13 @@ describe("CompiledQuery.tenantScope", () => {
 	})
 
 	it("requires handwritten SQL to state its scope", () => {
-		expect(unsafeCompiledQuery({ sql: "SELECT 1", tenantScope: "cross-org" }).tenantScope).toBe(
-			"cross-org",
-		)
+		expect(
+			unsafeCompiledQuery({
+				reason: "test-fixture",
+				note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
+				sql: "SELECT 1",
+				tenantScope: "cross-org",
+			}).tenantScope,
+		).toBe("cross-org")
 	})
 })

--- a/lib/clickhouse-builder/src/ch/compile.ts
+++ b/lib/clickhouse-builder/src/ch/compile.ts
@@ -161,17 +161,61 @@ const makeCompiledQuery = <Output>(
 }
 
 /**
- * Explicit constructor for SQL that cannot yet be expressed through the typed
- * DSL. Prefer `compile(CH.from(...))`; use this only for deliberately
- * handwritten ClickHouse SQL and pass `rowSchema` whenever possible.
+ * Why a query is handwritten SQL rather than a builder query.
  *
- * `tenantScope` is required and cannot be inferred here — there is no query AST
- * to inspect, only a string. Stating it is the point: a handwritten query that
- * forgets its tenant predicate should fail to compile until someone has looked.
+ * This union is the boundary between legitimate raw SQL and raw SQL nobody got
+ * round to converting — and adding a member is the review gate. It is a one-line
+ * diff in this file that a reviewer cannot miss, and it travels with the
+ * definition, so it survives file moves and copy-paste into new packages in a
+ * way a checked-in call-site list or a lint rule with an allowlist of paths
+ * does not.
+ *
+ * There is deliberately no `"legacy"` or `"todo"` member. With one, the gate is
+ * decorative.
+ */
+export type RawSqlReason =
+	/**
+	 * The SQL came from a user, so there is no AST to build. Isolation comes
+	 * from the credential layer and a separate validation pass, not from the
+	 * derived `tenantScope`.
+	 */
+	| "user-authored-sql"
+	/**
+	 * A constant zero-row result that reads no table (`SELECT … WHERE 0`). The
+	 * builder always emits a FROM, and naming a real table for a query designed
+	 * to touch none would be strictly worse.
+	 */
+	| "empty-result-stub"
+	/**
+	 * A `UNION ALL` of one builder compiled over two different parameter sets
+	 * (a current and a previous window, say). Params are substituted once,
+	 * across the whole query, at the end of `compileCH` — so a single `CHQuery`
+	 * cannot carry two of them, and `unionAll` cannot express this.
+	 *
+	 * Scope must still be *derived* from the compiled branches rather than
+	 * asserted; the branches are real compiled queries and each knows its own.
+	 */
+	| "param-varied-union"
+	/** A test asserting executor behaviour on synthetic SQL. */
+	| "test-fixture"
+
+/**
+ * Explicit constructor for SQL that cannot be expressed through the typed DSL.
+ *
+ * Prefer `compile(CH.from(...))`. `tenantScope` here is taken at face value —
+ * there is no query AST to inspect, only a string — which is exactly why this
+ * is the one place tenant scope can be *asserted* rather than derived, and why
+ * every use has to name a `reason` and justify itself in a `note`.
+ *
+ * DDL, migrations, and another engine's file formats don't reach this function
+ * at all; they never produce a `CompiledQuery`.
  */
 export const unsafeCompiledQuery = <Output>(args: {
 	readonly sql: string
 	readonly tenantScope: TenantScope
+	readonly reason: RawSqlReason
+	/** One sentence, at the call site, on why this instance qualifies. */
+	readonly note: string
 	readonly rowSchema?: CompiledQueryRowSchema<Output>
 	readonly routing?: "ingest"
 }): CompiledQuery<Output> => makeCompiledQuery(args.sql, args.tenantScope, args.rowSchema, args.routing)

--- a/lib/clickhouse-builder/src/ch/index.ts
+++ b/lib/clickhouse-builder/src/ch/index.ts
@@ -171,6 +171,7 @@ export {
 	compileCH as compile,
 	compileUnion,
 	unsafeCompiledQuery,
+	type RawSqlReason,
 	type CompiledQuery,
 	type CompiledQueryRowSchema,
 	type TenantScope,

--- a/lib/clickhouse-builder/src/docs-examples.test.ts
+++ b/lib/clickhouse-builder/src/docs-examples.test.ts
@@ -657,6 +657,8 @@ describe("docs/extending.md", () => {
 		Effect.gen(function* () {
 			const compiled = CH.unsafeCompiledQuery<{ readonly name: string }>({
 				sql: "SELECT Name AS name FROM events WHERE OrgId = 'org_123'",
+				reason: "user-authored-sql",
+				note: "The SQL came from a user; there is no AST to build.",
 				// Cannot be inferred from a raw string — the caller must assert it.
 				tenantScope: "org",
 				rowSchema: Schema.Struct({ name: Schema.String }),

--- a/packages/query-engine/src/ch/pipe-dispatch.ts
+++ b/packages/query-engine/src/ch/pipe-dispatch.ts
@@ -92,6 +92,8 @@ export function compilePipeQuery(
 				`UNION ALL\n` +
 				`SELECT 'previous' AS period, * FROM (\n${previous.sql}\n)\n` +
 				`FORMAT JSON`,
+			reason: "param-varied-union",
+			note: "One builder over a current and a previous window; params are substituted once per compile, so a single CHQuery cannot carry both.",
 			// Both branches are the same builder over different windows, so the
 			// union is scoped exactly when the branch is.
 			tenantScope:

--- a/packages/query-engine/src/ch/queries/activity.test.ts
+++ b/packages/query-engine/src/ch/queries/activity.test.ts
@@ -13,7 +13,8 @@ describe("active-org discovery queries", () => {
 		expect(sql).toContain("GROUP BY orgId")
 		// Cross-org: must NOT pin to a single org.
 		expect(sql).not.toContain("OrgId =")
-		// Required by WarehouseQueryService.sqlQuery's `sql.includes("OrgId")` guard.
+		// Deliberately cross-org: the executor refuses these on the ordinary read
+		// path, so they must go through `crossOrgQuery`.
 		expect(sql).toContain("OrgId")
 	})
 

--- a/packages/query-engine/src/ch/queries/service-infra.ts
+++ b/packages/query-engine/src/ch/queries/service-infra.ts
@@ -84,6 +84,8 @@ export function serviceWorkloadsSQL(
 		// in for a scoped call whose service list was empty.
 		return unsafeCompiledQuery({
 			sql: EMPTY_WORKLOADS_SQL,
+			reason: "empty-result-stub",
+			note: "SELECT of literals with WHERE 0 and no FROM; the builder always emits a FROM, and naming a table this reads no rows from would be worse.",
 			tenantScope: "org",
 			rowSchema: ServiceWorkloadsOutputSchema,
 		})

--- a/packages/query-engine/src/execution/executor.test.ts
+++ b/packages/query-engine/src/execution/executor.test.ts
@@ -65,10 +65,18 @@ const compiled = compile(listRuleChecksQuery({ limit: 1 }), {
 // The old `sqlQuery(tenant, sql)` entry point took a raw string; scope now
 // travels on the compiled query, so these execution/span/retry tests wrap their
 // SQL in a compiled value that declares it.
-const scoped = (sql: string) => unsafeCompiledQuery<Record<string, unknown>>({ sql, tenantScope: "org" })
+const scoped = (sql: string) =>
+	unsafeCompiledQuery<Record<string, unknown>>({
+		sql,
+		tenantScope: "org",
+		reason: "test-fixture",
+		note: "Synthetic SQL asserting executor behaviour, not a product query.",
+	})
 
 // A plain query with no routing declaration follows the default read route.
 const untaggedCompiled = unsafeCompiledQuery<{ readonly c: number }>({
+	reason: "test-fixture",
+	note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 	sql: "SELECT count() AS c FROM traces WHERE OrgId = 'org_test'\nFORMAT JSON",
 	tenantScope: "org",
 })
@@ -209,6 +217,8 @@ describe("makeWarehouseExecutor span instrumentation", () => {
 					tenant,
 					() =>
 						unsafeCompiledQuery<{ readonly c: number }>({
+							reason: "test-fixture",
+							note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 							sql: "SELECT count() AS c FROM logs WHERE OrgId = 'org_test' FORMAT JSON",
 							tenantScope: "org",
 						}),
@@ -321,6 +331,8 @@ describe("makeWarehouseExecutor compiled-query defaults", () => {
 					}),
 			}
 			const withSchema = unsafeCompiledQuery<{ readonly c: number }>({
+				reason: "test-fixture",
+				note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 				sql: "SELECT count() AS c FROM traces WHERE OrgId = 'org_test'\nFORMAT JSON",
 				tenantScope: "org",
 				rowSchema: Schema.Struct({ c: Schema.Number }),
@@ -438,6 +450,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 
 			const factory = (capabilities: WarehouseCapabilities) =>
 				unsafeCompiledQuery<{ readonly c: number }>({
+					reason: "test-fixture",
+					note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 					sql: `SELECT count() AS c FROM logs WHERE OrgId = 'org_test' AND '${logBodySearchMode(capabilities)}' = 'text' FORMAT JSON`,
 					tenantScope: "org",
 				})
@@ -492,6 +506,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 					tenant,
 					() =>
 						unsafeCompiledQuery<{ readonly c: number }>({
+							reason: "test-fixture",
+							note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 							sql: "SELECT count() AS c FROM logs WHERE OrgId = 'org_test' FORMAT JSON",
 							tenantScope: "org",
 						}),
@@ -536,6 +552,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 				tenant,
 				(capabilities) =>
 					unsafeCompiledQuery<{ readonly c: number }>({
+						reason: "test-fixture",
+						note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 						sql: `SELECT count() AS c FROM logs WHERE OrgId = 'org_test' AND '${logBodySearchMode(capabilities)}' = 'scan' FORMAT JSON`,
 						tenantScope: "org",
 					}),
@@ -587,6 +605,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 				tenant,
 				(capabilities) =>
 					unsafeCompiledQuery<{ readonly c: number }>({
+						reason: "test-fixture",
+						note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 						sql: `SELECT count() AS c FROM logs WHERE OrgId = 'org_test' AND '${logBodySearchMode(capabilities)}' = 'scan' FORMAT JSON`,
 						tenantScope: "org",
 					}),
@@ -629,6 +649,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 						tenant,
 						(capabilities) =>
 							unsafeCompiledQuery<{ readonly c: number }>({
+								reason: "test-fixture",
+								note: "Synthetic SQL asserting executor/compile behaviour, not a product query.",
 								sql: `SELECT count() AS c FROM logs WHERE OrgId = 'org_test' AND '${logBodySearchMode(capabilities)}' = 'scan' FORMAT JSON`,
 								tenantScope: "org",
 							}),

--- a/packages/query-engine/src/profiles/query-profile.ts
+++ b/packages/query-engine/src/profiles/query-profile.ts
@@ -55,7 +55,7 @@ export type QueryProfileName =
 
 /**
  * The shared profile/settings selector carried by every warehouse query path
- * (the `WarehouseExecutor` interface, `WarehouseQueryService.sqlQuery`, and the
+ * (the `WarehouseExecutor` interface, `WarehouseQueryService.compiledQuery`, and the
  * CLI executors). Profile defaults are overridden by explicit `settings`.
  */
 export type WarehouseQueryOptions = {


### PR DESCRIPTION
**Stack 3/3** · base: [#332](https://github.com/MapleTechLabs/maple/pull/332)

### Why

`unsafeCompiledQuery` is the one place tenant scope is *asserted* rather than derived — so it is the one place a query that forgot its `OrgId` filter can claim to be scoped and pass the executor's gate. With every product query converted (PR 2), this closes the door behind them.

It now requires a `RawSqlReason` and a one-sentence `note`. **The union is the boundary:**

| reason | when |
| --- | --- |
| `"user-authored-sql"` | came from a user; there is no AST to build |
| `"empty-result-stub"` | a constant zero-row result reading no table |
| `"param-varied-union"` | one builder over two parameter sets; params substitute once per compile, so one `CHQuery` cannot carry both |
| `"test-fixture"` | synthetic SQL asserting executor behaviour |

Adding a member is the review gate — a one-line diff in `compile.ts` a reviewer cannot miss, travelling with the definition so it survives file moves and copy-paste into new packages.

### Why this over the alternatives

- **A checked-in call-site list** is a second copy of the truth, and this repo has already taught everyone that golden files get regenerated with `-u` (`sql-catalog.baseline.test.ts` says so in its own header). "Add your line to the list" is a step people take without thinking; a type error at the definition site is not.
- **An oxlint `no-restricted-syntax` rule** is defeated by an inline disable comment and has to encode allowed *paths* — brittle across the monorepo, and it structurally could never have caught the two raw builders that lived in `packages/query-engine-integrations`.
- **`EXEMPT_BUILDERS`** guards *fixture coverage*, not raw SQL, and lives in `packages/query-engine`. Same blind spot.

There is deliberately **no `"legacy"` or `"todo"` member**. With one, the gate is decorative.

### What survives, and why

Two product call sites, both justified at the call site:

- `pipe-dispatch.ts` — a current-vs-previous window union. Scope is still *derived* from the compiled branches, not asserted.
- `service-infra.ts`'s `EMPTY_WORKLOADS_SQL` — `SELECT … WHERE 0` with **no FROM**. The builder always emits a FROM; naming a real table for a query designed to touch none would be strictly worse.

Everything else people think of as "raw SQL" — DDL, migrations, Tinybird `.datasource` files, chDB/local mode, DO SQLite — never produces a `CompiledQuery` at all, so it doesn't reach this function. That boundary is documented in exactly one place: the `RawSqlReason` doc comments. A separate policy doc would rot.

### Also

Fixes docs across `CLAUDE.md`, the telemetry-conventions skill and `.deepsec/INFO.md` that still described `WarehouseQueryService.sqlQuery()` — an entry point deleted some time ago.

### Verification

`bun run typecheck` is the real test here: the compile errors enumerate every remaining raw-SQL site, which is itself the deliverable. builder 141 ✓ · query-engine 949 ✓ · integrations 119 ✓ · api + cli typecheck clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788432224&installation_model_id=427786&pr_number=333&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F333&signature=083ded6499e59359f8dc7e0072a27da1b403be4e38ccef17c492d807c5ed0118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->