### PR TITLE
perf(warehouse): resolve org route once per bucket-cache fan-out

### DIFF
--- a/apps/api/src/routes/v2/v2-test-support.ts
+++ b/apps/api/src/routes/v2/v2-test-support.ts
@@ -151,6 +151,9 @@ export const WarehouseServiceStubLayer = Layer.succeed(WarehouseQueryService, {
 	compiledQueryBounded: die,
 	compiledQueryWithCapabilities: die,
 	compiledQueryFirst: die,
+	// Not `die`: warming is best-effort and silent by contract, so a stub that
+	// throws would fail a path that only tried to warm up.
+	warmRoute: () => Effect.void,
 	ingest: die,
 	asExecutor: dieSync,
 })

--- a/apps/api/src/services/warehouse/QueryEngineCacheHitRate.test.ts
+++ b/apps/api/src/services/warehouse/QueryEngineCacheHitRate.test.ts
@@ -127,6 +127,9 @@ const makeStub = (counter: { n: number }): WarehouseQueryServiceShape =>
 			counter.n += 1
 			return compiled.decodeFirstRow(ROWS).pipe(Effect.orDie)
 		},
+		// Deliberately does not touch `counter`: warming resolves route config, it
+		// does not issue a warehouse query, and these tests assert query counts.
+		warmRoute: () => Effect.void,
 		ingest: () => Effect.void,
 		sql: () => Promise.resolve({ data: [] }),
 	}) as unknown as WarehouseQueryServiceShape

--- a/apps/api/src/services/warehouse/QueryEngineEvaluateCache.test.ts
+++ b/apps/api/src/services/warehouse/QueryEngineEvaluateCache.test.ts
@@ -300,6 +300,9 @@ const makeFullStub = (
 			counter.n += 1
 			return compiled.decodeFirstRow(rows).pipe(Effect.orDie)
 		},
+		// Deliberately does not touch `counter`: warming resolves route config, it
+		// does not issue a warehouse query, and these tests assert query counts.
+		warmRoute: () => Effect.void,
 		ingest: () => Effect.void,
 		sql: () => Promise.resolve({ data: [] }),
 	}) as unknown as WarehouseQueryServiceShape

--- a/apps/api/src/services/warehouse/QueryEngineService.ts
+++ b/apps/api/src/services/warehouse/QueryEngineService.ts
@@ -196,6 +196,14 @@ export class QueryEngineService extends Context.Service<QueryEngineService, Quer
 								response.result.kind === "timeseries" ? response.result.data : [],
 							),
 						),
+					// Resolve this org's warehouse route once before the fill fans
+					// out. Without it each branch resolves it independently and they
+					// all miss the in-isolate memo, because they start together:
+					// measured in prod as the same config read running twice
+					// concurrently at 2.90s each, against warehouse queries of 428ms
+					// and 1179ms. The bucket cache only runs this on a >1-range fill,
+					// so cache hits and single-range fills are unaffected.
+					warehouse.warmRoute(tenant),
 				)
 
 				yield* Metric.update(QueryEngineMetrics.bucketCacheBucketsHit, outcome.bucketsHit)

--- a/packages/query-engine/src/caching/bucket-cache.ts
+++ b/packages/query-engine/src/caching/bucket-cache.ts
@@ -382,6 +382,25 @@ export interface BucketCacheServiceShape {
 	readonly getOrComputeBuckets: <E, R>(
 		request: BucketCacheRequest,
 		computeRange: (range: TimeRange) => Effect.Effect<ReadonlyArray<TimeseriesPoint>, E, R>,
+		/**
+		 * Optional warm-up run once before a multi-range fill fans out.
+		 *
+		 * Each `computeRange` branch resolves the tenant's warehouse route on its
+		 * own, and that resolution reads per-org config from Postgres (~2.9s
+		 * cold). Started together, every branch misses the in-isolate memo and
+		 * pays it: one prod trace resolved the identical config twice
+		 * concurrently at 2.90s each while the queries being prepared for took
+		 * 428ms and 1179ms. Running this first collapses that to one lookup.
+		 *
+		 * Deliberately NOT part of `BucketCacheRequest` — that object is
+		 * canonicalized into the cache-key fingerprint, and an Effect in it would
+		 * poison the key.
+		 *
+		 * Skipped when the fill is 0 or 1 ranges: with none there is nothing to
+		 * prepare, and with one the warm-up would move the same cost rather than
+		 * remove it, while adding a sequential step to a pure cache hit.
+		 */
+		prepare?: Effect.Effect<void>,
 	) => Effect.Effect<BucketCacheOutcome, E, R>
 }
 
@@ -431,6 +450,7 @@ export class BucketCacheService extends Context.Service<BucketCacheService, Buck
 			const getOrComputeBuckets = Effect.fn("BucketCacheService.getOrComputeBuckets")(function* <E, R>(
 				request: BucketCacheRequest,
 				computeRange: (range: TimeRange) => Effect.Effect<ReadonlyArray<TimeseriesPoint>, E, R>,
+				prepare?: Effect.Effect<void>,
 			) {
 				const bucketMs = request.bucketSeconds * 1000
 				const segmentMs = bucketMs * segmentBucketCount
@@ -536,6 +556,12 @@ export class BucketCacheService extends Context.Service<BucketCacheService, Buck
 						fluxBoundaryMs,
 					)
 					const fillRanges = coalesceMissingRanges(missing)
+					// One warm-up before the fan-out, not one route resolution per
+					// branch. See `prepare` on BucketCacheServiceShape for the trace
+					// this came from. Only worth it above one range — see the doc there.
+					if (prepare !== undefined && fillRanges.length > 1) {
+						yield* prepare
+					}
 					const freshByRange = yield* Effect.forEach(
 						fillRanges,
 						(item) => computeRange(item.range),

--- a/packages/query-engine/src/execution/executor.ts
+++ b/packages/query-engine/src/execution/executor.ts
@@ -1006,6 +1006,17 @@ WHERE name = 'enable_full_text_index'`,
 		compiledQueryWithCapabilities,
 		compiledQueryFirst: (tenant, compiled, options) =>
 			unbounded(compiledQueryFirst(tenant, compiled, withoutResponseLimits(options))),
+		// `resolveCapabilities` resolves the route on its way through, so warming
+		// it warms both. `ignore` keeps a failed warm-up invisible — the real
+		// query behind it fails with its own context a moment later.
+		warmRoute: (tenant, options) =>
+			resolveCapabilities(tenant, options).pipe(
+				Effect.asVoid,
+				Effect.ignore,
+				Effect.withSpan("WarehouseQueryService.warmRoute", {
+					attributes: { orgId: tenant.orgId },
+				}),
+			),
 		ingest,
 		asExecutor,
 	} satisfies WarehouseQueryServiceShape

--- a/packages/query-engine/src/execution/ports.ts
+++ b/packages/query-engine/src/execution/ports.ts
@@ -144,6 +144,24 @@ export interface WarehouseQueryServiceShape {
 		compiled: CompiledQuery<T> | ((capabilities: WarehouseCapabilities) => CompiledQuery<T>),
 		options?: SqlQueryOptions,
 	) => Effect.Effect<Option.Option<T>, WarehouseSqlError | WarehouseValidationError>
+	/**
+	 * Resolve this tenant's route and capabilities once, so a fan-out that
+	 * follows finds them memoized instead of each branch deriving them itself.
+	 *
+	 * Exists because route resolution reads per-org ClickHouse config from
+	 * Postgres, and that read has been measured at ~2.9s cold. A fan-out that
+	 * starts every branch at once has every branch miss the in-isolate memo:
+	 * one prod trace of a single dashboard panel resolved the identical config
+	 * twice concurrently at 2.90s each, while the two warehouse queries the
+	 * fan-out existed to run took 428ms and 1179ms. The lookup cost more than
+	 * double the work it was preparing for.
+	 *
+	 * Cheap and idempotent on a warm memo, so callers may invoke it
+	 * unconditionally. Errors are swallowed: this is a warm-up, and the real
+	 * query behind it reports failures with proper context. Never let this
+	 * change the error semantics of the path it precedes.
+	 */
+	readonly warmRoute: (tenant: ExecutionTenant, options?: SqlQueryOptions) => Effect.Effect<void>
 	readonly ingest: <T>(
 		tenant: ExecutionTenant,
 		datasource: string,


### PR DESCRIPTION
## What

`BucketCacheService.getOrComputeBuckets` fans out `computeRange` at `fillConcurrency`, and **every branch independently resolved the same org warehouse route** — including the Postgres read behind it. This resolves it once before the fan-out instead.

## Why

Found in prod trace `625a0740fffa7fbeecdcf2c03bcda4ea` — a 5.21s dashboard panel:

```
POST /api/query-engine/execute ......................... 4.17s
└─ BucketCacheService.readOrCompute .................... 4.17s
   ├─ EdgeCache.rawGetDetailed ........................ 40ms   (miss)
   ├─ QueryEngineService.execute ...................... 3.37s  ┐ two fill branches,
   │  ├─ resolveRoute → SELECT org_clickhouse_settings  2.90s  │ started together
   │  └─ executeSql  (the actual query) ............... 428ms  │
   └─ QueryEngineService.execute ...................... 4.13s  │
      ├─ resolveRoute → SELECT org_clickhouse_settings  2.90s  │ ← identical lookup
      └─ executeSql  (the actual query) .............. 1179ms  ┘
```

The identical config lookup ran twice, concurrently, at 2.90s each — more than double the cost of the two warehouse queries it was preparing for.

All branches start before any finishes, so all of them miss the 300s `runtimeConfigMemo`. It's a thundering herd *inside a single request*. The "no single-flight" rule in `EdgeCacheService` is about **cross-request** sharing (Cloudflare ties I/O objects to the request that created them) — it never applied within one request.

Supporting measurements across 2 days of prod traces:

| layer | n | p50 | p95 |
|---|---|---|---|
| `WarehouseQueryService.executeSql` (actual SQL) | 4343 | **192ms** | 3437ms |
| `SELECT org_clickhouse_settings` (maple-api) | 398 | **2322ms** | 4507ms |
| `SELECT org_ingest_keys` (same DB, same driver) | 3261 | 15ms | 26ms |

The queries are not the bottleneck; the metadata lookup beside them is.

## How

- **`warmRoute`** added to `WarehouseQueryServiceShape` — resolves route + capabilities once. `Effect.ignore`d, so a failed warm-up can never change the error semantics of the path it precedes; the real query behind it still reports failures with proper context.
- **`prepare`** — optional third arg to `getOrComputeBuckets`, run **only when `fillRanges.length > 1`**. With zero ranges there's nothing to prepare; with one, the warm-up would move the cost rather than remove it while adding a sequential step to what may be a pure cache hit.

## Reviewer notes

- `prepare` is a **separate parameter, not a field on `BucketCacheRequest`** — that object is canonicalized into the cache-key fingerprint, so an Effect in it would poison the key.
- The three warehouse test doubles used `as unknown as WarehouseQueryServiceShape`. The cast hid the missing method from `tsc`; only the runtime caught it. Worth knowing those stubs don't type-check against the real shape.
- Their `warmRoute` stubs **deliberately don't touch the call counters** — warming resolves config, it doesn't issue a warehouse query, and those tests assert query counts.
- Warehouse queries are still fanned out in parallel; only the route resolution is serialized ahead of them.

## Testing

- `bun run --cwd packages/query-engine typecheck` + `test` — 989 pass
- `bun run --cwd apps/api typecheck`
- `bunx vitest run src/services/warehouse/` — 130 pass, 126 skipped (ClickHouse e2e, needs `ch:up`)

**Not yet verified in prod.** After deploy, confirm `resolveRuntimeConfig` appears once per request rather than once per fill branch.

## Follow-ups (not in this PR)

- `executeQueryBuilder` runs `QueryEngineService.execute` at concurrency 4 and almost certainly has the same duplicate-resolution shape.
- The 2.9s itself is still unexplained — a primary-key lookup on a table in the same AWS region should be ~5ms. This removes one of two; the remaining one is still 2.9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788473920&installation_model_id=427786&pr_number=343&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F343&signature=453573c67a8de73aedeb72309aca003621f241e4f04ab3001ea942371c4ed8fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->