### PR TITLE
fix(web): scope warehouse atom cache keys by org

### DIFF
--- a/apps/api/src/routes/queries.ts
+++ b/apps/api/src/routes/queries.ts
@@ -3,6 +3,7 @@ import * as Integrations from "@maple/query-engine-integrations"
 import { defineQuery } from "@maple/query-engine/registry"
 import { Queries as Core } from "@maple/query-engine/registry"
 import type {
+	CloudflareInfraZoneBreakdownRequest,
 	HostInfraTimeseriesRequest,
 	CloudflareInfraZoneFacetsRequest,
 	CloudflareInfraZoneDetailRequest,
@@ -514,6 +515,90 @@ const hostInfraGaugeTimeseries = defineQuery({
 	},
 })
 
+// --- cloudflareInfraZoneBreakdown: three parallel, then one dependent -----
+
+const zoneBreakdownParams = (payload: CloudflareInfraZoneBreakdownRequest, orgId: string) => ({
+	orgId,
+	serviceName: payload.serviceName,
+	startTime: payload.startTime,
+	endTime: payload.endTime,
+})
+
+const cloudflareInfraZoneBreakdownTotals = defineQuery({
+	id: "cloudflareInfraZoneBreakdownTotals",
+	profile: "aggregation",
+	cache: undefined,
+	compile: (payload: CloudflareInfraZoneBreakdownRequest, orgId: string) =>
+		CH.compile(
+			Integrations.cloudflareZoneBreakdownTotalsSQL(
+				payload.dimension,
+				toCloudflareFilters(payload),
+				payload.limit ?? 100,
+			),
+			zoneBreakdownParams(payload, orgId),
+			{ rowSchema: Integrations.cloudflareZoneBreakdownTotalsRowSchema },
+		),
+})
+
+/**
+ * Coverage is deliberately UNFILTERED: it answers "what did the poller collect
+ * here", which the UI needs in order to say "not collected yet" rather than "no
+ * traffic" for a window that predates the dataset. Do not thread filters in.
+ */
+const cloudflareInfraZoneBreakdownCoverage = defineQuery({
+	id: "cloudflareInfraZoneBreakdownCoverage",
+	profile: "aggregation",
+	cache: undefined,
+	compile: (payload: CloudflareInfraZoneBreakdownRequest, orgId: string) =>
+		CH.compile(
+			Integrations.cloudflareZoneBreakdownCoverageSQL(payload.dimension),
+			zoneBreakdownParams(payload, orgId),
+			{ rowSchema: Integrations.cloudflareZoneBreakdownCoverageRowSchema },
+		),
+})
+
+const cloudflareInfraZoneBreakdownZoneTotal = defineQuery({
+	id: "cloudflareInfraZoneBreakdownZoneTotal",
+	profile: "aggregation",
+	cache: undefined,
+	compile: (payload: CloudflareInfraZoneBreakdownRequest, orgId: string) =>
+		CH.compile(
+			Integrations.cloudflareZoneCountersSQL(toCloudflareFilters(payload)),
+			zoneBreakdownParams(payload, orgId),
+			{ rowSchema: Integrations.cloudflareZoneCountersRowSchema },
+		),
+})
+
+/**
+ * The chart runs AFTER the totals rather than beside them: totals are already
+ * ranked by requests, so they name the series worth plotting. Without that the
+ * grouping is unbounded — a zone taking scanner traffic returns a distinct path
+ * per probe, and the response grows to buckets x thousands of keys. One extra
+ * round trip over the same warm scan buys a payload that can't blow up.
+ *
+ * `topKeys` therefore rides in the PAYLOAD rather than being derived inside
+ * `compile`: it is the output of a previous query, which a def has no way to
+ * see. The caller must also skip this entirely when `topKeys` is empty.
+ */
+const cloudflareInfraZoneBreakdownTimeseries = defineQuery({
+	id: "cloudflareInfraZoneBreakdownTimeseries",
+	profile: "aggregation",
+	cache: undefined,
+	compile: (
+		payload: CloudflareInfraZoneBreakdownRequest & { readonly topKeys: ReadonlyArray<string> },
+		orgId: string,
+	) =>
+		CH.compile(
+			Integrations.cloudflareZoneBreakdownTimeseriesSQL(
+				payload.dimension,
+				toCloudflareFilters(payload),
+				payload.topKeys,
+			),
+			{ ...zoneBreakdownParams(payload, orgId), bucketSeconds: payload.bucketSeconds },
+			{ rowSchema: Integrations.cloudflareZoneBreakdownTimeseriesRowSchema },
+		),
+})
+
 export const Queries = {
 	...Core,
 
@@ -698,4 +783,8 @@ export const Queries = {
 	cloudflareInfraZoneFacets,
 	hostInfraNetworkTimeseries,
 	hostInfraGaugeTimeseries,
+	cloudflareInfraZoneBreakdownTotals,
+	cloudflareInfraZoneBreakdownCoverage,
+	cloudflareInfraZoneBreakdownZoneTotal,
+	cloudflareInfraZoneBreakdownTimeseries,
 } as const

--- a/apps/api/src/routes/queries.ts
+++ b/apps/api/src/routes/queries.ts
@@ -3,6 +3,7 @@ import * as Integrations from "@maple/query-engine-integrations"
 import { defineQuery } from "@maple/query-engine/registry"
 import { Queries as Core } from "@maple/query-engine/registry"
 import type {
+	HostInfraTimeseriesRequest,
 	CloudflareInfraZoneFacetsRequest,
 	CloudflareInfraZoneDetailRequest,
 	ServicePlanetScaleStatsRequest,
@@ -24,6 +25,7 @@ import type {
 	WorkloadInfraTimeseriesRequest,
 } from "@maple/domain/http"
 import {
+	hostMetricSpec,
 	nodeMetricSpec,
 	partitionWindowAround,
 	podMetricSpec,
@@ -469,6 +471,49 @@ const cloudflareInfraZoneFacets = defineQuery({
 		}),
 })
 
+// --- hostInfraTimeseries: two query families behind one endpoint ----------
+//
+// Network reads a counter family, everything else a gauge family, so they are
+// separate defs rather than one def with a branch — the row shapes differ and
+// the handler maps them differently. Both keep the id "hostInfraTimeseries",
+// which is what their spans already report; renaming would break continuity of
+// existing telemetry for no gain.
+
+const hostInfraNetworkTimeseries = defineQuery({
+	id: "hostInfraTimeseries",
+	profile: "aggregation",
+	cache: undefined,
+	compile: (payload: HostInfraTimeseriesRequest, orgId: string) =>
+		CH.compile(CH.hostNetworkTimeseriesQuery({ hostName: payload.hostName }), {
+			orgId,
+			startTime: payload.startTime,
+			endTime: payload.endTime,
+			bucketSeconds: payload.bucketSeconds ?? 60,
+		}),
+})
+
+const hostInfraGaugeTimeseries = defineQuery({
+	id: "hostInfraTimeseries",
+	profile: "aggregation",
+	cache: undefined,
+	compile: (payload: HostInfraTimeseriesRequest, orgId: string) => {
+		const spec = hostMetricSpec(payload.metric)
+		return CH.compile(
+			CH.hostGaugeTimeseriesQuery({
+				hostName: payload.hostName,
+				metricName: spec.metricName,
+				groupByAttributeKey: spec.groupByAttributeKey,
+			}),
+			{
+				orgId,
+				startTime: payload.startTime,
+				endTime: payload.endTime,
+				bucketSeconds: payload.bucketSeconds ?? 60,
+			},
+		)
+	},
+})
+
 export const Queries = {
 	...Core,
 
@@ -651,4 +696,6 @@ export const Queries = {
 	planetscaleServiceConnections,
 	planetscaleServiceStorage,
 	cloudflareInfraZoneFacets,
+	hostInfraNetworkTimeseries,
+	hostInfraGaugeTimeseries,
 } as const

--- a/apps/api/src/routes/query-helpers.ts
+++ b/apps/api/src/routes/query-helpers.ts
@@ -1,6 +1,7 @@
 import * as Integrations from "@maple/query-engine-integrations"
 import { formatWarehouseDateTime, parseWarehouseDateTime } from "@maple/query-engine"
 import type {
+	HostInfraTimeseriesRequest,
 	NodeInfraTimeseriesRequest,
 	PodInfraTimeseriesRequest,
 	WorkloadInfraTimeseriesRequest,
@@ -108,6 +109,53 @@ export const workloadMetricSpec = (metric: WorkloadInfraTimeseriesRequest["metri
 			return {
 				metricName: "k8s.pod.memory_limit_utilization",
 				unit: "percent" as const,
+			}
+	}
+}
+
+/**
+ * Metric name, grouping key, unit and query-family flag for a host metric.
+ *
+ * Shared like the pod/node/workload specs: the registry needs `metricName` and
+ * `isNetwork` to build the query, the handler needs `unit` and
+ * `groupByAttributeKey` for its response.
+ */
+export const hostMetricSpec = (metric: HostInfraTimeseriesRequest["metric"]) => {
+	switch (metric) {
+		case "cpu":
+			return {
+				metricName: "system.cpu.utilization",
+				groupByAttributeKey: "state",
+				unit: "percent" as const,
+				isNetwork: false,
+			}
+		case "memory":
+			return {
+				metricName: "system.memory.utilization",
+				groupByAttributeKey: "state",
+				unit: "percent" as const,
+				isNetwork: false,
+			}
+		case "filesystem":
+			return {
+				metricName: "system.filesystem.utilization",
+				groupByAttributeKey: "mountpoint",
+				unit: "percent" as const,
+				isNetwork: false,
+			}
+		case "load15":
+			return {
+				metricName: "system.cpu.load_average.15m",
+				groupByAttributeKey: undefined,
+				unit: "load" as const,
+				isNetwork: false,
+			}
+		case "network":
+			return {
+				metricName: "system.network.io",
+				groupByAttributeKey: "direction",
+				unit: "bytes_per_second" as const,
+				isNetwork: true,
 			}
 	}
 }

--- a/apps/api/src/routes/query-runner.ts
+++ b/apps/api/src/routes/query-runner.ts
@@ -2,8 +2,8 @@ import type { QueryDef } from "@maple/query-engine/registry"
 import type { QueryEngineDirectError } from "@maple/query-engine/runtime"
 import { Clock, Effect, Option } from "effect"
 import type { TenantContext } from "@/services/auth/AuthService"
-import { QueryEngineService } from "@/services/warehouse/QueryEngineService"
-import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
+import type { QueryEngineServiceShape } from "@/services/warehouse/QueryEngineService"
+import type { WarehouseQueryServiceShape } from "@/services/warehouse/WarehouseQueryService"
 
 /**
  * Execute registry-declared warehouse queries.
@@ -15,72 +15,81 @@ import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryServic
  *
  * Handlers keep their own row-to-response mapping. What they lose is the
  * plumbing, not the presentation.
+ *
+ * The services are taken as VALUES, not read from context, and the runners are
+ * built once per handler group. That is load-bearing rather than stylistic:
+ * `QueryEngineService.cachedDirect` accepts an `Effect` with no requirements, so
+ * a context-reading runner could never be composed inside a cache wrapper —
+ * which `spanHierarchy` needs, since its probe must only fire on a cache miss.
+ * Currying here keeps every call site written as `runQuery(def, tenant, payload)`
+ * while the effects it returns carry `R = never`.
  */
-
-/**
- * Settings may be static or payload-dependent. Resolved to a spread so an
- * absent/undefined result omits the key entirely rather than passing an
- * explicit `settings: undefined`, which would read as "clear the profile
- * defaults" downstream.
- */
-const resolveSettings = <Payload, Row>(def: QueryDef<Payload, Row>, payload: Payload) => {
-	const settings = typeof def.settings === "function" ? def.settings(payload) : def.settings
-	return settings === undefined ? {} : { settings }
+export interface QueryRunnerDeps {
+	readonly warehouse: WarehouseQueryServiceShape
+	readonly queryEngine: QueryEngineServiceShape
 }
 
-/**
- * Shared tail: annotate failures with the query id, then apply the declared
- * cache policy (or don't). `cachedDirect` wraps the whole execution so a hit
- * skips the warehouse entirely, and it takes the raw payload as key input —
- * it snaps timestamps and sorts set-valued keys itself, which is why the
- * payload goes in unnormalized.
- */
-const withPolicy = <Payload, Row, A, E extends QueryEngineDirectError>(
-	def: QueryDef<Payload, Row>,
-	tenant: TenantContext,
-	payload: Payload,
-	execute: Effect.Effect<A, E>,
-) =>
-	Effect.gen(function* () {
-		const queryEngine = yield* QueryEngineService
-		// Only read the clock when a def actually needs it — a static policy must
-		// not pay for, or depend on, a Clock read.
-		const cache =
-			typeof def.cache === "function"
-				? def.cache(payload, yield* Clock.currentTimeMillis)
-				: def.cache
-		const labelled = execute.pipe(
-			// Same annotation the old inline `mapExecError` produced, with the label
-			// derived from `def.id` rather than a hand-written string that could
-			// disagree with the span context beside it.
-			Effect.tapError(() =>
-				Effect.annotateCurrentSpan({
-					"maple.query_engine.failed_step": `${def.id} query failed`,
-				}),
-			),
-		)
-		if (cache === undefined) {
-			return yield* labelled
-		}
-		return yield* queryEngine.cachedDirect(tenant, def.id, payload, labelled, cache)
-	})
+export const makeQueryRunners = ({ warehouse, queryEngine }: QueryRunnerDeps) => {
+	/**
+	 * Settings may be static or payload-dependent. Resolved to a spread so an
+	 * absent result omits the key entirely rather than passing an explicit
+	 * `settings: undefined`, which would read as "clear the profile defaults".
+	 */
+	const resolveSettings = <Payload, Row>(def: QueryDef<Payload, Row>, payload: Payload) => {
+		const settings = typeof def.settings === "function" ? def.settings(payload) : def.settings
+		return settings === undefined ? {} : { settings }
+	}
 
-/**
- * Run a `QueryDef` that returns many rows.
- *
- * Rows-vs-first-row is a call-site concern rather than a field on the def: the
- * same compiled query legitimately supports both, and `compiledQueryFirst`
- * takes the identical `CompiledQuery`. Putting it in the def would only let a
- * caller disagree with it.
- */
-export const runQuery = <Payload, Row>(
-	def: QueryDef<Payload, Row>,
-	tenant: TenantContext,
-	payload: Payload,
-) =>
-	Effect.gen(function* () {
-		const warehouse = yield* WarehouseQueryService
-		return yield* withPolicy(
+	/**
+	 * Annotate failures with the query id, then apply the declared cache policy
+	 * (or don't). `cachedDirect` wraps the whole execution so a hit skips the
+	 * warehouse entirely, and it takes the raw payload as key input — it snaps
+	 * timestamps and sorts set-valued keys itself, which is why the payload goes
+	 * in unnormalized.
+	 */
+	const withPolicy = <Payload, Row, A, E extends QueryEngineDirectError>(
+		def: QueryDef<Payload, Row>,
+		tenant: TenantContext,
+		payload: Payload,
+		execute: Effect.Effect<A, E>,
+	) =>
+		Effect.gen(function* () {
+			// Only read the clock when a def actually needs it — a static policy
+			// must not pay for, or depend on, a Clock read.
+			const cache =
+				typeof def.cache === "function"
+					? def.cache(payload, yield* Clock.currentTimeMillis)
+					: def.cache
+			const labelled = execute.pipe(
+				// Same annotation the old inline `mapExecError` produced, with the
+				// label derived from `def.id` rather than a hand-written string that
+				// could disagree with the span context beside it.
+				Effect.tapError(() =>
+					Effect.annotateCurrentSpan({
+						"maple.query_engine.failed_step": `${def.id} query failed`,
+					}),
+				),
+			)
+			if (cache === undefined) {
+				return yield* labelled
+			}
+			return yield* queryEngine.cachedDirect(tenant, def.id, payload, labelled, cache)
+		})
+
+	/**
+	 * Run a `QueryDef` that returns many rows.
+	 *
+	 * Rows-vs-first-row is a call-site concern rather than a field on the def:
+	 * the same compiled query legitimately supports both, and
+	 * `compiledQueryFirst` takes the identical `CompiledQuery`. Putting it in the
+	 * def would only let a caller disagree with it.
+	 */
+	const runQuery = <Payload, Row>(
+		def: QueryDef<Payload, Row>,
+		tenant: TenantContext,
+		payload: Payload,
+	) =>
+		withPolicy(
 			def,
 			tenant,
 			payload,
@@ -90,22 +99,19 @@ export const runQuery = <Payload, Row>(
 				context: def.id,
 			}),
 		)
-	})
 
-/**
- * Run a `QueryDef` that returns at most one row, as `Row | null`.
- *
- * Null rather than `Option` because every current caller immediately does
- * `Option.getOrNull` to build a nullable response field.
- */
-export const runQueryFirst = <Payload, Row>(
-	def: QueryDef<Payload, Row>,
-	tenant: TenantContext,
-	payload: Payload,
-) =>
-	Effect.gen(function* () {
-		const warehouse = yield* WarehouseQueryService
-		return yield* withPolicy(
+	/**
+	 * Run a `QueryDef` that returns at most one row, as `Row | null`.
+	 *
+	 * Null rather than `Option` because every current caller immediately does
+	 * `Option.getOrNull` to build a nullable response field.
+	 */
+	const runQueryFirst = <Payload, Row>(
+		def: QueryDef<Payload, Row>,
+		tenant: TenantContext,
+		payload: Payload,
+	) =>
+		withPolicy(
 			def,
 			tenant,
 			payload,
@@ -117,4 +123,6 @@ export const runQueryFirst = <Payload, Row>(
 				})
 				.pipe(Effect.map(Option.getOrNull)),
 		)
-	})
+
+	return { runQuery, runQueryFirst } as const
+}

--- a/apps/api/src/routes/v1/query-engine.http.ts
+++ b/apps/api/src/routes/v1/query-engine.http.ts
@@ -152,6 +152,16 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 	Effect.gen(function* () {
 		const queryEngine = yield* QueryEngineService
 		const warehouse = yield* WarehouseQueryService
+
+		// `cachedDirect` takes an Effect with no requirements, but `runQuery` reads
+		// its services from context. Supplying the ones already bound above lets a
+		// registry query run INSIDE a cache wrapper — needed by spanHierarchy,
+		// where the probe must only fire on an outer cache miss.
+		const withDeps = <A, E>(effect: Effect.Effect<A, E, WarehouseQueryService | QueryEngineService>) =>
+			effect.pipe(
+				Effect.provideService(WarehouseQueryService, warehouse),
+				Effect.provideService(QueryEngineService, queryEngine),
+			)
 		const serviceOperationsRollupEnabled = yield* Config.boolean(
 			"SERVICE_OPERATIONS_ROLLUP_ENABLED",
 		).pipe(Config.withDefault(false))
@@ -182,65 +192,33 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 						// shared link, AI link), resolve one via a cheap LIMIT-1 probe and
 						// derive a ±1h window so the main query can prune. The probe itself
 						// tries the recent window first (see PROBE_RECENT_WINDOW_MS).
-						Effect.gen(function* () {
-							let startTime = payload.startTime
-							let endTime = payload.endTime
-							if (startTime == null || endTime == null) {
-								const runProbe = (narrowByTime: boolean) =>
-									mapExecError(
-										warehouse
-											.compiledQueryFirst(
-												tenant,
-												CH.compile(
-													CH.traceTimeProbeQuery({
-														traceId: payload.traceId,
-														narrowByTime,
-													}),
-													narrowByTime
-														? {
-																orgId: tenant.orgId,
-																startTime: formatWarehouseDateTime(
-																	nowMs - PROBE_RECENT_WINDOW_MS,
-																),
-															}
-														: { orgId: tenant.orgId },
-												),
-												{
-													profile: "discovery",
-													context: narrowByTime
-														? "spanHierarchyProbeRecent"
-														: "spanHierarchyProbe",
-												},
-											)
-											.pipe(Effect.map(Option.getOrNull)),
-										"spanHierarchy probe failed",
-									)
-								const probe = (yield* runProbe(true)) ?? (yield* runProbe(false))
-								if (probe?.timestamp != null) {
-									const window = partitionWindowAround(probe.timestamp)
-									startTime = window.startTime
-									endTime = window.endTime
+						withDeps(
+							Effect.gen(function* () {
+								let startTime = payload.startTime
+								let endTime = payload.endTime
+								if (startTime == null || endTime == null) {
+									const probe =
+										(yield* runQueryFirst(Queries.spanHierarchyProbeRecent, tenant, {
+											traceId: payload.traceId,
+											startTime: formatWarehouseDateTime(
+												nowMs - PROBE_RECENT_WINDOW_MS,
+											),
+										})) ??
+										(yield* runQueryFirst(Queries.spanHierarchyProbe, tenant, payload))
+									if (probe?.timestamp != null) {
+										const window = partitionWindowAround(probe.timestamp)
+										startTime = window.startTime
+										endTime = window.endTime
+									}
 								}
-							}
-							const narrowByTime = startTime != null && endTime != null
-							const compiled = CH.compile(
-								CH.spanHierarchyQuery({
+								return yield* runQuery(Queries.spanHierarchy, tenant, {
 									traceId: payload.traceId,
 									spanId: payload.spanId,
-									narrowByTime,
-								}),
-								narrowByTime
-									? { orgId: tenant.orgId, startTime, endTime }
-									: { orgId: tenant.orgId },
-							)
-							return yield* mapExecError(
-								warehouse.compiledQuery(tenant, compiled, {
-									profile: "list",
-									context: "spanHierarchy",
-								}),
-								"spanHierarchy query failed",
-							)
-						}),
+									startTime,
+									endTime,
+								})
+							}),
+						),
 						traceCacheTtlSeconds(payload.endTime, nowMs),
 					)
 					const typedRows = rows.map((row) => ({

--- a/apps/api/src/routes/v1/query-engine.http.ts
+++ b/apps/api/src/routes/v1/query-engine.http.ts
@@ -516,23 +516,6 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 			.handle("planetscaleInfraTimeseries", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					const base = {
-						orgId: tenant.orgId,
-						startTime: payload.startTime,
-						endTime: payload.endTime,
-						bucketSeconds: Math.max(60, Math.floor(payload.bucketSeconds)),
-						database: payload.database,
-					}
-					const compiled =
-						payload.branch === undefined
-							? CH.compile(Integrations.planetscaleInfraTimeseriesSQL(), base, {
-									rowSchema: Integrations.planetscaleInfraTimeseriesRowSchema,
-								})
-							: CH.compile(
-									Integrations.planetscaleBranchInfraTimeseriesSQL(),
-									{ ...base, branch: payload.branch },
-									{ rowSchema: Integrations.planetscaleInfraTimeseriesRowSchema },
-								)
 					const rows = yield* runQuery(Queries.planetscaleInfraTimeseries, tenant, payload)
 					return new PlanetScaleInfraTimeseriesResponse({ data: rows.map((row) => ({ ...row })) })
 				}),
@@ -684,70 +667,14 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
 					const filters = toCloudflareFilters(payload)
-					const params = {
-						orgId: tenant.orgId,
-						serviceName: payload.serviceName,
-						startTime: payload.startTime,
-						endTime: payload.endTime,
-					}
-					const totalsCompiled = CH.compile(
-						Integrations.cloudflareZoneBreakdownTotalsSQL(
-							payload.dimension,
-							filters,
-							payload.limit ?? 100,
-						),
-						params,
-						{ rowSchema: Integrations.cloudflareZoneBreakdownTotalsRowSchema },
-					)
-					// Coverage is deliberately unfiltered: it answers "what did the poller collect
-					// here", which the UI needs in order to say "not collected yet" rather than
-					// "no traffic" for a window that predates the dataset.
-					const coverageCompiled = CH.compile(
-						Integrations.cloudflareZoneBreakdownCoverageSQL(payload.dimension),
-						params,
-						{ rowSchema: Integrations.cloudflareZoneBreakdownCoverageRowSchema },
-					)
-					const zoneTotalCompiled = CH.compile(
-						Integrations.cloudflareZoneCountersSQL(filters),
-						params,
-						{
-							rowSchema: Integrations.cloudflareZoneCountersRowSchema,
-						},
-					)
 					const [totalRows, coverageRows, zoneRows] = yield* Effect.all(
 						[
-							mapExecError(
-								warehouse.compiledQuery(tenant, totalsCompiled, {
-									profile: "aggregation",
-									context: "cloudflareInfraZoneBreakdownTotals",
-								}),
-								"cloudflareInfraZoneBreakdownTotals query failed",
-							),
-							mapExecError(
-								warehouse.compiledQuery(tenant, coverageCompiled, {
-									profile: "aggregation",
-									context: "cloudflareInfraZoneBreakdownCoverage",
-								}),
-								"cloudflareInfraZoneBreakdownCoverage query failed",
-							),
-							mapExecError(
-								warehouse.compiledQuery(tenant, zoneTotalCompiled, {
-									profile: "aggregation",
-									context: "cloudflareInfraZoneBreakdownZoneTotal",
-								}),
-								"cloudflareInfraZoneBreakdownZoneTotal query failed",
-							),
+							runQuery(Queries.cloudflareInfraZoneBreakdownTotals, tenant, payload),
+							runQuery(Queries.cloudflareInfraZoneBreakdownCoverage, tenant, payload),
+							runQuery(Queries.cloudflareInfraZoneBreakdownZoneTotal, tenant, payload),
 						],
 						{ concurrency: 3 },
 					)
-					// The chart runs after the totals rather than beside them: totals are already
-					// ranked by requests, so they name the series worth plotting. Without that the
-					// grouping is unbounded — a zone taking scanner traffic returns a distinct path
-					// per probe, and the response grows to buckets × thousands of keys. One extra
-					// round trip over the same warm scan buys a payload that can't blow up.
-					// The poller's own tail bucket is dropped from the picks, not plotted as a peer —
-					// it means the same thing as the fold, so it merges into it and leaves the slot
-					// for a real key.
 					const topKeys = totalRows
 						.filter((row) => row.key !== Integrations.CLOUDFLARE_BREAKDOWN_OTHER_KEY)
 						.slice(0, Integrations.CLOUDFLARE_BREAKDOWN_SERIES_LIMIT)
@@ -755,28 +682,10 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 					const bucketRows: ReadonlyArray<Integrations.CloudflareZoneBreakdownTimeseriesOutput> =
 						topKeys.length === 0
 							? []
-							: yield* mapExecError(
-									warehouse.compiledQuery(
-										tenant,
-										CH.compile(
-											Integrations.cloudflareZoneBreakdownTimeseriesSQL(
-												payload.dimension,
-												filters,
-												topKeys,
-											),
-											{ ...params, bucketSeconds: payload.bucketSeconds },
-											{
-												rowSchema:
-													Integrations.cloudflareZoneBreakdownTimeseriesRowSchema,
-											},
-										),
-										{
-											profile: "aggregation",
-											context: "cloudflareInfraZoneBreakdownTimeseries",
-										},
-									),
-									"cloudflareInfraZoneBreakdownTimeseries query failed",
-								)
+							: yield* runQuery(Queries.cloudflareInfraZoneBreakdownTimeseries, tenant, {
+									...payload,
+									topKeys,
+								})
 					const coverage = coverageRows[0]
 					const zoneRequests = zoneRows.find((row) => row.serviceName === payload.serviceName)
 					// Breakdown metrics are a per-window top-N fold of what Cloudflare returned, so
@@ -1106,11 +1015,6 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 						"serviceOperations",
 						payload,
 						Effect.gen(function* () {
-							const params = {
-								orgId: tenant.orgId,
-								startTime: payload.startTime,
-								endTime: payload.endTime,
-							}
 							yield* Effect.annotateCurrentSpan(
 								"query.rollup.enabled",
 								serviceOperationsRollupEnabled,
@@ -1118,50 +1022,27 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 							// The rollout flag stays off until migration 0008 is deployed,
 							// backfilled, and parity-checked. Disabling it restores the all-raw
 							// rollback path without changing the endpoint contract.
-							const summaryOptions = {
-								serviceName: payload.serviceName,
-								environments: payload.environments,
-								limit: payload.limit,
-							}
 							const runRawSummary = () =>
-								warehouse.compiledQuery(
-									tenant,
-									CH.compile(CH.serviceOperationsSummaryRawQuery(summaryOptions), params, {
-										rowSchema: CH.serviceOperationsSummaryRowSchema,
-									}),
-									{ profile: "aggregation", context: "serviceOperations" },
-								)
+								runQuery(Queries.serviceOperationsSummaryRaw, tenant, payload)
 							let useRollup = serviceOperationsRollupEnabled
 							const summaryEffect = useRollup
-								? warehouse
-										.compiledQuery(
-											tenant,
-											CH.compile(
-												CH.serviceOperationsSummaryQuery(summaryOptions),
-												params,
-												{
-													rowSchema: CH.serviceOperationsSummaryRowSchema,
-												},
-											),
-											{ profile: "aggregation", context: "serviceOperations" },
-										)
-										.pipe(
-											Effect.catch((error) => {
-												if (!isMissingServiceOperationsRollup(error))
-													return Effect.fail(error)
-												useRollup = false
-												return Effect.gen(function* () {
-													yield* Effect.logWarning(
-														"Service operations rollup is unavailable; using raw rollback path",
-													).pipe(Effect.annotateLogs({ orgId: tenant.orgId }))
-													yield* Effect.annotateCurrentSpan(
-														"query.rollup.fallback",
-														true,
-													)
-													return yield* runRawSummary()
-												})
-											}),
-										)
+								? runQuery(Queries.serviceOperationsSummary, tenant, payload).pipe(
+										Effect.catch((error) => {
+											if (!isMissingServiceOperationsRollup(error))
+												return Effect.fail(error)
+											useRollup = false
+											return Effect.gen(function* () {
+												yield* Effect.logWarning(
+													"Service operations rollup is unavailable; using raw rollback path",
+												).pipe(Effect.annotateLogs({ orgId: tenant.orgId }))
+												yield* Effect.annotateCurrentSpan(
+													"query.rollup.fallback",
+													true,
+												)
+												return yield* runRawSummary()
+											})
+										}),
+									)
 								: runRawSummary()
 							const summaryRows = yield* mapExecError(
 								summaryEffect,
@@ -1182,50 +1063,23 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 							)
 							const requestedBucketSeconds = payload.bucketSeconds ?? windowSeconds / 50
 							const bucketSeconds = Math.max(1, Math.round(requestedBucketSeconds / 60)) * 60
-							const timeseriesOptions = {
-								serviceName: payload.serviceName,
-								environments: payload.environments,
-								spanNames,
-								bucketSeconds,
-							}
-							const timeseriesParams = { ...params, bucketSeconds }
+							const timeseriesInput = { ...payload, spanNames, bucketSeconds }
 							const runRawTimeseries = () =>
-								warehouse.compiledQuery(
-									tenant,
-									CH.compile(
-										CH.serviceOperationsTimeseriesRawQuery(timeseriesOptions),
-										timeseriesParams,
-										{ rowSchema: CH.serviceOperationsTimeseriesRowSchema },
-									),
-									{ profile: "aggregation", context: "serviceOperationsTimeseries" },
-								)
+								runQuery(Queries.serviceOperationsTimeseriesRaw, tenant, timeseriesInput)
 							const timeseriesEffect = useRollup
-								? warehouse
-										.compiledQuery(
-											tenant,
-											CH.compile(
-												CH.serviceOperationsTimeseriesQuery(timeseriesOptions),
-												timeseriesParams,
-												{ rowSchema: CH.serviceOperationsTimeseriesRowSchema },
-											),
-											{
-												profile: "aggregation",
-												context: "serviceOperationsTimeseries",
-											},
-										)
-										.pipe(
-											Effect.catch((error) =>
-												isMissingServiceOperationsRollup(error)
-													? Effect.gen(function* () {
-															yield* Effect.annotateCurrentSpan(
-																"query.rollup.fallback",
-																true,
-															)
-															return yield* runRawTimeseries()
-														})
-													: Effect.fail(error),
-											),
-										)
+								? runQuery(Queries.serviceOperationsTimeseries, tenant, timeseriesInput).pipe(
+										Effect.catch((error) =>
+											isMissingServiceOperationsRollup(error)
+												? Effect.gen(function* () {
+														yield* Effect.annotateCurrentSpan(
+															"query.rollup.fallback",
+															true,
+														)
+														return yield* runRawTimeseries()
+													})
+												: Effect.fail(error),
+										),
+									)
 								: runRawTimeseries()
 							const timeseriesRows = yield* mapExecError(
 								timeseriesEffect,

--- a/apps/api/src/routes/v1/query-engine.http.ts
+++ b/apps/api/src/routes/v1/query-engine.http.ts
@@ -84,6 +84,7 @@ import {
 } from "@maple/query-engine"
 import { LOGS_BODY_SEARCH_SETTINGS } from "@maple/query-engine/profiles"
 import {
+	hostMetricSpec,
 	nodeMetricSpec,
 	partitionWindowAround,
 	podMetricSpec,
@@ -1501,66 +1502,12 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 					const tenant = yield* CurrentTenant.Context
 					const bucketSeconds = payload.bucketSeconds ?? 60
 
-					const spec = (() => {
-						switch (payload.metric) {
-							case "cpu":
-								return {
-									metricName: "system.cpu.utilization",
-									groupByAttributeKey: "state",
-									unit: "percent" as const,
-									isNetwork: false,
-								}
-							case "memory":
-								return {
-									metricName: "system.memory.utilization",
-									groupByAttributeKey: "state",
-									unit: "percent" as const,
-									isNetwork: false,
-								}
-							case "filesystem":
-								return {
-									metricName: "system.filesystem.utilization",
-									groupByAttributeKey: "mountpoint",
-									unit: "percent" as const,
-									isNetwork: false,
-								}
-							case "load15":
-								return {
-									metricName: "system.cpu.load_average.15m",
-									groupByAttributeKey: undefined,
-									unit: "load" as const,
-									isNetwork: false,
-								}
-							case "network":
-								return {
-									metricName: "system.network.io",
-									groupByAttributeKey: "direction",
-									unit: "bytes_per_second" as const,
-									isNetwork: true,
-								}
-						}
-					})()
+					const spec = hostMetricSpec(payload.metric)
 
 					if (spec.isNetwork) {
-						const compiled = CH.compile(
-							CH.hostNetworkTimeseriesQuery({ hostName: payload.hostName }),
-							{
-								orgId: tenant.orgId,
-								startTime: payload.startTime,
-								endTime: payload.endTime,
-								bucketSeconds,
-							},
-						)
-						const rows = yield* mapExecError(
-							warehouse.compiledQuery(tenant, compiled, {
-								profile: "aggregation",
-								context: "hostInfraTimeseries",
-							}),
-							"hostInfraTimeseries (network) query failed",
-						)
-						const typedRows = rows
+						const rows = yield* runQuery(Queries.hostInfraNetworkTimeseries, tenant, payload)
 						return new HostInfraTimeseriesResponse({
-							data: typedRows.map((row) => ({
+							data: rows.map((row) => ({
 								bucket: String(row.bucket),
 								attributeValue: String(row.attributeValue ?? ""),
 								value: Number(row.sumValue) || 0,
@@ -1570,29 +1517,9 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 						})
 					}
 
-					const compiled = CH.compile(
-						CH.hostGaugeTimeseriesQuery({
-							hostName: payload.hostName,
-							metricName: spec.metricName,
-							groupByAttributeKey: spec.groupByAttributeKey,
-						}),
-						{
-							orgId: tenant.orgId,
-							startTime: payload.startTime,
-							endTime: payload.endTime,
-							bucketSeconds,
-						},
-					)
-					const rows = yield* mapExecError(
-						warehouse.compiledQuery(tenant, compiled, {
-							profile: "aggregation",
-							context: "hostInfraTimeseries",
-						}),
-						"hostInfraTimeseries query failed",
-					)
-					const typedRows = rows
+					const rows = yield* runQuery(Queries.hostInfraGaugeTimeseries, tenant, payload)
 					return new HostInfraTimeseriesResponse({
-						data: typedRows.map((row) => ({
+						data: rows.map((row) => ({
 							bucket: String(row.bucket),
 							attributeValue: String(row.attributeValue ?? ""),
 							value: Number(row.avgValue) || 0,

--- a/apps/api/src/routes/v1/query-engine.http.ts
+++ b/apps/api/src/routes/v1/query-engine.http.ts
@@ -91,7 +91,7 @@ import {
 	workloadMetricSpec,
 } from "@/routes/query-helpers"
 import { Queries } from "@/routes/queries"
-import { runQuery, runQueryFirst } from "@/routes/query-runner"
+import { makeQueryRunners } from "@/routes/query-runner"
 import type { ExecutionTenant, WarehouseSqlError } from "@maple/query-engine/execution"
 import { buildBreakdownQuerySpec, buildTimeseriesQuerySpec } from "@maple/query-engine/query-builder"
 import * as Integrations from "@maple/query-engine-integrations"
@@ -152,16 +152,8 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 	Effect.gen(function* () {
 		const queryEngine = yield* QueryEngineService
 		const warehouse = yield* WarehouseQueryService
+		const { runQuery, runQueryFirst } = makeQueryRunners({ warehouse, queryEngine })
 
-		// `cachedDirect` takes an Effect with no requirements, but `runQuery` reads
-		// its services from context. Supplying the ones already bound above lets a
-		// registry query run INSIDE a cache wrapper — needed by spanHierarchy,
-		// where the probe must only fire on an outer cache miss.
-		const withDeps = <A, E>(effect: Effect.Effect<A, E, WarehouseQueryService | QueryEngineService>) =>
-			effect.pipe(
-				Effect.provideService(WarehouseQueryService, warehouse),
-				Effect.provideService(QueryEngineService, queryEngine),
-			)
 		const serviceOperationsRollupEnabled = yield* Config.boolean(
 			"SERVICE_OPERATIONS_ROLLUP_ENABLED",
 		).pipe(Config.withDefault(false))
@@ -192,33 +184,28 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 						// shared link, AI link), resolve one via a cheap LIMIT-1 probe and
 						// derive a ±1h window so the main query can prune. The probe itself
 						// tries the recent window first (see PROBE_RECENT_WINDOW_MS).
-						withDeps(
-							Effect.gen(function* () {
-								let startTime = payload.startTime
-								let endTime = payload.endTime
-								if (startTime == null || endTime == null) {
-									const probe =
-										(yield* runQueryFirst(Queries.spanHierarchyProbeRecent, tenant, {
-											traceId: payload.traceId,
-											startTime: formatWarehouseDateTime(
-												nowMs - PROBE_RECENT_WINDOW_MS,
-											),
-										})) ??
-										(yield* runQueryFirst(Queries.spanHierarchyProbe, tenant, payload))
-									if (probe?.timestamp != null) {
-										const window = partitionWindowAround(probe.timestamp)
-										startTime = window.startTime
-										endTime = window.endTime
-									}
+						Effect.gen(function* () {
+							let startTime = payload.startTime
+							let endTime = payload.endTime
+							if (startTime == null || endTime == null) {
+								const probe =
+									(yield* runQueryFirst(Queries.spanHierarchyProbeRecent, tenant, {
+										traceId: payload.traceId,
+										startTime: formatWarehouseDateTime(nowMs - PROBE_RECENT_WINDOW_MS),
+									})) ?? (yield* runQueryFirst(Queries.spanHierarchyProbe, tenant, payload))
+								if (probe?.timestamp != null) {
+									const window = partitionWindowAround(probe.timestamp)
+									startTime = window.startTime
+									endTime = window.endTime
 								}
-								return yield* runQuery(Queries.spanHierarchy, tenant, {
-									traceId: payload.traceId,
-									spanId: payload.spanId,
-									startTime,
-									endTime,
-								})
-							}),
-						),
+							}
+							return yield* runQuery(Queries.spanHierarchy, tenant, {
+								traceId: payload.traceId,
+								spanId: payload.spanId,
+								startTime,
+								endTime,
+							})
+						}),
 						traceCacheTtlSeconds(payload.endTime, nowMs),
 					)
 					const typedRows = rows.map((row) => ({

--- a/apps/web/src/hooks/use-widget-data.ts
+++ b/apps/web/src/hooks/use-widget-data.ts
@@ -23,7 +23,8 @@ export type WidgetDataSourceLike = {
 import { disabledResultAtom } from "@/lib/services/atoms/disabled-result-atom"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import type { WidgetDataState } from "@/components/dashboard-builder/types"
-import { encodeKey } from "@/lib/cache-key"
+import { encodeKey, encodeOrgScopedKey, orgScopedKeyPayload } from "@/lib/cache-key"
+import { getActiveOrgId } from "@/lib/services/common/auth-headers"
 import { formatBackendError } from "@/lib/error-messages"
 import { Cause, Option } from "effect"
 import { WarehouseDecodeError, type BackendError } from "@/api/warehouse/effect-utils"
@@ -318,8 +319,9 @@ const toWidgetDataAtomError = (error: unknown): WidgetFetchError => {
 const fetchWidgetData = Effect.fnUntraced(
 	function* (key: string) {
 		const parsed = yield* Effect.try({
+			// The key is org-scoped; only the payload after the separator is JSON.
 			try: () =>
-				JSON.parse(key) as {
+				JSON.parse(orgScopedKeyPayload(key)) as {
 					endpoint: string
 					params: Record<string, unknown>
 				},
@@ -355,7 +357,7 @@ const widgetFetchFamily = Atom.family((key: string) =>
 )
 
 const widgetFetchAtom = (input: { endpoint: string; params: Record<string, unknown> }) =>
-	widgetFetchFamily(encodeKey(input))
+	widgetFetchFamily(encodeOrgScopedKey(getActiveOrgId(), input))
 
 /**
  * Fetches and transforms data for a single data source. Powers both whole

--- a/apps/web/src/lib/cache-key.ts
+++ b/apps/web/src/lib/cache-key.ts
@@ -26,3 +26,31 @@ export function encodeKey(value: unknown): string {
 	const normalized = normalizeForKey(value)
 	return JSON.stringify(normalized === undefined ? null : normalized)
 }
+
+/**
+ * Separator between the active org and the encoded input in an atom family key.
+ *
+ * Atom keys used to carry only filters and time range. The org rode along
+ * invisibly in the auth header, so switching orgs left every cached entry
+ * addressable by the new org: the UI re-rendered the previous org's rows until
+ * the idle TTL expired — up to 30 minutes on some atoms. Electric collections
+ * never had this bug because their ids already embed the org.
+ *
+ * The org is prefixed rather than folded into the encoded object because atoms
+ * decode the key back into the query input; an extra field there would travel
+ * to the server as part of the request payload.
+ *
+ * NUL cannot occur in `encodeKey` output (it is JSON) or in a Clerk org id, so
+ * the first occurrence always marks the boundary.
+ */
+const ORG_KEY_SEPARATOR = "\u0000"
+
+/** Build an org-scoped atom family key. */
+export function encodeOrgScopedKey(orgId: string | null | undefined, value: unknown): string {
+	return `${orgId ?? ""}${ORG_KEY_SEPARATOR}${encodeKey(value)}`
+}
+
+/** Recover just the encoded input from a key built by `encodeOrgScopedKey`. */
+export function orgScopedKeyPayload(key: string): string {
+	return key.slice(key.indexOf(ORG_KEY_SEPARATOR) + 1)
+}

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
@@ -1,6 +1,7 @@
 import { Atom } from "@/lib/effect-atom"
 import { Effect, Schema } from "effect"
-import { encodeKey } from "@/lib/cache-key"
+import { encodeOrgScopedKey, orgScopedKeyPayload } from "@/lib/cache-key"
+import { getActiveOrgId } from "@/lib/services/common/auth-headers"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import type { BackendError, WarehouseApiError } from "@/api/warehouse/effect-utils"
 import {
@@ -161,7 +162,7 @@ function makeQueryAtomFamily<Input, Output>(query: QueryEffect<Input, Output>, o
 		// shipped). The inner query spans already export by re-providing this same
 		// (memoized) layer; this lifts the parent onto the same tracer.
 		let resultAtom = MapleApiAtomClient.runtime.atom(
-			Schema.decodeUnknownEffect(UnknownFromJson)(key).pipe(
+			Schema.decodeUnknownEffect(UnknownFromJson)(orgScopedKeyPayload(key)).pipe(
 				Effect.flatMap((input) => query(input as Input)),
 				Effect.mapError(toQueryAtomError),
 			),
@@ -174,7 +175,7 @@ function makeQueryAtomFamily<Input, Output>(query: QueryEffect<Input, Output>, o
 		return resultAtom
 	})
 
-	return (input: Input) => family(encodeKey(input))
+	return (input: Input) => family(encodeOrgScopedKey(getActiveOrgId(), input))
 }
 
 export const getServiceUsageResultAtom = makeQueryAtomFamily(getServiceUsage, {

--- a/packages/query-engine/src/registry/queries.ts
+++ b/packages/query-engine/src/registry/queries.ts
@@ -1,4 +1,5 @@
 import type {
+	ServiceOperationsRequest,
 	ListPodsRequest,
 	NodeFacetsRequest,
 	PodFacetsRequest,
@@ -808,4 +809,97 @@ export const spanHierarchy = defineQuery({
 			narrowByTime ? { orgId, startTime: payload.startTime, endTime: payload.endTime } : { orgId },
 		)
 	},
+})
+
+// --- serviceOperations: rollup and raw variants ---------------------------
+//
+// Four defs, two logical queries. Each has a rollup form and a raw form, and
+// the CHOICE between them stays in the handler because it is policy, not query
+// construction: a feature flag selects the rollup, and a typed
+// `isMissingServiceOperationsRollup` error falls back to raw at runtime,
+// flipping a flag that the timeseries query then honors too.
+//
+// Rollup/raw pairs share an id, matching the context their spans already
+// report — the fallback is recorded separately as `query.rollup.fallback`.
+//
+// All four are `cache: undefined`; the handler wraps the whole sequence in one
+// `cachedDirect`.
+
+const serviceOperationsSummaryOptions = (payload: ServiceOperationsRequest) => ({
+	serviceName: payload.serviceName,
+	environments: payload.environments,
+	limit: payload.limit,
+})
+
+const serviceOperationsParams = (payload: ServiceOperationsRequest, orgId: string) => ({
+	orgId,
+	startTime: payload.startTime,
+	endTime: payload.endTime,
+})
+
+export const serviceOperationsSummary = defineQuery({
+	id: "serviceOperations",
+	profile: "aggregation",
+	cache: undefined,
+	compile: (payload: ServiceOperationsRequest, orgId: string) =>
+		CH.compile(
+			CH.serviceOperationsSummaryQuery(serviceOperationsSummaryOptions(payload)),
+			serviceOperationsParams(payload, orgId),
+			{ rowSchema: CH.serviceOperationsSummaryRowSchema },
+		),
+})
+
+/** Rollback path, used when the rollup table is absent or the flag is off. */
+export const serviceOperationsSummaryRaw = defineQuery({
+	id: "serviceOperations",
+	profile: "aggregation",
+	cache: undefined,
+	compile: (payload: ServiceOperationsRequest, orgId: string) =>
+		CH.compile(
+			CH.serviceOperationsSummaryRawQuery(serviceOperationsSummaryOptions(payload)),
+			serviceOperationsParams(payload, orgId),
+			{ rowSchema: CH.serviceOperationsSummaryRowSchema },
+		),
+})
+
+/**
+ * `spanNames` and `bucketSeconds` ride in the payload: both are derived from the
+ * summary rows and the requested window, so `compile` cannot see them. The
+ * rollup is minute-grain, which is why the caller rounds the bucket to a whole
+ * minute before passing it here.
+ */
+type ServiceOperationsTimeseriesInput = ServiceOperationsRequest & {
+	readonly spanNames: ReadonlyArray<string>
+	readonly bucketSeconds: number
+}
+
+const serviceOperationsTimeseriesOptions = (payload: ServiceOperationsTimeseriesInput) => ({
+	serviceName: payload.serviceName,
+	environments: payload.environments,
+	spanNames: payload.spanNames,
+	bucketSeconds: payload.bucketSeconds,
+})
+
+export const serviceOperationsTimeseries = defineQuery({
+	id: "serviceOperationsTimeseries",
+	profile: "aggregation",
+	cache: undefined,
+	compile: (payload: ServiceOperationsTimeseriesInput, orgId: string) =>
+		CH.compile(
+			CH.serviceOperationsTimeseriesQuery(serviceOperationsTimeseriesOptions(payload)),
+			{ ...serviceOperationsParams(payload, orgId), bucketSeconds: payload.bucketSeconds },
+			{ rowSchema: CH.serviceOperationsTimeseriesRowSchema },
+		),
+})
+
+export const serviceOperationsTimeseriesRaw = defineQuery({
+	id: "serviceOperationsTimeseries",
+	profile: "aggregation",
+	cache: undefined,
+	compile: (payload: ServiceOperationsTimeseriesInput, orgId: string) =>
+		CH.compile(
+			CH.serviceOperationsTimeseriesRawQuery(serviceOperationsTimeseriesOptions(payload)),
+			{ ...serviceOperationsParams(payload, orgId), bucketSeconds: payload.bucketSeconds },
+			{ rowSchema: CH.serviceOperationsTimeseriesRowSchema },
+		),
 })

--- a/packages/query-engine/src/registry/queries.ts
+++ b/packages/query-engine/src/registry/queries.ts
@@ -749,3 +749,63 @@ export const listPodsCount = defineQuery({
 			{ rowSchema: CH.ListPodsSummaryOutputSchema },
 		),
 })
+
+// --- spanHierarchy: probe, then the pruned hierarchy read -----------------
+//
+// `trace_detail_spans` is partitioned by toDate(Timestamp); without a time
+// predicate the hierarchy query seeks every daily partition (~30) — p95 ~8.8s
+// vs ~2.3s when pruned to one. When the caller has no timestamp (direct URL,
+// shared link, AI link) a cheap LIMIT-1 probe resolves one.
+//
+// All three carry `cache: undefined` ON PURPOSE. The handler wraps the whole
+// probe-then-read sequence in a single `cachedDirect`, so the probe only fires
+// on an outer cache miss. Caching them individually would run the probe on
+// every request and cache a result nobody asked for.
+
+/** Probe restricted to the recent window — tries ~2 daily partitions first. */
+export const spanHierarchyProbeRecent = defineQuery({
+	id: "spanHierarchyProbeRecent",
+	profile: "discovery",
+	cache: undefined,
+	compile: (payload: { readonly traceId: string; readonly startTime: string }, orgId: string) =>
+		CH.compile(CH.traceTimeProbeQuery({ traceId: payload.traceId, narrowByTime: true }), {
+			orgId,
+			startTime: payload.startTime,
+		}),
+})
+
+/** Unbounded fallback probe: every partition, only when the recent one missed. */
+export const spanHierarchyProbe = defineQuery({
+	id: "spanHierarchyProbe",
+	profile: "discovery",
+	cache: undefined,
+	compile: (payload: { readonly traceId: string }, orgId: string) =>
+		CH.compile(CH.traceTimeProbeQuery({ traceId: payload.traceId, narrowByTime: false }), {
+			orgId,
+		}),
+})
+
+export const spanHierarchy = defineQuery({
+	id: "spanHierarchy",
+	profile: "list",
+	cache: undefined,
+	compile: (
+		payload: {
+			readonly traceId: string
+			readonly spanId?: string | undefined
+			readonly startTime?: string | undefined
+			readonly endTime?: string | undefined
+		},
+		orgId: string,
+	) => {
+		const narrowByTime = payload.startTime != null && payload.endTime != null
+		return CH.compile(
+			CH.spanHierarchyQuery({
+				traceId: payload.traceId,
+				spanId: payload.spanId,
+				narrowByTime,
+			}),
+			narrowByTime ? { orgId, startTime: payload.startTime, endTime: payload.endTime } : { orgId },
+		)
+	},
+})


### PR DESCRIPTION
**Stacked on #347** (which is stacked on #346) — review those first.

## The bug

Warehouse atom family keys carried only filters and time range. The org rode along invisibly in the auth header, so after an org switch **every cached entry stayed addressable by the new org** — the UI re-rendered the *previous* org's rows until the idle TTL expired. That's up to 30 minutes on some atoms (`getServiceHealthBaselineResultAtom`).

Electric collections never had this bug, because their collection ids already embed the org (`<shape>:<org>`).

The server side was already correct — `buildDirectRouteCacheKey` includes `orgId`. This was purely the client cache.

## The fix

`encodeOrgScopedKey` / `orgScopedKeyPayload` in `apps/web/src/lib/cache-key.ts`.

The org is **prefixed** rather than folded into the encoded object, because the atom decodes its key back into the query input — an extra field there would travel to the server as part of the request payload. NUL can't occur in `encodeKey` output (it's JSON) or in a Clerk org id, so the first occurrence always marks the boundary.

Applied at **both** key-building sites:
- the warehouse atom factory in `warehouse-query-atoms.ts` (~90 atom families)
- the dashboard widget family in `use-widget-data.ts`, which had the identical defect

## Two things I removed from this PR after checking them

I'd previously listed these as quick wins. Neither survived inspection, and I'd rather say so than ship churn:

- **`explore-attributes` "3 sequential queries"** — wrong. The three `executor.query` calls live across *two* exported functions, and the two inside `exploreAttributeKeys` are on mutually-exclusive branches (one returns early). Nothing runs sequentially; there is nothing to parallelize.
- **`inspect-widget.ts` `concurrency: 1`** — deliberate. It makes the push order into `formulaBaseInputs` deterministic for formula evaluation. Parallelizing means restructuring the side-effecting push, in an MCP inspection tool that isn't on a user-facing latency path.

## Testing

- `apps/web` typecheck clean
- **Tests not run locally at the author's request.** CI is the gate.

Worth a manual check on merge: sign in, load `/traces`, switch org, and confirm a fresh request fires rather than stale rows rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788479055&installation_model_id=427786&pr_number=348&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F348&signature=1083a15c78bc298bd656fe81838c260553fe1cfe9f45a291c5a57f27a5a283a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->