### PR TITLE
feat(slack-agent): give the bot the channel when the mention has no thread

### DIFF
--- a/apps/slack-agent/README.md
+++ b/apps/slack-agent/README.md
@@ -41,9 +41,12 @@ agent/
   channels/eve.ts     # auth policy for the browser/API routes
   connections/maple.ts # Maple MCP connection (per-workspace API key auth + approval gate)
   tools/render_chart.ts # renders a PNG chart in-process and posts it into the thread
+  tools/read_channel_history.ts # on-demand read of the channel's recent top-level messages
   tools/{bash,glob,grep,read_file,write_file,web_fetch,web_search}.ts
                       # `disableTool()` sentinels — see Framework tools below
   lib/thread-context.ts # full-thread turn context (renders Block Kit / alert cards too)
+  lib/channel-context.ts # channel turn context for a mention that starts its own thread
+  lib/slack-context-format.ts # shared renderer for both (blocks/attachments + attribution)
   lib/bot-identity.ts # per-team bot user id learned from the webhook envelope
   lib/chart.ts        # pure SVG chart renderer + unicode-sparkline fallback
   lib/slack-upload.ts # Slack external-upload flow (files.getUploadURLExternal → complete)
@@ -134,10 +137,10 @@ oauth_config:
             - chat:write # post replies
             - chat:write.public # post in channels the bot isn't a member of
             - channels:read # resolve public channel metadata
-            - channels:history
+            - channels:history # thread + channel context, follow-ups (no mpim:history — group DMs opt out)
             - files:write # upload rendered chart images (render_chart tool)
             - groups:read # resolve private channel metadata
-            - groups:history # thread context + follow-ups in private channels
+            - groups:history # thread + channel context + follow-ups in private channels
             - im:history # read DM history (message.im)
             - im:read # resolve DM conversation metadata
             - im:write # open/DM the user
@@ -506,6 +509,19 @@ and **activate public distribution** so the app can be installed into any worksp
   falls back to blocks/attachments for content, keeps the full thread (which also survives a
   session lost to a redeploy), and attributes speakers with the workspace's real bot user id from
   `agent/lib/bot-identity.ts` so a third-party app in the channel isn't quoted back as the agent.
+- **A mention that isn't in a thread gets the channel instead.** Maple posts alert cards to a
+  channel; people answer them by writing a new channel message ("the ship is sinking @Maple"), not
+  by replying inside a card's thread. That mention is its own thread root, so the thread transcript
+  is one message long — the user's own. `agent/lib/channel-context.ts` fills the gap with the
+  channel's last few top-level messages (`conversations.history`) as `<slack_channel_context>`,
+  rendered by the same code, on the same `waitUntil` path, degrading the same way. The trigger is
+  structural (`threadTs === ts`), not a model judgment call: the model cannot ask for context it
+  has never been shown a trace of. Inside a thread the same fetch is available on demand as the
+  `read_channel_history` tool. `conversations.history` returns top-level messages only, so the two
+  surfaces never quote the same message twice. Scope-wise this is free — `channels:history` /
+  `groups:history` / `im:history` are already installed. `mpim:history` is not requested, so a
+  group DM answers `missing_scope`; that degrades to a note telling the model not to retry, and
+  adding the scope would make every existing install report missing scopes until reinstalled.
 - **Auth:** `agent/channels/eve.ts` fails closed in deployed environments (`RAILWAY_ENVIRONMENT_NAME`
   set, or `NODE_ENV=production`): the browser/API routes always require HTTP Basic there. With
   `ROUTE_AUTH_BASIC_PASSWORD` set that's your stable credential; without it, a random per-boot

--- a/apps/slack-agent/agent/channels/slack.ts
+++ b/apps/slack-agent/agent/channels/slack.ts
@@ -3,6 +3,7 @@ import type { SlackContext, SlackMentionResult, SlackMessage, SlackWebhookVerifi
 import { acknowledgeIncomingMessage } from "#lib/ack-reaction.js"
 import { describeActions, truncateTypingStatus } from "#lib/action-status.js"
 import { botUserIdForTeam, rememberBotUserId } from "#lib/bot-identity.js"
+import { loadChannelContext } from "#lib/channel-context.js"
 import { resolveBotToken, verifySlackV0Signature, type SlackTokenContext } from "#lib/maple.js"
 import { loadThreadContext } from "#lib/thread-context.js"
 import { promoteThreadFollowUp } from "#lib/thread-follow-up.js"
@@ -85,7 +86,7 @@ const webhookVerifier: SlackWebhookVerifier = async (request, body) => {
 /**
  * Stands in for eve's default mention/DM pipeline: same two steps — a
  * "Thinking..." typing indicator and workspace-scoped auth derivation — plus
- * the thread transcript as turn context.
+ * the conversation around the mention as turn context.
  *
  * The context is ours rather than the channel's `threadContext` option because
  * eve reads a message's content from `text` alone and treats every bot post as
@@ -94,20 +95,29 @@ const webhookVerifier: SlackWebhookVerifier = async (request, body) => {
  * @mention in an alert thread reached the model with the alert blank and
  * everything before it cut away — see #lib/thread-context.js.
  *
- * Runs after eve has already returned 200 to Slack (`waitUntil`), so the thread
- * fetch is off the webhook's delivery budget. It must not throw: eve drops the
- * whole mention when this handler does, so `loadThreadContext` degrades to no
- * context instead.
+ * Exactly one of the two loads produces anything, and which one is structural:
+ * a mention inside a thread gets the thread transcript, a mention that starts
+ * its own thread gets the channel's last few messages (#lib/channel-context.js)
+ * — the case where the user @-mentions the bot under a pair of alert cards
+ * without replying in either one's thread. The model cannot ask for context it
+ * has never been shown a trace of, so this cannot wait for it to notice.
+ *
+ * Runs after eve has already returned 200 to Slack (`waitUntil`), so the Slack
+ * fetches are off the webhook's delivery budget. It must not throw: eve drops
+ * the whole mention when this handler does, so both loads degrade to no context
+ * instead.
  */
-async function dispatchWithThreadContext(
+async function dispatchWithConversationContext(
 	ctx: SlackContext,
 	message: SlackMessage,
 ): Promise<SlackMentionResult> {
 	await ctx.thread.startTyping("Thinking...")
-	const context = await loadThreadContext(ctx.thread, message, {
-		botUserId: botUserIdForTeam(message.teamId),
-	})
-	return { auth: defaultSlackAuth(message, ctx), context }
+	const [threadContext, channelContext] = await Promise.all([
+		loadThreadContext(ctx.thread, message, { botUserId: botUserIdForTeam(message.teamId) }),
+		loadChannelContext(message),
+	])
+	// Channel first: it is the background the thread happens in.
+	return { auth: defaultSlackAuth(message, ctx), context: [...channelContext, ...threadContext] }
 }
 
 export default slackChannel({
@@ -118,10 +128,10 @@ export default slackChannel({
 		// SLACK_BOT_TOKEN.
 		botToken: async (context?: SlackTokenContext) => resolveBotToken(context),
 	},
-	// Thread context is loaded by these two handlers, not by the channel's
-	// `threadContext` option — see dispatchWithThreadContext above.
-	onAppMention: dispatchWithThreadContext,
-	onDirectMessage: dispatchWithThreadContext,
+	// Thread and channel context are loaded by these two handlers, not by the
+	// channel's `threadContext` option — see dispatchWithConversationContext above.
+	onAppMention: dispatchWithConversationContext,
+	onDirectMessage: dispatchWithConversationContext,
 	events: {
 		// Eve's default flashes the raw tool-call label (`maple__list_services
 		// startTime=...`) into the typing status. Replace it with a plain

--- a/apps/slack-agent/agent/instructions.md
+++ b/apps/slack-agent/agent/instructions.md
@@ -114,6 +114,17 @@ reader's next move.
   name with a severity, an observed value, and an incident link), that alert is
   the subject: take the rule, window, and incident id straight from it and load
   the incident-investigation skill.
+- When the mention is not inside a thread, the turn instead carries the
+  channel's last few messages in `<slack_channel_context>` — same rules, and
+  the same treatment for a Maple alert card in it: the alert is the subject.
+  Alert cards there were posted to the channel, not addressed to you, so a
+  vague message under them ("what happened?", "this is bad") is about the
+  latest one.
+- If the user's message refers to something that is in neither context block —
+  "this alert", "why is it broken", a bare "why?" — call the
+  `read_channel_history` tool before answering. It returns the channel messages
+  that preceded the one you are answering. Ask the user to restate things only
+  after that comes back empty.
 - When you don't know something, say so plainly rather than guessing.
 
 ### Length calibration

--- a/apps/slack-agent/agent/lib/channel-context.test.ts
+++ b/apps/slack-agent/agent/lib/channel-context.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import {
+	CHANNEL_CONTEXT_MAX_MESSAGES,
+	CHANNEL_CONTEXT_MESSAGE_COUNT,
+	fetchChannelHistoryFromSlack,
+	loadChannelContext,
+	readChannelHistory,
+	SlackHistoryError,
+	type ChannelContextDeps,
+	type FetchChannelHistoryOptions,
+} from "./channel-context.js"
+import { installFetchStub, type FetchStub } from "./fetch-stub.js"
+import { clearAckedTriggeringMessages, registerAckedTriggeringMessage } from "./reaction.js"
+import type { RenderableSlackMessage } from "./slack-context-format.js"
+
+const BOT_USER_ID = "UBOT"
+
+afterEach(() => {
+	clearAckedTriggeringMessages()
+})
+
+/**
+ * A Maple alert card as `conversations.history` returns it: no top-level text,
+ * Block Kit inside one colored attachment. Mirrors
+ * apps/api/src/services/alerts/AlertDeliveryDispatch.ts.
+ */
+const alertHistoryMessage = (ts: string): Record<string, unknown> => ({
+	ts,
+	user: BOT_USER_ID,
+	bot_id: "B1",
+	text: "",
+	attachments: [
+		{
+			color: "#e11d48",
+			fallback: "🚨 Kafka consumer lag > 1h (sustained) — Triggered",
+			blocks: [
+				{
+					type: "header",
+					text: { type: "plain_text", text: "🚨 Kafka consumer lag > 1h (sustained) — Triggered" },
+				},
+				{
+					type: "section",
+					text: {
+						type: "mrkdwn",
+						text: "*builder_query* is *3685.79* — above the 3600 threshold.",
+					},
+				},
+				{
+					type: "actions",
+					elements: [
+						{
+							type: "button",
+							text: { type: "plain_text", text: "Open in Maple" },
+							url: "https://app.maple.dev/alerts/incidents/inc_1",
+						},
+					],
+				},
+			],
+		},
+	],
+})
+
+const userHistoryMessage = (text: string, ts: string): Record<string, unknown> => ({ ts, user: "U1", text })
+
+/** The mapping `fetchChannelHistoryFromSlack` applies, for the dep-injected tests. */
+const mapped = (raw: Record<string, unknown>): RenderableSlackMessage => ({
+	text: typeof raw.text === "string" ? raw.text : undefined,
+	user: typeof raw.user === "string" ? raw.user : undefined,
+	botId: typeof raw.bot_id === "string" ? raw.bot_id : undefined,
+	ts: typeof raw.ts === "string" ? raw.ts : undefined,
+	threadTs: typeof raw.thread_ts === "string" ? raw.thread_ts : undefined,
+	raw,
+})
+
+const makeDeps = (
+	messages: readonly Record<string, unknown>[],
+	overrides: Partial<ChannelContextDeps> = {},
+) => {
+	const fetches: FetchChannelHistoryOptions[] = []
+	const deps: ChannelContextDeps = {
+		resolveBotToken: () => Promise.resolve("xoxb-test"),
+		fetchChannelHistory: (options) => {
+			fetches.push(options)
+			// Oldest-first, as the real fetch returns after its reverse().
+			return Promise.resolve(messages.map(mapped))
+		},
+		botUserIdForTeam: () => BOT_USER_ID,
+		lookupAckedMessage: () => undefined,
+		...overrides,
+	}
+	return { deps, fetches }
+}
+
+const mention = (overrides: Partial<Parameters<typeof loadChannelContext>[0]> = {}) => ({
+	channelId: "C1",
+	teamId: "T1",
+	ts: "1700000000.000900",
+	threadTs: "1700000000.000900",
+	...overrides,
+})
+
+describe("loadChannelContext", () => {
+	test("renders the channel messages that preceded a threadless mention", async () => {
+		const { deps, fetches } = makeDeps([
+			alertHistoryMessage("1700000000.000700"),
+			userHistoryMessage("who is on call?", "1700000000.000800"),
+		])
+
+		const context = await loadChannelContext(mention(), deps)
+
+		expect(context).toHaveLength(1)
+		expect(context[0]?.startsWith("<slack_channel_context>")).toBe(true)
+		expect(context[0]?.endsWith("</slack_channel_context>")).toBe(true)
+		// The alert card is the whole point: it has no `text` at all.
+		expect(context[0]).toContain("🚨 Kafka consumer lag > 1h (sustained) — Triggered")
+		expect(context[0]).toContain("Open in Maple: https://app.maple.dev/alerts/incidents/inc_1")
+		expect(context[0]).toContain("who is on call?")
+		// The card came through the bot user, but it is not something the agent said.
+		expect(context[0]?.match(/sender_type: (\w+)/gu)).toEqual(["sender_type: bot", "sender_type: user"])
+		expect(fetches).toEqual([
+			{
+				botToken: "xoxb-test",
+				channelId: "C1",
+				latest: "1700000000.000900",
+				limit: CHANNEL_CONTEXT_MESSAGE_COUNT,
+				signal: expect.any(AbortSignal),
+			},
+		])
+	})
+
+	test("adds nothing for a mention inside a thread — that is thread context's job", async () => {
+		const { deps, fetches } = makeDeps([userHistoryMessage("noise", "1700000000.000800")])
+
+		const context = await loadChannelContext(
+			mention({ ts: "1700000000.000900", threadTs: "1700000000.000100" }),
+			deps,
+		)
+
+		expect(context).toEqual([])
+		expect(fetches).toEqual([])
+	})
+
+	test("adds nothing when the channel has no earlier messages", async () => {
+		const { deps } = makeDeps([])
+		expect(await loadChannelContext(mention(), deps)).toEqual([])
+	})
+
+	test("degrades to no context when Slack fails, so the turn still dispatches", async () => {
+		const { deps } = makeDeps([], {
+			fetchChannelHistory: mock(() => Promise.reject(new SlackHistoryError("not_in_channel"))),
+		})
+		expect(await loadChannelContext(mention(), deps)).toEqual([])
+	})
+
+	test("clips a single over-long message instead of paying for it every turn", async () => {
+		const { deps } = makeDeps([userHistoryMessage("x".repeat(5_000), "1700000000.000800")])
+		const context = await loadChannelContext(mention(), deps)
+		expect(context[0]).toContain("[truncated]")
+		expect(context[0]?.length).toBeLessThan(3_000)
+	})
+})
+
+describe("readChannelHistory", () => {
+	const session = (attributes: Record<string, unknown>) => ({ id: "session-1", attributes })
+
+	test("reads back from the triggering message the ack registered", async () => {
+		registerAckedTriggeringMessage({
+			teamId: "T1",
+			channelId: "C1",
+			messageTs: "1700000000.000950",
+			threadTs: "1700000000.000100",
+		})
+		const { deps, fetches } = makeDeps([alertHistoryMessage("1700000000.000700")], {
+			lookupAckedMessage: (context) =>
+				context.threadTs === "1700000000.000100" ? "1700000000.000950" : undefined,
+		})
+
+		const result = await readChannelHistory(
+			3,
+			session({ team_id: "T1", channel_id: "C1", thread_ts: "1700000000.000100" }),
+			deps,
+		)
+
+		expect(result).toMatchObject({ read: true, messageCount: 1 })
+		expect(fetches[0]?.latest).toBe("1700000000.000950")
+		expect(fetches[0]?.limit).toBe(3)
+	})
+
+	test("falls back to the thread root when the registry has nothing", async () => {
+		const { deps, fetches } = makeDeps([userHistoryMessage("deploy went out", "1700000000.000700")])
+
+		const result = await readChannelHistory(
+			CHANNEL_CONTEXT_MESSAGE_COUNT,
+			session({ team_id: "T1", channel_id: "C1", thread_ts: "1700000000.000900" }),
+			deps,
+		)
+
+		expect(result.read).toBe(true)
+		expect(fetches[0]?.latest).toBe("1700000000.000900")
+	})
+
+	test("bounds the limit to what Slack will actually return", async () => {
+		const { deps, fetches } = makeDeps([userHistoryMessage("hi", "1700000000.000700")])
+		const attributes = { team_id: "T1", channel_id: "C1", thread_ts: "1700000000.000900" }
+
+		await readChannelHistory(500, session(attributes), deps)
+		await readChannelHistory(0, session(attributes), deps)
+
+		expect(fetches.map((call) => call.limit)).toEqual([CHANNEL_CONTEXT_MAX_MESSAGES, 1])
+	})
+
+	test("explains a missing scope instead of leaving the model to retry", async () => {
+		const { deps } = makeDeps([], {
+			fetchChannelHistory: mock(() => Promise.reject(new SlackHistoryError("missing_scope"))),
+		})
+
+		const result = await readChannelHistory(
+			CHANNEL_CONTEXT_MESSAGE_COUNT,
+			session({ team_id: "T1", channel_id: "C1", thread_ts: "1700000000.000900" }),
+			deps,
+		)
+
+		expect(result.read).toBe(false)
+		const note = result.read ? "" : result.note
+		expect(note).toContain("missing scope")
+		expect(note).toContain("Do not retry")
+	})
+
+	test("says so plainly when the channel had nothing before this message", async () => {
+		const { deps } = makeDeps([])
+		const result = await readChannelHistory(
+			CHANNEL_CONTEXT_MESSAGE_COUNT,
+			session({ team_id: "T1", channel_id: "C1", thread_ts: "1700000000.000900" }),
+			deps,
+		)
+		expect(result).toMatchObject({ read: false, note: expect.stringContaining("Nothing was posted") })
+	})
+
+	test("skips without a channel, and without a message to read back from", async () => {
+		const { deps, fetches } = makeDeps([])
+		expect(await readChannelHistory(5, session({ team_id: "T1" }), deps)).toMatchObject({ read: false })
+		expect(await readChannelHistory(5, session({ team_id: "T1", channel_id: "C1" }), deps)).toMatchObject(
+			{ read: false },
+		)
+		expect(fetches).toEqual([])
+	})
+})
+
+describe("fetchChannelHistoryFromSlack", () => {
+	let stub: FetchStub | undefined
+
+	afterEach(() => {
+		stub?.restore()
+		stub = undefined
+	})
+
+	const respondWith = (payload: unknown, status = 200) => {
+		stub = installFetchStub(() => new Response(JSON.stringify(payload), { status }))
+		return stub
+	}
+
+	test("asks Slack for the messages before the triggering one, form-encoded", async () => {
+		const fetchStub = respondWith({ ok: true, messages: [] })
+
+		await fetchChannelHistoryFromSlack({
+			botToken: "xoxb-test",
+			channelId: "C1",
+			latest: "1700000000.000900",
+			limit: 5,
+		})
+
+		const call = fetchStub.calls[0]
+		expect(call?.url).toBe("https://slack.com/api/conversations.history")
+		expect(call?.method).toBe("POST")
+		expect(call?.headers.authorization).toBe("Bearer xoxb-test")
+		const body = new URLSearchParams(String(call?.body))
+		expect(body.get("channel")).toBe("C1")
+		expect(body.get("latest")).toBe("1700000000.000900")
+		// The message the agent is answering must not be read back to it.
+		expect(body.get("inclusive")).toBe("false")
+		expect(body.get("limit")).toBe("5")
+	})
+
+	test("returns Slack's newest-first page in the order it happened", async () => {
+		respondWith({
+			ok: true,
+			messages: [
+				userHistoryMessage("second", "1700000000.000800"),
+				{ ...alertHistoryMessage("1700000000.000700"), thread_ts: "1700000000.000700" },
+			],
+		})
+
+		const messages = await fetchChannelHistoryFromSlack({
+			botToken: "xoxb-test",
+			channelId: "C1",
+			latest: "1700000000.000900",
+			limit: 5,
+		})
+
+		expect(messages.map((message) => message.ts)).toEqual(["1700000000.000700", "1700000000.000800"])
+		expect(messages[0]).toMatchObject({
+			user: BOT_USER_ID,
+			botId: "B1",
+			// A thread_ts on a channel message means the discussion continued in a
+			// thread the model cannot see from here.
+			threadTs: "1700000000.000700",
+		})
+	})
+
+	test("surfaces Slack's error code so the caller can explain it", async () => {
+		respondWith({ ok: false, error: "missing_scope" })
+		expect(
+			fetchChannelHistoryFromSlack({ botToken: "t", channelId: "C1", latest: "1", limit: 5 }),
+		).rejects.toMatchObject({ code: "missing_scope" })
+	})
+
+	test("surfaces a transport failure as a code too", async () => {
+		respondWith({}, 503)
+		expect(
+			fetchChannelHistoryFromSlack({ botToken: "t", channelId: "C1", latest: "1", limit: 5 }),
+		).rejects.toMatchObject({ code: "http_503" })
+	})
+})

--- a/apps/slack-agent/agent/lib/channel-context.ts
+++ b/apps/slack-agent/agent/lib/channel-context.ts
@@ -1,0 +1,321 @@
+import { botUserIdForTeam } from "./bot-identity.js"
+import { resolveBotToken, type SlackTokenContext } from "./maple.js"
+import { lookupAckedTriggeringMessage } from "./reaction.js"
+import { formatContextBlock, type RenderableSlackMessage } from "./slack-context-format.js"
+
+/**
+ * The channel around the mention: the top-level messages posted just before the
+ * one the agent is answering.
+ *
+ * `#lib/thread-context.js` covers a mention *inside* a thread. It cannot cover
+ * the case in the screenshot that motivated this file: Maple posts two alert
+ * cards to a channel, and someone writes "the ship is sinking help my friend
+ * @Maple" as a new channel message rather than as a reply in either alert's
+ * thread. That mention is its own thread root, so the thread transcript is one
+ * message long — the user's own — and the model answers with no idea that two
+ * incidents are sitting directly above it.
+ *
+ * Two entry points, because "the agent notices it needs context" only works
+ * when the agent can tell there is any:
+ *
+ *   1. **Eager** (`loadChannelContext`, wired in `#channels/slack.js`): a
+ *      mention that is not in a thread carries the last few channel messages
+ *      as `<slack_channel_context>`. Structural trigger, no model judgment —
+ *      the model cannot suspect what it has never been shown.
+ *   2. **On demand** (`readChannelHistory`, behind the `read_channel_history`
+ *      tool): for a mention inside a thread, where the thread is the subject
+ *      but the channel may hold the reason.
+ *
+ * `conversations.history` returns top-level messages only — thread replies stay
+ * out unless they were also sent to the channel — so the two surfaces do not
+ * duplicate each other.
+ *
+ * DMs get the same treatment, and want it more: an unthreaded DM is its own
+ * session (eve keys them `channelId:threadTs`), so without this each message a
+ * user sends starts from nothing.
+ *
+ * Scope-wise this is free: `channels:history` / `groups:history` / `im:history`
+ * are already installed for `#lib/thread-follow-up.js` and eve's thread fetch.
+ * `mpim:history` is NOT requested, so a group DM answers `missing_scope`; that
+ * degrades to a note, not a failure, and adding the scope would make every
+ * existing install report missing scopes until it is reinstalled.
+ */
+
+/** How many channel messages the eager path injects for a threadless mention. */
+export const CHANNEL_CONTEXT_MESSAGE_COUNT = 5
+
+/**
+ * Ceiling on the `read_channel_history` tool's `limit`. Slack caps
+ * `conversations.history` at 15 messages per call for apps created after
+ * 2025-05-29 (the non-Marketplace rate-limit tier), so asking for more can
+ * silently return fewer — better to make the bound explicit than to let the
+ * model believe it read further back than it did.
+ */
+export const CHANNEL_CONTEXT_MAX_MESSAGES = 15
+
+/**
+ * Per-message content ceiling. A thread the bot was invited into is bounded by
+ * the conversation; a channel is not — one pasted stack trace or log dump would
+ * otherwise ride along on every turn of the session.
+ */
+const MAX_CONTENT_CHARS = 2_000
+
+/**
+ * The fetch runs after eve's 200 to Slack, so it does not spend the webhook
+ * budget — but it does hold up the turn, and a stalled Slack API must not hang
+ * a reply behind context that is only ever an improvement.
+ */
+const FETCH_TIMEOUT_MS = 5_000
+
+/** A Slack Web API error surfaced with its code, so callers can explain it. */
+export class SlackHistoryError extends Error {
+	readonly code: string
+	constructor(code: string) {
+		super(`Slack conversations.history failed: ${code}`)
+		this.name = "SlackHistoryError"
+		this.code = code
+	}
+}
+
+export interface FetchChannelHistoryOptions {
+	readonly botToken: string
+	readonly channelId: string
+	/** Slack ts of the triggering message — the exclusive upper bound. */
+	readonly latest: string
+	readonly limit: number
+	readonly signal?: AbortSignal
+}
+
+/** Injectable dependencies so tests never touch the network. */
+export interface ChannelContextDeps {
+	resolveBotToken(context: SlackTokenContext): Promise<string>
+	fetchChannelHistory(options: FetchChannelHistoryOptions): Promise<readonly RenderableSlackMessage[]>
+	botUserIdForTeam(teamId: string | undefined): string | undefined
+	lookupAckedMessage(context: {
+		readonly teamId?: string
+		readonly channelId: string
+		readonly threadTs?: string
+	}): string | undefined
+}
+
+export const defaultChannelContextDeps: ChannelContextDeps = {
+	resolveBotToken,
+	fetchChannelHistory: fetchChannelHistoryFromSlack,
+	botUserIdForTeam,
+	lookupAckedMessage: lookupAckedTriggeringMessage,
+}
+
+/**
+ * Eager path: the channel messages preceding a threadless mention, rendered as
+ * one `<slack_channel_context>` string.
+ *
+ * Returns `[]` when the mention is inside a thread (thread context has it), and
+ * on any failure. Never throws — eve drops the whole mention when an
+ * `onAppMention` handler throws, so a Slack hiccup must cost the context, not
+ * the reply.
+ */
+export async function loadChannelContext(
+	message: {
+		readonly channelId: string
+		readonly teamId: string | undefined
+		readonly ts: string
+		readonly threadTs: string
+	},
+	deps: ChannelContextDeps = defaultChannelContextDeps,
+): Promise<readonly string[]> {
+	// eve sets `threadTs === ts` for a message that is not a thread reply. A real
+	// thread reply already has its transcript; injecting channel history there
+	// too would bury the thread the user is actually in.
+	if (message.threadTs !== message.ts) return []
+
+	try {
+		const rendered = await renderChannelContext(
+			{
+				teamId: message.teamId,
+				channelId: message.channelId,
+				latest: message.ts,
+				limit: CHANNEL_CONTEXT_MESSAGE_COUNT,
+			},
+			deps,
+		)
+		return rendered === undefined ? [] : [rendered]
+	} catch (error) {
+		console.warn("[slack-channel-context] Failed to load channel context; dispatching without it.", error)
+		return []
+	}
+}
+
+export type ChannelHistoryResult =
+	| { readonly read: true; readonly messageCount: number; readonly context: string }
+	| { readonly read: false; readonly note: string }
+
+/** The slice of eve's session context the tool reads. */
+export interface ChannelHistorySession {
+	readonly id: string
+	/** Slack auth attributes: `team_id`, `channel_id`, `thread_ts`. */
+	readonly attributes: Readonly<Record<string, unknown>>
+}
+
+/**
+ * On-demand path behind the `read_channel_history` tool: the last `limit`
+ * top-level channel messages before the message that triggered this turn.
+ *
+ * Never throws — a tool that throws costs the model its turn, and missing
+ * channel context is worth a sentence, not a failed reply.
+ */
+export async function readChannelHistory(
+	limit: number,
+	session: ChannelHistorySession,
+	deps: ChannelContextDeps = defaultChannelContextDeps,
+): Promise<ChannelHistoryResult> {
+	const teamId = slackString(session.attributes.team_id)
+	const channelId = slackString(session.attributes.channel_id)
+	const threadTs = slackString(session.attributes.thread_ts)
+	if (!channelId) {
+		return { read: false, note: "This session has no Slack channel, so there is no history to read." }
+	}
+
+	// The `:eyes:` ack registered the exact triggering message; the thread root
+	// (which for an unthreaded message IS that message) is the degrade path.
+	// Both are upper bounds, so a miss reads slightly less recent history rather
+	// than the wrong history.
+	const latest = deps.lookupAckedMessage({ teamId, channelId, threadTs }) ?? threadTs
+	if (!latest) {
+		return { read: false, note: "The triggering message could not be identified." }
+	}
+
+	try {
+		const rendered = await renderChannelContext(
+			{ teamId, channelId, latest, limit: boundedLimit(limit) },
+			deps,
+		)
+		if (rendered === undefined) {
+			return {
+				read: false,
+				note: "Nothing was posted in this channel before the message you are answering. Do not retry.",
+			}
+		}
+		return {
+			read: true,
+			messageCount: countMessages(rendered),
+			context: rendered,
+		}
+	} catch (error) {
+		console.warn(`[slack-agent] read_channel_history failed session=${session.id}`, error)
+		return { read: false, note: explainFailure(error) }
+	}
+}
+
+async function renderChannelContext(
+	request: {
+		readonly teamId: string | undefined
+		readonly channelId: string
+		readonly latest: string
+		readonly limit: number
+	},
+	deps: ChannelContextDeps,
+): Promise<string | undefined> {
+	const botToken = await deps.resolveBotToken({
+		teamId: request.teamId,
+		channelId: request.channelId,
+	})
+	const messages = await deps.fetchChannelHistory({
+		botToken,
+		channelId: request.channelId,
+		latest: request.latest,
+		limit: request.limit,
+		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+	})
+	return formatContextBlock("slack_channel_context", messages, {
+		botUserId: deps.botUserIdForTeam(request.teamId),
+		maxContentChars: MAX_CONTENT_CHARS,
+	})
+}
+
+/**
+ * `conversations.history` via the Slack Web API, newest-first, reversed to
+ * oldest-first so the rendered transcript reads in the order it happened.
+ *
+ * `latest` is the triggering message's own ts and `inclusive` is false, so the
+ * message the agent is already answering is never repeated back to it. Slack
+ * rejects JSON for this method — form-encoded only.
+ *
+ * Exported for the request-shape tests; production reaches it through
+ * `defaultChannelContextDeps`.
+ */
+export async function fetchChannelHistoryFromSlack(
+	options: FetchChannelHistoryOptions,
+): Promise<readonly RenderableSlackMessage[]> {
+	const res = await fetch("https://slack.com/api/conversations.history", {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${options.botToken}`,
+			"content-type": "application/x-www-form-urlencoded",
+		},
+		body: new URLSearchParams({
+			channel: options.channelId,
+			latest: options.latest,
+			inclusive: "false",
+			limit: String(options.limit),
+		}),
+		...(options.signal ? { signal: options.signal } : {}),
+	})
+	if (!res.ok) {
+		throw new SlackHistoryError(`http_${res.status}`)
+	}
+	const payload = (await res.json()) as {
+		ok: boolean
+		error?: string
+		messages?: ReadonlyArray<Record<string, unknown>>
+	}
+	if (!payload.ok) {
+		throw new SlackHistoryError(payload.error ?? "unknown_error")
+	}
+	return (payload.messages ?? [])
+		.map((message): RenderableSlackMessage => ({
+			// Raw Slack text is mrkdwn: eve's GFM rendering only exists for
+			// messages that came through its own thread fetch.
+			text: typeof message.text === "string" ? message.text : undefined,
+			user: typeof message.user === "string" ? message.user : undefined,
+			botId: typeof message.bot_id === "string" ? message.bot_id : undefined,
+			ts: typeof message.ts === "string" ? message.ts : undefined,
+			// Present only when the message itself has replies — worth showing:
+			// it tells the model the discussion continued somewhere it cannot see.
+			threadTs: typeof message.thread_ts === "string" ? message.thread_ts : undefined,
+			raw: message,
+		}))
+		.reverse()
+}
+
+/**
+ * Turns a Slack failure into something the model can act on. The distinction
+ * that matters is "this will never work here" (a scope or membership problem,
+ * so stop asking) versus "this failed now" (retrying is pointless within a turn
+ * either way, but the user deserves a different sentence).
+ */
+function explainFailure(error: unknown): string {
+	const code = error instanceof SlackHistoryError ? error.code : ""
+	switch (code) {
+		case "missing_scope":
+			return "This Slack app cannot read this conversation's history (missing scope — group DMs are not covered). Do not retry; answer from the thread, or ask the user to paste what you need."
+		case "not_in_channel":
+		case "channel_not_found":
+			return "The bot is not a member of this channel, so its history is unreadable. Do not retry; ask the user to invite the bot or paste the relevant messages."
+		case "ratelimited":
+			return "Slack rate-limited the history read. Do not retry in this turn; answer from what you already have."
+		default:
+			return "Reading the channel history failed. Do not retry; answer from what you already have."
+	}
+}
+
+function countMessages(rendered: string): number {
+	return rendered.split("<slack_message>").length - 1
+}
+
+function boundedLimit(limit: number): number {
+	if (!Number.isFinite(limit)) return CHANNEL_CONTEXT_MESSAGE_COUNT
+	return Math.min(Math.max(Math.trunc(limit), 1), CHANNEL_CONTEXT_MAX_MESSAGES)
+}
+
+const slackString = (value: unknown): string | undefined =>
+	typeof value === "string" && value.length > 0 ? value : undefined

--- a/apps/slack-agent/agent/lib/slack-context-format.ts
+++ b/apps/slack-agent/agent/lib/slack-context-format.ts
@@ -1,0 +1,302 @@
+/**
+ * Rendering Slack messages as model-visible background context.
+ *
+ * Shared by the two context surfaces, which differ only in which messages they
+ * collect:
+ *
+ *   - `#lib/thread-context.js` — the thread the bot was tagged in
+ *     (`conversations.replies`), injected on every turn.
+ *   - `#lib/channel-context.js` — the channel messages that preceded a
+ *     channel-level mention (`conversations.history`), injected when there is
+ *     no thread to carry context, and on demand through the
+ *     `read_channel_history` tool.
+ *
+ * Both need the same two things eve's own renderer does not do: content that
+ * falls back to blocks and attachments (Maple's alert cards carry no top-level
+ * `text` at all — see `#lib/thread-context.js` for that story) and speaker
+ * attribution that tells this agent apart from every other bot in the channel.
+ *
+ * The envelope is eve's: `<slack_thread_context>` / `<slack_message>`, so the
+ * model's view keeps the shape it already knows.
+ */
+
+/** Who posted a context message, from the model's point of view. */
+export type ContextSenderType = "agent" | "bot" | "unknown" | "user"
+
+export interface ContextFormatOptions {
+	/**
+	 * This workspace's bot user id (`#lib/bot-identity.js`). Distinguishes the
+	 * agent's own replies from every other bot in the channel. When absent we
+	 * fall back to eve's coarser "any bot is me".
+	 */
+	readonly botUserId?: string | undefined
+	/**
+	 * Hard cap on one message's rendered content, in characters. Off by default;
+	 * `#lib/channel-context.js` sets it because channel history is unbounded in
+	 * a way a thread the bot was invited into is not.
+	 */
+	readonly maxContentChars?: number | undefined
+}
+
+/**
+ * The slice of a Slack message this renderer reads.
+ *
+ * eve's `SlackThreadMessage` satisfies it structurally, and so does a raw
+ * `conversations.history` message once mapped (`#lib/channel-context.js`) —
+ * which is the point: the two APIs return the same message with different
+ * field coverage, not two different things.
+ */
+export interface RenderableSlackMessage {
+	readonly text?: string | undefined
+	/** eve's mrkdwn → GFM rendering of `text`, when the source has one. */
+	readonly markdown?: string | undefined
+	readonly user?: string | undefined
+	readonly botId?: string | undefined
+	readonly ts?: string | undefined
+	readonly threadTs?: string | undefined
+	/** eve's coarse "any bot is me"; only consulted when `botUserId` is unknown. */
+	readonly isMe?: boolean | undefined
+	readonly raw: Record<string, unknown>
+}
+
+/**
+ * Renders messages inside a named context envelope, or `undefined` when there
+ * are none.
+ */
+export function formatContextBlock(
+	tag: string,
+	messages: readonly RenderableSlackMessage[],
+	options: ContextFormatOptions = {},
+): string | undefined {
+	if (messages.length === 0) return undefined
+	return [
+		`<${tag}>`,
+		...messages.map((message) => formatContextMessage(message, options)),
+		`</${tag}>`,
+	].join("\n")
+}
+
+/** One `<slack_message>` element: attribution, timestamps, content. */
+export function formatContextMessage(
+	message: RenderableSlackMessage,
+	options: ContextFormatOptions = {},
+): string {
+	const { content, fromAttachment } = slackMessageContent(message)
+	const senderId = message.user ?? message.botId
+	return [
+		"<slack_message>",
+		`sender_type: ${senderType(message, fromAttachment, options)}`,
+		...(senderId ? [`sender_id: ${senderId}`] : []),
+		...(message.threadTs ? [`thread_ts: ${message.threadTs}`] : []),
+		...(message.ts ? [`message_ts: ${message.ts}`] : []),
+		"<content>",
+		truncateContent(content, options.maxContentChars),
+		"</content>",
+		"</slack_message>",
+	].join("\n")
+}
+
+export function senderType(
+	message: RenderableSlackMessage,
+	fromAttachment: boolean,
+	options: ContextFormatOptions,
+): ContextSenderType {
+	// An app notification posted through the same bot user — a Maple alert card —
+	// is not something the agent said. Labelling it `agent` would have the model
+	// believe it already reported the incident it is being asked about. The
+	// agent's own replies never use attachments (eve posts `markdown_text` or
+	// top-level blocks), so "content came from an attachment" separates them.
+	if (fromAttachment) return "bot"
+	if (options.botUserId !== undefined) {
+		if (message.user === options.botUserId) return "agent"
+		if (message.botId !== undefined) return "bot"
+	} else if (message.isMe) {
+		return "agent"
+	}
+	if (message.user !== undefined) return "user"
+	if (message.botId !== undefined) return "bot"
+	return "unknown"
+}
+
+/**
+ * The readable content of a Slack message, and whether it had to be recovered
+ * from an attachment (Slack's legacy surface, which is where Block Kit cards
+ * with a color bar live — Maple alerts among them).
+ *
+ * Precedence is plain text → top-level blocks → attachments, so a message that
+ * has real text is never re-derived from its block rendering of that same text.
+ */
+export function slackMessageContent(message: RenderableSlackMessage): {
+	readonly content: string
+	readonly fromAttachment: boolean
+} {
+	// `markdown` is eve's mrkdwn → GFM rendering of `text`. Raw Slack API
+	// messages have no such field, so their `text` is mrkdwn — readable, just
+	// not GFM.
+	const text = (message.markdown ?? "").trim() || (message.text ?? "").trim()
+	if (text) return { content: text, fromAttachment: false }
+
+	const blocks = blocksText(message.raw.blocks)
+	if (blocks) return { content: blocks, fromAttachment: false }
+
+	const attachments = attachmentsText(message.raw.attachments)
+	if (attachments) return { content: attachments, fromAttachment: true }
+
+	return { content: "", fromAttachment: false }
+}
+
+/**
+ * Clips over-long content at a character budget. Kept crude on purpose: the
+ * point is a ceiling on what one pasted log dump can cost the turn, not a
+ * faithful summary.
+ */
+function truncateContent(content: string, maxChars: number | undefined): string {
+	if (maxChars === undefined || content.length <= maxChars) return content
+	return `${content.slice(0, maxChars)}\n[truncated]`
+}
+
+function attachmentsText(value: unknown): string {
+	return joinLines(
+		asArray(value).map((attachment) => {
+			if (!isRecord(attachment)) return ""
+			const blocks = blocksText(attachment.blocks)
+			if (blocks) return joinLines([str(attachment.title), blocks])
+			// Legacy attachments carry their body in `text`; `fallback` is the
+			// notification-preview one-liner and the last thing worth showing.
+			return joinLines([str(attachment.title), str(attachment.text)]) || str(attachment.fallback)
+		}),
+	)
+}
+
+function blocksText(value: unknown): string {
+	return joinLines(asArray(value).map(blockText))
+}
+
+function blockText(block: unknown): string {
+	if (!isRecord(block)) return ""
+	switch (block.type) {
+		case "divider":
+			return ""
+		case "header":
+		case "section":
+			return joinLines([textObject(block.text), ...asArray(block.fields).map(textObject)])
+		case "context":
+		case "actions":
+			return joinLines(asArray(block.elements).map(elementText))
+		case "rich_text":
+			return joinLines(asArray(block.elements).map(richTextBlockText))
+		case "markdown":
+			return str(block.text)
+		case "image":
+			return imageText(block)
+		default:
+			// Unknown / future block types: sweep every text object out of them
+			// rather than dropping content we simply don't have a case for.
+			return joinLines(collectTextObjects(block))
+	}
+}
+
+function elementText(element: unknown): string {
+	if (!isRecord(element)) return ""
+	if (element.type === "image") return imageText(element)
+	const label = textObject(element.text)
+	// Buttons: the label alone ("Open in Maple") says nothing the model can act
+	// on — the link is the payload.
+	const url = str(element.url)
+	if (label && url) return `${label}: ${url}`
+	return label || url || joinLines(collectTextObjects(element))
+}
+
+function richTextBlockText(element: unknown): string {
+	if (!isRecord(element)) return ""
+	switch (element.type) {
+		case "rich_text_list":
+			return joinLines(asArray(element.elements).map((item) => `- ${richTextBlockText(item)}`))
+		case "rich_text_quote":
+			return joinLines(
+				inlineText(element.elements)
+					.split("\n")
+					.map((line) => `> ${line}`),
+			)
+		default:
+			// rich_text_section / rich_text_preformatted, and anything Slack adds.
+			return inlineText(element.elements)
+	}
+}
+
+/** Inline rich-text runs concatenate — they are one paragraph, not a list. */
+function inlineText(value: unknown): string {
+	return asArray(value)
+		.map((element) => {
+			if (!isRecord(element)) return ""
+			switch (element.type) {
+				case "text":
+					// Not `str()`: the whitespace between runs is the sentence's own
+					// spacing, and trimming each run glues the words together.
+					return typeof element.text === "string" ? element.text : ""
+				case "link": {
+					const label = str(element.text)
+					const url = str(element.url)
+					return label && label !== url ? `${label} (${url})` : url
+				}
+				case "user":
+					return `<@${str(element.user_id)}>`
+				case "usergroup":
+					return `<!subteam^${str(element.usergroup_id)}>`
+				case "channel":
+					return `<#${str(element.channel_id)}>`
+				case "emoji":
+					return `:${str(element.name)}:`
+				case "broadcast":
+					return `<!${str(element.range)}>`
+				default:
+					return ""
+			}
+		})
+		.join("")
+		.trim()
+}
+
+function imageText(block: Record<string, unknown>): string {
+	const alt = str(block.alt_text) || textObject(block.title)
+	return alt ? `[image: ${alt}]` : ""
+}
+
+/** The text of a Slack `{ type: "mrkdwn" | "plain_text", text }` object. */
+function textObject(value: unknown): string {
+	return isRecord(value) ? str(value.text) : ""
+}
+
+function collectTextObjects(value: unknown, out: string[] = []): string[] {
+	if (Array.isArray(value)) {
+		for (const item of value) collectTextObjects(item, out)
+		return out
+	}
+	if (!isRecord(value)) return out
+	if ((value.type === "mrkdwn" || value.type === "plain_text") && typeof value.text === "string") {
+		const text = value.text.trim()
+		if (text) out.push(text)
+		return out
+	}
+	for (const item of Object.values(value)) collectTextObjects(item, out)
+	return out
+}
+
+function joinLines(parts: readonly string[]): string {
+	return parts
+		.map((part) => part.trim())
+		.filter((part) => part.length > 0)
+		.join("\n")
+}
+
+function str(value: unknown): string {
+	return typeof value === "string" ? value.trim() : ""
+}
+
+function asArray(value: unknown): readonly unknown[] {
+	return Array.isArray(value) ? value : []
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/apps/slack-agent/agent/lib/thread-context.test.ts
+++ b/apps/slack-agent/agent/lib/thread-context.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import type { SlackThreadMessage } from "eve/channels/slack"
 import { botUserIdForTeam, rememberBotUserId, resetBotUserIdCacheForTests } from "./bot-identity.js"
-import { formatThreadContext, loadThreadContext, slackMessageContent } from "./thread-context.js"
+import { slackMessageContent } from "./slack-context-format.js"
+import { formatThreadContext, loadThreadContext } from "./thread-context.js"
 
 afterEach(() => {
 	resetBotUserIdCacheForTests()

--- a/apps/slack-agent/agent/lib/thread-context.ts
+++ b/apps/slack-agent/agent/lib/thread-context.ts
@@ -1,4 +1,5 @@
 import { loadThreadContextMessages, type SlackThread, type SlackThreadMessage } from "eve/channels/slack"
+import { formatContextBlock, type ContextFormatOptions } from "./slack-context-format.js"
 
 /**
  * Background context for a turn: the Slack thread the bot was tagged in,
@@ -21,16 +22,18 @@ import { loadThreadContextMessages, type SlackThread, type SlackThreadMessage } 
  *      reply** (eve's `isMe` is `bot_id !== undefined`, i.e. any bot), and cut
  *      the context off *after* it — dropping the alert and everything before it.
  *
- * So we render context ourselves: same `<slack_thread_context>` /
- * `<slack_message>` envelope eve uses (the model's view is unchanged in shape),
- * but content falls back to blocks and attachments when `text` is empty, and
- * the whole thread is included — the `thread-root` boundary. Full-thread is
- * also what makes this survive a lost session: eve sessions are keyed
- * `channelId:threadTs` and a Railway redeploy can drop the history that an
- * incremental boundary silently assumes is still there.
+ * So we render context ourselves (`#lib/slack-context-format.js`): same
+ * `<slack_thread_context>` / `<slack_message>` envelope eve uses (the model's
+ * view is unchanged in shape), but content falls back to blocks and attachments
+ * when `text` is empty, and the whole thread is included — the `thread-root`
+ * boundary. Full-thread is also what makes this survive a lost session: eve
+ * sessions are keyed `channelId:threadTs` and a Railway redeploy can drop the
+ * history that an incremental boundary silently assumes is still there.
  *
  * Wired in `#channels/slack.js` through `onAppMention` / `onDirectMessage`,
- * which return these strings as the mention result's `context`.
+ * which return these strings as the mention result's `context`. A mention that
+ * is not itself in a thread has no thread context by construction — that case
+ * belongs to `#lib/channel-context.js`.
  *
  * Two bounds worth knowing: every turn re-injects the transcript (so a long
  * thread pays for its history once per mention), and eve's `thread.refresh()`
@@ -38,17 +41,7 @@ import { loadThreadContextMessages, type SlackThread, type SlackThreadMessage } 
  * that goes missing. Alert threads are short; revisit if that stops holding.
  */
 
-/** Who posted a context message, from the model's point of view. */
-export type ThreadContextSenderType = "agent" | "bot" | "unknown" | "user"
-
-export interface ThreadContextOptions {
-	/**
-	 * This workspace's bot user id (`#lib/bot-identity.js`). Distinguishes the
-	 * agent's own replies from every other bot in the channel. When absent we
-	 * fall back to eve's coarser "any bot is me".
-	 */
-	readonly botUserId?: string | undefined
-}
+export type ThreadContextOptions = ContextFormatOptions
 
 /**
  * Loads the thread the triggering message belongs to and renders it as one
@@ -82,219 +75,5 @@ export function formatThreadContext(
 	messages: readonly SlackThreadMessage[],
 	options: ThreadContextOptions = {},
 ): string | undefined {
-	if (messages.length === 0) return undefined
-	return [
-		"<slack_thread_context>",
-		...messages.map((message) => formatThreadContextMessage(message, options)),
-		"</slack_thread_context>",
-	].join("\n")
-}
-
-function formatThreadContextMessage(message: SlackThreadMessage, options: ThreadContextOptions): string {
-	const { content, fromAttachment } = slackMessageContent(message)
-	const senderId = message.user ?? message.botId
-	return [
-		"<slack_message>",
-		`sender_type: ${senderType(message, fromAttachment, options)}`,
-		...(senderId ? [`sender_id: ${senderId}`] : []),
-		`thread_ts: ${message.threadTs}`,
-		`message_ts: ${message.ts}`,
-		"<content>",
-		content,
-		"</content>",
-		"</slack_message>",
-	].join("\n")
-}
-
-function senderType(
-	message: SlackThreadMessage,
-	fromAttachment: boolean,
-	options: ThreadContextOptions,
-): ThreadContextSenderType {
-	// An app notification posted through the same bot user — a Maple alert card —
-	// is not something the agent said. Labelling it `agent` would have the model
-	// believe it already reported the incident it is being asked about. The
-	// agent's own replies never use attachments (eve posts `markdown_text` or
-	// top-level blocks), so "content came from an attachment" separates them.
-	if (fromAttachment) return "bot"
-	if (options.botUserId !== undefined) {
-		if (message.user === options.botUserId) return "agent"
-		if (message.botId !== undefined) return "bot"
-	} else if (message.isMe) {
-		return "agent"
-	}
-	if (message.user !== undefined) return "user"
-	if (message.botId !== undefined) return "bot"
-	return "unknown"
-}
-
-/**
- * The readable content of a thread message, and whether it had to be recovered
- * from an attachment (Slack's legacy surface, which is where Block Kit cards
- * with a color bar live — Maple alerts among them).
- *
- * Precedence is plain text → top-level blocks → attachments, so a message that
- * has real text is never re-derived from its block rendering of that same text.
- */
-export function slackMessageContent(message: SlackThreadMessage): {
-	readonly content: string
-	readonly fromAttachment: boolean
-} {
-	// `markdown` is eve's mrkdwn → GFM rendering of `text`.
-	const text = message.markdown.trim() || message.text.trim()
-	if (text) return { content: text, fromAttachment: false }
-
-	const blocks = blocksText(message.raw.blocks)
-	if (blocks) return { content: blocks, fromAttachment: false }
-
-	const attachments = attachmentsText(message.raw.attachments)
-	if (attachments) return { content: attachments, fromAttachment: true }
-
-	return { content: "", fromAttachment: false }
-}
-
-function attachmentsText(value: unknown): string {
-	return joinLines(
-		asArray(value).map((attachment) => {
-			if (!isRecord(attachment)) return ""
-			const blocks = blocksText(attachment.blocks)
-			if (blocks) return joinLines([str(attachment.title), blocks])
-			// Legacy attachments carry their body in `text`; `fallback` is the
-			// notification-preview one-liner and the last thing worth showing.
-			return joinLines([str(attachment.title), str(attachment.text)]) || str(attachment.fallback)
-		}),
-	)
-}
-
-function blocksText(value: unknown): string {
-	return joinLines(asArray(value).map(blockText))
-}
-
-function blockText(block: unknown): string {
-	if (!isRecord(block)) return ""
-	switch (block.type) {
-		case "divider":
-			return ""
-		case "header":
-		case "section":
-			return joinLines([textObject(block.text), ...asArray(block.fields).map(textObject)])
-		case "context":
-		case "actions":
-			return joinLines(asArray(block.elements).map(elementText))
-		case "rich_text":
-			return joinLines(asArray(block.elements).map(richTextBlockText))
-		case "markdown":
-			return str(block.text)
-		case "image":
-			return imageText(block)
-		default:
-			// Unknown / future block types: sweep every text object out of them
-			// rather than dropping content we simply don't have a case for.
-			return joinLines(collectTextObjects(block))
-	}
-}
-
-function elementText(element: unknown): string {
-	if (!isRecord(element)) return ""
-	if (element.type === "image") return imageText(element)
-	const label = textObject(element.text)
-	// Buttons: the label alone ("Open in Maple") says nothing the model can act
-	// on — the link is the payload.
-	const url = str(element.url)
-	if (label && url) return `${label}: ${url}`
-	return label || url || joinLines(collectTextObjects(element))
-}
-
-function richTextBlockText(element: unknown): string {
-	if (!isRecord(element)) return ""
-	switch (element.type) {
-		case "rich_text_list":
-			return joinLines(asArray(element.elements).map((item) => `- ${richTextBlockText(item)}`))
-		case "rich_text_quote":
-			return joinLines(
-				inlineText(element.elements)
-					.split("\n")
-					.map((line) => `> ${line}`),
-			)
-		default:
-			// rich_text_section / rich_text_preformatted, and anything Slack adds.
-			return inlineText(element.elements)
-	}
-}
-
-/** Inline rich-text runs concatenate — they are one paragraph, not a list. */
-function inlineText(value: unknown): string {
-	return asArray(value)
-		.map((element) => {
-			if (!isRecord(element)) return ""
-			switch (element.type) {
-				case "text":
-					// Not `str()`: the whitespace between runs is the sentence's own
-					// spacing, and trimming each run glues the words together.
-					return typeof element.text === "string" ? element.text : ""
-				case "link": {
-					const label = str(element.text)
-					const url = str(element.url)
-					return label && label !== url ? `${label} (${url})` : url
-				}
-				case "user":
-					return `<@${str(element.user_id)}>`
-				case "usergroup":
-					return `<!subteam^${str(element.usergroup_id)}>`
-				case "channel":
-					return `<#${str(element.channel_id)}>`
-				case "emoji":
-					return `:${str(element.name)}:`
-				case "broadcast":
-					return `<!${str(element.range)}>`
-				default:
-					return ""
-			}
-		})
-		.join("")
-		.trim()
-}
-
-function imageText(block: Record<string, unknown>): string {
-	const alt = str(block.alt_text) || textObject(block.title)
-	return alt ? `[image: ${alt}]` : ""
-}
-
-/** The text of a Slack `{ type: "mrkdwn" | "plain_text", text }` object. */
-function textObject(value: unknown): string {
-	return isRecord(value) ? str(value.text) : ""
-}
-
-function collectTextObjects(value: unknown, out: string[] = []): string[] {
-	if (Array.isArray(value)) {
-		for (const item of value) collectTextObjects(item, out)
-		return out
-	}
-	if (!isRecord(value)) return out
-	if ((value.type === "mrkdwn" || value.type === "plain_text") && typeof value.text === "string") {
-		const text = value.text.trim()
-		if (text) out.push(text)
-		return out
-	}
-	for (const item of Object.values(value)) collectTextObjects(item, out)
-	return out
-}
-
-function joinLines(parts: readonly string[]): string {
-	return parts
-		.map((part) => part.trim())
-		.filter((part) => part.length > 0)
-		.join("\n")
-}
-
-function str(value: unknown): string {
-	return typeof value === "string" ? value.trim() : ""
-}
-
-function asArray(value: unknown): readonly unknown[] {
-	return Array.isArray(value) ? value : []
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value)
+	return formatContextBlock("slack_thread_context", messages, options)
 }

--- a/apps/slack-agent/agent/tools/read_channel_history.ts
+++ b/apps/slack-agent/agent/tools/read_channel_history.ts
@@ -1,0 +1,55 @@
+import { defineTool } from "eve/tools"
+import { z } from "zod"
+import {
+	CHANNEL_CONTEXT_MAX_MESSAGES,
+	CHANNEL_CONTEXT_MESSAGE_COUNT,
+	readChannelHistory,
+} from "#lib/channel-context.js"
+
+/**
+ * Lets the agent read the top-level messages posted in this Slack channel just
+ * before the message it is answering — the alert cards, the incident chatter,
+ * whatever the user is pointing at with "this".
+ *
+ * A threadless mention gets those messages injected eagerly (see
+ * `agent/lib/channel-context.ts`), so this tool is for the other case: a
+ * mention *inside* a thread whose subject clearly started outside it. Thread
+ * replies are not returned — `conversations.history` is top-level only — so it
+ * never re-reads what `<slack_thread_context>` already carries.
+ *
+ * THE FILENAME IS THE TOOL NAME (see render_chart.ts for the contract);
+ * behaviour lives in `agent/lib/channel-context.ts`, this file stays the
+ * adapter from eve's tool contract to it.
+ */
+
+const inputSchema = z.object({
+	limit: z
+		.number()
+		.int()
+		.min(1)
+		.max(CHANNEL_CONTEXT_MAX_MESSAGES)
+		.optional()
+		.describe(
+			`How many messages back to read. Defaults to ${CHANNEL_CONTEXT_MESSAGE_COUNT}; ` +
+				`${CHANNEL_CONTEXT_MAX_MESSAGES} is the maximum Slack returns in one call.`,
+		),
+})
+
+export default defineTool({
+	description:
+		"Read the last few top-level messages posted in this Slack channel before the " +
+		"message you are answering, with Maple alert cards rendered in full. Call it " +
+		"whenever the user refers to something that is not in <slack_thread_context> — " +
+		'"this alert", "what happened", "the ship is sinking", a bare "why?" — or when ' +
+		"the thread you are in cannot explain what the user is reacting to. Read the " +
+		"result before answering, and never ask the user to restate something it " +
+		"already contains. Replies inside other threads are not returned, so a single " +
+		"call is enough — do not call it repeatedly for the same question.",
+	inputSchema,
+	async execute(input, ctx) {
+		return readChannelHistory(input.limit ?? CHANNEL_CONTEXT_MESSAGE_COUNT, {
+			id: ctx.session.id,
+			attributes: ctx.session.auth.current?.attributes ?? {},
+		})
+	},
+})


### PR DESCRIPTION
## The gap

Maple posts alert cards to a channel. People answer them by writing a **new channel message** — "the ship is sinking help my friend @Maple" — not by replying inside a card's thread. That mention is its own thread root, so the thread transcript from #351 is one message long: the user's own. The model was answering two live incidents it had never been shown.

An on-demand tool alone doesn't close that. "Call it when you need context" only works once the agent can tell there *is* any, and nothing in a bare mention hints that two alert cards are sitting directly above it.

## What this does

**Eager, structurally triggered.** `threadTs === ts` means there is no thread to carry context, so the turn instead carries the channel's last 5 top-level messages as `<slack_channel_context>` — same renderer, same `waitUntil` path (off the webhook budget), same never-throw degrade as thread context. `conversations.history` returns top-level messages only, so the two surfaces never quote the same message twice.

DMs benefit more than channels: an unthreaded DM is its own eve session (`channelId:threadTs`), so today every message a user sends starts cold.

**On demand for the rest.** Inside a thread, the same read is available as the `read_channel_history` tool — for when the thread is the subject but the channel holds the reason. Directive description, capped at 15.

## Shape

- `agent/lib/slack-context-format.ts` — the renderer, moved out of `thread-context.ts` unchanged (blocks + attachment fallback, i.e. the alert-card path; bot-user-id attribution) and now shared.
- `agent/lib/channel-context.ts` — `loadChannelContext` (eager) and `readChannelHistory` (tool), one `conversations.history` call, deps injected.
- `agent/tools/read_channel_history.ts` — thin adapter, per the filename-is-the-tool-name contract.
- `agent/channels/slack.ts` — both loads in parallel; exactly one ever produces anything.
- `agent/instructions.md` — how to read the new block, and when to reach for the tool.

## Notes

- **No new scopes.** `channels:history` / `groups:history` / `im:history` are already installed for eve's thread fetch and follow-up promotion, so existing workspaces need no reinstall.
- **`mpim:history` deliberately not added** — adding it would make every existing install report missing scopes until reinstalled. A group DM answers `missing_scope`, which degrades to a note telling the model not to retry. Same for `not_in_channel` and `ratelimited`.
- **Slack's post-2025-05 rate-limit tier** caps `conversations.history` at 15 messages for non-Marketplace apps; the tool's `limit` is bounded there rather than letting the model believe it read further back than it did.
- Per-message content is clipped at 2k chars — a channel is unbounded in a way an invited-into thread is not.
- Widened injection surface: channel chatter instead of just thread chatter. Same class as today, more authors.

## Verification

`bun test` in `apps/slack-agent`: 202 pass, 1 fail — `thread-follow-up > promotion deadline`, which **fails on `main` too** (verified by stashing); it's a local timing assertion, and this app sits outside CI. `bun run typecheck` clean, `oxfmt`/`oxlint` clean.

18 new tests cover: threadless mention renders the alert card and excludes the triggering message, thread reply is skipped without a fetch, Slack failure degrades to no context, over-long message clipped, ack-registry vs thread-root `latest`, limit bounds, `missing_scope`/empty notes, request shape (`inclusive=false`, form-encoded), and newest-first → oldest-first ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788545084&installation_model_id=427786&pr_number=354&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F354&signature=f9bdaf5097b4cd97405aac636768acc6ca27960f3853ed7748304d54e13d430d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->