### PR TITLE
fix(slack-agent): stop silently dropping thread follow-ups

### DIFF
--- a/apps/slack-agent/agent/channels/slack.ts
+++ b/apps/slack-agent/agent/channels/slack.ts
@@ -6,7 +6,7 @@ import { botUserIdForTeam, rememberBotUserId } from "#lib/bot-identity.js"
 import { loadChannelContext } from "#lib/channel-context.js"
 import { resolveBotToken, verifySlackV0Signature, type SlackTokenContext } from "#lib/maple.js"
 import { loadThreadContext } from "#lib/thread-context.js"
-import { promoteThreadFollowUp } from "#lib/thread-follow-up.js"
+import { promoteThreadFollowUp, recordThreadEngagement } from "#lib/thread-follow-up.js"
 import { forwardUninstallEvent } from "#lib/uninstall-detection.js"
 
 /**
@@ -45,6 +45,13 @@ const webhookVerifier: SlackWebhookVerifier = async (request, body) => {
 	// `authorizations`, so thread-context attribution gets it for free — no
 	// auth.test round-trip (#lib/bot-identity.js).
 	rememberBotUserId(body)
+
+	// Learn engagement from events that already prove it — the bot's own posts
+	// echoing back, and @mentions of it — so the promotion below can answer from
+	// cache instead of spending Slack's webhook budget on `conversations.replies`
+	// in a thread the bot is demonstrably active in (#lib/thread-follow-up.js).
+	// Synchronous and network-free; must run before the promotion.
+	recordThreadEngagement(body)
 
 	// app_uninstalled / tokens_revoked: eve only dispatches app_mention + DM
 	// events downstream, so it would otherwise drop these as "unsupported".

--- a/apps/slack-agent/agent/lib/thread-follow-up.test.ts
+++ b/apps/slack-agent/agent/lib/thread-follow-up.test.ts
@@ -3,6 +3,7 @@ import { installFetchStub } from "./fetch-stub.js"
 import {
 	fetchThreadRepliesFromSlack,
 	promoteThreadFollowUp,
+	recordThreadEngagement,
 	resetThreadEngagementCacheForTests,
 	type ThreadFollowUpDeps,
 	type ThreadReplyMessage,
@@ -331,6 +332,40 @@ describe("promotion deadline", () => {
 		}
 		expect(await promoteThreadFollowUp(envelope({}), deps)).toBeNull()
 	})
+
+	test("expiry is logged: it is the one path that drops a message with no other trace", async () => {
+		// No turn is created, eve drops the event as `unsupported` without a line
+		// of its own, and the :eyes: ack never fires — so unless this logs, the
+		// bot going quiet leaves nothing behind to find. hooks/outcome-log.ts
+		// cannot cover it: there is no turn for it to report on.
+		const warnings: string[] = []
+		const realWarn = console.warn
+		console.warn = (line: unknown) => {
+			warnings.push(String(line))
+		}
+		try {
+			const deps: ThreadFollowUpDeps = {
+				resolveBotToken: async () => "xoxb-test",
+				fetchThreadReplies: () =>
+					new Promise((resolve) => setTimeout(() => resolve(ENGAGED_THREAD), 200)),
+				promotionDeadlineMs: 20,
+			}
+			expect(await promoteThreadFollowUp(envelope({}), deps)).toBeNull()
+		} finally {
+			console.warn = realWarn
+		}
+
+		const logged = warnings.map((line) => JSON.parse(line) as Record<string, unknown>)
+		const timeout = logged.find(
+			(entry) => entry["maple.agent.event"] === "follow_up_promotion_timeout",
+		)
+		expect(timeout).toBeDefined()
+		// Enough to find the thread in Slack; never the message text.
+		expect(timeout?.["maple.slack.team_id"]).toBe("T123")
+		expect(timeout?.["maple.slack.channel_id"]).toBe("C123")
+		expect(timeout?.["maple.slack.thread_ts"]).toBe("1700000000.000100")
+		expect(timeout?.["maple.agent.deadline_ms"]).toBe(20)
+	})
 })
 
 // ── caching ─────────────────────────────────────────────────────────────────
@@ -398,5 +433,153 @@ describe("engagement cache", () => {
 		const otherTeam = envelope({ envelope: { team_id: "T999" } })
 		expect(await promoteThreadFollowUp(otherTeam, deps)).toBeNull()
 		expect(call).toBe(2)
+	})
+})
+
+// ── engagement learned from the event stream ────────────────────────────────
+
+// The cold path (conversations.replies) is the one that has to fit inside
+// Slack's webhook budget, and the one that drops a user's message when it
+// doesn't. Everything the bot does in a thread already comes back through the
+// events stream, so most threads should never reach it at all.
+
+/** The bot's own post echoing back: `bot_id` set AND `user` = the bot. */
+function botPost(overrides: Record<string, unknown> = {}): string {
+	return envelope({
+		event: {
+			bot_id: "B0BOT",
+			user: BOT_USER_ID,
+			text: "Here are the reasons why...",
+			ts: "1700000001.000100",
+			...overrides,
+		},
+	})
+}
+
+describe("recordThreadEngagement", () => {
+	test("the bot's own post warms the thread, so the next follow-up needs no fetch", async () => {
+		recordThreadEngagement(botPost())
+
+		const { deps, calls } = makeDeps(UNRELATED_THREAD)
+		expect(await promoteThreadFollowUp(envelope({}), deps)).not.toBeNull()
+		// Promoted purely from what the event stream already told us.
+		expect(calls()).toBe(0)
+	})
+
+	test("an @mention of the bot warms the thread too", async () => {
+		recordThreadEngagement(
+			envelope({
+				event: { text: `<@${BOT_USER_ID}> why is error rate up?`, ts: "1700000001.000100" },
+			}),
+		)
+
+		const { deps, calls } = makeDeps(UNRELATED_THREAD)
+		expect(await promoteThreadFollowUp(envelope({}), deps)).not.toBeNull()
+		expect(calls()).toBe(0)
+	})
+
+	test("a root-level mention is keyed by its own ts — the ts that becomes the thread", async () => {
+		// No thread_ts yet: the thread does not exist until the bot replies.
+		recordThreadEngagement(
+			envelope({
+				event: {
+					type: "app_mention",
+					channel_type: undefined,
+					thread_ts: undefined,
+					text: `<@${BOT_USER_ID}> take a look`,
+					ts: "1700000000.000100",
+				},
+			}),
+		)
+
+		// The default envelope replies in thread 1700000000.000100 — the mention's
+		// own ts. Its very first follow-up is already warm.
+		const { deps, calls } = makeDeps(UNRELATED_THREAD)
+		expect(await promoteThreadFollowUp(envelope({}), deps)).not.toBeNull()
+		expect(calls()).toBe(0)
+	})
+
+	test("the regression: a follow-up 3 minutes after the bot's last post stays warm", async () => {
+		// The incident. Engagement had only ever been written by the cold path, so
+		// it aged out 5 minutes after the last *promotion* rather than after the
+		// bot's last post — and the next follow-up paid the full round-trip inside
+		// Slack's webhook budget, missed the deadline, and was dropped in silence.
+		setSystemTime(new Date("2026-08-05T19:27:44Z"))
+		recordThreadEngagement(botPost({ ts: "1785958064.000100" }))
+
+		setSystemTime(new Date("2026-08-05T19:30:38Z"))
+		const { deps, calls } = makeDeps(UNRELATED_THREAD)
+		const followUp = envelope({ event: { ts: "1785958238.000200" } })
+		expect(await promoteThreadFollowUp(followUp, deps)).not.toBeNull()
+		expect(calls()).toBe(0)
+	})
+
+	test("a stranger's message teaches nothing", async () => {
+		recordThreadEngagement(envelope({ event: { text: "lunch?" } }))
+
+		const { deps, calls } = makeDeps(UNRELATED_THREAD)
+		expect(await promoteThreadFollowUp(envelope({}), deps)).toBeNull()
+		// Fell through to the cold path rather than caching a false positive.
+		expect(calls()).toBe(1)
+	})
+
+	test("another bot's post teaches nothing (it is not our engagement)", async () => {
+		recordThreadEngagement(botPost({ user: "U0OTHERBOT", bot_id: "B0GITHUB" }))
+
+		const { deps, calls } = makeDeps(UNRELATED_THREAD)
+		expect(await promoteThreadFollowUp(envelope({}), deps)).toBeNull()
+		expect(calls()).toBe(1)
+	})
+
+	test("engagement never moves backwards when Slack redelivers an older event", async () => {
+		recordThreadEngagement(botPost({ ts: "1700001000.000100" }))
+		// A retry of a much older post must not un-freshen the newer engagement.
+		recordThreadEngagement(botPost({ ts: "1700000001.000100" }))
+
+		const { deps, calls } = makeDeps(UNRELATED_THREAD)
+		// 20 minutes after the NEWER post; >30 min after the older one, so if the
+		// replay had won this would fall outside the recency bound.
+		const followUp = envelope({ event: { ts: "1700002200.000200" } })
+		expect(await promoteThreadFollowUp(followUp, deps)).not.toBeNull()
+		expect(calls()).toBe(0)
+	})
+
+	test("recorded engagement is still subject to the recency bound", async () => {
+		recordThreadEngagement(botPost({ ts: "1700000001.000100" }))
+
+		const { deps } = makeDeps(UNRELATED_THREAD)
+		// 31 minutes later: a warm cache does not make a dead thread live.
+		const followUp = envelope({ event: { ts: "1700001861.000200" } })
+		expect(await promoteThreadFollowUp(followUp, deps)).toBeNull()
+	})
+
+	test("teams stay isolated", async () => {
+		recordThreadEngagement(botPost())
+
+		const { deps, calls } = makeDeps(UNRELATED_THREAD)
+		const otherTeam = envelope({ envelope: { team_id: "T999" } })
+		expect(await promoteThreadFollowUp(otherTeam, deps)).toBeNull()
+		expect(calls()).toBe(1)
+	})
+
+	test("edits, DMs, non-events and unreadable bodies are all no-ops", async () => {
+		recordThreadEngagement(botPost({ subtype: "message_changed" }))
+		recordThreadEngagement(botPost({ channel_type: "im" }))
+		recordThreadEngagement(botPost({ type: "reaction_added" }))
+		recordThreadEngagement(botPost({ ts: undefined }))
+		recordThreadEngagement("not json")
+		recordThreadEngagement(JSON.stringify({ type: "url_verification", challenge: "x" }))
+
+		const { deps, calls } = makeDeps(UNRELATED_THREAD)
+		expect(await promoteThreadFollowUp(envelope({}), deps)).toBeNull()
+		expect(calls()).toBe(1)
+	})
+
+	test("a file_share post (the bot uploading a chart) counts", async () => {
+		recordThreadEngagement(botPost({ subtype: "file_share" }))
+
+		const { deps, calls } = makeDeps(UNRELATED_THREAD)
+		expect(await promoteThreadFollowUp(envelope({}), deps)).not.toBeNull()
+		expect(calls()).toBe(0)
 	})
 })

--- a/apps/slack-agent/agent/lib/thread-follow-up.ts
+++ b/apps/slack-agent/agent/lib/thread-follow-up.ts
@@ -273,22 +273,28 @@ async function isBotEngagedInThread(
  * Resolves/rejects with `promise`, but rejects as soon as `signal` aborts —
  * even when the underlying work ignores the signal. The work itself is not
  * cancelled; we just stop waiting for it.
+ *
+ * The abort listener is deliberately NOT removed once `promise` settles, which
+ * looks like a leak and is not one: `{ once: true }` drops it when it fires,
+ * the signal is created per promotion and lives at most
+ * `PROMOTION_DEADLINE_MS`, and rejecting an already-settled promise is a no-op.
+ *
+ * Removing it explicitly — the obvious tidier version — breaks this outright
+ * under Bun (1.3.14): taking the last `abort` listener off a signal from
+ * `AbortSignal.timeout()` stops its timer for good, so `.aborted` never
+ * becomes true and the deadline silently ceases to exist. Node is unaffected,
+ * so production behaved correctly and only the test runner saw it — which is
+ * precisely why it went unnoticed. Both calls below share one signal and the
+ * first one almost always settles fast, so the tidier version disarmed the
+ * deadline for the second, slower call: the one it exists to bound.
  */
 function withDeadline<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
 	if (signal.aborted) return Promise.reject(abortReason(signal))
 	return new Promise<T>((resolve, reject) => {
-		const onAbort = () => reject(abortReason(signal))
-		signal.addEventListener("abort", onAbort, { once: true })
-		promise.then(
-			(value) => {
-				signal.removeEventListener("abort", onAbort)
-				resolve(value)
-			},
-			(error: unknown) => {
-				signal.removeEventListener("abort", onAbort)
-				reject(error instanceof Error ? error : new Error(String(error)))
-			},
-		)
+		signal.addEventListener("abort", () => reject(abortReason(signal)), { once: true })
+		promise.then(resolve, (error: unknown) => {
+			reject(error instanceof Error ? error : new Error(String(error)))
+		})
 	})
 }
 

--- a/apps/slack-agent/agent/lib/thread-follow-up.ts
+++ b/apps/slack-agent/agent/lib/thread-follow-up.ts
@@ -1,5 +1,6 @@
 import { botUserIdFromEnvelope } from "./bot-identity.js"
 import { resolveBotToken } from "./maple.js"
+import { emitAgentLog } from "./telemetry-log.js"
 import { createTtlCache } from "./ttl-cache.js"
 
 /**
@@ -30,6 +31,14 @@ import { createTtlCache } from "./ttl-cache.js"
  *     mentioned it there (covers the follow-up racing ahead of the bot's
  *     first reply) — and that engagement is still RECENT (see
  *     `ENGAGEMENT_MAX_AGE_SECONDS` / `ENGAGEMENT_RECENT_MESSAGE_WINDOW`).
+ *
+ * Engagement is learned two ways, and the cheap one carries the load:
+ * `recordThreadEngagement` reads it straight off events that already prove it
+ * (the bot's own post echoing back, an @mention of it), while
+ * `isBotEngagedInThread` falls back to a `conversations.replies` round-trip for
+ * threads no such event has taught us about. The fallback is what has to fit
+ * inside Slack's webhook budget, so the fewer threads reach it, the fewer
+ * follow-ups are lost to `PROMOTION_DEADLINE_MS`.
  *
  * Requires the Slack app to subscribe to `message.channels` (public) /
  * `message.groups` (private) bot events; the engagement check reuses the
@@ -79,6 +88,13 @@ const defaultDeps: ThreadFollowUpDeps = {
 // a thread the bot joins moments later is picked up quickly. What the cache
 // stores is the *timestamp* of the engagement, not a boolean, so the recency
 // bound below is re-applied on every hit instead of being frozen for the TTL.
+//
+// The TTL is measured from the last time we LEARNED of engagement, and
+// `recordThreadEngagement` keeps that in step with what the bot is actually
+// doing: every post of its own that echoes back through the webhook refreshes
+// the entry. So a thread the bot is actively replying in never goes cold, and
+// this TTL only governs threads that have genuinely gone quiet — which are
+// exactly the ones worth re-verifying against Slack.
 const ENGAGED_TTL_MS = 5 * 60_000
 const NOT_ENGAGED_TTL_MS = 20_000
 const CACHE_MAX_ENTRIES = 500
@@ -126,6 +142,109 @@ const engagementCache = createTtlCache<EngagementCacheEntry>({
 /** Test-only: clears the engagement cache so each test starts cold. */
 export function resetThreadEngagementCacheForTests(): void {
 	engagementCache.clear()
+}
+
+/**
+ * The cache is process-global and this app serves every workspace that
+ * installed the Slack app. Slack channel ids are only unique per workspace, so
+ * a bare `channel:thread` key would let one tenant's engagement decide
+ * another tenant's dispatch.
+ */
+function engagementCacheKey(
+	teamId: string | undefined,
+	channelId: string,
+	threadTs: string,
+): string {
+	return `${teamId ?? "-"}:${channelId}:${threadTs}`
+}
+
+/**
+ * Refreshes the engagement cache from an event that already *proves* the bot is
+ * engaged — its own post echoing back through the events stream, or someone
+ * @-mentioning it. Free: the envelope in hand carries exactly what the
+ * `conversations.replies` round-trip would have gone to Slack to find out.
+ *
+ * Why this exists: engagement used to be learned only by the cold path in
+ * `isBotEngagedInThread`, so an entry aged out `ENGAGED_TTL_MS` after the last
+ * *promotion* rather than after the last thing the bot actually did. A thread
+ * the bot was still actively replying in could therefore hand the next
+ * un-mentioned follow-up a cold cache, making it pay the full two-call
+ * round-trip inside Slack's ~3s webhook budget — and a follow-up that misses
+ * `PROMOTION_DEADLINE_MS` is dropped outright, with no reply and no retry.
+ * That is a real incident, not a hypothetical: a follow-up was lost this way
+ * three minutes after the bot's own last post in the same thread.
+ *
+ * Call it on every verified inbound body, before promotion. Never throws — an
+ * envelope we cannot read simply teaches us nothing.
+ */
+export function recordThreadEngagement(rawBody: string): void {
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(rawBody)
+	} catch {
+		return
+	}
+	if (!isRecord(parsed) || parsed.type !== "event_callback") return
+
+	const event = parsed.event
+	if (!isRecord(event)) return
+	if (event.type !== "message" && event.type !== "app_mention") return
+
+	// Promotion only ever applies to channel threads, so nothing else is worth
+	// caching. `app_mention` carries no `channel_type`, and only arrives from a
+	// channel the app is in — so the filter applies to `message` events only.
+	const channelType = event.channel_type
+	if (
+		event.type === "message" &&
+		channelType !== "channel" &&
+		channelType !== "group" &&
+		channelType !== "mpim"
+	) {
+		return
+	}
+
+	// Edits and deletions carry the original under a nested `message`; their
+	// top-level ts is not a new engagement. Same filter as the dispatch path.
+	const subtype = event.subtype
+	if (typeof subtype === "string" && subtype.length > 0 && subtype !== "file_share") return
+
+	const channelId = typeof event.channel === "string" ? event.channel : ""
+	const ts = typeof event.ts === "string" ? event.ts : ""
+	if (!channelId || !ts) return
+
+	const botUserId = botUserIdFromEnvelope(parsed)
+	if (!botUserId) return
+
+	// The same predicate `latestEngagementSeconds` applies to fetched replies —
+	// the two must agree, or whether a thread counts as engaged would depend on
+	// which path happened to observe it.
+	//
+	// `bot_id` is deliberately NOT rejected here. `parseFollowUpCandidate` drops
+	// bot-authored messages to stop the bot dispatching a turn on its own reply;
+	// that is a rule about *dispatch*. For *learning*, the bot's own post is the
+	// single most reliable engagement signal there is.
+	const text = typeof event.text === "string" ? event.text : ""
+	const isOwnPost = typeof event.user === "string" && event.user === botUserId
+	if (!isOwnPost && !text.includes(`<@${botUserId}>`)) return
+
+	const seconds = Number(ts)
+	if (!Number.isFinite(seconds)) return
+
+	// A root-level mention has no `thread_ts` yet — its own ts is what becomes
+	// the thread's id once the bot replies, so key on that and the thread is
+	// already warm for its very first follow-up.
+	const threadTs =
+		typeof event.thread_ts === "string" && event.thread_ts.length > 0 ? event.thread_ts : ts
+	const teamId = typeof parsed.team_id === "string" ? parsed.team_id : undefined
+	const key = engagementCacheKey(teamId, channelId, threadTs)
+
+	// Never move engagement backwards: Slack redelivers, and a retry carrying an
+	// older event must not un-freshen what a newer one has already established.
+	const known = engagementCache.get(key)?.engagedAtSeconds ?? null
+	engagementCache.set(key, {
+		engagedAtSeconds: known === null ? seconds : Math.max(known, seconds),
+		expiresAt: Date.now() + ENGAGED_TTL_MS,
+	})
 }
 
 /**
@@ -222,11 +341,7 @@ async function isBotEngagedInThread(
 	candidate: FollowUpCandidate,
 	deps: ThreadFollowUpDeps,
 ): Promise<boolean> {
-	// teamId is part of the key: the cache is process-global and this app serves
-	// every workspace that installed the Slack app. Slack channel ids are only
-	// unique per workspace, so a bare `channel:thread` key lets one tenant's
-	// engagement decide another tenant's dispatch.
-	const cacheKey = `${candidate.teamId ?? "-"}:${candidate.channelId}:${candidate.threadTs}`
+	const cacheKey = engagementCacheKey(candidate.teamId, candidate.channelId, candidate.threadTs)
 	const cached = engagementCache.get(cacheKey)
 	if (cached) return isEngagementRecent(cached.engagedAtSeconds, candidate)
 
@@ -256,7 +371,23 @@ async function isBotEngagedInThread(
 	} catch (error) {
 		// Deadline expiry is an expected cold-cache outcome, not a failure: fall
 		// through unpromoted (nothing cached — the next reply retries, warmer).
-		if (deadline.aborted) return false
+		//
+		// Expected, but never silent. This is the one path that costs a user their
+		// message outright: no turn is created, eve drops the event as
+		// `unsupported` without a line of its own, and the `:eyes:` ack does not
+		// fire either — so from the outside the bot simply says nothing. Left
+		// unlogged it is invisible to `hooks/outcome-log.ts`, which can only ever
+		// report on turns that exist.
+		if (deadline.aborted) {
+			emitAgentLog("warn", "follow_up_promotion_timeout", {
+				"maple.agent.event": "follow_up_promotion_timeout",
+				"maple.slack.team_id": candidate.teamId,
+				"maple.slack.channel_id": candidate.channelId,
+				"maple.slack.thread_ts": candidate.threadTs,
+				"maple.agent.deadline_ms": deps.promotionDeadlineMs ?? PROMOTION_DEADLINE_MS,
+			})
+			return false
+		}
 		throw error
 	}
 


### PR DESCRIPTION
## What happened

A message to the bot in a Slack thread got no reply at all. Reconstructed from Railway HTTP logs, the eve `workflow_runs` table, and the agent's own OTLP capture:

| Time (UTC) | Event |
|---|---|
| 19:23:32 | An un-mentioned thread reply is **promoted** — webhook 392 ms (cold engagement lookup), turn dispatches |
| ~19:28:32 | Engagement cache entry expires (`ENGAGED_TTL_MS`, 5 min) |
| **19:30:38** | **Follow-up arrives. Webhook returns 200 in `2009 ms`. No turn. No log. No `:eyes:` ack.** |
| 19:31:36 | User re-asks *with* an `@mention` — webhook 7 ms, dispatches normally |

`2009 ms` is not a coincidence: `PROMOTION_DEADLINE_MS` is `2_000`.

A follow-up that does not @-mention the bot only dispatches if `promoteThreadFollowUp` rewrites it to an `app_mention`, and that needed a `conversations.replies` round-trip to re-prove engagement. On deadline expiry it falls through unpromoted and eve drops it as `unsupported` — no turn, no ack, no log line anywhere. The bot just goes quiet.

The aggravating factor: **the bot had posted in that thread three minutes earlier.** Engagement was never in doubt. But the entry was only ever written by the cold path, so it aged out five minutes after the last *promotion* rather than after the last thing the bot actually did.

## The fix

Everything the bot does in a thread already comes back through `message.channels`. `recordThreadEngagement` reads engagement straight off those envelopes — the bot's own posts echoing back, and @mentions of it — with zero network calls. The round-trip stays as the fallback for threads nothing has taught us about, so far fewer messages ever reach the path that can drop them.

- Reuses the exact predicate `latestEngagementSeconds` applies to fetched replies, so engagement cannot depend on which path observed it.
- `bot_id` is deliberately *not* rejected here. The dispatch path drops bot-authored messages to stop the bot answering itself — a rule about *dispatch*. For *learning*, the bot's own post is the best signal available. Another app's post (GitHub, CI) still teaches nothing.
- A root-level mention has no `thread_ts` yet, so it is keyed by its own `ts` — the id that becomes the thread's — warming it before its first follow-up.
- Engagement never moves backwards when Slack redelivers an older event.
- The 30-minute recency bound still applies on read; a warm cache does not make a dead thread live.
- `ENGAGED_TTL_MS` stays at 5 minutes. With recording in place it no longer binds, and a thread the bot has not touched in five minutes is exactly one worth re-verifying.

**Deadline expiry is now logged.** It was the only path that could cost a user their message leaving nothing behind; `hooks/outcome-log.ts` cannot cover it, because there is no turn for it to report on. Ids only, never message text.

## Second commit: a latent bug this uncovered

`withDeadline` removed its own abort listener once the wrapped promise settled. Under **Bun 1.3.14**, taking the last `abort` listener off an `AbortSignal.timeout()` signal stops its timer permanently:

```
bun 1.3.14   listener added then removed: aborted=false
node v26.0.0 listener added then removed: aborted=true
```

Both calls in `isBotEngagedInThread` share one signal and the first settles fast, so the removal disarmed the deadline for the second, slower call — the thread fetch it exists to bound.

Node is unaffected, so **production behaved correctly** (corroborated by the 2009 ms webhook above) and only the test runner saw it. The consequence was that `a slow thread fetch falls through unpromoted at the deadline` **has been failing on `main`**, masking this path entirely. Split into its own commit since it is a bug fix on `main`, not part of the feature.

## Testing

`bun test` — 215 pass, 0 fail (16 files). `bun typecheck` clean.

New coverage for engagement recording: bot's own post, @mention, root-level mention keying, stranger's message, another bot's post, out-of-order redelivery, recency bound still applied, team isolation, edits/DMs/non-events, `file_share` uploads. Plus a regression test pinned to the real incident timing (post 19:27:44 → follow-up 19:30:38 → promoted, zero Slack calls), and one asserting the timeout log fires with ids and no message text.

The follow-up suite also went 486 ms → 98 ms, since the deadline now actually fires at 20 ms instead of running the full 200 ms.

## Not addressed here

Two separate issues found during the investigation, both worth their own PRs:

1. **MCP session expiry across turns.** eve persists `initialSessionId` in durable session state; Maple's `/mcp` 404s it after idle (~13 min in the observed case) or a container restart. The agent self-heals via `connection_search` + retry, but burns a tool call — and it then narrated that error as the cause of the silence above, which it was not.
2. **The agent has no idea what time it is.** Nothing injects the current date/time into the prompt or thread context, so a "past 6 hours" chart came back anchored an hour stale. During an incident that is genuinely dangerous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788553112&installation_model_id=427786&pr_number=355&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F355&signature=e946c69f89fef0476f0dd17afed9ab7d0a8b2cce150ba4bd9095b4edf3bb3ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->