### PR TITLE
perf(query-engine): enable the serviceOperations rollup, warm the missed fan-outs

### DIFF
--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -260,8 +260,16 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 				// 16/250 and the code defaults moved to 6/40 underneath them.
 				QE_BUCKET_CACHE_READ_CONCURRENCY: process.env.QE_BUCKET_CACHE_READ_CONCURRENCY?.trim() || "6",
 				EDGE_CACHE_READ_TIMEOUT_MS: process.env.EDGE_CACHE_READ_TIMEOUT_MS?.trim() || "40",
+				// Migration 0008's rollout gate. Flipped to on after verifying parity on
+				// the managed warehouse: `service_operations_minutely` matches raw
+				// `traces` to the digit over 2026-07-28..08-01 (36.07 / 30.76 / 5.15 /
+				// 33.08 / 29.19 M estimated spans), and both rollups are continuous back
+				// to 2026-07-01, so the backfill ran. Live-write parity is within 0.4%
+				// (boundary-minute inclusion). BYO clusters that never ran 0008 are
+				// unaffected: `isMissingServiceOperationsRollup` falls the read back to
+				// the raw path per-org.
 				SERVICE_OPERATIONS_ROLLUP_ENABLED:
-					process.env.SERVICE_OPERATIONS_ROLLUP_ENABLED?.trim() || "false",
+					process.env.SERVICE_OPERATIONS_ROLLUP_ENABLED?.trim() || "true",
 				...optionalPlain("MAPLE_ENDPOINT"),
 				// Derived from the stage, deliberately NOT `optionalPlain` — that helper
 				// lets `process.env` win over the fallback, so a stray

--- a/apps/api/src/routes/v1/query-engine.http.ts
+++ b/apps/api/src/routes/v1/query-engine.http.ts
@@ -1032,9 +1032,11 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 								"query.rollup.enabled",
 								serviceOperationsRollupEnabled,
 							)
-							// The rollout flag stays off until migration 0008 is deployed,
-							// backfilled, and parity-checked. Disabling it restores the all-raw
-							// rollback path without changing the endpoint contract.
+							// Migration 0008 is deployed, backfilled, and parity-checked, so
+							// deployed stages ship this on (`alchemy.run.ts`). The Config
+							// default stays `false` for local/test, where the rollup tables
+							// may not exist. Disabling it restores the all-raw rollback path
+							// without changing the endpoint contract.
 							const runRawSummary = () =>
 								runQuery(Queries.serviceOperationsSummaryRaw, tenant, payload)
 							let useRollup = serviceOperationsRollupEnabled

--- a/apps/api/src/routes/v1/query-engine.http.ts
+++ b/apps/api/src/routes/v1/query-engine.http.ts
@@ -1192,6 +1192,14 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 						// but collect positionally: Effect.forEach returns results in input
 						// order regardless of concurrency, so series naming/merge order stays
 						// deterministic instead of depending on which query finishes first.
+						//
+						// Warm first, like the other fan-outs. `queryEngine.execute` warms
+						// inside the bucket cache, but only when a fill splits into more than
+						// one range — so a cold 4-way fan-out here still raced four config
+						// reads, each contending for a connection slot with its siblings'
+						// warehouse fetches. Measured cost of that contention: a cache read
+						// abandoned at its 40ms deadline whose span still runs ~2.3s.
+						yield* warehouse.warmRoute(tenant)
 						const outcomes: QueryOutcome[] = yield* Effect.forEach(
 							enabledQueries,
 							(query) =>

--- a/apps/api/src/routes/v1/session-replay.http.ts
+++ b/apps/api/src/routes/v1/session-replay.http.ts
@@ -146,6 +146,10 @@ export const HttpSessionReplaysLive = HttpApiBuilder.group(MapleApi, "sessionRep
 						}),
 						{ orgId: tenant.orgId, sessionId: payload.sessionId },
 					)
+					// Resolve the org's route before fanning out, so the config read lands
+					// on an empty connection pool instead of queueing behind a sibling's
+					// warehouse fetch. No-op once the in-isolate memo is warm.
+					yield* warehouse.warmRoute(tenant)
 					const [maybeData, maybeActivity] = yield* Effect.all(
 						[
 							warehouse.compiledQueryFirst(tenant, compiled, {

--- a/apps/api/src/routes/v2/phase1-resources.http.test.ts
+++ b/apps/api/src/routes/v2/phase1-resources.http.test.ts
@@ -305,6 +305,9 @@ const warehouseStub: WarehouseQueryServiceShape = {
 	// response-byte ceiling), so the stub has to answer it too.
 	compiledQueryBounded: (_tenant, compiled) => compiled.decodeRows([]).pipe(Effect.orDie),
 	compiledQueryFirst: () => Effect.succeed(Option.none()),
+	// Handlers warm the org route before fanning out; the real one resolves
+	// route + capabilities, which this stub has nothing to resolve.
+	warmRoute: () => Effect.void,
 	ingest: () => Effect.void,
 	asExecutor: () => {
 		throw new Error("asExecutor is not supported by this test stub")

--- a/apps/api/src/routes/v2/session-replays.http.ts
+++ b/apps/api/src/routes/v2/session-replays.http.ts
@@ -221,6 +221,8 @@ const HttpV2SessionReplaysGroup = HttpApiBuilder.group(MapleApiV2, "sessionRepla
 						CH.sessionActivityQuery({ startTime: windowStart, endTime: windowEnd }),
 						{ orgId: tenant.orgId, sessionId: params.id },
 					)
+					// Warm the route before fanning out — see the v1 handler for why.
+					yield* warehouse.warmRoute(tenant)
 					const [maybeData, maybeActivity] = yield* Effect.all(
 						[
 							warehouse.compiledQueryFirst(tenant, detailCompiled, {

--- a/apps/api/src/routes/v2/setup-audit.http.test.ts
+++ b/apps/api/src/routes/v2/setup-audit.http.test.ts
@@ -78,6 +78,9 @@ const warehouseStub = (
 		return compiled.decodeRows(table === undefined ? [] : rowsByTable[table]!).pipe(Effect.orDie)
 	},
 	compiledQueryFirst: () => Effect.die(new Error("unexpected compiled query")),
+	// `fetchWarehouseInputs` / `fetchTraceCompleteness` warm the route before
+	// their fan-outs; nothing to resolve against a stub.
+	warmRoute: () => Effect.void,
 	ingest: () => Effect.void,
 	asExecutor: () => {
 		throw new Error("asExecutor is not supported by this test stub")

--- a/apps/api/src/services/alerts/AnomalyDetectionService.ts
+++ b/apps/api/src/services/alerts/AnomalyDetectionService.ts
@@ -295,6 +295,7 @@ const make = Effect.gen(function* () {
 
 		const startTime = formatWarehouseDateTime(nowMs - ANOMALY_ACTIVE_DISCOVERY_WINDOW_MS)
 		const routingTenant = systemTenant(knownOrgs[0])
+		yield* warehouse.warmRoute(routingTenant)
 		return yield* Effect.all(
 			[
 				warehouse.crossOrgQuery(
@@ -1135,6 +1136,10 @@ const make = Effect.gen(function* () {
 		const elapsedMinutes = Math.floor((nowMs - currentHourStartMs) / 60_000)
 		const config = { sensitivity, elapsedMinutes }
 
+		// Warm this org's route before the three-way fan-out. Deliberately here and
+		// not at the outer per-org `Effect.forEach`: the route is per-org, so
+		// warming at the outer level would resolve the wrong org's config.
+		yield* warehouse.warmRoute(tenant)
 		const [goldenSeries, logSeries, spikes] = yield* Effect.all(
 			[
 				fetchGoldenSeries(tenant, nowMs, currentHourStartMs),

--- a/apps/api/src/services/alerts/telemetry-liveness.ts
+++ b/apps/api/src/services/alerts/telemetry-liveness.ts
@@ -77,7 +77,10 @@ export type ServiceWindowPair = readonly [
  * dependency legible, and it keeps `WarehouseQueryService` out of the R channel
  * of callers that already resolved the service inside their own closure.
  */
-export type LivenessWarehouse = Pick<WarehouseQueryServiceShape, "compiledQuery" | "compiledQueryFirst">
+export type LivenessWarehouse = Pick<
+	WarehouseQueryServiceShape,
+	"compiledQuery" | "compiledQueryFirst" | "warmRoute"
+>
 
 export interface LivenessProbeInput {
 	readonly warehouse: LivenessWarehouse
@@ -166,6 +169,11 @@ export const probeLiveness: (input: LivenessProbeInput) => Effect.Effect<Livenes
 )(function* (input) {
 	const { warehouse, tenant, serviceNames } = input
 	const { windowStartMs, windowEndMs, baselineStartMs, baselineEndMs } = input
+
+	// Both branches fan out (the service branch to 4×2 concurrent probes), so warm
+	// the route once up front rather than letting the first wave race for it.
+	// `warmRoute` never fails, which keeps this probe's `never` error channel.
+	yield* warehouse.warmRoute(tenant)
 
 	const result =
 		serviceNames.length === 0

--- a/apps/api/src/services/digest/DigestService.test.ts
+++ b/apps/api/src/services/digest/DigestService.test.ts
@@ -59,6 +59,8 @@ const warehouseStub = Layer.succeed(WarehouseQueryService, {
 	rawSqlQuery: () => Effect.die("rawSqlQuery not used by DigestService tests"),
 	compiledQuery: () => Effect.die("compiledQuery not used by DigestService tests"),
 	compiledQueryFirst: () => Effect.die("compiledQueryFirst not used by DigestService tests"),
+	// The digest warms the route before its five-way fan-out.
+	warmRoute: () => Effect.void,
 	ingest: () => Effect.die("ingest not used by DigestService tests"),
 	asExecutor: () => {
 		throw new Error("asExecutor not used by DigestService tests")

--- a/apps/api/src/services/digest/DigestService.ts
+++ b/apps/api/src/services/digest/DigestService.ts
@@ -240,6 +240,9 @@ export class DigestService extends Context.Service<DigestService>()("@maple/api/
 			// into a single Tinybird query, tagging rows with a `period` column.
 			// The daily timeseries drives the trend sparkline; the previous-week
 			// errors give us a fingerprint set so we can flag genuinely NEW errors.
+			// Warm the route once before the five-way fan-out, so the org-config read
+			// isn't racing five concurrent warehouse fetches for a connection slot.
+			yield* warehouse.warmRoute(systemTenant)
 			const [overviewResponse, usageResponse, seriesResponse, topErrors, prevErrorsResponse] =
 				yield* Effect.all(
 					[

--- a/apps/api/src/services/org/SetupAuditService.ts
+++ b/apps/api/src/services/org/SetupAuditService.ts
@@ -357,6 +357,10 @@ const make: Effect.Effect<SetupAuditServiceShape, never, Database | WarehouseQue
 				traceSampleModulus: Integrations.auditTraceSampleModulus(spanCountOverLookback),
 			}
 
+			// Warm the route before fanning out, so the org-config read happens on an
+			// empty connection pool rather than queueing behind a sibling's warehouse
+			// fetch. No-op on a warm memo.
+			yield* warehouse.warmRoute(tenant)
 			const joined = yield* Effect.all(
 				{
 					orphans: warehouse.compiledQuery(tenant, Integrations.auditOrphanSpansSQL(window), {
@@ -409,6 +413,10 @@ const make: Effect.Effect<SetupAuditServiceShape, never, Database | WarehouseQue
 				profile: "discovery" | "list",
 			) => warehouse.compiledQuery(tenant, compiled, { profile, context: "setupAudit" })
 
+			// Same reason as `fetchTraceCompleteness`. Both are independent entry
+			// points, so each warms; whichever runs second finds the memo warm and
+			// pays nothing.
+			yield* warehouse.warmRoute(tenant)
 			const results = yield* Effect.all(
 				{
 					usage: run(

--- a/apps/api/src/services/warehouse/QueryEngineService.ts
+++ b/apps/api/src/services/warehouse/QueryEngineService.ts
@@ -399,11 +399,7 @@ export class QueryEngineService extends Context.Service<QueryEngineService, Quer
 						yield* recordCacheOutcome(hit)
 						yield* Effect.annotateCurrentSpan("cache.hit", hit)
 						return value
-					}).pipe(
-						Effect.withSpan("QueryEngineService.cachedEvaluate", {
-							attributes: { orgId: tenant.orgId },
-						}),
-					),
+					}),
 				)
 			})
 
@@ -414,6 +410,12 @@ export class QueryEngineService extends Context.Service<QueryEngineService, Quer
 				effect: Effect.Effect<A, QueryEngineDirectError>,
 				policyInput: DirectRouteCachePolicyInput = 15,
 			) {
+				// Attributes go on the `Effect.fn` span, not an inner `withSpan` of the
+				// same name. Wrapping the body in a second same-named span emitted two
+				// spans per call: the inner one closed interrupt-only as `Ok` while the
+				// outer recorded the real `Error`, so every timed-out request showed up
+				// twice — once at 30s `Ok`, once at 30s `Error`.
+				yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId, routeName })
 				return yield* withTimeout(
 					Effect.gen(function* () {
 						const startMs = yield* Clock.currentTimeMillis
@@ -435,11 +437,7 @@ export class QueryEngineService extends Context.Service<QueryEngineService, Quer
 							(yield* Clock.currentTimeMillis) - startMs,
 						)
 						return value
-					}).pipe(
-						Effect.withSpan("QueryEngineService.cachedDirect", {
-							attributes: { orgId: tenant.orgId, routeName },
-						}),
-					),
+					}),
 				)
 			})
 

--- a/packages/query-engine/src/registry/queries.ts
+++ b/packages/query-engine/src/registry/queries.ts
@@ -880,10 +880,27 @@ export const serviceOperationsSummary = defineQuery({
 		),
 })
 
+/**
+ * Ceiling for the two all-raw rollback shapes.
+ *
+ * These full-scan `traces` and compute the display-name rewrite per row, so on a
+ * cluster without the 0008 rollup they are unbounded in practice: measured on a
+ * BYO org, `serviceOperations` ran a p50 of 12.8s and 8 of 19 requests were
+ * killed outright by the `aggregation` profile's 30s cap — returning nothing
+ * after holding the tab for the full budget.
+ *
+ * 10s converts that into a fast, visible failure. It is deliberately below the
+ * profile default rather than above it: a raw scan that has not finished in 10s
+ * is not going to produce a usable interactive result, and the actionable fix is
+ * applying migration 0008 to that cluster, not waiting longer.
+ */
+const SERVICE_OPERATIONS_RAW_SETTINGS = { maxExecutionTime: 10 }
+
 /** Rollback path, used when the rollup table is absent or the flag is off. */
 export const serviceOperationsSummaryRaw = defineQuery({
 	id: "serviceOperations",
 	profile: "aggregation",
+	settings: SERVICE_OPERATIONS_RAW_SETTINGS,
 	cache: undefined,
 	compile: (payload: ServiceOperationsRequest, orgId: string) =>
 		CH.compile(
@@ -926,6 +943,7 @@ export const serviceOperationsTimeseries = defineQuery({
 export const serviceOperationsTimeseriesRaw = defineQuery({
 	id: "serviceOperationsTimeseries",
 	profile: "aggregation",
+	settings: SERVICE_OPERATIONS_RAW_SETTINGS,
 	cache: undefined,
 	compile: (payload: ServiceOperationsTimeseriesInput, orgId: string) =>
 		CH.compile(


### PR DESCRIPTION
Follow-up to the query-engine push that landed on `main` overnight (#343–#348, plus `f2dd068a8` / `53dad908d` / `75c61b96c`). The question was whether that work helped and what was still slow. It helped at p50; the tail did not move, and the biggest remaining problem turned out not to be caching at all.

## Did the previous work help?

Matched hours-of-day (09:00–15:00 UTC), `maple-api` entry-point spans:

| Day | n | p50 | p95 | p99 |
|---|---|---|---|---|
| Aug 1 | 14,804 | 37 ms | 938 | 2,928 |
| Aug 2 | 13,837 | 38 ms | 637 | 2,720 |
| Aug 3 | 15,847 | 49 ms | 2,241 | 4,658 |
| Aug 4 | 15,541 | 66 ms | 2,551 | 4,811 |
| **Aug 5 (after)** | 13,751 | **27 ms** | 1,113 | 3,607 |

Best p50 of the week, and `resolveRoute` / `resolveCachedSettings` now report **0 ms** where they sat at a p95 of ~2 s. Separately, `inspectCapabilities` went p50 **2000 ms → 26.5 ms** — a p50 of exactly 2000 ms was the probe budget being exhausted every single time, which is why bloom/tokenbf indices were never actually used.

p95/p99 are mid-pack: better than Aug 3–4, worse than Aug 1–2. The tail was not fixed.

## What this PR changes

**1. `SERVICE_OPERATIONS_ROLLUP_ENABLED` → `true`.** It has been `false` in every deployed stage since migration 0008 landed, and set nowhere in CI, so every `serviceOperations` request ran the path the code itself labels a rollback — a full scan of `traces`. On a BYO-ClickHouse org that meant p50 **12.8 s** and **8 of 19 requests killed** at the 30 s cap, returning nothing. Caching could never reach it: the query never completes, so it never populates an entry.

0008 asks for a parity check before enabling hybrid reads, so this is checked rather than assumed — `service_operations_minutely` matches raw `traces` **to the digit** per day (Jul 28–Aug 1: 36.07 / 30.76 / 5.15 / 33.08 / 29.19 M), and both rollups run continuously back to Jul 1, which is what proves the backfill ran rather than the MV merely live-writing. Jul 30's 6× dip is a real ingest dip, identical on both sides.

**2. Raw fallback bounded to `maxExecutionTime: 10`.** The flag fixes managed orgs. BYO clusters that never ran 0008 still fall back via the typed `isMissingServiceOperationsRollup` catch — safe, but it leaves them on the same raw path. Until 0008 is applied there, the raw defs now fail fast and visibly instead of holding the tab for the full 30 s budget and returning nothing.

**3. `warmRoute` at eight fan-out sites the last pass missed** — `executeQueryBuilder` (concurrency 4) being the one that matters, plus session-replay v1/v2, `SetupAuditService`, `telemetry-liveness`, `AnomalyDetectionService`, `DigestService`.

**4. Duplicate span fix.** `cachedDirect` **and** `cachedEvaluate` each declared an `Effect.fn` span and an inner `withSpan` of the same name, emitting two spans per call. On timeout they disagreed — inner `Ok` + `interrupted`, outer `Error` — so any panel keyed on that name double-counts and misreports error rate in both directions.

## Reviewer notes

- **Highest-risk change is the flag.** It is a one-line default flip, but it changes which query every `serviceOperations` request runs in production. The parity evidence above is the basis; worth a second opinion on whether it is sufficient. Rollback is the same one line.
- The `Config` default stays `false` for local/test, where the rollup tables may not exist. Deployed stages get the explicit env var from `alchemy.run.ts`.
- Adding `settings` to a `QueryDef` does **not** move the SQL baseline — settings are appended by the executor at execution time, not by `CH.compile`. `sql-catalog.test.ts` passes unchanged. (Contrast `capabilityAware`, which does change emitted SQL.)
- In `AnomalyDetectionService` the warm is deliberately on the *inner* per-org fan-out, not the outer loop over orgs — the route is per-org, so warming outside would resolve the wrong org's config.
- `LivenessWarehouse` widens by one method. `warmRoute` is `Effect<void, never>`, so no caller's error channel changes, including `probeLiveness`, which is typed to never fail.

## Deliberately not done

The 40 ms edge-cache abandonment still fires on **20.5%** of reads and `avg_cfg_reads_per_trace` is unchanged at **0.52** — ordering changed *when* the read contends, not *whether* it happens. I measured before touching it: the memo is healthier than it looks (hit rate 71.6% → **78.5%**; memo hit 0 ms, memo-miss-then-edge-hit 8 ms), and only ~110 reads/day take the 2.3 s path.

The one lever there, `ORG_CH_CONFIG_MEMO_TTL_MS` (300 s vs the 1 h edge TTL), is a deliberate correctness bound, not an oversight: the per-isolate memo is not busted by another isolate's config write, so it caps how long a BYO-CH credential rotation takes to propagate. Trading that for a tail win was considered and rejected.

Worth recording for whoever picks this up: a timed-out read is abandoned at 40 ms yet its span still runs **~2.3 s**, while a non-timing-out miss on the same bucket finishes in **28 ms total including the same Postgres read**. So the residual cost is contention on both hops — raising `EDGE_CACHE_READ_TIMEOUT_MS` would convert fast failures into slow ones rather than fix anything. The real fix belongs in `edge-cache.ts`.

Also out of scope: `tracesBreakdown` (p95 29,952 ms on the same BYO cluster) is the MCP/CLI `Ops.tracesBreakdown` path, not in the API registry.

## Verification

- `bun typecheck` — 36/36 clean
- `apps/api` scoped tests — 158 passed
- `packages/query-engine` service-operations + sql-catalog — 29 passed
- `oxfmt --check` — clean

Full suite not run. Post-deploy the signal is: zero 30 s entry-point spans on `/api/query-engine/service-operations`, and BYO `serviceOperations` p50 under ~500 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788555669&installation_model_id=427786&pr_number=356&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F356&signature=140161dc79b40caf0a657ac470d02d183fd6c2e486b8b4fba99cb636d365bd51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->