### PR TITLE
fix(dashboards): stop creation silently doing nothing

### DIFF
--- a/apps/web/src/components/dashboard-builder/config/chart-picker.test.tsx
+++ b/apps/web/src/components/dashboard-builder/config/chart-picker.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { WidgetPicker } from "./chart-picker"
+
+afterEach(cleanup)
+
+// One card per section shape: a chart style (built here from a fresh query
+// draft) and a preset (taken from a widget type's `presets`).
+const CARDS = ["Bar Chart", "Total Traces"]
+
+describe("WidgetPicker", () => {
+	for (const label of CARDS) {
+		it(`offers "${label}" to the dashboard`, () => {
+			const onSelect = vi.fn().mockReturnValue({ id: "widget-1" })
+			render(<WidgetPicker open onOpenChange={vi.fn()} onSelect={onSelect} />)
+
+			fireEvent.click(screen.getAllByText(label)[0]!)
+
+			expect(onSelect).toHaveBeenCalledOnce()
+		})
+	}
+
+	it("closes once the widget has been added", () => {
+		const onOpenChange = vi.fn()
+		render(<WidgetPicker open onOpenChange={onOpenChange} onSelect={() => ({ id: "widget-1" })} />)
+
+		fireEvent.click(screen.getAllByText("Bar Chart")[0]!)
+
+		expect(onOpenChange).toHaveBeenCalledWith(false)
+	})
+
+	it("stays open when the add is refused", () => {
+		// The reported bug: the dialog dismissed itself whatever happened, so a
+		// refused add was indistinguishable from a dead click. The caller reports
+		// the reason (a toast); the dialog's job is to not pretend it worked.
+		const onOpenChange = vi.fn()
+		render(<WidgetPicker open onOpenChange={onOpenChange} onSelect={() => undefined} />)
+
+		fireEvent.click(screen.getAllByText("Bar Chart")[0]!)
+
+		expect(onOpenChange).not.toHaveBeenCalled()
+	})
+})

--- a/apps/web/src/components/dashboard-builder/config/chart-picker.tsx
+++ b/apps/web/src/components/dashboard-builder/config/chart-picker.tsx
@@ -117,11 +117,16 @@ function PickerSection({
 interface WidgetPickerProps {
 	open: boolean
 	onOpenChange: (open: boolean) => void
+	/**
+	 * Returns the widget that was added, or a falsy value when the add was
+	 * refused. The dialog stays open in that case — dismissing itself with
+	 * nothing added is indistinguishable from a dead click.
+	 */
 	onSelect: (
 		visualization: VisualizationType,
 		dataSource: WidgetDataSource,
 		display: WidgetDisplayConfig,
-	) => void
+	) => unknown
 }
 
 export function WidgetPicker({ open, onOpenChange, onSelect }: WidgetPickerProps) {
@@ -131,7 +136,7 @@ export function WidgetPicker({ open, onOpenChange, onSelect }: WidgetPickerProps
 
 	const handleSelectChart = (chartId: string) => {
 		const draft = createQueryDraft(0)
-		onSelect(
+		const added = onSelect(
 			"chart",
 			{
 				endpoint: "custom_query_builder_timeseries",
@@ -146,12 +151,12 @@ export function WidgetPicker({ open, onOpenChange, onSelect }: WidgetPickerProps
 			// charts never render as "Untitled".
 			{ chartId, title: deriveDefaultWidgetTitle([draft]) },
 		)
-		onOpenChange(false)
+		if (added) onOpenChange(false)
 	}
 
 	const handleSelectPreset = (preset: WidgetPresetDefinition) => {
-		onSelect(preset.visualization, preset.dataSource, preset.display)
-		onOpenChange(false)
+		const added = onSelect(preset.visualization, preset.dataSource, preset.display)
+		if (added) onOpenChange(false)
 	}
 
 	return (

--- a/apps/web/src/components/dashboard-builder/dashboard-actions-context.tsx
+++ b/apps/web/src/components/dashboard-builder/dashboard-actions-context.tsx
@@ -23,11 +23,15 @@ interface DashboardActionsContextValue {
 	updateWidgetDisplay: (widgetId: string, display: Partial<WidgetDisplayConfig>) => void
 	updateWidgetDataSource: (widgetId: string, dataSource: WidgetDataSource) => void
 	updateWidgetLayouts: (layouts: Array<{ i: string; x: number; y: number; w: number; h: number }>) => void
+	/**
+	 * Returns the widget that was applied, or `undefined` when the add was
+	 * refused — callers (the picker) use that to decide whether to close.
+	 */
 	addWidget: (
 		visualization: VisualizationType,
 		dataSource: WidgetDataSource,
 		display: WidgetDisplayConfig,
-	) => void
+	) => DashboardWidget | undefined
 	autoLayoutWidgets: () => void
 }
 
@@ -44,7 +48,7 @@ interface DashboardActionsProviderProps {
 			visualization: VisualizationType,
 			dataSource: WidgetDataSource,
 			display: WidgetDisplayConfig,
-		) => void
+		) => DashboardWidget
 		removeWidget: (dashboardId: string, widgetId: string) => DashboardWidget | undefined
 		restoreWidget: (dashboardId: string, widget: DashboardWidget) => void
 		cloneWidget: (dashboardId: string, widgetId: string) => void
@@ -125,9 +129,32 @@ export function DashboardActionsProvider({
 				if (readOnly) return
 				store.updateWidgetLayouts(dashboardId, layouts)
 			},
+			// Never fails silently: a refused or failed add used to return here with
+			// no trace, while the picker closed anyway — so the user saw a dialog
+			// dismiss itself and no widget appear. The optimistic apply is
+			// synchronous, so the returned widget is a true "it landed" signal; a
+			// later persistence failure surfaces through the store's error banner.
 			addWidget: (visualization, dataSource, display) => {
-				if (readOnly) return
-				store.addWidget(dashboardId, visualization, dataSource, display)
+				if (readOnly) {
+					toastManager.add({
+						title: "Dashboard editing is unavailable right now",
+						description: "Reconnect to the dashboard store, then add the widget again.",
+						type: "error",
+					})
+					return undefined
+				}
+
+				let widget: DashboardWidget
+				try {
+					widget = store.addWidget(dashboardId, visualization, dataSource, display)
+				} catch (cause) {
+					toastManager.add({
+						title: cause instanceof Error ? cause.message : "Couldn’t add the widget",
+						type: "error",
+					})
+					return undefined
+				}
+
 				if (mode === "view") {
 					navigate({
 						to: "/dashboards/$dashboardId",
@@ -135,6 +162,7 @@ export function DashboardActionsProvider({
 						search: { mode: "edit" },
 					})
 				}
+				return widget
 			},
 			autoLayoutWidgets: () => {
 				if (readOnly) return

--- a/apps/web/src/components/metrics/metric-graduation-actions.tsx
+++ b/apps/web/src/components/metrics/metric-graduation-actions.tsx
@@ -10,6 +10,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@maple/ui/components/ui/dialog"
+import { defaultWidgetLayout } from "@maple/domain/http"
 import { BellIcon, GridSquareCirclePlusIcon, LinkIcon } from "@/components/icons"
 import { useDashboardStore } from "@/hooks/use-dashboard-store"
 import { CopyButton } from "@maple/ui/components/ui/copy-button"
@@ -85,17 +86,16 @@ function AddToDashboardDialog({
 	draft: MetricsQueryDraft
 }) {
 	const navigate = useNavigate()
-	const { dashboards, readOnly, addWidget, createDashboard } = useDashboardStore()
+	const { dashboards, readOnly, addWidget, importDashboard } = useDashboardStore()
 	const [newName, setNewName] = React.useState("")
 	const [creating, setCreating] = React.useState(false)
 	const [error, setError] = React.useState<string | null>(null)
 
+	const widgetDisplay = { title: draft.metricName, chartId: "query-builder-area" }
+
 	const addToDashboard = (dashboardId: string) => {
 		try {
-			addWidget(dashboardId, "chart", buildWidgetDataSource(draft), {
-				title: draft.metricName,
-				chartId: "query-builder-area",
-			})
+			addWidget(dashboardId, "chart", buildWidgetDataSource(draft), widgetDisplay)
 		} catch (cause) {
 			setError(cause instanceof Error ? cause.message : "Failed to add widget")
 			return
@@ -107,14 +107,37 @@ function AddToDashboardDialog({
 		})
 	}
 
+	/**
+	 * Creates the dashboard WITH the widget in one call rather than creating it
+	 * and then adding to it. The widget mutators write through the Electric
+	 * collection, and a dashboard created a moment ago may not have synced into it
+	 * yet — that gap used to swallow the widget, leaving a brand-new empty
+	 * dashboard and no explanation.
+	 */
 	const handleCreate = async () => {
 		const name = newName.trim()
 		if (!name || creating) return
 		setCreating(true)
 		setError(null)
 		try {
-			const dashboard = await createDashboard(name)
-			addToDashboard(dashboard.id)
+			const dashboard = await importDashboard({
+				name,
+				timeRange: { type: "relative", value: "12h" },
+				widgets: [
+					{
+						id: crypto.randomUUID(),
+						visualization: "chart",
+						dataSource: buildWidgetDataSource(draft),
+						display: widgetDisplay,
+						layout: { x: 0, y: 0, ...defaultWidgetLayout("chart") },
+					},
+				],
+			})
+			onOpenChange(false)
+			void navigate({
+				to: "/dashboards/$dashboardId",
+				params: { dashboardId: dashboard.id },
+			})
 		} catch (cause) {
 			setError(cause instanceof Error ? cause.message : "Failed to create dashboard")
 		} finally {

--- a/apps/web/src/hooks/use-dashboard-store.test.tsx
+++ b/apps/web/src/hooks/use-dashboard-store.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { WidgetDataSource } from "@/components/dashboard-builder/types"
+import type { DashboardRow } from "@/lib/collections/dashboards"
+
+// ---------------------------------------------------------------------------
+// A stand-in for the Electric-synced collection. `useDashboardMutations` runs no
+// live query, so the write half only needs `get`/`update`/`delete` plus the txid
+// util — which makes the whole mutator surface testable without a shape stream.
+// ---------------------------------------------------------------------------
+
+const rows = new Map<string, DashboardRow>()
+let persistResult: () => Promise<void> = () => Promise.resolve()
+
+const collection = {
+	id: "dashboards:org_test",
+	get: (id: string) => rows.get(id),
+	update: (id: string, updater: (draft: DashboardRow) => void) => {
+		const next = structuredClone(rows.get(id)!)
+		updater(next)
+		rows.set(id, next)
+		return { isPersisted: { promise: persistResult() } }
+	},
+	delete: (id: string) => {
+		rows.delete(id)
+		return { isPersisted: { promise: persistResult() } }
+	},
+	preload: () => Promise.resolve(),
+	utils: { awaitTxId: () => Promise.resolve(true) },
+}
+
+vi.mock("@/lib/collections/org-collections", () => ({
+	getOrgCollections: () => ({ dashboards: collection }),
+	useActiveOrgId: () => "org_test",
+	useCollectionsGeneration: () => 0,
+	retryOrgCollections: () => undefined,
+	handleCollectionStuck: () => undefined,
+}))
+
+const toastAdd = vi.fn()
+vi.mock("@maple/ui/components/ui/toast", () => ({
+	toastManager: {
+		add: (...args: unknown[]) => toastAdd(...args),
+	},
+}))
+
+const { useDashboardMutations } = await import("@/hooks/use-dashboard-store")
+const { persistenceErrorAtom } = await import("@/atoms/dashboard-store-atoms")
+const { useAtom } = await import("@/lib/effect-atom")
+
+/**
+ * The mutations plus a handle on the persistence banner. `persistenceErrorAtom`
+ * is module-level shared state, so a latched error from one test would leave
+ * every later one read-only.
+ */
+const useStoreUnderTest = () => {
+	const [persistenceError, setPersistenceError] = useAtom(persistenceErrorAtom)
+	return { ...useDashboardMutations(), persistenceError, setPersistenceError }
+}
+
+const ISO = "2026-01-01T00:00:00.000Z"
+
+const makeRow = (id: string, widgets: ReadonlyArray<unknown> = []): DashboardRow => ({
+	org_id: "org_test",
+	id,
+	name: `Dashboard ${id}`,
+	payload_json: {
+		id,
+		name: `Dashboard ${id}`,
+		timeRange: { type: "relative", value: "12h" },
+		widgets,
+		createdAt: ISO,
+		updatedAt: ISO,
+	},
+	created_at: ISO,
+	updated_at: ISO,
+	created_by: "user_test",
+	updated_by: "user_test",
+	version: 1,
+})
+
+const chartDataSource: WidgetDataSource = {
+	endpoint: "custom_query_builder_timeseries",
+	params: { queries: [], formulas: [] },
+}
+
+const widgetsOf = (id: string) =>
+	(rows.get(id)!.payload_json as { widgets: ReadonlyArray<{ id: string }> }).widgets
+
+/** Mounts the hook with the shared persistence banner cleared. */
+const mountStore = () => {
+	const rendered = renderHook(() => useStoreUnderTest())
+	if (rendered.result.current.persistenceError !== null) {
+		act(() => rendered.result.current.setPersistenceError(null))
+	}
+	return rendered
+}
+
+beforeEach(() => {
+	rows.clear()
+	toastAdd.mockClear()
+	persistResult = () => Promise.resolve()
+})
+
+afterEach(cleanup)
+
+describe("addWidget", () => {
+	it("lands the widget in the dashboard's stored payload", async () => {
+		rows.set("dash_a", makeRow("dash_a"))
+		const { result } = mountStore()
+
+		await act(async () => {
+			result.current.addWidget("dash_a", "chart", chartDataSource, { title: "Errors" })
+		})
+
+		expect(widgetsOf("dash_a")).toHaveLength(1)
+	})
+
+	it("places the second widget beside the first rather than on top of it", async () => {
+		rows.set("dash_a", makeRow("dash_a"))
+		const { result } = mountStore()
+
+		await act(async () => {
+			result.current.addWidget("dash_a", "chart", chartDataSource, { title: "One" })
+		})
+		await act(async () => {
+			result.current.addWidget("dash_a", "chart", chartDataSource, { title: "Two" })
+		})
+
+		const layouts = (
+			rows.get("dash_a")!.payload_json as { widgets: ReadonlyArray<{ layout: { x: number } }> }
+		).widgets.map((w) => w.layout.x)
+		expect(layouts).toEqual([0, 4])
+	})
+
+	it("throws instead of silently dropping the widget when the dashboard isn't loaded", () => {
+		const { result } = mountStore()
+
+		// The regression this guards: `mutateDashboard` used to `return` on a
+		// collection miss, so the caller got a widget back, the picker closed, and
+		// nothing was ever written or rendered.
+		expect(() =>
+			result.current.addWidget("dash_missing", "chart", chartDataSource, { title: "Errors" }),
+		).toThrow(/may still be loading/)
+	})
+
+	it("throws when the dashboard's stored payload can't be decoded", () => {
+		const corrupt = makeRow("dash_bad")
+		rows.set("dash_bad", { ...corrupt, payload_json: { nope: true } })
+		const { result } = mountStore()
+
+		expect(() =>
+			result.current.addWidget("dash_bad", "chart", chartDataSource, { title: "Errors" }),
+		).toThrow(/Couldn’t read this dashboard/)
+	})
+})
+
+describe("write failures", () => {
+	it("surfaces a rejected persist on the banner instead of an unhandled rejection", async () => {
+		rows.set("dash_a", makeRow("dash_a"))
+		persistResult = () => Promise.reject(new Error("PATCH /v2/dashboards failed"))
+
+		const { result, rerender } = mountStore()
+
+		await act(async () => {
+			result.current.addWidget("dash_a", "chart", chartDataSource, { title: "Errors" })
+			await Promise.resolve()
+		})
+		rerender()
+
+		expect(result.current.persistenceError).toBe("PATCH /v2/dashboards failed")
+		expect(result.current.readOnly).toBe(true)
+	})
+
+	it("tells the user when the write landed but this tab's sync fell behind", async () => {
+		rows.set("dash_a", makeRow("dash_a"))
+		const timeout = new Error("Timeout waiting for txId 42")
+		persistResult = () => Promise.reject(timeout)
+
+		const { result, rerender } = mountStore()
+
+		await act(async () => {
+			result.current.addWidget("dash_a", "chart", chartDataSource, { title: "Errors" })
+			await Promise.resolve()
+		})
+		rerender()
+
+		// Editing stays enabled — the server has the write — but the rollback is no
+		// longer silent.
+		expect(result.current.persistenceError).toBeNull()
+		expect(toastAdd).toHaveBeenCalledWith(
+			expect.objectContaining({ title: expect.stringContaining("Saved") }),
+		)
+	})
+})

--- a/apps/web/src/hooks/use-dashboard-store.ts
+++ b/apps/web/src/hooks/use-dashboard-store.ts
@@ -12,6 +12,7 @@ import {
 import type { DashboardRefreshIntervalSeconds } from "@maple/domain/http"
 import type { V2DashboardMutation } from "@maple/domain/http/v2"
 import { useLiveQuery } from "@tanstack/react-db"
+import { toastManager } from "@maple/ui/components/ui/toast"
 import { trackProduct } from "@/lib/analytics"
 import { runMapleApiV2 } from "@/lib/collections/api-runner"
 import { rowToDashboard, v2DashboardToDashboard } from "@/lib/collections/dashboards"
@@ -110,7 +111,7 @@ function getErrorMessage(error: unknown): string {
 // txid never appears and TanStack DB rolls the optimistic state back. Latching
 // the read-only banner here would punish a *successful* write; instead the
 // caller triggers the stuck-collection self-heal so a fresh stream re-syncs the
-// saved row.
+// saved row, and tells the user why their change just disappeared from view.
 function isTxidAwaitTimeout(error: unknown): boolean {
 	if (typeof error !== "object" || error === null) return false
 	const named = error as { name?: unknown; message?: unknown }
@@ -193,18 +194,30 @@ function toPortableDashboardDocument(dashboard: PortableDashboard): PortableDash
 // transform pushed through the injected `mutateDashboard`. `readDashboard`
 // supplies the current dashboard (from the collection) for the two mutators
 // that read it.
+//
+// Every fire-and-forget call routes its rejection through `onMutationFailed`.
+// These used to be bare `void mutateDashboard(...)`, which turned a synchronous
+// encode throw (a Schema.Class constructor rejecting a widget, a bad ISO
+// timestamp) into an unhandled promise rejection: the edit vanished and the UI
+// said nothing.
 function makeWidgetMutators(deps: {
 	mutateDashboard: (id: string, updater: (dashboard: Dashboard) => Dashboard) => Promise<void>
 	readOnly: boolean
 	readDashboard: (id: string) => Dashboard | undefined
+	onMutationFailed: (error: unknown) => void
 }) {
-	const { mutateDashboard, readOnly, readDashboard } = deps
+	const { mutateDashboard, readOnly, readDashboard, onMutationFailed } = deps
+
+	/** Fire-and-forget, but never silent: a rejection reaches the persistence banner. */
+	const push = (id: string, updater: (dashboard: Dashboard) => Dashboard): void => {
+		void mutateDashboard(id, updater).catch(onMutationFailed)
+	}
 
 	const updateDashboard = (
 		id: string,
 		updates: Partial<Pick<Dashboard, "name" | "description" | "tags">>,
 	) => {
-		void mutateDashboard(id, (dashboard) => ({
+		push(id, (dashboard) => ({
 			...dashboard,
 			...updates,
 			updatedAt: new Date().toISOString(),
@@ -212,7 +225,7 @@ function makeWidgetMutators(deps: {
 	}
 
 	const updateDashboardTimeRange = (id: string, timeRange: TimeRange) => {
-		void mutateDashboard(id, (dashboard) => ({
+		push(id, (dashboard) => ({
 			...dashboard,
 			timeRange,
 			updatedAt: new Date().toISOString(),
@@ -220,7 +233,7 @@ function makeWidgetMutators(deps: {
 	}
 
 	const updateDashboardVariables = (id: string, variables: DashboardVariable[]) => {
-		void mutateDashboard(id, (dashboard) => ({
+		push(id, (dashboard) => ({
 			...dashboard,
 			variables,
 			updatedAt: new Date().toISOString(),
@@ -234,7 +247,7 @@ function makeWidgetMutators(deps: {
 		id: string,
 		refreshIntervalSeconds: DashboardRefreshIntervalSeconds,
 	) => {
-		void mutateDashboard(id, (dashboard) => ({
+		push(id, (dashboard) => ({
 			...dashboard,
 			refreshIntervalSeconds,
 			updatedAt: new Date().toISOString(),
@@ -259,7 +272,19 @@ function makeWidgetMutators(deps: {
 		// inside it would still be null at return — the old `widgetRef!` masked a
 		// runtime null. `readDashboard` reads the current dashboard in both paths;
 		// the grid compactor resolves any position drift between build and apply.
-		const position = findNextPosition(readDashboard(dashboardId)?.widgets ?? [], layoutDefaults.w)
+		//
+		// Fail here rather than defaulting to an empty widget list: `mutateDashboard`
+		// can only write a dashboard the collection holds, so building a widget for
+		// one it doesn't would return a widget to the caller that is never persisted
+		// and never rendered — the "the picker just closed and nothing happened" bug.
+		// `readDashboard` returns undefined both for a row this tab hasn't synced
+		// yet and for one whose payload won't decode, so the message covers both.
+		const current = readDashboard(dashboardId)
+		if (!current) {
+			throw new Error("Couldn’t read this dashboard — it may still be loading. Try again.")
+		}
+
+		const position = findNextPosition(current.widgets, layoutDefaults.w)
 		const widget: DashboardWidget = {
 			id: generateId(),
 			visualization,
@@ -268,7 +293,7 @@ function makeWidgetMutators(deps: {
 			layout: { ...position, ...layoutDefaults },
 		}
 
-		void mutateDashboard(dashboardId, (dashboard) => ({
+		push(dashboardId, (dashboard) => ({
 			...dashboard,
 			widgets: [...dashboard.widgets, widget],
 			updatedAt: new Date().toISOString(),
@@ -279,7 +304,7 @@ function makeWidgetMutators(deps: {
 
 	const cloneWidget = (dashboardId: string, widgetId: string) => {
 		if (readOnly) return
-		void mutateDashboard(dashboardId, (dashboard) => {
+		push(dashboardId, (dashboard) => {
 			const source = dashboard.widgets.find((w) => w.id === widgetId)
 			if (!source) return dashboard
 
@@ -313,7 +338,7 @@ function makeWidgetMutators(deps: {
 		// here matches what the async write will actually delete.
 		const removed = readDashboard(dashboardId)?.widgets.find((w) => w.id === widgetId)
 
-		void mutateDashboard(dashboardId, (dashboard) => ({
+		push(dashboardId, (dashboard) => ({
 			...dashboard,
 			widgets: dashboard.widgets.filter((widget) => widget.id !== widgetId),
 			updatedAt: new Date().toISOString(),
@@ -324,7 +349,7 @@ function makeWidgetMutators(deps: {
 
 	const restoreWidget = (dashboardId: string, widget: DashboardWidget) => {
 		if (readOnly) return
-		void mutateDashboard(dashboardId, (dashboard) => {
+		push(dashboardId, (dashboard) => {
 			// Idempotent: a server refetch may have already reinstated the widget.
 			if (dashboard.widgets.some((w) => w.id === widget.id)) return dashboard
 			return {
@@ -340,7 +365,7 @@ function makeWidgetMutators(deps: {
 		widgetId: string,
 		display: Partial<WidgetDisplayConfig>,
 	) => {
-		void mutateDashboard(dashboardId, (dashboard) => ({
+		push(dashboardId, (dashboard) => ({
 			...dashboard,
 			widgets: dashboard.widgets.map((widget) =>
 				widget.id === widgetId ? { ...widget, display: { ...widget.display, ...display } } : widget,
@@ -353,7 +378,7 @@ function makeWidgetMutators(deps: {
 		dashboardId: string,
 		layouts: Array<{ i: string; x: number; y: number; w: number; h: number }>,
 	) => {
-		void mutateDashboard(dashboardId, (dashboard) => {
+		push(dashboardId, (dashboard) => {
 			let changed = false
 			const widgets = dashboard.widgets.map((widget) => {
 				const layout = layouts.find((item) => item.i === widget.id)
@@ -411,7 +436,7 @@ function makeWidgetMutators(deps: {
 	}
 
 	const autoLayoutWidgets = (dashboardId: string) => {
-		void mutateDashboard(dashboardId, (dashboard) => {
+		push(dashboardId, (dashboard) => {
 			if (dashboard.widgets.length === 0) return dashboard
 
 			const sorted = dashboard.widgets.toSorted((a, b) => {
@@ -529,14 +554,26 @@ export function useDashboardsRead(): DashboardsRead {
 	const syncFailed = useCollectionLoadFailed(collection.id, stillLoading)
 	const fallback = useDashboardsFallback(syncFailed)
 
+	// Whether the live query has produced a real answer. Gate the fallback on
+	// THIS rather than on the row count: `useDashboardsFallback` is a module-level
+	// store that latches at `ready` for the rest of the session, so keying off
+	// `synced.length === 0` marked a perfectly healthy org that simply has no
+	// dashboards yet (or has just deleted its last one) as degraded — which
+	// consumers turn into `readOnly`, disabling "New dashboard" and forcing the
+	// dashboard page out of edit mode with nothing on screen to explain it.
+	const liveResolved = !liveLoading && !isError
+
 	// Live rows always win. The HTTP snapshot only stands in while sync is down,
 	// and once it has loaded it keeps standing in across heal attempts rather than
 	// blinking back to a skeleton every time a retry re-enters `loading`.
-	const degraded = synced.length === 0 && fallback.status === "ready"
+	const degraded = !liveResolved && fallback.status === "ready"
 	// `idle` counts as pending for one commit: `useSyncExternalStore` fires the
 	// fetch from `subscribe`, i.e. after the render that first saw the failure.
 	const fallbackPending = fallback.status === "loading" || (syncFailed && fallback.status === "idle")
-	const failed = isError || fallback.status === "failed" || (syncFailed && !fallbackPending)
+	// A resolved live query is the answer even when a stale stuck-verdict lingers
+	// in `syncFailed`; only an unresolved one can be a failure.
+	const failed =
+		!liveResolved && (isError || fallback.status === "failed" || (syncFailed && !fallbackPending))
 
 	return {
 		dashboards: degraded ? fallback.dashboards : synced,
@@ -573,8 +610,21 @@ export function useDashboardMutations() {
 			if (isTxidAwaitTimeout(error)) {
 				// The write reached the server (the handler returned a txid) — only the
 				// sync-back timed out because this tab's shape stream is dead. Heal the
-				// stream instead of disabling editing; the refetch restores the saved row.
+				// stream instead of disabling editing, since editing still works.
+				//
+				// Say so, though: TanStack DB has already rolled the optimistic edit off
+				// the screen, and `handleCollectionStuck` is a *bounded* heal that is a
+				// no-op once its budget is spent — so staying quiet here left the user
+				// watching a change they made get undone for no stated reason.
 				handleCollectionStuck()
+				toastManager.add({
+					title: "Saved, but this tab is behind",
+					description:
+						"The change reached the server; this tab’s live sync didn’t catch up, so it isn’t shown yet.",
+					type: "warning",
+					actionProps: { children: "Reconnect", onClick: retryOrgCollections },
+					timeout: 10000,
+				})
 				return
 			}
 			const concurrency =
@@ -602,10 +652,17 @@ export function useDashboardMutations() {
 		// next render, which reading the collection directly avoids.
 		async (dashboardId: string, updater: (dashboard: Dashboard) => Dashboard): Promise<void> => {
 			const active = collection
+			// Both misses used to `return` silently, which is how an edit could
+			// disappear with nothing on screen to explain it. They are real failures:
+			// the caller asked to write a dashboard this tab cannot read.
 			const row = active.get(dashboardId)
-			if (!row) return
+			if (!row) {
+				throw new Error("This dashboard hasn’t finished loading — try again in a moment")
+			}
 			const current = rowToDashboard(row)
-			if (!current) return
+			if (!current) {
+				throw new Error("This dashboard’s saved layout couldn’t be read, so it can’t be edited")
+			}
 
 			const updated = updater(current)
 			if (updated === current) return // no-op
@@ -714,8 +771,14 @@ export function useDashboardMutations() {
 	)
 
 	const widgetMutators = useMemo(
-		() => makeWidgetMutators({ mutateDashboard, readOnly, readDashboard }),
-		[mutateDashboard, readOnly, readDashboard],
+		() =>
+			makeWidgetMutators({
+				mutateDashboard,
+				readOnly,
+				readDashboard,
+				onMutationFailed: applyMutationError,
+			}),
+		[mutateDashboard, readOnly, readDashboard, applyMutationError],
 	)
 
 	const deleteDashboard = useCallback(

--- a/apps/web/src/lib/models/dashboards-list-model.test.ts
+++ b/apps/web/src/lib/models/dashboards-list-model.test.ts
@@ -141,4 +141,13 @@ describe("buildList", () => {
 			degraded: false,
 		})
 	})
+
+	it("keeps an empty org out of degraded even after the snapshot has latched", () => {
+		// The fallback store latches at `ready` for the whole session once it has
+		// loaded once. Treating "no rows" as "sync is down" made a healthy org with
+		// no dashboards read-only, which disables the only way out of that state:
+		// the "New dashboard" button.
+		const list = buildList(rowsReady([]), { status: "ready", dashboards: fallbackDashboards })
+		expect(list).toEqual({ phase: "ready", dashboards: [], degraded: false })
+	})
 })

--- a/apps/web/src/lib/models/dashboards-list-model.ts
+++ b/apps/web/src/lib/models/dashboards-list-model.ts
@@ -78,7 +78,13 @@ export const buildList = (
 	rows: Db.CollectionState<DashboardRow>,
 	fallback: DashboardsFallbackState,
 ): DashboardsListData => {
-	if (AsyncResult.isSuccess(rows) && rows.value.length > 0) {
+	// A success is authoritative even when it carries no rows: `Db.changes` only
+	// emits `success` once the collection reaches `ready`, so "no dashboards" is a
+	// real answer, not a loading state. Requiring `length > 0` here made a healthy
+	// org that simply has none yet fall through to the snapshot branch and render
+	// `degraded` — which the route turns into read-only, disabling the one control
+	// that could fix it ("New dashboard"), with nothing on screen to explain why.
+	if (AsyncResult.isSuccess(rows)) {
 		return { phase: "ready", dashboards: deriveDashboardsList(rows.value), degraded: false }
 	}
 	if (fallback.status === "ready") {
@@ -93,10 +99,9 @@ export const buildList = (
 	if (message !== null) {
 		return { phase: "error", message }
 	}
-	if (!AsyncResult.isSuccess(rows)) {
-		return { phase: "loading" }
-	}
-	return { phase: "ready", dashboards: deriveDashboardsList(rows.value), degraded: false }
+	// Everything else is a collection that hasn't resolved yet (`initial`) — the
+	// success case returned above.
+	return { phase: "loading" }
 }
 
 export class DashboardsListModel extends Model.Service<DashboardsListModel>()("maple/dashboards/list")({

--- a/apps/web/src/routes/dashboards/$dashboardId_.widgets.$widgetId.tsx
+++ b/apps/web/src/routes/dashboards/$dashboardId_.widgets.$widgetId.tsx
@@ -20,6 +20,7 @@ import { useDashboardStore } from "@/hooks/use-dashboard-store"
 import { WidgetEditorSkeleton } from "@/components/dashboard-builder/loading-skeletons"
 import { pickVariableParams, variableSearchRest } from "@/lib/dashboard-variables/search-params"
 import { Button } from "@maple/ui/components/ui/button"
+import { toastManager } from "@maple/ui/components/ui/toast"
 
 // The editor carries the dashboard's `var-*` selections through its own search
 // (as opaque pass-through — it renders variables at defaults) so returning to the
@@ -65,6 +66,13 @@ function WidgetConfigurePage() {
 		try {
 			await updateWidget(dashboardId, widgetId, updates)
 			navigateBack()
+		} catch (cause) {
+			// `onApply` is a fire-and-forget callback, so an uncaught rejection here
+			// would strand the user on the editor with no idea the save failed.
+			toastManager.add({
+				title: cause instanceof Error ? cause.message : "Couldn’t save this widget",
+				type: "error",
+			})
 		} finally {
 			setIsSaving(false)
 		}


### PR DESCRIPTION
Adding a widget closed the Add Widget dialog without adding anything, and creation controls could sit there refusing clicks — in both cases with no banner, no toast, and no disabled styling to explain it.

The picker itself is fine (every card fires `onSelect`, `DashboardDocument` accepts the widget it builds, `addWidget` writes it). The problem is a write path with five silent exits, plus a latch that can put the page into a read-only state without saying so.

## The read path treated "no rows" as "sync is down"

`useDashboardsFallback` is a module-level store that latches at `ready` for the rest of the session once the HTTP snapshot loads (only invalidated on an org switch, or on a generation bump when it `failed`). Both readers keyed off row count:

- `useDashboardsRead`: `degraded = synced.length === 0 && fallback.status === "ready"`
- `buildList`: the success branch required `rows.value.length > 0`

So a healthy org that simply has no dashboards yet — or one whose rows hadn't landed — reported `degraded`, which consumers turn into `readOnly`: "New dashboard" disabled, dashboard page forced out of edit mode. `Db.changes` only emits `success` once the collection reaches `ready`, so an empty success is a real answer. Both now gate on whether the live query resolved rather than on how many rows came back.

## The write path had five exits that dropped an edit without a word

| Where | Was | Now |
| --- | --- | --- |
| `mutateDashboard` collection miss / undecodable payload | bare `return` | throws a stated reason |
| every widget mutator | `void mutateDashboard(...)` → a synchronous encode throw became an unhandled rejection | rejections route to the persistence banner |
| txid-timeout branch | TanStack DB rolled the optimistic edit off screen, nothing said (and `handleCollectionStuck` is a *bounded* heal that no-ops once its budget is spent) | still heals, plus a toast: the write reached the server, this tab is behind — with a Reconnect action |
| `addWidget` when read-only | silent `return` | toast, and returns `undefined` |
| `WidgetPicker` | `onOpenChange(false)` regardless of outcome | closes only when a widget actually landed |

`addWidget` also fails fast when the dashboard isn't in the collection, instead of building a widget it hands back to the caller and never persists.

## Also

The metrics **Create & add** flow created the dashboard and then wrote the widget through the Electric collection, which may not hold the brand-new row yet — that gap swallowed the widget, leaving an empty dashboard. It now creates the dashboard *with* its widget in one call.

The widget editor's `handleApply` catches and toasts; `onApply` is fire-and-forget, so a rejection there stranded the user on the editor with no idea the save failed.

## Testing

- New `use-dashboard-store.test.tsx` — mocks the synced collection; covers the widget landing in the stored payload, side-by-side placement, both fail-fast throws, a rejected persist reaching the banner, and the txid-timeout toast.
- New `chart-picker.test.tsx` — the dialog closes on a successful add and **stays open** when the add is refused.
- `dashboards-list-model.test.ts` — an empty org stays out of `degraded` even after the snapshot has latched.
- `bunx turbo typecheck` — 36/36 pass. Full JS test suite passes (web 1309, api 1491, query-engine 989, …). The 3 `@maple/cli` failures are environmental in this sandbox (no `/usr/bin/time`, no IPv6 loopback) and are untouched by this change.

Not reproduced end-to-end: this environment has no backend, and every one of these exits is only reachable when sync misbehaves. The txid-timeout branch is the closest match to the reported symptom — no visual clue at all — but each exit was independently capable of producing it, so all five now report.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1hYxjQF7fky5h66Tby3Tm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788634193&installation_model_id=427786&pr_number=361&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F361&signature=f721a77a347b56f81a29ebd5e452b6bbf770915763c5adb9985e8a2c0fd78169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->