### PR TITLE
fix(api): stop asserting which fiber won in the turn-retry test

### DIFF
--- a/apps/api/src/chat/loop/turn.test.ts
+++ b/apps/api/src/chat/loop/turn.test.ts
@@ -350,19 +350,28 @@ const fold = (events: ReadonlyArray<ChatTurnEvent>): string =>
 	}, "")
 
 describe("runChatTurn retry", () => {
-	it("retracts nothing when the failed attempt's batch never flushed", async () => {
+	it("retracts exactly what a sub-batch attempt had flushed, whatever that was", async () => {
 		const result = await Effect.runPromise(
 			collect([{ events: [textDelta("Hello wo")], fail: true }, [textDelta("Hello world."), finish()]]),
 		)
 
-		// `Stream.groupedWithin` drops its pending buffer on an upstream failure rather than
-		// flushing it, so a provider that dies inside one batching window emitted nothing and there
-		// is nothing to take back. The marker is still emitted — it is also the progress signal.
+		// Below `DELTA_BATCH_SIZE`, so whether this attempt emitted anything is a race between the
+		// provider's failure and the 16ms window: `Stream.groupedWithin` drops a pending buffer on an
+		// upstream failure, but a window that fires first ships it. Both are correct — the invariant
+		// is that the marker takes back exactly what reached a consumer and no more, so the reader's
+		// fold lands on the retry's text alone. Asserting a literal count here would be asserting
+		// which fiber won.
 		const retracted = retries(result.events)
 		assert.lengthOf(retracted, 1)
-		assert.equal(retracted[0]?.type === "turn-retry" ? retracted[0].retractChars : undefined, 0)
+		const at = result.events.findIndex((event) => event.type === "turn-retry")
+		const marker = result.events[at]
+		const flushedBefore = textOf(result.events.slice(0, at))
+		assert.equal(
+			marker?.type === "turn-retry" ? marker.retractChars : undefined,
+			flushedBefore.length,
+		)
 		assert.equal(result.calls, 2)
-		assert.equal(textOf(result.events), "Hello world.")
+		assert.equal(fold(result.events), "Hello world.")
 		assert.lengthOf(terminal(result.events), 1)
 	})
 


### PR DESCRIPTION
CI on `main` has been red since 4977476bb. One job failed — **TypeScript** — on one test:

```
FAIL src/chat/loop/turn.test.ts > runChatTurn retry > retracts nothing when the failed attempt's batch never flushed
AssertionError: expected 8 to equal +0
```

It's a flaky assertion, not a product bug. The fixture emits `textDelta("Hello wo")` — 8 chars, under `DELTA_BATCH_SIZE` — then fails the stream, so whether that text ever reached a consumer is a race between the provider failure and the 16 ms `DELTA_BATCH_WINDOW`. `Stream.groupedWithin` drops a pending buffer on upstream failure, but a window that fires first ships it. Locally the failure always wins; on a loaded CI runner the timer won and `retractChars` was a correct `8` against an asserted literal `0`. Both outcomes are correct behaviour — the assertion was pinning which fiber won.

This asserts the invariant that actually matters instead: `retractChars` equals exactly the text flushed before the marker, and the reader's `fold` lands on the retry's text alone. That holds on either side of the race.

Coverage is unchanged — the deterministic exact-retraction case is still pinned by the neighbouring test, which fills a whole batch and flushes on the size cap regardless of timing.

Verified: `vitest run src/chat/loop/turn.test.ts` → 27 passed; `bun typecheck` in `apps/api` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788787300&installation_model_id=427786&pr_number=366&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F366&signature=48596065bb73cb9a3b7f45c182681d072cdfb8e2ae67f5202210b0f4467357fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->