### PR TITLE
feat(ingest): deploy the OTLP gateway to ECS Fargate via alchemy

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -1,12 +1,16 @@
 import { appendFileSync } from "node:fs"
 import * as Alchemy from "alchemy"
+import * as AWS from "alchemy/AWS"
 import * as Cloudflare from "alchemy/Cloudflare"
 import * as RemovalPolicy from "alchemy/RemovalPolicy"
 import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import { parseMapleRegion, resolveAwsRegion, stageDeploysIngest } from "@maple/infra/aws"
 import { formatMapleStage, parseMapleStage, resolveMapleDomains } from "@maple/infra/cloudflare"
 import { createAlertingWorker } from "./apps/alerting/alchemy.run.ts"
 import { createMapleApi } from "./apps/api/alchemy.run.ts"
 import { createElectricSyncWorker } from "./apps/electric-sync/alchemy.run.ts"
+import { createMapleIngest } from "./apps/ingest/alchemy.run.ts"
 import { createLandingWorker } from "./apps/landing/alchemy.run.ts"
 import { createLocalUiWorker } from "./apps/local-ui/alchemy.run.ts"
 import { createMapleWeb } from "./apps/web/alchemy.run.ts"
@@ -76,7 +80,11 @@ const createProductionSharedResources = (stage: ReturnType<typeof parseMapleStag
 export default Alchemy.Stack(
 	"maple",
 	{
-		providers: Cloudflare.providers(),
+		// Cloudflare hosts the Workers/DO/R2 surface; AWS hosts the Rust OTLP
+		// gateway on ECS (`apps/ingest`). AWS credentials arrive as env vars from
+		// Infisical exactly like the Cloudflare ones — `AWS.providers()` reads
+		// AWS_REGION / AWS_ACCOUNT_ID / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
+		providers: Layer.mergeAll(Cloudflare.providers(), AWS.providers()),
 		// Shared account-wide state store (Worker + DO SQLite) — bootstrapped once
 		// per Cloudflare account (`alchemy bootstrap cloudflare` or the first
 		// `deploy --yes`). ALCHEMY_LOCAL_STATE=1 opts into .alchemy/ file state for
@@ -90,8 +98,31 @@ export default Alchemy.Stack(
 
 		const apiUrl = resolveUrl(domains.api, "MAPLE_API_BASE_URL")
 		const electricSyncUrl = resolveUrl(domains.sync, "MAPLE_ELECTRIC_SYNC_URL")
-		// ingest is not deployed via alchemy; for non-custom-domain stages, fall
-		// back to a caller-supplied env var or the public Maple ingest endpoint.
+		// Geographic instance this deploy belongs to. `us` today; an EU instance is
+		// the same stack deployed with MAPLE_REGION=eu against that instance's own
+		// Tinybird workspace and application database. Guarded here because a
+		// mismatch between MAPLE_REGION and AWS_REGION would put the ACM
+		// certificate in a different region from the ALB that must use it — and
+		// worse, would export telemetry across the residency boundary the EU
+		// instance exists to enforce.
+		const region = parseMapleRegion(process.env.MAPLE_REGION)
+		const expectedAwsRegion = resolveAwsRegion(region)
+		const configuredAwsRegion = process.env.AWS_REGION?.trim()
+		if (configuredAwsRegion && configuredAwsRegion !== expectedAwsRegion) {
+			throw new Error(
+				`AWS_REGION="${configuredAwsRegion}" does not match MAPLE_REGION="${region}" (expects "${expectedAwsRegion}").`,
+			)
+		}
+
+		// The Rust OTLP gateway on ECS Fargate (prd/stg only — PR previews get no
+		// ingest domain, and a VPC + ALB per PR is real money for a stack nothing
+		// points at; dev stages run it through docker-compose). `domains.ingest`
+		// reaches it via a Cloudflare CNAME at the ALB, so the URL below stays a
+		// plain string and does not depend on the service resource.
+		const ingest = stageDeploysIngest(stage)
+			? yield* createMapleIngest({ stage, domains, region })
+			: undefined
+
 		const ingestUrl = resolveUrl(domains.ingest, "VITE_INGEST_URL", "https://ingest.maple.dev")
 
 		// Chat and AI triage run inside the api worker (ChatSession Durable Object),
@@ -164,6 +195,12 @@ export default Alchemy.Stack(
 		// and the summary carries their identity for the CLI output.
 		return {
 			...summary,
+			// ALB hostname to CNAME `domains.ingest` at, plus the one-time ACM
+			// validation record — both are manual entries in the Cloudflare
+			// `maple.dev` zone, surfaced here so they come out of the deploy rather
+			// than the AWS console.
+			ingestServiceUrl: ingest?.serviceUrl,
+			ingestCertificateValidation: ingest?.certificateValidation,
 			electricSyncWorker: electricSync.workerName,
 			webWorker: web.workerName,
 			landingWorker: landing.workerName,

--- a/apps/ingest/.dockerignore
+++ b/apps/ingest/.dockerignore
@@ -1,0 +1,14 @@
+# The build context is `apps/ingest` itself (see the Dockerfile's `COPY . .`),
+# so anything not excluded here is both uploaded to the daemon AND folded into
+# the context hash alchemy uses to decide whether to rebuild. A local `cargo
+# build` leaves ~27 GB in target/, which would make every deploy from a dev
+# machine ship that directory and re-hash on every touch. CI never has it,
+# which is exactly why the problem hides until someone deploys locally.
+target/
+node_modules/
+
+# Not inputs to `cargo build --release`.
+alchemy.run.ts
+package.json
+railway.json
+LOAD_TESTS.md

--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -1,0 +1,269 @@
+import * as AWS from "alchemy/AWS"
+import * as Effect from "effect/Effect"
+import * as Redacted from "effect/Redacted"
+import type { MapleRegion } from "@maple/infra/aws"
+import {
+	resolveAwsRegion,
+	resolveAwsResourceName,
+	resolveIngestCidrBlock,
+	resolveIngestDesiredCount,
+	resolveIngestTaskSize,
+} from "@maple/infra/aws"
+import type { MapleDomains, MapleStage } from "@maple/infra/cloudflare"
+import { resolveDeploymentEnvironment } from "@maple/infra/cloudflare"
+
+const requireEnv = (key: string): string => {
+	const value = process.env[key]?.trim()
+	if (!value) {
+		throw new Error(`Missing required deployment env: ${key}`)
+	}
+	return value
+}
+
+const optionalPlain = (key: string, fallback?: string): Record<string, string> => {
+	const value = process.env[key]?.trim() || fallback
+	return value ? { [key]: value } : {}
+}
+
+/** Port the gateway binds (`apps/ingest/Dockerfile` EXPOSEs the same). */
+const INGEST_PORT = 3474
+
+/**
+ * WAL cap, deliberately well below Fargate's 20 GB of included ephemeral
+ * storage — that 20 GB also holds the image and the OS, and the gateway's own
+ * default (`INGEST_QUEUE_MAX_BYTES` = 20 GiB, `apps/ingest/src/main.rs`) would
+ * sit exactly on the line. 8 GiB still buys hours of buffering at current
+ * volume; raising it means paying for ephemeral storage beyond the free tier.
+ */
+const WAL_MAX_BYTES = 8 * 1024 * 1024 * 1024
+
+/**
+ * Pinned rather than derived. The gateway defaults to `num_cpus * 2`, which
+ * makes on-disk layout and fd count a function of task size — so a Fargate to
+ * EC2 move, or a cpu bump, would silently reshape the WAL. Two lanes per shard
+ * (Tinybird + ClickHouse) means this is 8 open WAL files.
+ */
+const WAL_SHARDS = 4
+
+export interface CreateMapleIngestOptions {
+	stage: MapleStage
+	domains: MapleDomains
+	/** Geographic instance. Every AWS resource here is scoped to it. */
+	region: MapleRegion
+}
+
+/**
+ * The Rust OTLP gateway (`apps/ingest`) on ECS Fargate.
+ *
+ * Migrated off Railway. Fargate rather than EC2 because below ~16 vCPU the
+ * fractional-vCPU pricing beats EC2 on-demand and there is no ASG or AMI to
+ * own; the two are capacity providers on the same cluster, so crossing that
+ * threshold later is a config change, not a rearchitecture.
+ *
+ * One fleet per `MapleRegion`. A second instance is this factory called again
+ * with `region: "eu"` and that instance's own TINYBIRD_* / MAPLE_PG_URL — the
+ * resources below carry no cross-region references, so the two never touch.
+ */
+export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestOptions) =>
+	Effect.gen(function* () {
+		const taskSize = resolveIngestTaskSize(stage)
+		const name = (base: string) => resolveAwsResourceName(base, stage, region)
+
+		// Public subnets with public IPs on the tasks, and NO NAT gateway. NAT
+		// bills $0.045/GB PROCESSED on top of egress, and this service exists to
+		// push gzipped telemetry outbound — at current volume NAT alone would cost
+		// more than the compute and the egress combined, and it scales linearly
+		// with growth. The S3 gateway endpoint keeps ECR image pulls (S3-backed)
+		// off the public path and is free.
+		const network = yield* AWS.EC2.Network("ingest-network", {
+			cidrBlock: resolveIngestCidrBlock(region),
+			availabilityZones: 2,
+			nat: "none",
+			gatewayEndpoints: ["s3"],
+			tags: { Service: "maple-ingest", Region: region },
+		})
+
+		// The ALB is the only thing that should reach the tasks, but Fargate tasks
+		// in public subnets need a public IP to egress without NAT, so the port is
+		// open to the internet. Tightening this to the ALB's security group is a
+		// follow-up once the ALB SG is addressable from here.
+		const securityGroup = yield* AWS.EC2.SecurityGroup("ingest-sg", {
+			vpcId: network.vpcId,
+			groupName: name("ingest"),
+			description: "Maple OTLP ingest gateway",
+			ingress: [
+				{
+					ipProtocol: "tcp",
+					fromPort: INGEST_PORT,
+					toPort: INGEST_PORT,
+					cidrIpv4: "0.0.0.0/0",
+					description: "OTLP over HTTP",
+				},
+			],
+		})
+
+		const cluster = yield* AWS.ECS.Cluster("ingest-cluster", {
+			clusterName: name("ingest"),
+			tags: { Service: "maple-ingest", Region: region },
+		})
+
+		// Real credentials go through Secrets Manager, not `env`: ECS stores task
+		// definition environment variables in plaintext, readable by anyone with
+		// `ecs:DescribeTaskDefinition`. Alchemy grants the execution role
+		// `secretsmanager:GetSecretValue` on exactly these ARNs.
+		const secret = (id: string, value: string) =>
+			AWS.SecretsManager.Secret(id, {
+				name: `${name("ingest")}/${id}`,
+				secretString: Redacted.make(value),
+				tags: { Service: "maple-ingest", Region: region },
+			})
+
+		const tinybirdToken = yield* secret("tinybird-token", requireEnv("TINYBIRD_TOKEN"))
+		// Deliberately NOT `MAPLE_PG_URL`. That one is the direct-5432 admin URL the
+		// deploy workflows use for DDL; the gateway must reach Postgres through
+		// PSBouncer (6432) as a role that only reads ingest keys. Sharing the name
+		// would silently hand every task the migration admin's credentials.
+		const pgUrl = yield* secret("maple-pg-url", requireEnv("MAPLE_INGEST_PG_URL"))
+		const keyEncryptionKey = yield* secret(
+			"ingest-key-encryption-key",
+			requireEnv("MAPLE_INGEST_KEY_ENCRYPTION_KEY"),
+		)
+		const keyLookupHmacKey = yield* secret(
+			"ingest-key-lookup-hmac-key",
+			requireEnv("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
+		)
+
+		// Optional credentials — absent in a stage that hasn't enabled the feature.
+		// Autumn absent means billing enforcement is dark; the R2 secret absent
+		// means replay payloads stay inline in ClickHouse rather than moving to the
+		// blob store (`apps/ingest/src/main.rs` refuses a half-set R2 config, so
+		// the endpoint env below is gated on the same value).
+		const autumnKey = process.env.AUTUMN_SECRET_KEY?.trim()
+		const autumnSecret = autumnKey ? yield* secret("autumn-secret-key", autumnKey) : undefined
+		const replayR2Key = process.env.INGEST_REPLAY_R2_SECRET_ACCESS_KEY?.trim()
+		const replayR2Secret = replayR2Key
+			? yield* secret("replay-r2-secret-access-key", replayR2Key)
+			: undefined
+
+		// An ALB can only use a certificate from its OWN region, and the ACM
+		// resource otherwise defaults to us-east-1 (the CloudFront requirement).
+		// Derived from the Maple region so the cert can never drift from where the
+		// ALB actually lands — CI must set AWS_REGION to the same value, since
+		// that is what `AWS.providers()` places every other resource with.
+		//
+		// Without `hostedZoneId` the provider does not block on issuance, so the
+		// first deploy of a new stage lands the certificate PENDING_VALIDATION;
+		// add the DNS validation record in Cloudflare, then re-run to attach the
+		// listener once ACM reports ISSUED.
+		const certificate = domains.ingest
+			? yield* AWS.ACM.Certificate("ingest-cert", {
+					domainName: domains.ingest,
+					validationMethod: "DNS",
+					region: resolveAwsRegion(region),
+					tags: { Service: "maple-ingest", Region: region },
+				})
+			: undefined
+
+		const service = yield* AWS.ECS.Service("ingest", {
+			cluster,
+			serviceName: name("ingest"),
+
+			// Dockerfile source: alchemy builds `apps/ingest/Dockerfile`, creates a
+			// private ECR repository, and pushes under a content-hash tag. Rebuilds
+			// only when the context hash changes, so CI needs no docker step.
+			context: "apps/ingest",
+			// The docker build platform is derived from this (`taskImagePlatform` in
+			// alchemy's ECS/Task). Explicit so a build from an Apple Silicon machine
+			// produces the same artifact CI does — an arm64 image on an X86_64 task
+			// fails at start with "image Manifest does not contain descriptor
+			// matching platform 'linux/amd64'". Flipping cpuArchitecture to "ARM64"
+			// is the whole Graviton switch (~20% cheaper), but it needs an ARM
+			// builder: cross-compiling Rust under QEMU is 10-30 min a build, for
+			// single-digit dollars a month at this size. Revisit with an ARM runner.
+			runtimePlatform: { cpuArchitecture: "X86_64", operatingSystemFamily: "LINUX" },
+			cpu: taskSize.cpu,
+			memory: taskSize.memory,
+
+			desiredCount: resolveIngestDesiredCount(stage),
+			vpcId: network.vpcId,
+			subnets: network.publicSubnetIds,
+			securityGroups: [securityGroup.groupId],
+			assignPublicIp: true,
+
+			public: true,
+			listenerPort: INGEST_PORT,
+			healthCheckPath: "/health",
+			...(certificate ? { certificateArn: certificate.certificateArn } : {}),
+
+			// `/health` returns a bare 200 with no dependency checks, so it detects a
+			// dead task but not a wedged export lane or a dead Postgres pool. The
+			// grace period covers the startup Postgres probe, which exits the
+			// process on failure rather than serving degraded.
+			healthCheckGracePeriod: "60 seconds",
+
+			logging: { retention: "30 days" },
+
+			secrets: {
+				TINYBIRD_TOKEN: tinybirdToken.secretArn,
+				MAPLE_PG_URL: pgUrl.secretArn,
+				MAPLE_INGEST_KEY_ENCRYPTION_KEY: keyEncryptionKey.secretArn,
+				MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: keyLookupHmacKey.secretArn,
+				...(autumnSecret ? { AUTUMN_SECRET_KEY: autumnSecret.secretArn } : {}),
+				...(replayR2Secret ? { INGEST_REPLAY_R2_SECRET_ACCESS_KEY: replayR2Secret.secretArn } : {}),
+			},
+
+			env: {
+				INGEST_PORT: String(INGEST_PORT),
+				MAPLE_ENVIRONMENT: resolveDeploymentEnvironment(stage),
+				TINYBIRD_HOST: requireEnv("TINYBIRD_HOST"),
+				INGEST_KEY_STORE_BACKEND: "postgres",
+
+				INGEST_QUEUE_MAX_BYTES: String(WAL_MAX_BYTES),
+				INGEST_WAL_SHARDS: String(WAL_SHARDS),
+
+				// Replay blobs stay on Cloudflare R2. The AWS egress this costs is
+				// single-digit dollars a month; moving them to S3 would save nothing
+				// and would require a SigV4 or presigned read path in the Worker
+				// (`apps/api/src/platform/ReplayBlobStore.ts` uses the native R2
+				// binding). Gated on the secret above — a half-set R2 config refuses
+				// to boot, so all-or-nothing is deliberate.
+				...(replayR2Secret
+					? {
+							...optionalPlain("INGEST_REPLAY_R2_ENDPOINT"),
+							...optionalPlain("INGEST_REPLAY_R2_BUCKET"),
+							...optionalPlain("INGEST_REPLAY_R2_ACCESS_KEY_ID"),
+							...optionalPlain("INGEST_REPLAY_R2_REGION", "auto"),
+						}
+					: {}),
+
+				...optionalPlain("INGEST_WRITE_MODE"),
+				...optionalPlain("INGEST_FORWARD_OTLP_ENDPOINT"),
+				...optionalPlain("INGEST_BATCH_MAX_ROWS"),
+				...optionalPlain("INGEST_BATCH_MAX_BYTES"),
+				...optionalPlain("INGEST_BATCH_MAX_WAIT_MS"),
+				...optionalPlain("INGEST_ORG_QUEUE_MAX_BYTES"),
+				...optionalPlain("INGEST_ORG_MAX_IN_FLIGHT"),
+				...optionalPlain("INGEST_MAX_REQUEST_BODY_BYTES"),
+				...optionalPlain("INGEST_EXPORT_MAX_ATTEMPTS"),
+				...optionalPlain("INGEST_TINYBIRD_CONCURRENCY_PER_SHARD"),
+				...optionalPlain("INGEST_REPLAY_MAX_SESSION_BYTES"),
+				...optionalPlain("MAPLE_INTERNAL_ORG_ID"),
+				...optionalPlain("AUTUMN_API_URL"),
+				...optionalPlain("COMMIT_SHA", process.env.GITHUB_SHA?.trim()),
+			},
+
+			tags: { Service: "maple-ingest", Region: region },
+		})
+
+		return {
+			serviceUrl: service.url,
+			// One-time manual DNS, surfaced here so it is discoverable from the
+			// deploy output rather than the AWS console:
+			//   1. the ACM validation CNAME (below) — added once per domain, reused
+			//      for every renewal;
+			//   2. a CNAME for `domains.ingest` at `serviceUrl` (the ALB), proxied.
+			// Both live in the Cloudflare `maple.dev` zone, which this stack does
+			// not otherwise touch.
+			certificateValidation: certificate?.domainValidationOptions,
+		}
+	})

--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -83,11 +83,33 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 			tags: { Service: "maple-ingest", Region: region },
 		})
 
-		// The ALB is the only thing that should reach the tasks, but Fargate tasks
-		// in public subnets need a public IP to egress without NAT, so the port is
-		// open to the internet. Tightening this to the ALB's security group is a
-		// follow-up once the ALB SG is addressable from here.
-		const securityGroup = yield* AWS.EC2.SecurityGroup("ingest-sg", {
+		// Two groups, because `AWS.ECS.Service` applies `securityGroups` to BOTH the
+		// ALB and the tasks — there is no separate knob for the load balancer. Both
+		// are attached to both, and the split lives in the RULES: the internet
+		// reaches 443 (the ALB listener), and INGEST_PORT is reachable only from
+		// something already in the ALB group.
+		//
+		// This matters more here than it would behind a NAT: the tasks carry public
+		// IPs so they can egress without one, so an ENI's address is directly
+		// dialable. Opening INGEST_PORT to 0.0.0.0/0 would let anyone who finds it
+		// post OTLP straight to a task over plaintext HTTP, skipping the ALB and,
+		// since the domain is proxied, Cloudflare's TLS and rate limiting with it.
+		const albSecurityGroup = yield* AWS.EC2.SecurityGroup("ingest-alb-sg", {
+			vpcId: network.vpcId,
+			groupName: name("ingest-alb"),
+			description: "Maple OTLP ingest — public HTTPS to the load balancer",
+			ingress: [
+				{
+					ipProtocol: "tcp",
+					fromPort: 443,
+					toPort: 443,
+					cidrIpv4: "0.0.0.0/0",
+					description: "OTLP over HTTPS",
+				},
+			],
+		})
+
+		const taskSecurityGroup = yield* AWS.EC2.SecurityGroup("ingest-sg", {
 			vpcId: network.vpcId,
 			groupName: name("ingest"),
 			description: "Maple OTLP ingest gateway",
@@ -96,8 +118,8 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 					ipProtocol: "tcp",
 					fromPort: INGEST_PORT,
 					toPort: INGEST_PORT,
-					cidrIpv4: "0.0.0.0/0",
-					description: "OTLP over HTTP",
+					referencedGroupId: albSecurityGroup.groupId,
+					description: "ALB to task",
 				},
 			],
 		})
@@ -134,15 +156,26 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 		)
 
 		// Optional credentials — absent in a stage that hasn't enabled the feature.
-		// Autumn absent means billing enforcement is dark; the R2 secret absent
-		// means replay payloads stay inline in ClickHouse rather than moving to the
-		// blob store (`apps/ingest/src/main.rs` refuses a half-set R2 config, so
-		// the endpoint env below is gated on the same value).
+		// Autumn absent means billing enforcement is dark.
 		const autumnKey = process.env.AUTUMN_SECRET_KEY?.trim()
 		const autumnSecret = autumnKey ? yield* secret("autumn-secret-key", autumnKey) : undefined
-		const replayR2Key = process.env.INGEST_REPLAY_R2_SECRET_ACCESS_KEY?.trim()
-		const replayR2Secret = replayR2Key
-			? yield* secret("replay-r2-secret-access-key", replayR2Key)
+
+		// Replay blob storage keys off the ENDPOINT, matching the gateway's own
+		// switch (`Config::from_env` in `apps/ingest/src/main.rs` treats
+		// INGEST_REPLAY_R2_ENDPOINT as the enable flag and `required()`s the rest).
+		// Gating on any other variable inverts the contract: a deploy holding the
+		// endpoint, bucket and access key but missing the secret would drop the
+		// endpoint from the task env, and the gateway — seeing no R2 config at all —
+		// would silently fall back to storing replay payloads inline. That is the
+		// exact failure the Rust guard exists to prevent, so the check moves here:
+		// endpoint set means the deploy fails now rather than the tasks crash-loop
+		// later.
+		const replayR2Endpoint = process.env.INGEST_REPLAY_R2_ENDPOINT?.trim()
+		const replayR2Secret = replayR2Endpoint
+			? yield* secret(
+					"replay-r2-secret-access-key",
+					requireEnv("INGEST_REPLAY_R2_SECRET_ACCESS_KEY"),
+				)
 			: undefined
 
 		// An ALB can only use a certificate from its OWN region, and the ACM
@@ -187,11 +220,19 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 			desiredCount: resolveIngestDesiredCount(stage),
 			vpcId: network.vpcId,
 			subnets: network.publicSubnetIds,
-			securityGroups: [securityGroup.groupId],
+			securityGroups: [albSecurityGroup.groupId, taskSecurityGroup.groupId],
 			assignPublicIp: true,
 
 			public: true,
-			listenerPort: INGEST_PORT,
+			// `port` is the CONTAINER port (what the target group forwards to); the
+			// listener port is separate and defaults to 443 once `certificateArn` is
+			// set, which is what we want. Setting `listenerPort: INGEST_PORT` instead
+			// would break twice over: the listener would sit on 3474, which
+			// Cloudflare's proxy does not forward to (it only fetches origins on its
+			// supported port list), and `port` would fall back to alchemy's default
+			// of 3000 while the gateway binds 3474 — so no target would ever pass
+			// `/health` and the service would never stabilize.
+			port: INGEST_PORT,
 			healthCheckPath: "/health",
 			...(certificate ? { certificateArn: certificate.certificateArn } : {}),
 
@@ -225,13 +266,14 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 				// single-digit dollars a month; moving them to S3 would save nothing
 				// and would require a SigV4 or presigned read path in the Worker
 				// (`apps/api/src/platform/ReplayBlobStore.ts` uses the native R2
-				// binding). Gated on the secret above — a half-set R2 config refuses
-				// to boot, so all-or-nothing is deliberate.
-				...(replayR2Secret
+				// binding). `requireEnv` on the companions rather than
+				// `optionalPlain`, so a half-set config fails the deploy instead of
+				// reaching a task that refuses to boot.
+				...(replayR2Endpoint
 					? {
-							...optionalPlain("INGEST_REPLAY_R2_ENDPOINT"),
-							...optionalPlain("INGEST_REPLAY_R2_BUCKET"),
-							...optionalPlain("INGEST_REPLAY_R2_ACCESS_KEY_ID"),
+							INGEST_REPLAY_R2_ENDPOINT: replayR2Endpoint,
+							INGEST_REPLAY_R2_BUCKET: requireEnv("INGEST_REPLAY_R2_BUCKET"),
+							INGEST_REPLAY_R2_ACCESS_KEY_ID: requireEnv("INGEST_REPLAY_R2_ACCESS_KEY_ID"),
 							...optionalPlain("INGEST_REPLAY_R2_REGION", "auto"),
 						}
 					: {}),

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -4,6 +4,7 @@
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts",
+		"./aws": "./src/aws/index.ts",
 		"./cloudflare": "./src/cloudflare/index.ts",
 		"./dev-urls": "./src/dev-urls.ts"
 	},

--- a/packages/infra/src/aws/index.ts
+++ b/packages/infra/src/aws/index.ts
@@ -1,0 +1,1 @@
+export * from "./stage.ts"

--- a/packages/infra/src/aws/stage.test.ts
+++ b/packages/infra/src/aws/stage.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { parseMapleStage } from "../cloudflare/stage.ts"
+import {
+	parseMapleRegion,
+	resolveAwsRegion,
+	resolveAwsResourceName,
+	resolveIngestCidrBlock,
+} from "./stage.ts"
+
+describe("parseMapleRegion", () => {
+	it("defaults to us when unset", () => {
+		expect(parseMapleRegion(undefined)).toBe("us")
+		expect(parseMapleRegion("")).toBe("us")
+		expect(parseMapleRegion("  ")).toBe("us")
+	})
+
+	it("accepts either region, case-insensitively", () => {
+		expect(parseMapleRegion("EU")).toBe("eu")
+		expect(parseMapleRegion(" us ")).toBe("us")
+	})
+
+	it("rejects anything else rather than silently defaulting", () => {
+		expect(() => parseMapleRegion("apac")).toThrow(/Unsupported Maple region/)
+	})
+})
+
+describe("resolveAwsResourceName", () => {
+	it("leaves us unsuffixed so adding eu renames nothing", () => {
+		expect(resolveAwsResourceName("ingest", parseMapleStage("prd"), "us")).toBe("maple-ingest")
+		expect(resolveAwsResourceName("ingest", parseMapleStage("stg"), "us")).toBe("maple-ingest-stg")
+	})
+
+	it("defaults to us when no region is passed", () => {
+		expect(resolveAwsResourceName("ingest", parseMapleStage("prd"))).toBe("maple-ingest")
+	})
+
+	it("suffixes eu, keeping the two instances distinct at every stage", () => {
+		expect(resolveAwsResourceName("ingest", parseMapleStage("prd"), "eu")).toBe("maple-ingest-eu")
+		expect(resolveAwsResourceName("ingest", parseMapleStage("stg"), "eu")).toBe("maple-ingest-eu-stg")
+	})
+})
+
+describe("region topology", () => {
+	it("maps each region to a distinct AWS region and a non-overlapping CIDR", () => {
+		expect(resolveAwsRegion("us")).toBe("us-east-1")
+		expect(resolveAwsRegion("eu")).toBe("eu-central-1")
+		expect(resolveIngestCidrBlock("us")).not.toBe(resolveIngestCidrBlock("eu"))
+	})
+})

--- a/packages/infra/src/aws/stage.ts
+++ b/packages/infra/src/aws/stage.ts
@@ -1,0 +1,131 @@
+import type { MapleStage } from "../cloudflare/stage.ts"
+
+/**
+ * Geographic instance a deployment belongs to.
+ *
+ * Orthogonal to `MapleStage`: stage is prd/stg/pr/dev, region is which
+ * geographic instance. A full EU instance is `region: "eu"` at every stage,
+ * with its OWN Tinybird workspace, application database, and ingest fleet —
+ * telemetry that lands in `eu` must never transit `us`, which is the whole
+ * point of having one.
+ *
+ * `us` is deliberately the unsuffixed default so adding `eu` later renames
+ * nothing (a rename destroys and recreates every resource).
+ */
+export type MapleRegion = "us" | "eu"
+
+export const DEFAULT_MAPLE_REGION: MapleRegion = "us"
+
+export function parseMapleRegion(value: string | undefined): MapleRegion {
+	const normalized = value?.trim().toLowerCase()
+	if (!normalized) {
+		return DEFAULT_MAPLE_REGION
+	}
+	if (normalized === "us" || normalized === "eu") {
+		return normalized
+	}
+	throw new Error(`Unsupported Maple region "${value}". Expected "us" or "eu".`)
+}
+
+/**
+ * AWS region backing each Maple region.
+ *
+ * This MUST match the region of the Tinybird workspace the instance exports to.
+ * AWS bills $0.09/GB to the public internet but only $0.01/GB to a public IP in
+ * the SAME region, and the gateway's export traffic dwarfs every other line
+ * item — at 200k req/s that difference is ~$83k/mo vs ~$16k/mo. Tinybird's AWS
+ * regions are us-east-1, us-west-2, eu-central-1, eu-west-1, ap-east-1,
+ * ap-southeast-2; a workspace on `https://api.tinybird.co` is GCP Frankfurt, in
+ * which case NO AWS region colocates and the move costs more than Railway.
+ *
+ * Verify the instance's TINYBIRD_HOST before changing a mapping.
+ */
+export function resolveAwsRegion(region: MapleRegion): string {
+	switch (region) {
+		case "us":
+			return "us-east-1"
+		case "eu":
+			return "eu-central-1"
+	}
+}
+
+/**
+ * VPC CIDR per Maple region, kept non-overlapping so two instances can be
+ * peered later without renumbering. Nothing peers them today.
+ */
+export function resolveIngestCidrBlock(region: MapleRegion): string {
+	switch (region) {
+		case "us":
+			return "10.20.0.0/16"
+		case "eu":
+			return "10.21.0.0/16"
+	}
+}
+
+/**
+ * Physical name for an AWS resource, mirroring `resolveWorkerName` so both
+ * clouds read the same in a console. Kept as a separate function rather than
+ * reusing the Cloudflare one because AWS name constraints differ per service
+ * (ECS names allow `[a-zA-Z0-9-_]`, but ALB names cap at 32 chars).
+ *
+ * `us` carries no region suffix — see `MapleRegion`.
+ */
+export function resolveAwsResourceName(
+	base: string,
+	stage: MapleStage,
+	region: MapleRegion = DEFAULT_MAPLE_REGION,
+): string {
+	const suffix = region === DEFAULT_MAPLE_REGION ? "" : `-${region}`
+	switch (stage.kind) {
+		case "prd":
+			return `maple-${base}${suffix}`
+		case "stg":
+			return `maple-${base}${suffix}-stg`
+		case "pr":
+			return `maple-${base}${suffix}-pr-${stage.prNumber}`
+		case "dev":
+			return `maple-${base}${suffix}-dev-${stage.name}`
+	}
+}
+
+/**
+ * Desired ECS task count per stage.
+ *
+ * prd runs 2 for availability across AZs; everything else runs 1. Note the
+ * per-org replay byte budget in the gateway is process-local
+ * (`apps/ingest/src/main.rs`), so the effective ceiling is roughly N x the
+ * configured limit — raising this raises that ceiling too.
+ */
+export function resolveIngestDesiredCount(stage: MapleStage): number {
+	return stage.kind === "prd" ? 2 : 1
+}
+
+export interface IngestTaskSize {
+	/** Fargate CPU units. 1024 = 1 vCPU. */
+	cpu: number
+	/** Fargate memory in MiB. Must be a legal pairing with `cpu`. */
+	memory: number
+}
+
+/**
+ * Fargate task size per stage.
+ *
+ * Sized from ~1,300 req/s per vCPU — gzip level 6 on the export path
+ * (`apps/ingest/src/telemetry.rs`) is the binding constraint, not protobuf
+ * decode. prd gets 1 vCPU x 2 tasks, which carries today's ~500 req/s with
+ * roughly 4x headroom for bursts.
+ */
+export function resolveIngestTaskSize(stage: MapleStage): IngestTaskSize {
+	return stage.kind === "prd" ? { cpu: 1024, memory: 2048 } : { cpu: 512, memory: 1024 }
+}
+
+/**
+ * Whether a stage gets an AWS ingest deployment at all.
+ *
+ * PR previews are excluded deliberately: `resolveMapleDomains` gives them no
+ * `ingest` domain, and a VPC + ALB per PR is real money for a stack nothing
+ * points at. Dev stages run the gateway through docker-compose instead.
+ */
+export function stageDeploysIngest(stage: MapleStage): boolean {
+	return stage.kind === "prd" || stage.kind === "stg"
+}


### PR DESCRIPTION
Moves `apps/ingest` off Railway and into the alchemy stack as AWS resources. The OIDC wiring in the deploy workflows already landed on `main` (335ea2ced); this is the stack itself.

## What's here

- `packages/infra/src/aws/` — `MapleRegion`, the region → AWS-region mapping, per-stage task sizing/desired count, resource naming, and `stageDeploysIngest`. Unit-tested.
- `apps/ingest/alchemy.run.ts` — VPC (public subnets, **no NAT**), ECS Fargate service behind an ALB, ECR image built from `apps/ingest/Dockerfile`, ACM certificate, and Secrets Manager entries for every real credential.
- `alchemy.run.ts` — merges `AWS.providers()` alongside Cloudflare's, and guards `AWS_REGION` against `MAPLE_REGION`.
- `apps/ingest/.dockerignore` — new.

## Decisions worth reviewing

**No NAT gateway.** NAT bills $0.045/GB *processed* on top of egress, and this service exists to push gzipped telemetry outbound — at current volume it would cost more than the compute and the egress combined, and it scales linearly with growth. Tasks get public IPs in public subnets instead; an S3 gateway endpoint keeps ECR pulls off the public path. The tradeoff is that the task security group opens the OTLP port to `0.0.0.0/0` rather than to the ALB's SG — noted inline as a follow-up.

**AWS region is derived, not configured.** An ALB can only use a certificate from its own region, and for a future `eu` instance a mismatch would export telemetry across the residency boundary that instance exists to enforce. Hence the throw rather than a silent default.

**`MAPLE_INGEST_PG_URL`, not `MAPLE_PG_URL`.** The latter is the direct-5432 admin URL the deploy workflows use for DDL; the gateway must reach Postgres through PSBouncer (6432) as a role that only reads ingest keys. Sharing the name would have handed every ECS task the migration admin's credentials.

**prd/stg only.** PR previews get no ingest domain and a VPC + ALB per PR is real money for a stack nothing points at; dev stages keep using docker-compose.

## Before merging — this breaks all deploys without them

`createMapleIngest` runs before any Worker in the stack and its `requireEnv` throws synchronously, so a missing value fails the *entire* prd deploy, not just ingest.

1. Repo variable `AWS_DEPLOY_ROLE_ARN` (the OIDC role, trust scoped to `environment:production` / `environment:staging`).
2. `MAPLE_INGEST_PG_URL` in the `prod` and `staging` Infisical envs — PSBouncer 6432, gateway role.

Optional, and silently falling back to Rust defaults if skipped: the `INGEST_REPLAY_R2_*` plain vars, `AUTUMN_API_URL`, `INGEST_FORWARD_OTLP_ENDPOINT`, `MAPLE_INTERNAL_ORG_ID`, and the batch tunables. Worth diffing against the live Railway env before cutover.

## Deploy notes

- **Expect two runs.** Without `hostedZoneId` the ACM resource doesn't block on issuance, so run one lands the certificate `PENDING_VALIDATION` and prints the validation CNAME as `ingestCertificateValidation`. Add it in the Cloudflare `maple.dev` zone, re-run to attach the listener.
- **No traffic moves.** Ingest DNS still points at Railway until someone CNAMEs `domains.ingest` at the emitted `ingestServiceUrl`.
- **Job timeout is tight.** The Dockerfile is `COPY . . && cargo build --release` with no dependency layer and no registry cache, so every CI deploy is a cold Rust release build on top of install + migrations + the Cloudflare stack, against `timeout-minutes: 30`. Suggest bumping prd/stg to 45 before the first run.

## Verification

- `packages/infra/src/aws/stage.test.ts` — 7/7 pass.
- Import smoke test of the root `alchemy.run.ts` passes (the check that catches alchemy/effect import-time breakage).
- Confirmed PR-preview and orphan-cleanup workflows still work **without** AWS credentials: `AWSEnvironment.Default` pipes through `Effect.cached`, so credential resolution is deferred until an AWS resource is actually created, and `stageDeploysIngest` excludes pr/dev.
- Repo-wide `bun typecheck` not run locally — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788907947&installation_model_id=427786&pr_number=374&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F374&signature=d09f98bdd7cdb80ccc53f0a23ca6e9647b7c5ae82367ea5cb3d07350ca40993b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->