### PR TITLE
perf(ingest): compile the gateway before the image build, not inside it

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
     deploy-prd:
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        timeout-minutes: 45
         # On a workflow_run event `github.sha` is the default branch head, not the
         # commit CI actually ran against — so pin everything to head_sha, both for
         # what gets deployed and for the telemetry stamp.
@@ -65,6 +65,42 @@ jobs:
 
             - name: Install dependencies
               run: bun install --frozen-lockfile
+
+            # The Rust gateway is compiled HERE, not inside the image build.
+            # alchemy's docker build passes no --cache-from (AWS/ECR/Image.ts), and
+            # a fresh runner's layer cache is empty, so a Dockerfile that runs
+            # `cargo build` recompiles all 385 crates on every deploy — ~20 minutes,
+            # however the layers are arranged. Out here the cargo cache survives
+            # between runs, so an unchanged ingest is a no-op and a one-crate change
+            # is about a minute. Dockerfile.prebuilt then just COPYs the result.
+            #
+            # Inside rust:1.88-bookworm rather than on the runner: the runtime base
+            # is debian:bookworm-slim (glibc 2.36) and ubuntu-24.04 ships 2.39, so a
+            # host-built binary starts and immediately dies with
+            # `version 'GLIBC_2.39' not found`.
+            - name: Cache ingest cargo build
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: |
+                      ~/.cargo-ingest
+                      apps/ingest/target-ci
+                  key: ingest-cargo-${{ runner.os }}-${{ hashFiles('apps/ingest/Cargo.lock') }}-${{ hashFiles('apps/ingest/src/**') }}
+                  restore-keys: |
+                      ingest-cargo-${{ runner.os }}-${{ hashFiles('apps/ingest/Cargo.lock') }}-
+                      ingest-cargo-${{ runner.os }}-
+
+            - name: Build ingest binary
+              run: |
+                  mkdir -p ~/.cargo-ingest apps/ingest/dist
+                  docker run --rm \
+                      --user "$(id -u):$(id -g)" \
+                      -e CARGO_HOME=/cargo \
+                      -v "$HOME/.cargo-ingest:/cargo" \
+                      -v "$PWD/apps/ingest:/app" \
+                      -w /app \
+                      rust:1.88-bookworm \
+                      cargo build --release --target-dir /app/target-ci
+                  cp apps/ingest/target-ci/release/maple-ingest apps/ingest/dist/maple-ingest
 
             # NOTE: prod schema migrations are applied OUT OF BAND (manually, via
             # `bun run migrate:prod` → `ps:apply-schema main`, against the direct 5432

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
     deploy-stg:
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        timeout-minutes: 45
         if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
         environment: staging
         env:
@@ -56,6 +56,32 @@ jobs:
 
             - name: Install dependencies
               run: bun install --frozen-lockfile
+
+            # Compiled outside the image build, in a bookworm container — see the
+            # note in deploy-prd.yml.
+            - name: Cache ingest cargo build
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: |
+                      ~/.cargo-ingest
+                      apps/ingest/target-ci
+                  key: ingest-cargo-${{ runner.os }}-${{ hashFiles('apps/ingest/Cargo.lock') }}-${{ hashFiles('apps/ingest/src/**') }}
+                  restore-keys: |
+                      ingest-cargo-${{ runner.os }}-${{ hashFiles('apps/ingest/Cargo.lock') }}-
+                      ingest-cargo-${{ runner.os }}-
+
+            - name: Build ingest binary
+              run: |
+                  mkdir -p ~/.cargo-ingest apps/ingest/dist
+                  docker run --rm \
+                      --user "$(id -u):$(id -g)" \
+                      -e CARGO_HOME=/cargo \
+                      -v "$HOME/.cargo-ingest:/cargo" \
+                      -v "$PWD/apps/ingest:/app" \
+                      -w /app \
+                      rust:1.88-bookworm \
+                      cargo build --release --target-dir /app/target-ci
+                  cp apps/ingest/target-ci/release/maple-ingest apps/ingest/dist/maple-ingest
 
             # BEFORE migrate: installs default privileges granting PUBLIC on every
             # table created from here on, so a new or rebuilt table can never land

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ playwright/.cache/
 drizzle.config.local.ts
 .18bd7*.bun-build
 .[0-9a-f]*.bun-build
+apps/ingest/dist/
+apps/ingest/target-ci/

--- a/apps/ingest/.dockerignore
+++ b/apps/ingest/.dockerignore
@@ -5,6 +5,10 @@
 # machine ship that directory and re-hash on every touch. CI never has it,
 # which is exactly why the problem hides until someone deploys locally.
 target/
+# The CI compile's target dir. `dist/` is deliberately NOT ignored — that is the
+# binary Dockerfile.prebuilt copies in, and it must stay part of the context
+# hash so a rebuilt binary produces a new image tag.
+target-ci/
 node_modules/
 
 # Not inputs to `cargo build --release`.

--- a/apps/ingest/Dockerfile.prebuilt
+++ b/apps/ingest/Dockerfile.prebuilt
@@ -1,0 +1,30 @@
+# Runner-only image. The binary is compiled BEFORE the deploy (see the "Build
+# ingest binary" step in .github/workflows/deploy-*.yml) and dropped at
+# dist/maple-ingest, so `alchemy deploy` pays a COPY instead of a from-scratch
+# cargo build of 385 crates.
+#
+# Why not just cache the Docker layers: alchemy's image build passes only
+# tag/context/file/platform/build-arg to the daemon (`AWS/ECR/Image.ts`), with
+# no --cache-from, and a fresh CI runner has an empty local cache. So a
+# Dockerfile that compiles is a cold compile every single deploy, however it is
+# layered. Moving the compile out is the only place a cache can exist.
+#
+# The compile MUST happen against bookworm's glibc (2.36) — building on the
+# ubuntu-24.04 runner (2.39) instead produces a binary that dies at startup with
+# `version 'GLIBC_2.39' not found`. The workflow enforces this by compiling
+# inside rust:1.88-bookworm rather than on the host.
+#
+# `Dockerfile` (the self-contained source build) stays the default and is what a
+# local `alchemy deploy` uses; alchemy.run.ts picks this one only when
+# dist/maple-ingest is actually present.
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY dist/maple-ingest /usr/local/bin/maple-ingest
+
+EXPOSE 3474
+
+CMD ["maple-ingest"]

--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs"
 import * as AWS from "alchemy/AWS"
 import * as Effect from "effect/Effect"
 import * as Redacted from "effect/Redacted"
@@ -11,6 +12,13 @@ import {
 } from "@maple/infra/aws"
 import type { MapleDomains, MapleStage } from "@maple/infra/cloudflare"
 import { resolveDeploymentEnvironment } from "@maple/infra/cloudflare"
+
+/**
+ * Binary the deploy workflows compile ahead of time (with a warm cargo cache)
+ * so the image build is a COPY rather than a from-scratch build of 385 crates.
+ * Present in CI, absent on a dev machine — see `Dockerfile.prebuilt`.
+ */
+const PREBUILT_BINARY = "apps/ingest/dist/maple-ingest"
 
 const requireEnv = (key: string): string => {
 	const value = process.env[key]?.trim()
@@ -201,10 +209,20 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 			cluster,
 			serviceName: name("ingest"),
 
-			// Dockerfile source: alchemy builds `apps/ingest/Dockerfile`, creates a
-			// private ECR repository, and pushes under a content-hash tag. Rebuilds
-			// only when the context hash changes, so CI needs no docker step.
+			// Alchemy creates a private ECR repository and pushes under a content-hash
+			// tag, rebuilding only when the context hash changes — so a deploy that
+			// doesn't touch apps/ingest never builds at all.
+			//
+			// When it DOES build, the Dockerfile depends on where we are. CI compiles
+			// the binary in a separate, cached step and leaves it at dist/, so the
+			// image build is a COPY (~30s). A dev machine has no dist/, so it falls
+			// back to the self-contained source build. Keyed on the file rather than
+			// on `process.env.CI` so a local run that happens to have built the binary
+			// gets the fast path too, and so CI can never silently ship a stale one.
 			context: "apps/ingest",
+			...(existsSync(PREBUILT_BINARY)
+				? { dockerfile: "apps/ingest/Dockerfile.prebuilt" }
+				: {}),
 			// The docker build platform is derived from this (`taskImagePlatform` in
 			// alchemy's ECS/Task). Explicit so a build from an Apple Silicon machine
 			// produces the same artifact CI does — an arm64 image on an X86_64 task


### PR DESCRIPTION
Deploys that touch `apps/ingest` recompile all 385 crates from scratch — ~20 min on a 2-core runner, against a 30 min job timeout. The run for #374 is currently sitting in exactly that build.

## Why the Dockerfile can't fix this

Alchemy's image build passes only `tag` / `context` / `file` / `platform` / `build-arg` to the daemon (`node_modules/alchemy/src/AWS/ECR/Image.ts:61`) — **no `--cache-from`**. A fresh runner's local layer cache is empty. So a Dockerfile that runs `cargo build` is a cold compile on every deploy no matter how it's layered; cargo-chef, a dependency layer, and BuildKit cache mounts all buy nothing in CI. The only place a cache can live is outside the image build.

## What this does

- **Deploy workflows** compile the binary in a cached step (`actions/cache` over the cargo registry and target dir) and drop it at `apps/ingest/dist/maple-ingest`.
- **`Dockerfile.prebuilt`** is a runner-only image that `COPY`s that binary into `debian:bookworm-slim`.
- **`alchemy.run.ts`** selects it by testing for the file, not by reading `CI` — a dev machine with no `dist/` still gets the self-contained source build, and CI can't silently ship a stale artifact.
- Job timeouts 30 → 45 min to cover the first uncached run.

Expected: unchanged ingest is a no-op, one-crate change ~1 min, `Cargo.lock` change back to a full build (but only that once).

## The glibc trap

The compile runs **inside `rust:1.88-bookworm`**, not on the runner. The runtime base is bookworm (glibc 2.36) and `ubuntu-24.04` ships 2.39 — a host-built binary starts and immediately dies with `version 'GLIBC_2.39' not found`. Containerizing the compile pins that contract instead of coupling it to whatever glibc the runner image happens to carry.

## Reviewer notes

- **Unverified until this actually runs in CI.** Locally I confirmed the YAML parses, both jobs keep their step order, and `tsc -p tsconfig.alchemy.json` passes (which is what proves `dockerfile` is a real `ECS.Service` prop). The cache hit rate, the container build, and the glibc assumption can only be proven by a run.
- **Cache size.** A release `target/` for 385 crates is plausibly 2–5 GB. GitHub's per-repo cache budget is 10 GB, so this may start evicting the bun/turbo caches. Worth watching; if it bites, drop `target-ci` from the cached paths and keep only the registry (slower, but still far better than cold).
- **Version drift, pre-existing:** `mise.toml` pins Rust 1.94.1 and the tests use it, while the Dockerfile builds on 1.88. I kept 1.88 here so the shipped artifact is byte-comparable with today's, but the two should converge.
- `dist/` and `target-ci/` are gitignored; `dist/` is deliberately *not* in `.dockerignore`, since the binary has to stay in the context hash for a rebuild to produce a new image tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788910885&installation_model_id=427786&pr_number=375&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F375&signature=ad4f7ef6313029b316fca72ba6e5d5dc4f1f413aa4d0ceab3ac8c41ebbdb38e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->