### PR TITLE
ci(ingest): log alchemy at debug, and keep build artifacts out of the context hash

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -83,24 +83,32 @@ jobs:
               with:
                   path: |
                       ~/.cargo-ingest
-                      apps/ingest/target-ci
+                      ${{ runner.temp }}/ingest-target
                   key: ingest-cargo-${{ runner.os }}-${{ hashFiles('apps/ingest/Cargo.lock') }}-${{ hashFiles('apps/ingest/src/**') }}
                   restore-keys: |
                       ingest-cargo-${{ runner.os }}-${{ hashFiles('apps/ingest/Cargo.lock') }}-
                       ingest-cargo-${{ runner.os }}-
 
+            # --target-dir points OUTSIDE apps/ingest deliberately. Alchemy hashes
+            # the image context with `hashDirectory`, which has no .dockerignore
+            # support and derives its exclusions from gitignore rules WITHOUT
+            # rebasing root-anchored ones onto the context dir — `/apps/ingest/target`
+            # becomes the glob `apps/ingest/target/**` evaluated with cwd=apps/ingest,
+            # which matches nothing. A target dir inside the context would therefore
+            # be walked and hashed in full on every deploy.
             - name: Build ingest binary
               run: |
-                  mkdir -p ~/.cargo-ingest apps/ingest/dist
+                  mkdir -p ~/.cargo-ingest "$RUNNER_TEMP/ingest-target" apps/ingest/dist
                   docker run --rm \
                       --user "$(id -u):$(id -g)" \
                       -e CARGO_HOME=/cargo \
                       -v "$HOME/.cargo-ingest:/cargo" \
                       -v "$PWD/apps/ingest:/app" \
+                      -v "$RUNNER_TEMP/ingest-target:/target" \
                       -w /app \
                       rust:1.88-bookworm \
-                      cargo build --release --target-dir /app/target-ci
-                  cp apps/ingest/target-ci/release/maple-ingest apps/ingest/dist/maple-ingest
+                      cargo build --release --target-dir /target
+                  cp "$RUNNER_TEMP/ingest-target/release/maple-ingest" apps/ingest/dist/maple-ingest
 
             # NOTE: prod schema migrations are applied OUT OF BAND (manually, via
             # `bun run migrate:prod` → `ps:apply-schema main`, against the direct 5432
@@ -112,4 +120,4 @@ jobs:
             # including the ingest gateway, which reaches Postgres through PSBouncer as
             # a role that does NOT inherit `postgres`.
             - name: Deploy PRD stack with Alchemy
-              run: bun run alchemy:deploy:prd
+              run: bun run alchemy:deploy:prd -- --log-level debug

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -64,24 +64,32 @@ jobs:
               with:
                   path: |
                       ~/.cargo-ingest
-                      apps/ingest/target-ci
+                      ${{ runner.temp }}/ingest-target
                   key: ingest-cargo-${{ runner.os }}-${{ hashFiles('apps/ingest/Cargo.lock') }}-${{ hashFiles('apps/ingest/src/**') }}
                   restore-keys: |
                       ingest-cargo-${{ runner.os }}-${{ hashFiles('apps/ingest/Cargo.lock') }}-
                       ingest-cargo-${{ runner.os }}-
 
+            # --target-dir points OUTSIDE apps/ingest deliberately. Alchemy hashes
+            # the image context with `hashDirectory`, which has no .dockerignore
+            # support and derives its exclusions from gitignore rules WITHOUT
+            # rebasing root-anchored ones onto the context dir — `/apps/ingest/target`
+            # becomes the glob `apps/ingest/target/**` evaluated with cwd=apps/ingest,
+            # which matches nothing. A target dir inside the context would therefore
+            # be walked and hashed in full on every deploy.
             - name: Build ingest binary
               run: |
-                  mkdir -p ~/.cargo-ingest apps/ingest/dist
+                  mkdir -p ~/.cargo-ingest "$RUNNER_TEMP/ingest-target" apps/ingest/dist
                   docker run --rm \
                       --user "$(id -u):$(id -g)" \
                       -e CARGO_HOME=/cargo \
                       -v "$HOME/.cargo-ingest:/cargo" \
                       -v "$PWD/apps/ingest:/app" \
+                      -v "$RUNNER_TEMP/ingest-target:/target" \
                       -w /app \
                       rust:1.88-bookworm \
-                      cargo build --release --target-dir /app/target-ci
-                  cp apps/ingest/target-ci/release/maple-ingest apps/ingest/dist/maple-ingest
+                      cargo build --release --target-dir /target
+                  cp "$RUNNER_TEMP/ingest-target/release/maple-ingest" apps/ingest/dist/maple-ingest
 
             # BEFORE migrate: installs default privileges granting PUBLIC on every
             # table created from here on, so a new or rebuilt table can never land
@@ -99,4 +107,4 @@ jobs:
               run: DATABASE_URL="$MAPLE_PG_URL" bun run --cwd packages/db db:migrate
 
             - name: Deploy STG stack with Alchemy
-              run: bun run alchemy:deploy:stg
+              run: bun run alchemy:deploy:stg -- --log-level debug

--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,3 @@ drizzle.config.local.ts
 .18bd7*.bun-build
 .[0-9a-f]*.bun-build
 apps/ingest/dist/
-apps/ingest/target-ci/

--- a/apps/ingest/.dockerignore
+++ b/apps/ingest/.dockerignore
@@ -1,3 +1,8 @@
+# NOTE: this file covers the docker daemon only. Alchemy's own context hash
+# (`hashDirectory`) does NOT read .dockerignore — it uses gitignore rules — so
+# `/target` in apps/ingest/.gitignore is what keeps 27 GB of build artifacts out
+# of the hash. Both are required; neither substitutes for the other.
+#
 # The build context is `apps/ingest` itself (see the Dockerfile's `COPY . .`),
 # so anything not excluded here is both uploaded to the daemon AND folded into
 # the context hash alchemy uses to decide whether to rebuild. A local `cargo
@@ -5,10 +10,6 @@
 # machine ship that directory and re-hash on every touch. CI never has it,
 # which is exactly why the problem hides until someone deploys locally.
 target/
-# The CI compile's target dir. `dist/` is deliberately NOT ignored — that is the
-# binary Dockerfile.prebuilt copies in, and it must stay part of the context
-# hash so a rebuilt binary produces a new image tag.
-target-ci/
 node_modules/
 
 # Not inputs to `cargo build --release`.

--- a/apps/ingest/.gitignore
+++ b/apps/ingest/.gitignore
@@ -1,3 +1,11 @@
+# Cargo build artifacts (27 GB and growing). The root .gitignore already has
+# `/apps/ingest/target`, but alchemy's image-context hash re-reads gitignore
+# rules with cwd=apps/ingest and does not rebase root-anchored patterns, so that
+# one converts to a glob matching nothing. Declaring it HERE makes the rule
+# relative to this directory, which is what actually excludes it from the hash —
+# without this a local `alchemy deploy` walks the whole tree.
+/target
+
 target/.wal
 
 # ui-dist/ is a build artifact: `scripts/build-local-binary.sh` builds the


### PR DESCRIPTION
Two prd deploys have now burned their entire timeout with **zero output** from `alchemy deploy` — not one resource line. This makes it talk, and fixes a real problem found while investigating.

## What the evidence says

- **No AWS resources exist.** The account holds only AWS's default VPC (`172.31.0.0/16`); no ACM, ECR, ECS, ALB, or Secrets Manager entries.
- **Alchemy never called AWS.** CloudTrail over the first run's full silent window (23:19→23:48 UTC) shows the `GitHubActions` session assuming the role at 23:18:11 and then making **no API calls whatsoever**. The only other activity is console browsing as `root`.
- **A normal deploy of this stack takes 2m05s** (run `31324241273`) and prints a line per resource.

So it stalls between process start and the first resource — before any AWS work. That rules out the ACM/listener theory and everything downstream of it. `--log-level debug` on the deploy is the cheapest way to find where; **remove the flag once the cause is known.**

Also worth noting: `Build ingest binary` from #375 came in at **2m54s on a cold cache**, so the Rust build was never the bottleneck either.

## The context-hash bug (real, independent of the hang)

Alchemy hashes the image context with `hashDirectory` (`Command/Memo.ts:202`). It has **no `.dockerignore` support** — exclusions come from gitignore rules — and it does not rebase root-anchored patterns onto the context directory. Verified by calling the converter directly:

```
rule  "/apps/ingest/target"  →  glob "apps/ingest/target/**"   (evaluated with cwd=apps/ingest)
rule  "/target"              →  glob "target/**"               ✅ matches
```

The first matches nothing, so today alchemy walks and hashes every build artifact under `apps/ingest`:

- **In CI:** `target-ci/` (gigabytes) sat inside the context — introduced by #375. Now `--target-dir` points at `$RUNNER_TEMP/ingest-target`, outside it.
- **Locally:** `apps/ingest/target` is **27 GB**. Adding `/target` to `apps/ingest/.gitignore` (where the rule is relative to that directory) is what actually excludes it. Without this a local `alchemy deploy` walks the whole tree.

`.dockerignore` keeps its `target/` entry — the two mechanisms are independent and both are needed. Documented inline so the next person doesn't delete one as redundant.

## Verified locally

- `gitignoreRulesToGlobs(["/target"])` → `["target", "target/**"]`, i.e. the new rule genuinely matches.
- `bun run <script> -- --log-level debug` appends the flag to the `alchemy deploy` call and strips the `--` (tested with a scratch package.json).
- Both workflows still parse and keep their step order.

The cache path moved with the target dir, so the first run after this merges is another cold ~3 min build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788912526&installation_model_id=427786&pr_number=377&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F377&signature=fd170cee4b2ab1c0aa35970a572c01f6a340432eec12a1ff3bd42a8afa8cc159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->