### PR TITLE
fix(deploy): make the AWS ingest half opt-in so production can ship again

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -28,6 +28,10 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
         environment: production
         env:
+            # Opt-in for the AWS/ECS ingest half (see alchemy.run.ts). Unset or not
+            # "1", the deploy is the pure-Cloudflare stack that shipped in 2m05s.
+            # Set the repo variable to "1" to reproduce the hang under investigation.
+            MAPLE_DEPLOY_AWS_INGEST: ${{ vars.MAPLE_DEPLOY_AWS_INGEST }}
             INFISICAL_ENV_SLUG: prod
             # Stamped onto deployed telemetry as `deployment.commit_sha` (server SDK
             # reads COMMIT_SHA; web build reads VITE_COMMIT_SHA via Vite define).
@@ -120,4 +124,4 @@ jobs:
             # including the ingest gateway, which reaches Postgres through PSBouncer as
             # a role that does NOT inherit `postgres`.
             - name: Deploy PRD stack with Alchemy
-              run: bun run alchemy:deploy:prd -- --log-level debug
+              run: bun run alchemy:deploy:prd

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -23,6 +23,10 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
         environment: staging
         env:
+            # Opt-in for the AWS/ECS ingest half (see alchemy.run.ts). Unset or not
+            # "1", the deploy is the pure-Cloudflare stack that shipped in 2m05s.
+            # Set the repo variable to "1" to reproduce the hang under investigation.
+            MAPLE_DEPLOY_AWS_INGEST: ${{ vars.MAPLE_DEPLOY_AWS_INGEST }}
             INFISICAL_ENV_SLUG: staging
             # Stamped onto deployed telemetry as `deployment.commit_sha` (server SDK
             # reads COMMIT_SHA; web build reads VITE_COMMIT_SHA via Vite define).
@@ -107,4 +111,4 @@ jobs:
               run: DATABASE_URL="$MAPLE_PG_URL" bun run --cwd packages/db db:migrate
 
             - name: Deploy STG stack with Alchemy
-              run: bun run alchemy:deploy:stg -- --log-level debug
+              run: bun run alchemy:deploy:stg

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -77,6 +77,18 @@ const createProductionSharedResources = (stage: ReturnType<typeof parseMapleStag
 		return { logsDestination, tracesDestination }
 	})
 
+/**
+ * Opt-in switch for the AWS half of the stack (`apps/ingest` on ECS).
+ *
+ * Set `MAPLE_DEPLOY_AWS_INGEST=1` to include it. Unset, both the AWS providers
+ * and the ingest resources drop out and the stack is exactly what shipped
+ * before the AWS work landed — which is the point: the ingest deploy currently
+ * hangs, and it hangs in the same `alchemy deploy` run that ships every
+ * Cloudflare worker, so an unconditional AWS half means no production deploys
+ * at all.
+ */
+const DEPLOY_AWS_INGEST = process.env.MAPLE_DEPLOY_AWS_INGEST === "1"
+
 export default Alchemy.Stack(
 	"maple",
 	{
@@ -84,7 +96,17 @@ export default Alchemy.Stack(
 		// gateway on ECS (`apps/ingest`). AWS credentials arrive as env vars from
 		// Infisical exactly like the Cloudflare ones — `AWS.providers()` reads
 		// AWS_REGION / AWS_ACCOUNT_ID / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
-		providers: Layer.mergeAll(Cloudflare.providers(), AWS.providers()),
+		//
+		// OPT-IN, because the AWS half currently wedges the deploy. Four prd runs
+		// have burned their whole timeout inside `alchemy deploy` with no output
+		// at any log level, no AWS API call in CloudTrail, and no resource
+		// created — while blocking every Cloudflare worker behind them, since
+		// they deploy in the same run. Unset, this stack is byte-identical to the
+		// last one that shipped (2m05s), so production keeps deploying while the
+		// hang is investigated with the flag on.
+		providers: DEPLOY_AWS_INGEST
+			? Layer.mergeAll(Cloudflare.providers(), AWS.providers())
+			: Cloudflare.providers(),
 		// Shared account-wide state store (Worker + DO SQLite) — bootstrapped once
 		// per Cloudflare account (`alchemy bootstrap cloudflare` or the first
 		// `deploy --yes`). ALCHEMY_LOCAL_STATE=1 opts into .alchemy/ file state for
@@ -119,9 +141,12 @@ export default Alchemy.Stack(
 		// points at; dev stages run it through docker-compose). `domains.ingest`
 		// reaches it via a Cloudflare CNAME at the ALB, so the URL below stays a
 		// plain string and does not depend on the service resource.
-		const ingest = stageDeploysIngest(stage)
-			? yield* createMapleIngest({ stage, domains, region })
-			: undefined
+		// Gated on the same flag as `AWS.providers()` above — creating the resource
+		// without its provider registered is not a runnable combination.
+		const ingest =
+			DEPLOY_AWS_INGEST && stageDeploysIngest(stage)
+				? yield* createMapleIngest({ stage, domains, region })
+				: undefined
 
 		const ingestUrl = resolveUrl(domains.ingest, "VITE_INGEST_URL", "https://ingest.maple.dev")
 


### PR DESCRIPTION
**Production has not deployed since 16:38 yesterday.** Four consecutive prd runs have burned their entire timeout inside `alchemy deploy`, and since the Cloudflare workers ship in that same run, every unrelated web/api/landing/alerting change behind them has gone nowhere.

This separates the two so the broken half stops holding the working half hostage. It does **not** fix the hang.

## What we know about the hang

| Evidence | Result |
|---|---|
| Output at `--log-level debug` | **None**, across a full 40-minute run |
| CloudTrail during the silent window | OIDC session assumes the role, then **zero** AWS API calls |
| Resources in account `465760687006` | **None** — only AWS's default VPC |
| Local `alchemy plan` | Reaches the stack generator in **under a second** |
| `import "alchemy/AWS"` | 1.2s |
| Auth lockfile | Caps at 120s and throws a clear error, so not a 40-min stall |
| `Build ingest binary` (#375) | 2m54s cold — the Rust build was never the bottleneck |

So it stalls in CI, ahead of the first AWS call, and logs nothing. The remaining candidate is the image step (docker build / `hashDirectory` over the context), which runs in exactly that window and produces no alchemy output — but that's a hypothesis, not a finding.

## What this does

`MAPLE_DEPLOY_AWS_INGEST=1` opts the AWS half in. Unset, `AWS.providers()` and the ingest resources both drop out and the stack is what last shipped successfully in **2m05s**. Both gates are on the same flag deliberately — creating the resource without its provider registered isn't a runnable combination.

The flag comes from a repo variable, so the hang can be reproduced on demand without another code change:

```bash
gh variable set MAPLE_DEPLOY_AWS_INGEST --body 1     # reproduce
gh variable delete MAPLE_DEPLOY_AWS_INGEST           # back to shipping
```

Also drops `--log-level debug` from the deploy command. It produced no output whatsoever across a 40-minute hang, so it buys no diagnosis and costs noise on every production deploy.

## Verified

- `tsc -p tsconfig.alchemy.json` passes.
- Both workflows parse; `MAPLE_DEPLOY_AWS_INGEST` lands in the job env and the deploy step is back to its plain form.

## Next

Merge this, confirm prd goes green in ~2 minutes, then flip the variable on a `workflow_dispatch` run to keep debugging without production riding on it. The next diagnostic I'd add is a watchdog in the deploy step dumping `ps`/`docker ps` every 60s — that distinguishes "bun idle" from "cargo/docker still working" and needs no cooperation from alchemy's logger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788950391&installation_model_id=427786&pr_number=378&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F378&signature=b22025d7e5af654d6d008bf3677eefaeb832c98535dd74e43c9218d24f9d0726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->