### PR TITLE
ci(deploy): watchdog the prd deploy when the AWS half is opted in

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -123,5 +123,27 @@ jobs:
             # migrates, so new and rebuilt tables are readable by every consumer —
             # including the ingest gateway, which reaches Postgres through PSBouncer as
             # a role that does NOT inherit `postgres`.
+            # The watchdog only arms when the AWS half is opted in, so a normal
+            # production deploy is untouched. Four runs have hung inside this step
+            # emitting nothing at any log level, with no AWS API call ever reaching
+            # CloudTrail — so the question is no longer "what does alchemy say" but
+            # "what is the process actually doing". `ps` answers what nothing inside
+            # alchemy will: a busy cargo/docker child means the build is simply slow,
+            # a bun process at 0% CPU means it is blocked on something (a lock, a
+            # socket, a prompt on a stdin that will never deliver).
             - name: Deploy PRD stack with Alchemy
-              run: bun run alchemy:deploy:prd
+              run: |
+                  if [ "${MAPLE_DEPLOY_AWS_INGEST:-}" = "1" ]; then
+                      (
+                          while true; do
+                              sleep 60
+                              echo "=== watchdog $(date -u +%H:%M:%S) ==="
+                              ps -eo pid,ppid,etime,pcpu,rss,stat,args --sort=-pcpu | head -15
+                              echo "--- docker ---"
+                              docker ps --format '{{.ID}} {{.Image}} {{.Status}}' 2>&1 | head -5
+                          done
+                      ) &
+                      watchdog=$!
+                      trap 'kill "$watchdog" 2>/dev/null || true' EXIT
+                  fi
+                  bun run alchemy:deploy:prd

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -83,6 +83,7 @@ jobs:
             # host-built binary starts and immediately dies with
             # `version 'GLIBC_2.39' not found`.
             - name: Cache ingest cargo build
+              if: vars.MAPLE_DEPLOY_AWS_INGEST == '1'
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   path: |
@@ -101,6 +102,7 @@ jobs:
             # which matches nothing. A target dir inside the context would therefore
             # be walked and hashed in full on every deploy.
             - name: Build ingest binary
+              if: vars.MAPLE_DEPLOY_AWS_INGEST == '1'
               run: |
                   mkdir -p ~/.cargo-ingest "$RUNNER_TEMP/ingest-target" apps/ingest/dist
                   docker run --rm \


### PR DESCRIPTION
Follow-up to #378. That one stopped the hang from blocking production; this one is for finding it.

## Why an OS-level probe

Everything that could explain the hang *from inside alchemy* has now been ruled out by measurement:

| Suspect | Measured | Verdict |
|---|---|---|
| `import "alchemy/AWS"` | 1.2s | not it |
| `hashDirectory("apps/ingest")` | 39ms | not it |
| Auth lockfile | 120s cap, then a clear error | not it |
| Eager credential resolution | behind `Effect.cached` | not it |
| Layer build + stack generator | local `plan` < 1s | not it |
| ACM / ECS / anything AWS | **zero** CloudTrail calls, empty account | impossible |
| `--log-level debug` | no output across 40 min | tells us nothing |

A process that prints nothing at debug level for 40 minutes isn't going to explain itself. So the probe moves outside it.

## What it prints

Every 60s, the process table (sorted by CPU) and `docker ps`. That separates the only two shapes this can have:

- **a busy `cargo`/`docker` child** → the build is merely slow, and the fix is caching or a bigger runner;
- **`bun` pinned at 0% CPU** → it's blocked, and the process tree plus state (`S`/`D`) says on what: a lock, a socket, or a prompt reading a stdin that will never deliver.

## Scope

Armed only when `MAPLE_DEPLOY_AWS_INGEST=1`, so a normal production deploy is byte-identical to today's. prd only — stg isn't where this reproduces, and there's no reason to add noise there.

Smoke-tested the wrapper locally: the watchdog fires on schedule and the `EXIT` trap reaps it with no orphan left behind. `--sort=-pcpu` is procps-only, which is correct for `ubuntu-latest` (it isn't valid on macOS, so don't be surprised if you try it locally).

## Using it

```bash
gh variable set MAPLE_DEPLOY_AWS_INGEST --body 1 -R MapleTechLabs/maple
gh workflow run "Deploy PRD (Cloudflare via Alchemy)" -R MapleTechLabs/maple
gh variable delete MAPLE_DEPLOY_AWS_INGEST -R MapleTechLabs/maple   # once it hangs or passes
```

Leave the variable off between experiments so production keeps shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788950605&installation_model_id=427786&pr_number=379&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F379&signature=e849c8c7c429c8e549c86e85926a000e376389d0ab49048a3f69e5ae6edb6c34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->