### PR TITLE
fix(perf): gate service-map idle on frame pacing, not fps

### DIFF
--- a/apps/web/perf/service-map.perf.spec.ts
+++ b/apps/web/perf/service-map.perf.spec.ts
@@ -174,10 +174,23 @@ test("service map renders filter/SMIL-free and animates smoothly under heavy tra
 	// SVG-filter cost of ~23 fps / p95 ~50ms) plus a "pan isn't frozen" floor.
 	const ci = !!process.env.CI
 
-	// Idle is the headline, rock-stable metric — it captures the continuous
-	// SVG-filter/SMIL cost that this change removes.
-	expect(idle.fps, "idle fps").toBeGreaterThan(ci ? 45 : 55)
+	// Idle captures the continuous SVG-filter/SMIL cost this change removes — but
+	// gate it on frame PACING, not fps. On a GPU-less shared runner the same code
+	// measured p50 16.7ms / p95 33.4ms, identical to the decimal, across three
+	// consecutive attempts while fps drifted 44.7 -> 43.6 -> 41.7 and red-failed a
+	// 45 floor on a branch that touches no web code. fps is frames divided by
+	// wall-clock, so it counts time the CI host descheduled the browser entirely;
+	// p50/p95 measure how the frames that DID run were paced. 16.7ms is exactly
+	// vsync and 33.4ms is exactly one dropped frame — the rendering was perfect on
+	// the run that "failed".
+	//
+	// Pacing still separates the regression this test exists to catch by a wide
+	// margin: the pre-fix per-edge blur + SMIL cost ~23 fps with p50/p95 far above
+	// vsync (~50ms p95), against 16.7/33.4 here. fps keeps a not-frozen floor
+	// only, exactly as pan already does below.
+	expect(idle.frameP50, "idle p50 frame time (ms)").toBeLessThan(ci ? 25 : 20)
 	expect(idle.frameP95, "idle p95 frame time (ms)").toBeLessThan(ci ? 40 : 20)
+	expect(idle.fps, "idle fps (not frozen)").toBeGreaterThan(ci ? 20 : 55)
 
 	if (ci) {
 		// GPU-less runner: pan fps can't discriminate impl quality, only catch a


### PR DESCRIPTION
The service-map idle gate red-failed three consecutive attempts on a branch that touches **no web code** (workflows and a deploy tsconfig), while every structural assertion in the same test — `feGaussianBlur === 0`, `animateMotion === 0`, particles drawn — passed.

## The measurements

| attempt | fps | frameP50 | frameP95 |
|---|---|---|---|
| 1 | 44.66 | **16.7** | **33.4** |
| 2 | 43.57 | **16.7** | **33.4** |
| 3 | 41.71 | **16.7** | **33.4** |

Frame pacing is **identical to the decimal** across all three, while fps drifts through the 45 floor. 16.7ms is exactly vsync and 33.4ms is exactly one dropped frame — the rendering was *perfect* on the run that failed.

`fps` is frames ÷ wall-clock, so it also counts time the CI host descheduled the browser. It measures runner load, not the code under test. p50/p95 measure how the frames that actually ran were paced.

## Why pacing is still a real gate

The regression this test exists to catch — per-edge SVG blur + SMIL — cost ~23 fps with p95 around **50ms**, against **33.4ms** here. So the p50/p95 gates keep a wide margin while surviving a slow runner. `fps` keeps a not-frozen floor only (`> 20` on CI), exactly as `pan` already does two lines below.

```diff
-expect(idle.fps, "idle fps").toBeGreaterThan(ci ? 45 : 55)
-expect(idle.frameP95, "idle p95 frame time (ms)").toBeLessThan(ci ? 40 : 20)
+expect(idle.frameP50, "idle p50 frame time (ms)").toBeLessThan(ci ? 25 : 20)
+expect(idle.frameP95, "idle p95 frame time (ms)").toBeLessThan(ci ? 40 : 20)
+expect(idle.fps, "idle fps (not frozen)").toBeGreaterThan(ci ? 20 : 55)
```

Local thresholds are unchanged in strictness (`fps > 55` still gates a dev machine; the new p50 ceiling of 20ms is slack there by construction, since >55 fps implies <18ms).

## Precedent

Same failure mode as `apps/web/perf/infra.perf.spec.ts`, which moved off wall-clock ratios to React commit counts after red-failing main for exactly this reason: the wall-clock metric anti-correlated with runner speed. The rule that came out of that — assert the structural metric, keep the noisy one loose — is what this applies. `apps/web/perf/service-detail.perf.spec.ts` still carries the old duration-ratio style and is a candidate for the same treatment if it starts flaking.

## Note on why it ran at all

`web` in the paths filter includes `*base`, which includes `tsconfig*.json` — so editing `tsconfig.alchemy.json` (a deploy-only config that cannot affect the web app) pulls in the entire web matrix. Excluding it would cut spurious runs, but negation patterns in `dorny/paths-filter` risk silently disabling a filter if I get the semantics wrong, so I've left it alone rather than guess. Worth a deliberate look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788954107&installation_model_id=427786&pr_number=381&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F381&signature=ea4927c8fa68a5b0b6228795749ee0cccb6e6dafcd6e3d8f4fead99f55bd7a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->