### PR TITLE
ci(probe): surface the alchemy log — it was never silent

### DIFF
--- a/.github/workflows/aws-probe.yml
+++ b/.github/workflows/aws-probe.yml
@@ -125,10 +125,37 @@ jobs:
                               ls -l "/proc/$p/fd" 2>/dev/null | tail -12
                           done
                           docker ps --format '{{.ID}} {{.Image}} {{.Status}}' 2>&1 | head -5
+                          echo "--- .alchemy/log/out (tail) ---"
+                          tail -n 20 .alchemy/log/out 2>/dev/null || echo "(no log yet)"
                       done
                   ) &
                   trap 'kill %1 2>/dev/null || true' EXIT
                   bunx alchemy deploy scripts/aws-probe.run.ts --yes --adopt --stage probe
+
+            # alchemy writes its stdout to .alchemy/log/out, NOT to the console. That
+            # single fact explains every "silent hang" in this investigation: four
+            # production runs and a --log-level debug run all looked like 40 minutes
+            # of nothing while the log sat in the workspace. Found via /proc/<pid>/fd
+            # in the watchdog output.
+            # BEFORE destroy, always: `alchemy destroy` removes the local state
+            # directory on success, so uploading afterwards captured nothing and
+            # `if-no-files-found: ignore` swallowed the fact silently.
+            - name: Upload probe state for recovery
+              if: always()
+              uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+              with:
+                  name: alchemy-probe-state
+                  path: .alchemy/
+                  if-no-files-found: warn
+                  retention-days: 7
+
+            - name: Dump alchemy log
+              if: always()
+              run: |
+                  echo "===== .alchemy/log/out ====="
+                  cat .alchemy/log/out 2>/dev/null || echo "(missing)"
+                  echo "===== .alchemy/log/err ====="
+                  cat .alchemy/log/err 2>/dev/null || echo "(missing)"
 
             - name: Destroy probe resources
               if: always() && !inputs.keep
@@ -136,16 +163,3 @@ jobs:
                   if ! bunx alchemy destroy scripts/aws-probe.run.ts --yes --stage probe; then
                       echo "::warning title=Probe teardown failed::Probe resources may still exist in 465760687006. Download the alchemy-probe-state artifact from this run, unpack it at the repo root, and re-run: bunx alchemy destroy scripts/aws-probe.run.ts --yes --stage probe"
                   fi
-
-            # The state lives in the workspace, which dies with the runner — so a
-            # failed OR cancelled teardown would otherwise leave a VPC in the
-            # account with nothing to destroy it from. Timeouts are the EXPECTED
-            # outcome here, so this is the normal path, not the edge case.
-            - name: Upload probe state for recovery
-              if: always() && !inputs.keep
-              uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
-              with:
-                  name: alchemy-probe-state
-                  path: .alchemy/
-                  if-no-files-found: ignore
-                  retention-days: 7


### PR DESCRIPTION
The watchdog from #380 paid off on its first run. `/proc/<pid>/fd` on the hung `bun` process:

```
fd 17 -> /home/runner/work/maple/maple/.alchemy/log/out
```

**alchemy redirects its own stdout to a file.** Every "silent hang" in this investigation — four production deploys, one of them at `--log-level debug` — was writing progress to the workspace the entire time while the console showed nothing. We have been reading the wrong stream for two days.

The same dump also shows the process at **20–38% CPU** in `Sl`/`ep_poll`, not parked at 0% — so it was *working*, not deadlocked. That kills the lock/socket/stdin-prompt family of hypotheses outright.

## Probe results that motivated this

| run | level | state | result |
|---|---|---|---|
| [31385950209](https://github.com/MapleTechLabs/maple/actions/runs/31385950209) | image | local | hung → cancelled at 20m |
| [31385976601](https://github.com/MapleTechLabs/maple/actions/runs/31385976601) | image | cloud | hung → cancelled at 20m |

Both hung **identically**, so the Cloudflare state store is **not** the cause — my leading hypothesis is dead. And `image` is the level that passes locally in 115s, so the reproduction is now down to a single resource in CI.

## Changes

- The watchdog tails `.alchemy/log/out` every 30s, so progress is visible live.
- The full log (`out` and `err`) is dumped into the job output on exit, `if: always()`.
- **The state upload moves before the destroy step.** `alchemy destroy` removes the state directory on success, which is why both probe runs produced no artifact at all — and `if-no-files-found: ignore` hid that. Now `warn`.

## Next

Re-run `level=image` and read the log. It will show which resource the deploy is sitting on and what it's retrying — the thing we have never once been able to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788958127&installation_model_id=427786&pr_number=384&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F384&signature=a44a1171b756fad5e646ada05b66887e188ce376d94cc79e8995d6f475c2e450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->