### PR TITLE
feat: trademark terms on /brand, and name Makisuo, Inc. as the owning entity

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@ FSL-1.1-ALv2
 
 ## Notice
 
-Copyright 2026 David Granzin
+Copyright 2026 Makisuo, Inc.
 
 ## Terms and Conditions
 

--- a/apps/landing/messages/en.json
+++ b/apps/landing/messages/en.json
@@ -331,7 +331,7 @@
 	"footer_github": "GitHub",
 	"footer_twitter": "Twitter / X",
 	"footer_discord": "Discord",
-	"footer_copyright": "\u00a9 2026 Maple. All rights reserved.",
+	"footer_copyright": "\u00a9 2026 Makisuo, Inc.",
 	"footer_privacy": "Privacy Policy",
 	"footer_terms": "Terms of Service",
 	"footer_brand": "Brand",

--- a/apps/landing/messages/ja.json
+++ b/apps/landing/messages/ja.json
@@ -331,7 +331,7 @@
 	"footer_github": "GitHub",
 	"footer_twitter": "Twitter / X",
 	"footer_discord": "Discord",
-	"footer_copyright": "\u00a9 2026 Maple. All rights reserved.",
+	"footer_copyright": "\u00a9 2026 Makisuo, Inc.",
 	"footer_privacy": "\u30d7\u30e9\u30a4\u30d0\u30b7\u30fc\u30dd\u30ea\u30b7\u30fc",
 	"footer_terms": "\u5229\u7528\u898f\u7d04",
 	"footer_brand": "\u30d6\u30e9\u30f3\u30c9",

--- a/apps/landing/messages/ko.json
+++ b/apps/landing/messages/ko.json
@@ -331,7 +331,7 @@
 	"footer_github": "GitHub",
 	"footer_twitter": "Twitter / X",
 	"footer_discord": "Discord",
-	"footer_copyright": "\u00a9 2026 Maple. All rights reserved.",
+	"footer_copyright": "\u00a9 2026 Makisuo, Inc.",
 	"footer_privacy": "\uac1c\uc778\uc815\ubcf4 \ucc98\ub9ac\ubc29\uce68",
 	"footer_terms": "\uc774\uc6a9\uc57d\uad00",
 	"footer_brand": "\ube0c\ub79c\ub4dc",

--- a/apps/landing/src/components/PrivacyContent.astro
+++ b/apps/landing/src/components/PrivacyContent.astro
@@ -6,7 +6,7 @@
         <section>
             <h2 class="text-fg text-base font-medium mb-3">1. Introduction</h2>
             <p>
-                Maple is operated by Makisuo LLC ("we", "us", "our"). This Privacy Policy explains how we collect,
+                Maple is operated by Makisuo, Inc. ("we", "us", "our"). This Privacy Policy explains how we collect,
                 use, and protect information when you use the Maple observability platform and related services
                 (the "Service").
             </p>

--- a/apps/landing/src/components/TermsContent.astro
+++ b/apps/landing/src/components/TermsContent.astro
@@ -6,7 +6,7 @@
         <section>
             <h2 class="text-fg text-base font-medium mb-3">1. Acceptance of Terms</h2>
             <p>
-                By accessing or using Maple (the "Service"), operated by Makisuo LLC ("we", "us", "our"),
+                By accessing or using Maple (the "Service"), operated by Makisuo, Inc. ("we", "us", "our"),
                 you agree to be bound by these Terms of Service. If you do not agree, do not use the Service.
             </p>
         </section>
@@ -77,7 +77,7 @@
         <section>
             <h2 class="text-fg text-base font-medium mb-3">8. Limitation of Liability</h2>
             <p>
-                To the maximum extent permitted by law, Makisuo LLC shall not be liable for any indirect,
+                To the maximum extent permitted by law, Makisuo, Inc. shall not be liable for any indirect,
                 incidental, special, consequential, or punitive damages, including loss of profits, data,
                 or business opportunities, arising from your use of the Service. Our total liability shall
                 not exceed the amount you paid us in the twelve months preceding the claim.
@@ -111,7 +111,7 @@
             <p>
                 Maple's source code is available under the Functional Source License (FSL-1.1-ALv2). Your use of the self-hosted
                 version is governed by that license. These Terms of Service apply specifically to the
-                cloud-hosted Service operated by Makisuo LLC.
+                cloud-hosted Service operated by Makisuo, Inc.
             </p>
         </section>
 

--- a/apps/landing/src/pages/brand.astro
+++ b/apps/landing/src/pages/brand.astro
@@ -368,6 +368,36 @@ const rules = [
         </div>
     </section>
 
+    <!-- 05 — Terms -->
+    <section class="bg-bg-deep border-t border-border">
+        <div class="mx-auto max-w-6xl px-6 py-20 md:py-24">
+            <div class="max-w-2xl">
+                <LocalEyebrow index="05" label="Terms" />
+                <h2
+                    class="font-display text-3xl sm:text-4xl font-semibold leading-[1.06] tracking-tight">
+                    The licence covers the code, not the name
+                </h2>
+                <p class="mt-5 text-sm md:text-base text-fg-muted leading-relaxed">
+                    Maple's source is FSL-1.1-ALv2, and each release converts to Apache 2.0 two
+                    years after we publish it. Neither one hands over the name or the artwork. The
+                    FSL says so in its own words, and Apache repeats it in its section 6. So a fork
+                    gets every line of the code and none of this page: ship it under your own name
+                    and your own mark. Saying what it is stays fine. “A fork of Maple”, “built on
+                    Maple”, “compatible with Maple” are all true, and none of them needs asking.
+                </p>
+                <p class="mt-4 text-sm md:text-base text-fg-muted leading-relaxed">
+                    What isn't fine is looking like us when you aren't: Maple in your product name,
+                    domain, or handle, or the mark placed so it reads as endorsement or partnership
+                    where there's no agreement. We can ask you to stop, and if we do, please stop.
+                </p>
+                <p class="mt-4 text-sm text-fg-muted leading-relaxed">
+                    Maple and the Maple mark are trademarks of Makisuo, Inc. Other names and logos on
+                    this site belong to their owners.
+                </p>
+            </div>
+        </div>
+    </section>
+
     <Footer />
 </Layout>
 

--- a/apps/landing/src/pages/brand.md.ts
+++ b/apps/landing/src/pages/brand.md.ts
@@ -78,6 +78,13 @@ export const GET: APIRoute = ({ site }) => {
 				"- **Do respect the 16px floor** for the bare mark — below that its eyes antialias into a blob, so use the tile instead.",
 			),
 
+			"## Terms",
+			blocks(
+				"Maple's source is FSL-1.1-ALv2, and each release converts to Apache 2.0 two years after we publish it. Neither one hands over the name or the artwork. The FSL says so in its own words, and Apache repeats it in its section 6. So a fork gets every line of the code and none of this page: ship it under your own name and your own mark. Saying what it is stays fine. \"A fork of Maple\", \"built on Maple\", \"compatible with Maple\" are all true, and none of them needs asking.",
+				"What isn't fine is looking like us when you aren't: Maple in your product name, domain, or handle, or the mark placed so it reads as endorsement or partnership where there's no agreement. We can ask you to stop, and if we do, please stop.",
+				"Maple and the Maple mark are trademarks of Makisuo, Inc. Other names and logos on this site belong to their owners.",
+			),
+
 			"## Contact",
 			"Anything the kit doesn't cover — a partner lockup, a different ratio, or permission for one of the don'ts above: hello@maple.dev",
 

--- a/apps/landing/src/paraglide/messages/en.js
+++ b/apps/landing/src/paraglide/messages/en.js
@@ -2463,7 +2463,7 @@ export const footer_discord = () => `Discord`
  * @returns {string}
  */
 /* @__NO_SIDE_EFFECTS__ */
-export const footer_copyright = () => `© 2026 Maple. All rights reserved.`
+export const footer_copyright = () => `© 2026 Makisuo, Inc.`
 
 
 /**

--- a/apps/landing/src/paraglide/messages/ja.js
+++ b/apps/landing/src/paraglide/messages/ja.js
@@ -2463,7 +2463,7 @@ export const footer_discord = () => `Discord`
  * @returns {string}
  */
 /* @__NO_SIDE_EFFECTS__ */
-export const footer_copyright = () => `© 2026 Maple. All rights reserved.`
+export const footer_copyright = () => `© 2026 Makisuo, Inc.`
 
 
 /**

--- a/apps/landing/src/paraglide/messages/ko.js
+++ b/apps/landing/src/paraglide/messages/ko.js
@@ -2463,7 +2463,7 @@ export const footer_discord = () => `Discord`
  * @returns {string}
  */
 /* @__NO_SIDE_EFFECTS__ */
-export const footer_copyright = () => `© 2026 Maple. All rights reserved.`
+export const footer_copyright = () => `© 2026 Makisuo, Inc.`
 
 
 /**

--- a/lib/clickhouse-builder/LICENSE
+++ b/lib/clickhouse-builder/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Maple
+Copyright (c) 2026 Makisuo, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/clickhouse-builder/package.json
+++ b/lib/clickhouse-builder/package.json
@@ -14,7 +14,7 @@
 		"url": "https://github.com/MapleTechLabs/maple/issues"
 	},
 	"license": "MIT",
-	"author": "Maple Tech Labs",
+	"author": "Makisuo, Inc.",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/MapleTechLabs/maple.git",

--- a/packages/alchemy-maple/LICENSE
+++ b/packages/alchemy-maple/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Maple Tech Labs
+Copyright (c) 2026 Makisuo, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/alchemy-maple/package.json
+++ b/packages/alchemy-maple/package.json
@@ -13,7 +13,7 @@
 	"homepage": "https://maple.dev",
 	"bugs": "https://github.com/MapleTechLabs/maple/issues",
 	"license": "MIT",
-	"author": "Maple Tech Labs",
+	"author": "Makisuo, Inc.",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/MapleTechLabs/maple.git",

--- a/packages/browser/LICENSE
+++ b/packages/browser/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Maple Tech Labs
+Copyright (c) 2026 Makisuo, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/effect-sdk/LICENSE
+++ b/packages/effect-sdk/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Maple Tech Labs
+Copyright (c) 2026 Makisuo, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What

Adds section **05 — Terms** to `/brand` (and its `/brand.md` twin), and reconciles the legal entity name across the whole repo.

## Why the section

`/brand` granted the artwork with no boundary: *"take what you need — no permission required, and no need to ask first"*, and nothing at all about the name. On a source-available project that points the wrong way. The licence hands a forker every line of the code and none of the marks, but the page most likely to be read by whoever is forking said only that the assets were free.

`FSL-1.1-ALv2` already withholds trademarks in its own Trademarks clause, and the Apache 2.0 it converts to withholds them again in §6. So this is a restatement for people who will never open `LICENSE`, not a new grant. It also states the other half out loud: describing what you built ("a fork of Maple", "built on Maple", "compatible with Maple") is protected nominative use, and a policy pretending otherwise would be unenforceable and would read as bluster.

Scoped to what a rebranded fork actually turns on:

- licence ≠ trademark, forks rename
- no use in product names, domains, or handles
- no implied endorsement or partnership
- revocability

Deliberately **not** included: a merchandise ban and a standalone trademark-registration clause. Both appear in well under half of the comparable policies surveyed (Rust, CNCF/Linux Foundation, Kubernetes, Grafana, HashiCorp, Docker, Mozilla, PSF, PostgreSQL), and neither bears on the fork case. Mark modification is already covered four times over by section 04.

Register is closer to PostHog than to Docker, which is the right reference class for this page. Rust's 2023 trademark-policy backlash is the documented failure mode for over-lawyering a brand page.

## The ownership record named five different parties

| Location | Was | Now |
|---|---|---|
| `TermsContent.astro` ×3, `PrivacyContent.astro` ×1 | Makisuo LLC | **Makisuo, Inc.** |
| root `LICENSE` (FSL-1.1-ALv2) | David Granzin | **Makisuo, Inc.** |
| `packages/{effect-sdk,browser,alchemy-maple}/LICENSE` | Maple Tech Labs | **Makisuo, Inc.** |
| `lib/clickhouse-builder/LICENSE` | Maple | **Makisuo, Inc.** |
| footer `messages/{en,ja,ko}.json` | © 2026 Maple. All rights reserved. | **© 2026 Makisuo, Inc.** |
| `brand.astro`, `brand.md.ts` | *(no statement)* | **Makisuo, Inc.** |
| `alchemy-maple`, `clickhouse-builder` `package.json` author | Maple Tech Labs | **Makisuo, Inc.** |

The company is incorporated, so Terms and Privacy — the two documents that actually bind users, including the limitation-of-liability clause — were naming an entity that does not exist. That is the most serious item here.

Updating the root `LICENSE` also matters structurally: the FSL defines Licensor generically as *"The party offering the Software"*, so the Notice copyright line is what identifies them. The "we" in its Trademarks clause now resolves to the same entity the brand page names.

**Vendored copyright is untouched** — `lib/llm` stays with opencode, `lib/thinking-orbs` with Jakub Antalik.

## The footer

`© 2026 Maple. All rights reserved.` was two problems in one line: **Maple** is a product, not a legal person, and *"all rights reserved"* contradicts the `FSL-1.1 → Apache 2.0` badge rendered 12px to its right in the same flex row.

"All rights reserved" is dropped rather than reworded: a Buenos Aires Convention formality, obsolete since 2000, and the badge already does the licensing work accurately. Side benefit, the string is locale-neutral, so the `ja` and `ko` footers no longer carry untranslated English.

`src/paraglide/messages/*.js` are regenerated. They are tracked despite paraglide writing its own `.gitignore`, so they have to stay in sync with the message JSONs.

## Reviewer note

Editing a copyright line **asserts** ownership; it does not transfer it. This change assumes the founder IP assignment to the company has actually been executed. If it hasn't, the paperwork is the real fix and these lines should follow it rather than lead it.

## Still not addressed

- Repo URLs are split between `Makisuo/maple` (~60 references) and the real remote `MapleTechLabs/maple` (two `package.json`s, one workflow comment).
- Legal contacts are on `getmaple.dev` (`legal@`, `privacy@`) while the brand page uses `hello@maple.dev`.
- The Terms' governing law names "the laws of the United States" with no state, which is worth revisiting now that the entity is a corporation.

## Verification

- `bun run --filter=@maple/landing build` → 109 pages, exit 0
- `Makisuo, Inc.` renders correctly in the built `index`, `terms`, `privacy`, and `brand` pages, and in `brand.md`
- No `Makisuo LLC`, `David Granzin`, or `Maple Tech Labs` remaining in any `LICENSE`, `package.json`, `.astro`, or `.ts` outside `node_modules`
- No doubled `Inc..` anywhere; no surviving "All rights reserved"
- Both edited `package.json`s and all three message JSONs still parse; the `©` escape style is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)