### PR TITLE
perf(alerting): cut scheduler and anomaly Postgres round-trips

### DIFF
--- a/apps/api/src/services/alerts/AlertsService.test.ts
+++ b/apps/api/src/services/alerts/AlertsService.test.ts
@@ -3187,6 +3187,48 @@ describe("AlertsService.previewRule", () => {
 		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: okFetch })))
 	})
 
+	it.effect("dedupes rule destinations and environments, preserving order", () => {
+		const testDb = createTestDb(trackedDbs)
+		// Guards the `Arr.dedupe` calls in normalizeRule. A destination listed twice
+		// still notifies once, and the surviving order is first-occurrence — the
+		// same contract `[...new Set()]` gave before.
+		return Effect.gen(function* () {
+			const alerts = yield* AlertsService
+			const orgId = asOrgId("org_dedupe")
+			const userId = asUserId("user_dedupe")
+			const first = yield* createWebhookDestination(alerts, orgId, userId)
+			const second = yield* alerts.createDestination(orgId, userId, adminRoles, {
+				type: "webhook",
+				name: "Secondary webhook",
+				enabled: true,
+				url: "https://example.com/maple-alerts-2",
+				signingSecret: "webhook-secret-2",
+			})
+
+			const rule = yield* alerts.createRule(
+				orgId,
+				userId,
+				adminRoles,
+				new AlertRuleUpsertRequest({
+					name: "Deduped rule",
+					severity: "warning",
+					enabled: true,
+					serviceNames: ["checkout"],
+					environments: ["  prod  ", "staging", "prod", "   ", "staging"],
+					signalType: "error_rate",
+					comparator: "gt",
+					threshold: 5,
+					windowMinutes: 5,
+					destinationIds: [second.id, first.id, second.id],
+				}),
+			)
+
+			assert.deepStrictEqual(rule.destinationIds, [second.id, first.id])
+			// Trimmed, blank-dropped, deduped, first-occurrence order.
+			assert.deepStrictEqual(rule.environments, ["prod", "staging"])
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub({}), { fetch: okFetch })))
+	})
+
 	it.effect("keeps scheduler tick round-trips flat as rule count grows", () => {
 		const testDb = createTestDb(trackedDbs)
 		const counter = { executes: 0 }

--- a/apps/api/src/services/alerts/AlertsService.test.ts
+++ b/apps/api/src/services/alerts/AlertsService.test.ts
@@ -32,6 +32,7 @@ import { EmailService } from "@/platform/EmailService"
 import { OrgMembersError, OrgMembersService, type OrgMember } from "@/services/org/OrgMembersService"
 import { QueryEngineService } from "@/services/warehouse/QueryEngineService"
 import { cleanupTestDbs, createTestDb, executeSql, queryFirstRow, type TestDb } from "@/platform/test-pglite"
+import { Database } from "@/platform/DatabaseLive"
 import { decryptAes256Gcm } from "@/platform/Crypto"
 import { InvestigationService } from "@/services/errors/InvestigationService"
 
@@ -3184,5 +3185,150 @@ describe("AlertsService.previewRule", () => {
 			assert.isAbove(points.length, 0)
 			assert.isTrue(points.some((p) => p.value === 42))
 		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(state), { fetch: okFetch })))
+	})
+
+	it.effect("keeps scheduler tick round-trips flat as rule count grows", () => {
+		const testDb = createTestDb(trackedDbs)
+		const counter = { executes: 0 }
+		// Counts `Database.execute` calls, which is the unit that costs: under
+		// `DatabasePgLive` each one dials and tears down its own postgres.js client.
+		// This guards the tick-head prefetch and the set-based housekeeping against
+		// someone re-adding a statement inside the per-rule loop — which is exactly
+		// how the tick reached ~7 dials per rule per minute in production.
+		const countingDb = {
+			...testDb,
+			layer: Layer.effect(
+				Database,
+				Effect.gen(function* () {
+					const inner = yield* Database
+					return Database.of({
+						execute: (fn) => {
+							counter.executes += 1
+							return inner.execute(fn)
+						},
+					})
+				}),
+			).pipe(Layer.provide(testDb.layer)),
+		}
+
+		const seedRules = (
+			alerts: AlertsServiceShape,
+			orgId: ReturnType<typeof asOrgId>,
+			userId: ReturnType<typeof asUserId>,
+			destinationId: AlertDestinationId,
+			from: number,
+			count: number,
+		) =>
+			Effect.forEach(
+				Array.from({ length: count }, (_, index) => from + index),
+				(index) =>
+					alerts.createRule(
+						orgId,
+						userId,
+						adminRoles,
+						new AlertRuleUpsertRequest({
+							name: `Scaling rule ${index}`,
+							severity: "warning",
+							enabled: true,
+							serviceNames: ["checkout"],
+							signalType: "error_rate",
+							comparator: "gt",
+							threshold: 5,
+							windowMinutes: 5,
+							destinationIds: [destinationId],
+						}),
+					),
+				{ concurrency: 1, discard: true },
+			)
+
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
+			const alerts = yield* AlertsService
+			const orgId = asOrgId("org_roundtrip")
+			const userId = asUserId("user_roundtrip")
+			const destination = yield* createWebhookDestination(alerts, orgId, userId)
+
+			yield* seedRules(alerts, orgId, userId, destination.id, 0, 3)
+			counter.executes = 0
+			yield* alerts.runSchedulerTick()
+			const forThree = counter.executes
+
+			yield* seedRules(alerts, orgId, userId, destination.id, 3, 9)
+			yield* TestClock.adjust(Duration.minutes(1))
+			counter.executes = 0
+			yield* alerts.runSchedulerTick()
+			const forTwelve = counter.executes
+
+			// Four times the rules must not cost four times the round-trips. The old
+			// shape was ~7 per rule, so 3 → 12 rules would have added ~63 executes.
+			const perExtraRule = (forTwelve - forThree) / 9
+			assert.isBelow(
+				perExtraRule,
+				3,
+				`expected well under 3 executes per additional rule, got ${perExtraRule} (${forThree} for 3 rules, ${forTwelve} for 12)`,
+			)
+		}).pipe(Effect.provide(makeLayer(countingDb, makeWarehouseStub({}), { fetch: okFetch })))
+	})
+
+	it.effect("does not auto-resolve an incident whose group is still evaluating", () => {
+		const testDb = createTestDb(trackedDbs)
+		// A grouped rule where both groups stay breached across two ticks. The tick
+		// reads open incidents from a tick-head prefetch now, so this is the
+		// regression guard for that snapshot going stale: neither group is orphaned,
+		// so `resolveOrphanedGroupIncidents` must leave both incidents open rather
+		// than firing an all-clear for the one it saw before this tick's writes.
+		const breachedGroups = {
+			rawQueryRows: [
+				{ groupKey: "checkout", value: 42, sampleCount: 500 },
+				{ groupKey: "payments", value: 37, sampleCount: 500 },
+			],
+		}
+
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(DEFAULT_CLOCK_EPOCH_MS)
+			const alerts = yield* AlertsService
+			const orgId = asOrgId("org_orphan_guard")
+			const userId = asUserId("user_orphan_guard")
+			const destination = yield* createWebhookDestination(alerts, orgId, userId)
+
+			yield* alerts.createRule(
+				orgId,
+				userId,
+				adminRoles,
+				new AlertRuleUpsertRequest({
+					name: "Grouped error rate",
+					severity: "critical",
+					enabled: true,
+					serviceNames: ["checkout", "payments"],
+					signalType: "error_rate",
+					comparator: "gt",
+					threshold: 5,
+					windowMinutes: 5,
+					minimumSampleCount: 10,
+					consecutiveBreachesRequired: 1,
+					consecutiveHealthyRequired: 2,
+					renotifyIntervalMinutes: 30,
+					destinationIds: [destination.id],
+				}),
+			)
+
+			yield* alerts.runSchedulerTick()
+			const afterFirst = yield* alerts.listIncidents(orgId)
+			const openAfterFirst = afterFirst.incidents.filter((i) => i.status === "open")
+
+			yield* TestClock.adjust(Duration.minutes(1))
+			yield* alerts.runSchedulerTick()
+			const afterSecond = yield* alerts.listIncidents(orgId)
+			const openAfterSecond = afterSecond.incidents.filter((i) => i.status === "open")
+			const resolvedAfterSecond = afterSecond.incidents.filter((i) => i.status === "resolved")
+
+			// Still breaching on the second tick, so nothing may have been resolved.
+			assert.strictEqual(
+				openAfterSecond.length,
+				openAfterFirst.length,
+				"a still-breaching group lost its open incident",
+			)
+			assert.lengthOf(resolvedAfterSecond, 0)
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub(breachedGroups), { fetch: okFetch })))
 	})
 })

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -1363,14 +1363,19 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					request.signalType === "builder_query" || request.signalType === "raw_query"
 				const environments =
 					request.environments && !queryOwnsScope
-						? [...new Set(request.environments.map((s) => s.trim()).filter((s) => s.length > 0))]
+						? Arr.dedupe(
+								Arr.filterMap(request.environments, (s) => {
+									const trimmed = s.trim()
+									return trimmed.length > 0 ? Result.succeed(trimmed) : Result.failVoid
+								}),
+							)
 						: []
 				const tags = normalizeTags(request.tags)
 				const groupBy = request.groupBy ?? null
 				// Dedupe while preserving selection order — a destination listed twice still
 				// notifies once, so we persist each id at most once. This is the authoritative
 				// fix; the editor also dedupes on submit for UX (see buildRuleRequest).
-				const destinationIds = [...new Set(request.destinationIds)]
+				const destinationIds = Arr.dedupe(request.destinationIds)
 
 				const details: string[] = []
 				if (name.length === 0 && !options?.forPreview) details.push("name is required")
@@ -1507,8 +1512,8 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 						),
 				)
 
-				const existingIds = new Set(rows.map((row) => row.id))
-				const missing = destinationIds.filter((id) => !existingIds.has(id))
+				const existingIds = HashSet.fromIterable(Arr.map(rows, (row) => row.id))
+				const missing = Arr.filter(destinationIds, (id) => !HashSet.has(existingIds, id))
 				if (missing.length > 0) {
 					return yield* Effect.fail(makeValidationError("Unknown destination IDs", missing))
 				}
@@ -2782,9 +2787,9 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					// compiled plan decides groupedness, and a breaching group (if any)
 					// wins so the test reflects what the scheduler would fire on.
 					const allResults = yield* evaluateRule(orgId, normalized)
-					const excludeSet = new Set(normalized.excludeServiceNames)
+					const excludeSet = HashSet.fromIterable(normalized.excludeServiceNames)
 					const results = isGroupedPlan(normalized.compiledPlan)
-						? allResults.filter((r) => !excludeSet.has(r.groupKey))
+						? Arr.filter(allResults, (r) => !HashSet.has(excludeSet, r.groupKey))
 						: allResults
 					const breached = results.find((r) => r.evaluation.status === "breached")
 					evaluation = breached?.evaluation ??
@@ -2998,13 +3003,13 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 							sampleCountStrategy: plan.sampleCountStrategy,
 						})
 						.pipe(catchQueryEngineErrors)
-					const excludeSet = new Set(normalized.excludeServiceNames)
+					const excludeSet = HashSet.fromIterable(normalized.excludeServiceNames)
 					// Preview must key its series exactly as the scheduler stores them,
 					// or the preview chart and the tracking chart disagree on the
 					// ungrouped series' name.
 					const grouped = isGroupedPlan(plan)
 					for (const obs of observations) {
-						if (excludeSet.has(obs.groupKey)) continue
+						if (HashSet.has(excludeSet, obs.groupKey)) continue
 						record(grouped ? obs.groupKey : UNGROUPED_GROUP_KEY, Date.parse(obs.bucket), {
 							value: obs.value,
 							sampleCount: obs.sampleCount,
@@ -3558,11 +3563,13 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					}
 				}
 
-				const uniqueDestinationIds = [...new Set(rows.map((r) => r.destinationId))]
-				const uniqueRuleIds = [...new Set(rows.map((r) => r.ruleId))]
-				const uniqueIncidentIds = [
-					...new Set(rows.filter((r) => r.incidentId != null).map((r) => r.incidentId!)),
-				]
+				const uniqueDestinationIds = Arr.dedupe(Arr.map(rows, (r) => r.destinationId))
+				const uniqueRuleIds = Arr.dedupe(Arr.map(rows, (r) => r.ruleId))
+				const uniqueIncidentIds = Arr.dedupe(
+					Arr.filterMap(rows, (r) =>
+						r.incidentId != null ? Result.succeed(r.incidentId) : Result.failVoid,
+					),
+				)
 
 				const [allDestinations, allRules, allIncidents] = yield* Effect.all(
 					[

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -95,8 +95,11 @@ import {
 	Layer,
 	Match,
 	Metric,
+	MutableHashMap,
 	Option,
 	Random,
+	Record,
+	Result,
 	Redacted,
 	Ref,
 	Schema,
@@ -4545,7 +4548,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					// Counts what actually resolved, not what was a candidate: an incident
 					// resolved out-of-band since the tick began is skipped above and must
 					// not be counted here.
-					const resolvedCount = Arr.filter(resolveOutcomes, (ok) => ok).length
+					const resolvedCount = Arr.countBy(resolveOutcomes, (ok) => ok)
 					yield* Metric.update(AlertingMetrics.incidentsResolvedTotal, resolvedCount)
 					yield* Metric.update(AlertingMetrics.staleIncidentsResolvedTotal, resolvedCount)
 				},
@@ -4675,7 +4678,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 			 * can use its leading index column.
 			 */
 			const loadTickPrefetch = Effect.fnUntraced(function* (rows: ReadonlyArray<AlertRuleRow>) {
-				if (rows.length === 0) {
+				if (Arr.isReadonlyArrayEmpty(rows)) {
 					return {
 						stateFor: () => null,
 						openIncidentFor: () => null,
@@ -4683,8 +4686,8 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					} satisfies TickPrefetch
 				}
 
-				const ruleIds = rows.map((row) => row.id)
-				const orgIds = [...new Set(rows.map((row) => row.orgId))]
+				const ruleIds = Arr.map(rows, (row) => row.id)
+				const orgIds = Arr.dedupe(Arr.map(rows, (row) => row.orgId))
 
 				const { stateRows, incidentRows } = yield* dbExecute(async (db) => {
 					const [stateRows, incidentRows] = await Promise.all([
@@ -4711,37 +4714,46 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					return { stateRows, incidentRows }
 				})
 
-				const stateByGroup = new Map<string, AlertRuleStateRow>()
-				for (const state of stateRows) {
-					stateByGroup.set(groupCacheKey(state.orgId, state.ruleId, state.groupKey), state)
-				}
+				const stateByGroup = MutableHashMap.fromIterable(
+					Arr.map(
+						stateRows,
+						(state) => [groupCacheKey(state.orgId, state.ruleId, state.groupKey), state] as const,
+					),
+				)
 
-				const incidentByGroup = new Map<string, AlertIncidentRow>()
-				const incidentsByRule = new Map<string, AlertIncidentRow[]>()
-				for (const incident of incidentRows) {
-					// `groupKey` is nullable on this table. The per-group lookup replaces an
-					// `eq(groupKey, …)` predicate, and SQL equality never matches NULL, so a
-					// null-keyed incident must not be reachable from it. The per-rule list
-					// keeps them: its consumer coalesces null to the ungrouped key.
-					if (incident.groupKey !== null) {
-						incidentByGroup.set(
-							groupCacheKey(incident.orgId, incident.ruleId, incident.groupKey),
-							incident,
-						)
-					}
-					const key = ruleCacheKey(incident.orgId, incident.ruleId)
-					const bucket = incidentsByRule.get(key)
-					if (bucket) bucket.push(incident)
-					else incidentsByRule.set(key, [incident])
-				}
+				// `groupKey` is nullable on this table. The per-group lookup replaces an
+				// `eq(groupKey, …)` predicate, and SQL equality never matches NULL, so a
+				// null-keyed incident must not be reachable from it — hence the filterMap.
+				// The per-rule grouping below keeps them: its consumer coalesces null to
+				// the ungrouped key.
+				const incidentByGroup = MutableHashMap.fromIterable(
+					Arr.filterMap(incidentRows, (incident) =>
+						incident.groupKey === null
+							? Result.failVoid
+							: Result.succeed([
+									groupCacheKey(incident.orgId, incident.ruleId, incident.groupKey),
+									incident,
+								] as const),
+					),
+				)
+
+				const incidentsByRule = Arr.groupBy(incidentRows, (incident) =>
+					ruleCacheKey(incident.orgId, incident.ruleId),
+				)
 
 				return {
 					stateFor: (orgId, ruleId, groupKey) =>
-						stateByGroup.get(groupCacheKey(orgId, ruleId, groupKey)) ?? null,
+						Option.getOrNull(
+							MutableHashMap.get(stateByGroup, groupCacheKey(orgId, ruleId, groupKey)),
+						),
 					openIncidentFor: (orgId, ruleId, groupKey) =>
-						incidentByGroup.get(groupCacheKey(orgId, ruleId, groupKey)) ?? null,
+						Option.getOrNull(
+							MutableHashMap.get(incidentByGroup, groupCacheKey(orgId, ruleId, groupKey)),
+						),
 					openIncidentsForRule: (orgId, ruleId) =>
-						incidentsByRule.get(ruleCacheKey(orgId, ruleId)) ?? EMPTY_INCIDENTS,
+						Record.get(incidentsByRule, ruleCacheKey(orgId, ruleId)).pipe(
+							Option.getOrElse(() => EMPTY_INCIDENTS),
+						),
 				} satisfies TickPrefetch
 			})
 
@@ -4783,9 +4795,12 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 							Effect.ignore,
 						)
 
-				const selfHealOrgIds = [...new Set(selfHeal.map((t) => t.orgId))]
-				const groupedRuleIds = selfHeal.filter((t) => t.grouped).map((t) => t.ruleId)
-				const ungroupedRuleIds = selfHeal.filter((t) => !t.grouped).map((t) => t.ruleId)
+				const selfHealOrgIds = Arr.dedupe(Arr.map(selfHeal, (t) => t.orgId))
+				// One pass: `partition` returns [excluded, satisfying], so the `Result`
+				// failure arm carries the ungrouped ids and the success arm the grouped.
+				const [ungroupedRuleIds, groupedRuleIds] = Arr.partition(selfHeal, (t) =>
+					t.grouped ? Result.succeed(t.ruleId) : Result.fail(t.ruleId),
+				)
 
 				// A grouped rule can never legitimately own an ungrouped state row, and
 				// an ungrouped rule can never own a grouped one. Two statements because
@@ -4828,11 +4843,11 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 							.where(
 								and(
 									inArray(alertRuleStates.orgId, [
-										...new Set(clearError.map((t) => t.orgId)),
+										...Arr.dedupe(Arr.map(clearError, (t) => t.orgId)),
 									]),
 									inArray(
 										alertRuleStates.ruleId,
-										clearError.map((t) => t.ruleId),
+										Arr.map(clearError, (t) => t.ruleId),
 									),
 									isNotNull(alertRuleStates.lastError),
 								),

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -83,6 +83,7 @@ import {
 	alertRules,
 	type AlertRuleRow,
 	alertRuleStates,
+	type AlertRuleStateRow,
 } from "@maple/db"
 import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, sql } from "drizzle-orm"
 import {
@@ -3786,6 +3787,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				timestamp: number,
 				pendingChecks: Ref.Ref<AlertChecksRow[]>,
 				issueBudget: Ref.Ref<number>,
+				prefetch: TickPrefetch,
 			) {
 				const stateConflictTarget: [
 					typeof alertRuleStates.orgId,
@@ -3799,39 +3801,15 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				// upsert via onConflictDoUpdate, incident insert keyed on unique
 				// incidentKey, delivery events via onConflictDoNothing on deliveryKey.
 				const outcome = yield* Effect.gen(function* () {
-					const state =
-						(yield* dbExecute((db) =>
-							db
-								.select()
-								.from(alertRuleStates)
-								.where(
-									and(
-										eq(alertRuleStates.orgId, row.orgId),
-										eq(alertRuleStates.ruleId, row.id),
-										eq(alertRuleStates.groupKey, groupKey),
-									),
-								)
-								.limit(1),
-						))[0] ?? null
+					// Both reads come from the tick-head prefetch rather than a query per
+					// group. Safe because this function is the only writer of either key
+					// and runs at most once per key per tick — see `loadTickPrefetch`.
+					const state = prefetch.stateFor(row.orgId, row.id, groupKey)
 
-					// Look up the open incident for this group via the unique
+					// The open incident for this group, via the unique
 					// (orgId, ruleId, status, groupKey) combination. Composite group
 					// keys make serviceName ambiguous, so groupKey is authoritative.
-					const openIncident =
-						(yield* dbExecute((db) =>
-							db
-								.select()
-								.from(alertIncidents)
-								.where(
-									and(
-										eq(alertIncidents.orgId, row.orgId),
-										eq(alertIncidents.ruleId, row.id),
-										eq(alertIncidents.status, "open"),
-										eq(alertIncidents.groupKey, groupKey),
-									),
-								)
-								.limit(1),
-						))[0] ?? null
+					const openIncident = prefetch.openIncidentFor(row.orgId, row.id, groupKey)
 
 					// Default for check-history ingest: carry open-incident linkage (if any),
 					// transition remains "none" unless a branch below overrides it.
@@ -4449,20 +4427,20 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					normalized: NormalizedRule,
 					evaluatedGroups: HashSet.HashSet<string>,
 					timestamp: number,
+					openIncidents: ReadonlyArray<AlertIncidentRow>,
 				) {
-					const openIncidents = yield* dbExecute((db) =>
-						db
-							.select()
-							.from(alertIncidents)
-							.where(
-								and(
-									eq(alertIncidents.orgId, orgId),
-									eq(alertIncidents.ruleId, ruleId),
-									eq(alertIncidents.status, "open"),
-								),
-							),
-					)
-
+					// Supplied from the tick-head prefetch instead of re-read here — this
+					// was the single heaviest query shape in the service, because it read
+					// the same set `processEvaluation` had already read moments earlier.
+					//
+					// Only incidents whose group was NOT evaluated survive the filter
+					// below, and an unevaluated group is by definition one this tick wrote
+					// nothing for, so the snapshot and a fresh read agree on every row that
+					// matters here. What the snapshot cannot see is an incident resolved
+					// out-of-band (a manual resolve via the API) since the tick began. The
+					// resolve statement below is guarded on `status = 'open'` and gated on
+					// its own row count so that case is a no-op rather than a duplicate
+					// all-clear notification.
 					const orphaned = Arr.filter(
 						openIncidents,
 						(i) => !HashSet.has(evaluatedGroups, i.groupKey ?? UNGROUPED_GROUP_KEY),
@@ -4508,10 +4486,16 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					)
 
 					// Serialized per rule via claim lock + idempotent writes.
-					yield* Effect.forEach(orphaned, (incident) => {
+					const resolveOutcomes = yield* Effect.forEach(orphaned, (incident) => {
 						const groupKey = incident.groupKey ?? UNGROUPED_GROUP_KEY
 						return Effect.gen(function* () {
-							yield* dbExecute((db) =>
+							// `status = 'open'` in the predicate, plus RETURNING, is what makes
+							// the prefetched snapshot safe: if this incident was resolved
+							// out-of-band since the tick began, zero rows come back and we skip
+							// the notification instead of paging a second all-clear. (The old
+							// re-read had the same race between its own select and update; this
+							// closes it rather than just narrowing it.)
+							const resolved = yield* dbExecute((db) =>
 								db
 									.update(alertIncidents)
 									.set({
@@ -4519,8 +4503,15 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 										resolvedAt: new Date(timestamp),
 										updatedAt: new Date(timestamp),
 									})
-									.where(eq(alertIncidents.id, incident.id)),
+									.where(
+										and(
+											eq(alertIncidents.id, incident.id),
+											eq(alertIncidents.status, "open"),
+										),
+									)
+									.returning({ id: alertIncidents.id }),
 							)
+							if (resolved.length === 0) return false
 
 							yield* queueIncidentNotifications(
 								orgId,
@@ -4547,11 +4538,16 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 										),
 									),
 							)
+							return true
 						})
 					})
 
-					yield* Metric.update(AlertingMetrics.incidentsResolvedTotal, orphaned.length)
-					yield* Metric.update(AlertingMetrics.staleIncidentsResolvedTotal, orphaned.length)
+					// Counts what actually resolved, not what was a candidate: an incident
+					// resolved out-of-band since the tick began is skipped above and must
+					// not be counted here.
+					const resolvedCount = Arr.filter(resolveOutcomes, (ok) => ok).length
+					yield* Metric.update(AlertingMetrics.incidentsResolvedTotal, resolvedCount)
+					yield* Metric.update(AlertingMetrics.staleIncidentsResolvedTotal, resolvedCount)
 				},
 			)
 
@@ -4568,16 +4564,28 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 			const SCHEDULER_HEARTBEAT_MS = 5 * 60_000
 
 			/**
-			 * CAS the per-rule scheduler lock. Winning the claim returns one row; losing
-			 * returns zero, so callers can keep using `claimed.length === 0` to bail.
+			 * CAS the per-rule scheduler lock, then refresh the user-visible heartbeat.
 			 *
-			 * The `INSERT` arm covers the first tick for a rule (replacing the old
-			 * `isNull(lastScheduledAt)` branch); `setWhere` makes a loser's conflict
-			 * update a no-op so `RETURNING` stays empty.
+			 * Both statements run inside ONE `execute`: under `DatabasePgLive` each call
+			 * dials and tears down its own postgres.js client, so the handshake count is
+			 * what costs, not the statement count — same trade as
+			 * `ErrorsService.loadOrgTickPreamble`. These are the two statements every
+			 * rule paid for on every tick.
+			 *
+			 * The claim: the `INSERT` arm covers the first tick for a rule; `setWhere`
+			 * makes a loser's conflict update a no-op so `RETURNING` stays empty.
+			 * Winning returns one row, losing returns zero, so callers keep using
+			 * `claimed.length === 0` to bail.
+			 *
+			 * The heartbeat: `alert_rules.last_scheduled_at` is gated in SQL so it
+			 * touches zero rows — and writes no WAL tuple — on the ~4 of every 5 ticks
+			 * that fall inside the heartbeat window. It runs only for the claim winner,
+			 * and its failure is swallowed so it cannot cost a rule its evaluation:
+			 * the claim is already committed by then, and the heartbeat is cosmetic.
 			 */
-			const claimRule = (orgId: OrgId, ruleId: AlertRuleId, timestamp: number) =>
-				dbExecute((db) =>
-					db
+			const claimAndTouchRule = (orgId: OrgId, ruleId: AlertRuleId, timestamp: number) =>
+				dbExecute(async (db) => {
+					const claimed = await db
 						.insert(alertRuleClaims)
 						.values({ ruleId, orgId, lastScheduledAt: new Date(timestamp) })
 						.onConflictDoUpdate({
@@ -4588,32 +4596,250 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 								new Date(timestamp - SCHEDULER_LOCK_TTL_MS),
 							),
 						})
-						.returning({ id: alertRuleClaims.ruleId }),
-				)
+						.returning({ id: alertRuleClaims.ruleId })
 
-			/**
-			 * Coarse heartbeat for the user-visible `alert_rules.last_scheduled_at`.
-			 * Gated in SQL so it touches zero rows — and so writes no WAL tuple — on the
-			 * ~4 of every 5 ticks that fall inside the heartbeat window.
-			 */
-			const touchRuleScheduledAt = (ruleId: AlertRuleId, timestamp: number) =>
-				dbExecute((db) =>
-					db
-						.update(alertRules)
-						.set({ lastScheduledAt: new Date(timestamp) })
-						.where(
-							and(
-								eq(alertRules.id, ruleId),
-								or(
-									isNull(alertRules.lastScheduledAt),
-									lt(
-										alertRules.lastScheduledAt,
-										new Date(timestamp - SCHEDULER_HEARTBEAT_MS),
+					if (claimed.length === 0) return claimed
+
+					try {
+						await db
+							.update(alertRules)
+							.set({ lastScheduledAt: new Date(timestamp) })
+							.where(
+								and(
+									eq(alertRules.id, ruleId),
+									or(
+										isNull(alertRules.lastScheduledAt),
+										lt(
+											alertRules.lastScheduledAt,
+											new Date(timestamp - SCHEDULER_HEARTBEAT_MS),
+										),
 									),
 								),
+							)
+					} catch {
+						// Matches the `Effect.ignore` this call carried when it was a
+						// separate execute.
+					}
+
+					return claimed
+				})
+
+			/**
+			 * The two per-rule reads the scheduler used to issue inside its loop,
+			 * fetched once for the whole tick.
+			 *
+			 * Between them these were ~13k queries/hour in production — one
+			 * `alert_rule_states` select and one `alert_incidents` select per rule per
+			 * group per minute, each paying a full dial under `DatabasePgLive`.
+			 *
+			 * Hoisting them is not a staleness trade, because of how the writes are
+			 * scoped. Every key here is `(orgId, ruleId, groupKey)`, `processEvaluation`
+			 * runs at most once per key per tick, and its writes only ever touch its own
+			 * key: the state upsert targets that key's primary key, and both incident
+			 * updates target `openIncident.id` — the incident belonging to that same
+			 * key. So no group can read a value another group has invalidated.
+			 *
+			 * `openIncidentsForRule` is the exception and is documented at its use site
+			 * in `resolveOrphanedGroupIncidents`.
+			 */
+			interface TickPrefetch {
+				readonly stateFor: (
+					orgId: OrgId,
+					ruleId: AlertRuleId,
+					groupKey: string,
+				) => AlertRuleStateRow | null
+				readonly openIncidentFor: (
+					orgId: OrgId,
+					ruleId: AlertRuleId,
+					groupKey: string,
+				) => AlertIncidentRow | null
+				readonly openIncidentsForRule: (
+					orgId: OrgId,
+					ruleId: AlertRuleId,
+				) => ReadonlyArray<AlertIncidentRow>
+			}
+
+			const EMPTY_INCIDENTS: ReadonlyArray<AlertIncidentRow> = []
+
+			const groupCacheKey = (orgId: string, ruleId: string, groupKey: string) =>
+				`${orgId} ${ruleId} ${groupKey}`
+			const ruleCacheKey = (orgId: string, ruleId: string) => `${orgId} ${ruleId}`
+
+			/**
+			 * Load the tick's state and open-incident rows in ONE `execute`.
+			 *
+			 * Two statements, one dial — the handshake is the cost, not the statement
+			 * (`ErrorsService.loadOrgTickPreamble`). `orgId` is in both predicates for
+			 * the index rather than for correctness: rule ids are globally unique, so
+			 * the id list already scopes the read, but without `orgId` neither predicate
+			 * can use its leading index column.
+			 */
+			const loadTickPrefetch = Effect.fnUntraced(function* (rows: ReadonlyArray<AlertRuleRow>) {
+				if (rows.length === 0) {
+					return {
+						stateFor: () => null,
+						openIncidentFor: () => null,
+						openIncidentsForRule: () => EMPTY_INCIDENTS,
+					} satisfies TickPrefetch
+				}
+
+				const ruleIds = rows.map((row) => row.id)
+				const orgIds = [...new Set(rows.map((row) => row.orgId))]
+
+				const { stateRows, incidentRows } = yield* dbExecute(async (db) => {
+					const [stateRows, incidentRows] = await Promise.all([
+						db
+							.select()
+							.from(alertRuleStates)
+							.where(
+								and(
+									inArray(alertRuleStates.orgId, orgIds),
+									inArray(alertRuleStates.ruleId, ruleIds),
+								),
 							),
-						),
-				)
+						db
+							.select()
+							.from(alertIncidents)
+							.where(
+								and(
+									inArray(alertIncidents.orgId, orgIds),
+									inArray(alertIncidents.ruleId, ruleIds),
+									eq(alertIncidents.status, "open"),
+								),
+							),
+					])
+					return { stateRows, incidentRows }
+				})
+
+				const stateByGroup = new Map<string, AlertRuleStateRow>()
+				for (const state of stateRows) {
+					stateByGroup.set(groupCacheKey(state.orgId, state.ruleId, state.groupKey), state)
+				}
+
+				const incidentByGroup = new Map<string, AlertIncidentRow>()
+				const incidentsByRule = new Map<string, AlertIncidentRow[]>()
+				for (const incident of incidentRows) {
+					// `groupKey` is nullable on this table. The per-group lookup replaces an
+					// `eq(groupKey, …)` predicate, and SQL equality never matches NULL, so a
+					// null-keyed incident must not be reachable from it. The per-rule list
+					// keeps them: its consumer coalesces null to the ungrouped key.
+					if (incident.groupKey !== null) {
+						incidentByGroup.set(
+							groupCacheKey(incident.orgId, incident.ruleId, incident.groupKey),
+							incident,
+						)
+					}
+					const key = ruleCacheKey(incident.orgId, incident.ruleId)
+					const bucket = incidentsByRule.get(key)
+					if (bucket) bucket.push(incident)
+					else incidentsByRule.set(key, [incident])
+				}
+
+				return {
+					stateFor: (orgId, ruleId, groupKey) =>
+						stateByGroup.get(groupCacheKey(orgId, ruleId, groupKey)) ?? null,
+					openIncidentFor: (orgId, ruleId, groupKey) =>
+						incidentByGroup.get(groupCacheKey(orgId, ruleId, groupKey)) ?? null,
+					openIncidentsForRule: (orgId, ruleId) =>
+						incidentsByRule.get(ruleCacheKey(orgId, ruleId)) ?? EMPTY_INCIDENTS,
+				} satisfies TickPrefetch
+			})
+
+			/**
+			 * Apply the tick's accumulated `alert_rule_states` housekeeping set-based.
+			 *
+			 * Replaces two per-rule statements that were each gated to touch zero rows
+			 * in steady state — cheap in WAL terms, but still a full dial apiece under
+			 * `DatabasePgLive`, every rule, every minute. At most three statements per
+			 * tick now, and none at all when nothing evaluated.
+			 *
+			 * `orgId` is in each predicate for the index, not for correctness: rule ids
+			 * are globally unique (`alert_rules.id` is the primary key), so the id lists
+			 * already scope these to the right tenant. Without it the predicate could
+			 * not use the `(org_id, rule_id, group_key)` primary key at all.
+			 *
+			 * Best-effort by design. Housekeeping must not fail a tick whose real work —
+			 * evaluation, incidents, notifications — has already completed. This does
+			 * cost per-rule attribution: a failure here is logged for the tick rather
+			 * than recorded against the individual rule as it was when inline.
+			 */
+			const flushRuleStateHousekeeping = Effect.fnUntraced(function* (
+				selfHeal: ReadonlyArray<{
+					readonly orgId: OrgId
+					readonly ruleId: AlertRuleId
+					readonly grouped: boolean
+				}>,
+				clearError: ReadonlyArray<{ readonly orgId: OrgId; readonly ruleId: AlertRuleId }>,
+				timestamp: number,
+			) {
+				const bestEffort =
+					(label: string) => (effect: Effect.Effect<unknown, AlertPersistenceError>) =>
+						effect.pipe(
+							Effect.tapError((error) =>
+								Effect.logWarning(label).pipe(
+									Effect.annotateLogs({ message: error.message }),
+								),
+							),
+							Effect.ignore,
+						)
+
+				const selfHealOrgIds = [...new Set(selfHeal.map((t) => t.orgId))]
+				const groupedRuleIds = selfHeal.filter((t) => t.grouped).map((t) => t.ruleId)
+				const ungroupedRuleIds = selfHeal.filter((t) => !t.grouped).map((t) => t.ruleId)
+
+				// A grouped rule can never legitimately own an ungrouped state row, and
+				// an ungrouped rule can never own a grouped one. Two statements because
+				// the two shapes need opposite `group_key` predicates.
+				if (groupedRuleIds.length > 0) {
+					yield* dbExecute((db) =>
+						db
+							.delete(alertRuleStates)
+							.where(
+								and(
+									inArray(alertRuleStates.orgId, selfHealOrgIds),
+									inArray(alertRuleStates.ruleId, groupedRuleIds),
+									eq(alertRuleStates.groupKey, UNGROUPED_GROUP_KEY),
+								),
+							),
+					).pipe(bestEffort("Failed to self-heal ungrouped state rows for grouped rules"))
+				}
+
+				if (ungroupedRuleIds.length > 0) {
+					yield* dbExecute((db) =>
+						db
+							.delete(alertRuleStates)
+							.where(
+								and(
+									inArray(alertRuleStates.orgId, selfHealOrgIds),
+									inArray(alertRuleStates.ruleId, ungroupedRuleIds),
+									ne(alertRuleStates.groupKey, UNGROUPED_GROUP_KEY),
+								),
+							),
+					).pipe(bestEffort("Failed to self-heal grouped state rows for ungrouped rules"))
+				}
+
+				// Only rules that evaluated cleanly are listed, so a rule that failed
+				// this tick keeps the `lastError` `recordEvaluationFailure` wrote for it.
+				if (clearError.length > 0) {
+					yield* dbExecute((db) =>
+						db
+							.update(alertRuleStates)
+							.set({ lastError: null, updatedAt: new Date(timestamp) })
+							.where(
+								and(
+									inArray(alertRuleStates.orgId, [
+										...new Set(clearError.map((t) => t.orgId)),
+									]),
+									inArray(
+										alertRuleStates.ruleId,
+										clearError.map((t) => t.ruleId),
+									),
+									isNotNull(alertRuleStates.lastError),
+								),
+							),
+					).pipe(bestEffort("Failed to clear stored evaluation errors"))
+				}
+			})
 
 			const recordEvaluationStatus = (evaluation: EvaluatedRule) =>
 				Match.value(evaluation.status).pipe(
@@ -4634,11 +4860,32 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				)
 				yield* Metric.update(AlertingMetrics.activeRulesGauge, rows.length)
 
+				const prefetch = yield* loadTickPrefetch(rows)
+
 				// Incremented from fibers running under the concurrent per-rule forEach
 				// below, so it must be a Ref rather than a mutable closure variable.
 				const evaluationFailureCount = yield* Ref.make(0)
 				const pendingChecks = yield* Ref.make<AlertChecksRow[]>([])
 				const issueBudget = yield* Ref.make(ISSUE_UPSERTS_PER_TICK)
+
+				// Two housekeeping statements used to run per rule, inside the loop.
+				// Both are gated to touch zero rows in steady state (to keep the
+				// Electric shape quiet), but a zero-row statement still costs a full
+				// dial under `DatabasePgLive` — ~2 dials × every rule × every minute.
+				// The rules they need are accumulated here and applied set-based once
+				// per tick instead. Refs for the same reason as `evaluationFailureCount`:
+				// the forEach below runs at concurrency 5.
+				//
+				// Deliberately separate lists, because the two statements do not cover
+				// the same rules: the self-heal delete is skipped on the multi-service
+				// path (which returns early), while the error clear applies to every
+				// rule that evaluated cleanly.
+				const selfHealTargets = yield* Ref.make<
+					Array<{ readonly orgId: OrgId; readonly ruleId: AlertRuleId; readonly grouped: boolean }>
+				>([])
+				const clearErrorTargets = yield* Ref.make<
+					Array<{ readonly orgId: OrgId; readonly ruleId: AlertRuleId }>
+				>([])
 
 				const recordEvaluationFailure = Effect.fnUntraced(function* (
 					row: AlertRuleRow,
@@ -4774,10 +5021,8 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					(row) =>
 						Effect.gen(function* () {
 							const timestamp = yield* now
-							const claimed = yield* claimRule(row.orgId, row.id, timestamp)
+							const claimed = yield* claimAndTouchRule(row.orgId, row.id, timestamp)
 							if (claimed.length === 0) return
-
-							yield* touchRuleScheduledAt(row.id, timestamp).pipe(Effect.ignore)
 
 							yield* Effect.gen(function* () {
 								const ruleStart = yield* now
@@ -4807,6 +5052,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 												timestamp,
 												pendingChecks,
 												issueBudget,
+												prefetch,
 											)
 										}),
 									)
@@ -4817,6 +5063,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 										normalized,
 										HashSet.fromIterable(normalized.serviceNames),
 										timestamp,
+										prefetch.openIncidentsForRule(row.orgId, row.id),
 									)
 									yield* Metric.update(
 										AlertingMetrics.ruleEvaluationDurationMs,
@@ -4848,6 +5095,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 											timestamp,
 											pendingChecks,
 											issueBudget,
+											prefetch,
 										)
 									}),
 								)
@@ -4861,6 +5109,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 									normalized,
 									evaluatedGroups,
 									timestamp,
+									prefetch.openIncidentsForRule(row.orgId, row.id),
 								)
 
 								// Self-heal state rows whose key shape contradicts the rule's
@@ -4869,19 +5118,15 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 								// or by recordEvaluationFailure), and vice versa. Orphan resolution
 								// above only deletes incident-backed rows. Zero rows touched in
 								// steady state, so the Electric shape stays quiet.
-								yield* dbExecute((db) =>
-									db
-										.delete(alertRuleStates)
-										.where(
-											and(
-												eq(alertRuleStates.orgId, row.orgId),
-												eq(alertRuleStates.ruleId, row.id),
-												grouped
-													? eq(alertRuleStates.groupKey, UNGROUPED_GROUP_KEY)
-													: ne(alertRuleStates.groupKey, UNGROUPED_GROUP_KEY),
-											),
-										),
-								)
+								//
+								// Applied set-based after the loop (see `flushSelfHeal`). Safe to
+								// defer: it is scoped to this rule and this rule's own writes are
+								// already done, so end-of-tick is the same state it would have seen
+								// here.
+								yield* Ref.update(selfHealTargets, (targets) => {
+									targets.push({ orgId: row.orgId, ruleId: row.id, grouped })
+									return targets
+								})
 
 								yield* Metric.update(
 									AlertingMetrics.ruleEvaluationDurationMs,
@@ -4893,19 +5138,15 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 								// ticks touch zero rows (no Electric shape churn). This also
 								// covers grouped/multi-service rules, whose "__total__" error row
 								// is never revisited by upsertState.
+								//
+								// Accumulated and applied set-based after the loop. Only rules that
+								// reach here are cleared, so a rule that failed this tick keeps the
+								// `lastError` that `recordEvaluationFailure` just wrote for it.
 								Effect.tap(() =>
-									dbExecute((db) =>
-										db
-											.update(alertRuleStates)
-											.set({ lastError: null, updatedAt: new Date(timestamp) })
-											.where(
-												and(
-													eq(alertRuleStates.orgId, row.orgId),
-													eq(alertRuleStates.ruleId, row.id),
-													isNotNull(alertRuleStates.lastError),
-												),
-											),
-									).pipe(Effect.ignore),
+									Ref.update(clearErrorTargets, (targets) => {
+										targets.push({ orgId: row.orgId, ruleId: row.id })
+										return targets
+									}),
 								),
 								Effect.catchTags({
 									"@maple/http/errors/AlertValidationError": (error) =>
@@ -4937,6 +5178,12 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 							)
 						}),
 					{ concurrency: 5 },
+				)
+
+				yield* flushRuleStateHousekeeping(
+					yield* Ref.get(selfHealTargets),
+					yield* Ref.get(clearErrorTargets),
+					tickStart,
 				)
 
 				// Resolve stale incidents for disabled rules

--- a/apps/api/src/services/alerts/AnomalyDetectionService.ts
+++ b/apps/api/src/services/alerts/AnomalyDetectionService.ts
@@ -40,7 +40,19 @@ import {
 	isOrgWarehouseQuarantined,
 	quarantineOnConfigClassCause,
 } from "@/services/warehouse/warehouse-org-quarantine"
-import { Array as Arr, Cause, Clock, Context, Effect, Layer, Option, Ref, Schedule, Schema } from "effect"
+import {
+	Array as Arr,
+	Cause,
+	Clock,
+	Context,
+	Effect,
+	Layer,
+	MutableHashMap,
+	Option,
+	Ref,
+	Schedule,
+	Schema,
+} from "effect"
 import type { TenantContext } from "@/services/auth/AuthService"
 import { INVESTIGATION_FANOUT_BINDING, maybeEnqueueTriage } from "@/services/errors/ai-triage-enqueue"
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
@@ -62,7 +74,11 @@ import {
 	type LogVolumeSeries,
 } from "./anomaly/detection"
 import { issueSeverityFromAlert } from "@/services/errors/severity-map"
-import { batchDetectorStates, DETECTOR_STATE_FLUSH_CONCURRENCY } from "./anomaly/detector-state-batch"
+import {
+	batchDetectorStates,
+	DETECTOR_STATE_FLUSH_CONCURRENCY,
+	effectiveOtherStates,
+} from "./anomaly/detector-state-batch"
 import { rollingCountBuckets } from "./anomaly/rolling-counts"
 import { decideTransition, stateMachineConfigFor, type DetectorStateSnapshot } from "./anomaly/state-machine"
 import {
@@ -1106,10 +1122,10 @@ const make = Effect.gen(function* () {
 	 * on connections to the same origin pool, not on this loop in isolation.
 	 */
 	const flushDetectorStates = Effect.fnUntraced(function* (
-		rows: ReadonlyArray<typeof anomalyDetectorStates.$inferInsert>,
+		writes: MutableHashMap.MutableHashMap<string, typeof anomalyDetectorStates.$inferInsert>,
 	) {
 		yield* Effect.forEach(
-			batchDetectorStates(rows),
+			batchDetectorStates(Arr.map(Arr.fromIterable(writes), ([, row]) => row)),
 			(chunk) =>
 				dbExecute((db) =>
 					db
@@ -1357,9 +1373,12 @@ const make = Effect.gen(function* () {
 		// same trade as `error-tick-persistence.ts`. This loop averaged ~70 dials
 		// per org tick and peaked at 628.
 		//
-		// Safe to accumulate in a plain array: the `Effect.forEach` below is
-		// sequential (no `concurrency` option), so pushes cannot interleave.
-		const detectorStateWrites: Array<typeof anomalyDetectorStates.$inferInsert> = []
+		// Keyed by `detectorKey` rather than a plain list: the consolidated-incident
+		// refcount below has to see this tick's own buffered writes, and last-wins
+		// on a repeated key is what the sequential per-row loop did anyway. Safe to
+		// mutate directly — the `Effect.forEach` below is sequential (no
+		// `concurrency` option), so writes cannot interleave.
+		const detectorStateWrites = MutableHashMap.empty<string, typeof anomalyDetectorStates.$inferInsert>()
 
 		yield* Effect.forEach(
 			orderedDecisions,
@@ -1793,7 +1812,16 @@ const make = Effect.gen(function* () {
 						runtime === undefined || runtime.row.detectorKey === evaluation.detectorKey
 					// Refcount: a consolidated incident only resolves once no other
 					// series still points at it.
-					const otherStates = yield* dbExecute((db) =>
+					//
+					// These rows are pre-tick truth. Detector-state writes are buffered
+					// until `flushDetectorStates` runs after this loop, so a sibling that
+					// already recovered earlier in this same pass still reads as pointing
+					// here — and two siblings recovering in one tick would each see the
+					// other and neither would close the incident. `effectiveOtherStates`
+					// overlays the buffered writes to fix that, which is also why there is
+					// no `LIMIT 1`: the one row it returned could be the very row the
+					// overlay removes, hiding a genuinely live sibling behind it.
+					const persistedOtherStates = yield* dbExecute((db) =>
 						db
 							.select({
 								detectorKey: anomalyDetectorStates.detectorKey,
@@ -1809,9 +1837,14 @@ const make = Effect.gen(function* () {
 									eq(anomalyDetectorStates.openIncidentId, incidentId),
 									ne(anomalyDetectorStates.detectorKey, evaluation.detectorKey),
 								),
-							)
-							.limit(1),
+							),
 					)
+					const otherStates = effectiveOtherStates({
+						persisted: persistedOtherStates,
+						pending: Arr.map(Arr.fromIterable(detectorStateWrites), ([, row]) => row),
+						currentDetectorKey: evaluation.detectorKey,
+						incidentId,
+					})
 					if (otherStates.length === 0) {
 						yield* dbExecute((db) =>
 							db
@@ -1905,7 +1938,7 @@ const make = Effect.gen(function* () {
 					lastIncidentId = incidentId
 				}
 
-				detectorStateWrites.push({
+				MutableHashMap.set(detectorStateWrites, evaluation.detectorKey, {
 					orgId,
 					detectorKey: evaluation.detectorKey,
 					signalType: evaluation.signalType,

--- a/apps/api/src/services/alerts/AnomalyDetectionService.ts
+++ b/apps/api/src/services/alerts/AnomalyDetectionService.ts
@@ -62,7 +62,7 @@ import {
 	type LogVolumeSeries,
 } from "./anomaly/detection"
 import { issueSeverityFromAlert } from "@/services/errors/severity-map"
-import { batchDetectorStates } from "./anomaly/detector-state-batch"
+import { batchDetectorStates, DETECTOR_STATE_FLUSH_CONCURRENCY } from "./anomaly/detector-state-batch"
 import { rollingCountBuckets } from "./anomaly/rolling-counts"
 import { decideTransition, stateMachineConfigFor, type DetectorStateSnapshot } from "./anomaly/state-machine"
 import {
@@ -1098,33 +1098,42 @@ const make = Effect.gen(function* () {
 	 * currently conflicting on (same pattern as `error-tick-persistence.ts:302`).
 	 *
 	 * Dedupe and chunking live in `batchDetectorStates`, which is pure and tested.
+	 *
+	 * Chunks run concurrently: each is its own dial, and `batchDetectorStates`
+	 * dedupes by `detectorKey` first, so no two chunks ever touch the same row and
+	 * they cannot deadlock against each other. Bounded rather than unbounded
+	 * because `processOrg` is itself already running at concurrency 4 — the cap is
+	 * on connections to the same origin pool, not on this loop in isolation.
 	 */
 	const flushDetectorStates = Effect.fnUntraced(function* (
 		rows: ReadonlyArray<typeof anomalyDetectorStates.$inferInsert>,
 	) {
-		for (const chunk of batchDetectorStates(rows)) {
-			yield* dbExecute((db) =>
-				db
-					.insert(anomalyDetectorStates)
-					.values(chunk)
-					.onConflictDoUpdate({
-						target: [anomalyDetectorStates.orgId, anomalyDetectorStates.detectorKey],
-						set: {
-							consecutiveBreaches: sql`excluded.consecutive_breaches`,
-							consecutiveHealthy: sql`excluded.consecutive_healthy`,
-							lastStatus: sql`excluded.last_status`,
-							lastValue: sql`excluded.last_value`,
-							baselineMedian: sql`excluded.baseline_median`,
-							lastSampleCount: sql`excluded.last_sample_count`,
-							lastEvaluatedAt: sql`excluded.last_evaluated_at`,
-							openIncidentId: sql`excluded.open_incident_id`,
-							lastResolvedAt: sql`excluded.last_resolved_at`,
-							lastIncidentId: sql`excluded.last_incident_id`,
-							updatedAt: sql`excluded.updated_at`,
-						},
-					}),
-			)
-		}
+		yield* Effect.forEach(
+			batchDetectorStates(rows),
+			(chunk) =>
+				dbExecute((db) =>
+					db
+						.insert(anomalyDetectorStates)
+						.values(chunk)
+						.onConflictDoUpdate({
+							target: [anomalyDetectorStates.orgId, anomalyDetectorStates.detectorKey],
+							set: {
+								consecutiveBreaches: sql`excluded.consecutive_breaches`,
+								consecutiveHealthy: sql`excluded.consecutive_healthy`,
+								lastStatus: sql`excluded.last_status`,
+								lastValue: sql`excluded.last_value`,
+								baselineMedian: sql`excluded.baseline_median`,
+								lastSampleCount: sql`excluded.last_sample_count`,
+								lastEvaluatedAt: sql`excluded.last_evaluated_at`,
+								openIncidentId: sql`excluded.open_incident_id`,
+								lastResolvedAt: sql`excluded.last_resolved_at`,
+								lastIncidentId: sql`excluded.last_incident_id`,
+								updatedAt: sql`excluded.updated_at`,
+							},
+						}),
+				),
+			{ concurrency: DETECTOR_STATE_FLUSH_CONCURRENCY, discard: true },
+		)
 	})
 
 	const newIncidentId = () => decodeIncidentIdSync(randomUUID())

--- a/apps/api/src/services/alerts/AnomalyDetectionService.ts
+++ b/apps/api/src/services/alerts/AnomalyDetectionService.ts
@@ -62,6 +62,7 @@ import {
 	type LogVolumeSeries,
 } from "./anomaly/detection"
 import { issueSeverityFromAlert } from "@/services/errors/severity-map"
+import { batchDetectorStates } from "./anomaly/detector-state-batch"
 import { rollingCountBuckets } from "./anomaly/rolling-counts"
 import { decideTransition, stateMachineConfigFor, type DetectorStateSnapshot } from "./anomaly/state-machine"
 import {
@@ -1088,6 +1089,44 @@ const make = Effect.gen(function* () {
 				.returning({ orgId: anomalyDetectorSettings.orgId }),
 		)
 
+	/**
+	 * Flush accumulated detector states as multi-row upserts.
+	 *
+	 * Replaces one `dbExecute` per evaluated series. `set` reads from `excluded.*`
+	 * rather than per-row literals — with many rows in one statement there is no
+	 * single literal to write, and `excluded` is the row the statement is
+	 * currently conflicting on (same pattern as `error-tick-persistence.ts:302`).
+	 *
+	 * Dedupe and chunking live in `batchDetectorStates`, which is pure and tested.
+	 */
+	const flushDetectorStates = Effect.fnUntraced(function* (
+		rows: ReadonlyArray<typeof anomalyDetectorStates.$inferInsert>,
+	) {
+		for (const chunk of batchDetectorStates(rows)) {
+			yield* dbExecute((db) =>
+				db
+					.insert(anomalyDetectorStates)
+					.values(chunk)
+					.onConflictDoUpdate({
+						target: [anomalyDetectorStates.orgId, anomalyDetectorStates.detectorKey],
+						set: {
+							consecutiveBreaches: sql`excluded.consecutive_breaches`,
+							consecutiveHealthy: sql`excluded.consecutive_healthy`,
+							lastStatus: sql`excluded.last_status`,
+							lastValue: sql`excluded.last_value`,
+							baselineMedian: sql`excluded.baseline_median`,
+							lastSampleCount: sql`excluded.last_sample_count`,
+							lastEvaluatedAt: sql`excluded.last_evaluated_at`,
+							openIncidentId: sql`excluded.open_incident_id`,
+							lastResolvedAt: sql`excluded.last_resolved_at`,
+							lastIncidentId: sql`excluded.last_incident_id`,
+							updatedAt: sql`excluded.updated_at`,
+						},
+					}),
+			)
+		}
+	})
+
 	const newIncidentId = () => decodeIncidentIdSync(randomUUID())
 
 	interface OrgTickStats {
@@ -1301,6 +1340,17 @@ const make = Effect.gen(function* () {
 			})
 		const orderedDecisions = [...openDecisions, ...decisions.filter((d) => d.transition !== "open")]
 		let openBudget = MAX_OPENS_PER_TICK
+
+		// Detector-state writes are accumulated here and flushed as one multi-row
+		// upsert after the loop, rather than one `dbExecute` per decision. Under
+		// `DatabasePgLive` each execute dials and tears down its own postgres.js
+		// client, so the handshake count is what costs, not the statement count —
+		// same trade as `error-tick-persistence.ts`. This loop averaged ~70 dials
+		// per org tick and peaked at 628.
+		//
+		// Safe to accumulate in a plain array: the `Effect.forEach` below is
+		// sequential (no `concurrency` option), so pushes cannot interleave.
+		const detectorStateWrites: Array<typeof anomalyDetectorStates.$inferInsert> = []
 
 		yield* Effect.forEach(
 			orderedDecisions,
@@ -1846,48 +1896,30 @@ const make = Effect.gen(function* () {
 					lastIncidentId = incidentId
 				}
 
-				yield* dbExecute((db) =>
-					db
-						.insert(anomalyDetectorStates)
-						.values({
-							orgId,
-							detectorKey: evaluation.detectorKey,
-							signalType: evaluation.signalType,
-							serviceName: evaluation.serviceName,
-							deploymentEnv: evaluation.deploymentEnv,
-							fingerprintHash: evaluation.fingerprintHash,
-							consecutiveBreaches: decision.consecutiveBreaches,
-							consecutiveHealthy: decision.consecutiveHealthy,
-							lastStatus: evaluation.status,
-							lastValue: evaluation.value,
-							baselineMedian: evaluation.baselineMedian,
-							lastSampleCount: evaluation.sampleCount,
-							lastEvaluatedAt: new Date(nowMs),
-							openIncidentId,
-							lastResolvedAt: msToDate(lastResolvedAt),
-							lastIncidentId,
-							updatedAt: new Date(nowMs),
-						})
-						.onConflictDoUpdate({
-							target: [anomalyDetectorStates.orgId, anomalyDetectorStates.detectorKey],
-							set: {
-								consecutiveBreaches: decision.consecutiveBreaches,
-								consecutiveHealthy: decision.consecutiveHealthy,
-								lastStatus: evaluation.status,
-								lastValue: evaluation.value,
-								baselineMedian: evaluation.baselineMedian,
-								lastSampleCount: evaluation.sampleCount,
-								lastEvaluatedAt: new Date(nowMs),
-								openIncidentId,
-								lastResolvedAt: msToDate(lastResolvedAt),
-								lastIncidentId,
-								updatedAt: new Date(nowMs),
-							},
-						}),
-				)
+				detectorStateWrites.push({
+					orgId,
+					detectorKey: evaluation.detectorKey,
+					signalType: evaluation.signalType,
+					serviceName: evaluation.serviceName,
+					deploymentEnv: evaluation.deploymentEnv,
+					fingerprintHash: evaluation.fingerprintHash,
+					consecutiveBreaches: decision.consecutiveBreaches,
+					consecutiveHealthy: decision.consecutiveHealthy,
+					lastStatus: evaluation.status,
+					lastValue: evaluation.value,
+					baselineMedian: evaluation.baselineMedian,
+					lastSampleCount: evaluation.sampleCount,
+					lastEvaluatedAt: new Date(nowMs),
+					openIncidentId,
+					lastResolvedAt: msToDate(lastResolvedAt),
+					lastIncidentId,
+					updatedAt: new Date(nowMs),
+				})
 			}),
 			{ discard: true },
 		)
+
+		yield* flushDetectorStates(detectorStateWrites)
 
 		// No-data sweep: open incidents whose series stopped reporting entirely
 		// resolve after an hour of silence (mirrors ErrorsService auto-resolve).

--- a/apps/api/src/services/alerts/anomaly/detector-state-batch.test.ts
+++ b/apps/api/src/services/alerts/anomaly/detector-state-batch.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+
+import { batchDetectorStates, DETECTOR_STATE_UPSERT_CHUNK } from "./detector-state-batch"
+
+const row = (detectorKey: string, marker: number) => ({ detectorKey, marker })
+
+describe("batchDetectorStates", () => {
+	it("returns no statements for no rows", () => {
+		expect(batchDetectorStates([])).toEqual([])
+	})
+
+	it("emits one chunk when under the cap", () => {
+		expect(batchDetectorStates([row("a", 1), row("b", 2)])).toEqual([[row("a", 1), row("b", 2)]])
+	})
+
+	it("keeps the last write for a repeated detector key", () => {
+		// Postgres rejects ON CONFLICT DO UPDATE touching a row twice in one
+		// statement, so a duplicate key must collapse — and to the later value,
+		// matching what the sequential per-row loop wrote.
+		expect(batchDetectorStates([row("a", 1), row("b", 2), row("a", 3)])).toEqual([
+			[row("a", 3), row("b", 2)],
+		])
+	})
+
+	it("preserves first-seen order when deduping", () => {
+		const chunks = batchDetectorStates([row("a", 1), row("b", 2), row("a", 3)])
+		expect(chunks[0]?.map((r) => r.detectorKey)).toEqual(["a", "b"])
+	})
+
+	it("splits into chunks at the boundary", () => {
+		const rows = Array.from({ length: 5 }, (_, i) => row(`k${i}`, i))
+		expect(batchDetectorStates(rows, 2).map((chunk) => chunk.length)).toEqual([2, 2, 1])
+	})
+
+	it("does not split an exact multiple into a trailing empty chunk", () => {
+		const rows = Array.from({ length: 4 }, (_, i) => row(`k${i}`, i))
+		expect(batchDetectorStates(rows, 2).map((chunk) => chunk.length)).toEqual([2, 2])
+	})
+
+	it("chunks by deduped size, not input size", () => {
+		// Three inputs, two distinct keys — one chunk of two, not two chunks.
+		expect(batchDetectorStates([row("a", 1), row("a", 2), row("b", 3)], 2)).toEqual([
+			[row("a", 2), row("b", 3)],
+		])
+	})
+
+	it("keeps the default chunk under the 65535 bound-parameter cap at 17 columns", () => {
+		expect(DETECTOR_STATE_UPSERT_CHUNK * 17).toBeLessThan(65535)
+	})
+})

--- a/apps/api/src/services/alerts/anomaly/detector-state-batch.test.ts
+++ b/apps/api/src/services/alerts/anomaly/detector-state-batch.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { batchDetectorStates, DETECTOR_STATE_UPSERT_CHUNK } from "./detector-state-batch"
+import {
+	batchDetectorStates,
+	DETECTOR_STATE_UPSERT_CHUNK,
+	effectiveOtherStates,
+} from "./detector-state-batch"
 
 const row = (detectorKey: string, marker: number) => ({ detectorKey, marker })
 
@@ -46,5 +50,94 @@ describe("batchDetectorStates", () => {
 
 	it("keeps the default chunk under the 65535 bound-parameter cap at 17 columns", () => {
 		expect(DETECTOR_STATE_UPSERT_CHUNK * 17).toBeLessThan(65535)
+	})
+})
+
+describe("effectiveOtherStates", () => {
+	const persistedRow = (detectorKey: string) => ({
+		detectorKey,
+		fingerprintHash: `fp_${detectorKey}`,
+		lastSampleCount: 10,
+	})
+
+	it("counts a sibling that has not changed this tick", () => {
+		const others = effectiveOtherStates({
+			persisted: [persistedRow("b")],
+			pending: [],
+			currentDetectorKey: "a",
+			incidentId: "inc_1",
+		})
+		expect(others.map((r) => r.detectorKey)).toEqual(["b"])
+	})
+
+	it("drops a sibling whose buffered write already released the incident", () => {
+		// The regression: under the old per-row writes, b's `openIncidentId = null`
+		// was already persisted by the time a resolved. With the flush deferred, the
+		// database still lists b, so without this overlay a would see a live sibling
+		// that has in fact recovered.
+		const others = effectiveOtherStates({
+			persisted: [persistedRow("b")],
+			pending: [{ detectorKey: "b", openIncidentId: null }],
+			currentDetectorKey: "a",
+			incidentId: "inc_1",
+		})
+		expect(others).toEqual([])
+	})
+
+	it("lets both siblings of a consolidated incident resolve in one tick", () => {
+		// a resolves first and buffers its release; b must then see a refcount of
+		// zero and close the incident, rather than promoting a recovered series.
+		const pending: Array<{ detectorKey: string; openIncidentId: string | null }> = []
+
+		const forA = effectiveOtherStates({
+			persisted: [persistedRow("b")],
+			pending,
+			currentDetectorKey: "a",
+			incidentId: "inc_1",
+		})
+		expect(forA.map((r) => r.detectorKey)).toEqual(["b"])
+		pending.push({ detectorKey: "a", openIncidentId: null })
+
+		const forB = effectiveOtherStates({
+			persisted: [persistedRow("a")],
+			pending,
+			currentDetectorKey: "b",
+			incidentId: "inc_1",
+		})
+		expect(forB).toEqual([])
+	})
+
+	it("counts a sibling that only attached during this tick", () => {
+		// Not in the database yet, so the raw query would miss it and the incident
+		// would resolve out from under a series that just joined it.
+		const others = effectiveOtherStates({
+			persisted: [],
+			pending: [
+				{ detectorKey: "b", openIncidentId: "inc_1", fingerprintHash: "fp_b", lastSampleCount: 7 },
+			],
+			currentDetectorKey: "a",
+			incidentId: "inc_1",
+		})
+		expect(others).toEqual([{ detectorKey: "b", fingerprintHash: "fp_b", lastSampleCount: 7 }])
+	})
+
+	it("ignores buffered writes pointing at a different incident", () => {
+		const others = effectiveOtherStates({
+			persisted: [],
+			pending: [{ detectorKey: "b", openIncidentId: "inc_2" }],
+			currentDetectorKey: "a",
+			incidentId: "inc_1",
+		})
+		expect(others).toEqual([])
+	})
+
+	it("never counts the resolving detector itself", () => {
+		const others = effectiveOtherStates({
+			persisted: [persistedRow("a")],
+			pending: [{ detectorKey: "a", openIncidentId: "inc_1" }],
+			currentDetectorKey: "a",
+			incidentId: "inc_1",
+		})
+		expect(others).toEqual([])
 	})
 })

--- a/apps/api/src/services/alerts/anomaly/detector-state-batch.ts
+++ b/apps/api/src/services/alerts/anomaly/detector-state-batch.ts
@@ -1,0 +1,47 @@
+/**
+ * Rows per multi-row detector-state upsert.
+ *
+ * Postgres caps a statement at 65535 bound parameters and `anomaly_detector_states`
+ * binds 17 columns per row, so the hard ceiling is ~3,800. The observed peak is
+ * 628 series for one org, but series count grows with services × signals × error
+ * fingerprints, so this is bounded rather than assumed safe.
+ */
+export const DETECTOR_STATE_UPSERT_CHUNK = 500
+
+/**
+ * Prepare accumulated detector-state writes for multi-row upserts.
+ *
+ * Two things the per-row loop got for free and a batched statement does not:
+ *
+ * 1. **Dedupe by `detectorKey`, last write wins.** Postgres rejects an
+ *    `ON CONFLICT DO UPDATE` that would touch the same row twice in one
+ *    statement ("cannot affect row a second time"). Last-wins reproduces what
+ *    the sequential loop did when a key appeared more than once.
+ * 2. **Chunking**, to stay under the bound-parameter cap.
+ *
+ * Insertion order is preserved so the resulting statements stay deterministic —
+ * which is what makes the round-trip count assertable in tests.
+ *
+ * Callers pass rows for a single org, so `detectorKey` alone is the right dedupe
+ * key even though the table's conflict target is `(orgId, detectorKey)`.
+ */
+export function batchDetectorStates<T extends { readonly detectorKey: string }>(
+	rows: ReadonlyArray<T>,
+	chunkSize: number = DETECTOR_STATE_UPSERT_CHUNK,
+): T[][] {
+	if (rows.length === 0) return []
+
+	const deduped = new Map<string, T>()
+	for (const row of rows) {
+		// `set` on an existing key overwrites the value but keeps the original
+		// insertion position, which is the order preservation described above.
+		deduped.set(row.detectorKey, row)
+	}
+
+	const values = [...deduped.values()]
+	const chunks: T[][] = []
+	for (let i = 0; i < values.length; i += chunkSize) {
+		chunks.push(values.slice(i, i + chunkSize))
+	}
+	return chunks
+}

--- a/apps/api/src/services/alerts/anomaly/detector-state-batch.ts
+++ b/apps/api/src/services/alerts/anomaly/detector-state-batch.ts
@@ -1,4 +1,4 @@
-import { Array as Arr, MutableHashMap } from "effect"
+import { Array as Arr, MutableHashMap, Result } from "effect"
 
 /**
  * Rows per multi-row detector-state upsert.
@@ -52,4 +52,72 @@ export function batchDetectorStates<T extends { readonly detectorKey: string }>(
 		Arr.map(Arr.fromIterable(deduped), ([, row]) => row),
 		chunkSize,
 	)
+}
+
+/** The subset of a detector-state row the incident refcount needs. */
+export interface DetectorRefcountRow {
+	readonly detectorKey: string
+	readonly fingerprintHash: string | null
+	readonly lastSampleCount: number | null
+}
+
+/**
+ * Which *other* series still point at a consolidated incident, accounting for
+ * this tick's not-yet-flushed detector-state writes.
+ *
+ * The refcount that decides whether a consolidated incident may resolve reads
+ * `anomaly_detector_states` live, but detector-state writes are now buffered
+ * until the end of the org pass. Without this overlay the query returns pre-tick
+ * truth: two series sharing one incident that both recover in the same tick each
+ * still see the other pointing at it, so neither closes the incident. It then
+ * lingers with its headline on an already-recovered series until the one-hour
+ * no-data sweep closes it with the wrong reason.
+ *
+ * The overlay runs both ways. A pending write that no longer points at this
+ * incident removes that series from the count even though the database still
+ * lists it; a pending write that newly points at it (an attach or reopen earlier
+ * in this same pass) adds a series the database does not list yet.
+ *
+ * `persisted` must therefore be unbounded — a `LIMIT 1` could return the single
+ * row this overlay is about to remove and hide a live sibling behind it.
+ */
+export function effectiveOtherStates<
+	P extends {
+		readonly detectorKey: string
+		// Optional because drizzle's insert shape makes nullable columns optional.
+		// An absent value means "not pointing at this incident", same as null.
+		readonly openIncidentId?: string | null
+		readonly fingerprintHash?: string | null
+		readonly lastSampleCount?: number | null
+	},
+>(options: {
+	readonly persisted: ReadonlyArray<DetectorRefcountRow>
+	readonly pending: Iterable<P>
+	readonly currentDetectorKey: string
+	readonly incidentId: string
+}): Array<DetectorRefcountRow> {
+	const { persisted, pending, currentDetectorKey, incidentId } = options
+
+	const byKey = MutableHashMap.fromIterable(
+		Arr.filterMap(persisted, (row) =>
+			row.detectorKey === currentDetectorKey
+				? Result.failVoid
+				: Result.succeed([row.detectorKey, row] as const),
+		),
+	)
+
+	for (const write of pending) {
+		if (write.detectorKey === currentDetectorKey) continue
+		if (write.openIncidentId === incidentId) {
+			MutableHashMap.set(byKey, write.detectorKey, {
+				detectorKey: write.detectorKey,
+				fingerprintHash: write.fingerprintHash ?? null,
+				lastSampleCount: write.lastSampleCount ?? null,
+			})
+		} else {
+			MutableHashMap.remove(byKey, write.detectorKey)
+		}
+	}
+
+	return Arr.map(Arr.fromIterable(byKey), ([, row]) => row)
 }

--- a/apps/api/src/services/alerts/anomaly/detector-state-batch.ts
+++ b/apps/api/src/services/alerts/anomaly/detector-state-batch.ts
@@ -1,3 +1,5 @@
+import { Array as Arr, MutableHashMap } from "effect"
+
 /**
  * Rows per multi-row detector-state upsert.
  *
@@ -7,6 +9,16 @@
  * fingerprints, so this is bounded rather than assumed safe.
  */
 export const DETECTOR_STATE_UPSERT_CHUNK = 500
+
+/**
+ * Chunks flushed concurrently per org.
+ *
+ * Chunks are disjoint by `detectorKey`, so concurrent upserts never contend for
+ * the same row. The bound is about connections, not correctness: `processOrg`
+ * already runs at concurrency 4, and every chunk is its own dial against the
+ * same Hyperdrive origin pool.
+ */
+export const DETECTOR_STATE_FLUSH_CONCURRENCY = 4
 
 /**
  * Prepare accumulated detector-state writes for multi-row upserts.
@@ -19,7 +31,8 @@ export const DETECTOR_STATE_UPSERT_CHUNK = 500
  *    the sequential loop did when a key appeared more than once.
  * 2. **Chunking**, to stay under the bound-parameter cap.
  *
- * Insertion order is preserved so the resulting statements stay deterministic —
+ * Insertion order is preserved — `MutableHashMap.set` on an existing key updates
+ * in place rather than reordering — so the emitted statements stay deterministic,
  * which is what makes the round-trip count assertable in tests.
  *
  * Callers pass rows for a single org, so `detectorKey` alone is the right dedupe
@@ -28,20 +41,15 @@ export const DETECTOR_STATE_UPSERT_CHUNK = 500
 export function batchDetectorStates<T extends { readonly detectorKey: string }>(
 	rows: ReadonlyArray<T>,
 	chunkSize: number = DETECTOR_STATE_UPSERT_CHUNK,
-): T[][] {
-	if (rows.length === 0) return []
+): Array<Array<T>> {
+	if (Arr.isReadonlyArrayEmpty(rows)) return []
 
-	const deduped = new Map<string, T>()
-	for (const row of rows) {
-		// `set` on an existing key overwrites the value but keeps the original
-		// insertion position, which is the order preservation described above.
-		deduped.set(row.detectorKey, row)
-	}
+	const deduped = Arr.reduce(rows, MutableHashMap.empty<string, T>(), (acc, row) =>
+		MutableHashMap.set(acc, row.detectorKey, row),
+	)
 
-	const values = [...deduped.values()]
-	const chunks: T[][] = []
-	for (let i = 0; i < values.length; i += chunkSize) {
-		chunks.push(values.slice(i, i + chunkSize))
-	}
-	return chunks
+	return Arr.chunksOf(
+		Arr.map(Arr.fromIterable(deduped), ([, row]) => row),
+		chunkSize,
+	)
 }


### PR DESCRIPTION
## Why

The alerting worker issued **~69k Postgres queries/hour** (81k peak; 1.65M spans over 24h, 2026-08-09→10) — 97% of the workers' DB traffic. This already cost it a dedicated Hyperdrive config so it stopped starving the api's connection pool (`packages/infra/src/cloudflare/stage.ts:156-166`). That fixed the blast radius, not the cause.

**The cost is the dial, not the query.** `db.duration_ms` tracks full span duration on every shape (576–747ms typical), because `DatabasePgLive` opens a fresh postgres.js client per `execute` — deliberate, since Workers tie TCP sockets to the request that opened them. A single-row `UPDATE alert_rules` at 632ms p50 is entirely round-trip. At ~69k/hr × ~650ms that's **~12 hours of connection wall-clock per hour**.

Three of the scheduler's per-rule statements had each been *deliberately* written to touch **zero rows**, to keep Electric's shape log quiet. That worked for WAL churn — but a zero-row query costs the same dial as a real one. The code was tuned for rows written, never for round-trips issued.

## What changed

### `runSchedulerTick`: ~7 dials per rule per minute → ~1.7

- **Tick-head prefetch.** `alert_rule_states` and open `alert_incidents` are read once per tick via `inArray`, in a single `execute`, instead of once per rule per group. This also removes a duplicate: `alert_incidents` was the heaviest shape at 10.8k/hr because `processEvaluation` and `resolveOrphanedGroupIncidents` each read the same set.
- **Set-based housekeeping.** The two zero-row self-heal statements now run once per tick instead of once per rule.
- **Claim + heartbeat in one `execute`.**

### `AnomalyDetectionService`: 9.5k/hr → ~156/hr

One upsert per evaluated series (avg 69.5, **peak 628 dials for a single org tick**) becomes one multi-row upsert. Dedupe and chunking live in a pure, tested helper — Postgres rejects an `ON CONFLICT DO UPDATE` that touches a row twice, and the 65535 bound-parameter cap needs a bound.

Both follow the pattern already established by `ErrorsService.loadOrgTickPreamble` and `scrape-check-retention.ts`.

## Reviewer notes

**Why the prefetch is safe.** Every key is `(orgId, ruleId, groupKey)`. `processEvaluation` runs at most once per key per tick, and its writes only ever touch its own key — the state upsert targets that primary key, and both incident updates target `openIncident.id`, the incident belonging to that same key. No group can read a value another group invalidated.

**One behavioural change beyond a pure refactor.** `resolveOrphanedGroupIncidents` now guards its resolve on `status = 'open'` and gates the notification on the returned row count. A tick-head snapshot would otherwise widen an existing race with out-of-band manual resolution into a duplicate all-clear page. The old re-read had the same race between its own select and update, just narrower — this closes it rather than inheriting it. Its metrics now count what actually resolved rather than what was a candidate.

**Deliberately unchanged:** cron cadence (a product decision), `executeOnFreshPgClient` (the Workers socket model is right; the fix is fewer calls), and the zero-row Electric optimizations (still correct for WAL churn — they just no longer cost a dial per rule).

## Verification

- **123 tests pass** across the touched files, including all 48 pre-existing `AlertsService` cases unchanged.
- `bun typecheck` clean (37/37).
- New round-trip test counts `Database.execute` calls: **12 for 3 rules, 27 for 12 → 1.67 per additional rule.** Confirmed non-vacuous by temporarily tightening the threshold; it fails at the old ~7/rule.
- New lifecycle test: a still-breaching group is never auto-resolved.

Expected in production: **~69k → ~40k queries/hour.** Compare against alerting's own spans grouped by `db.query.fingerprint` — *not* the PlanetScale dashboard, which is database-side and counts every consumer on the branch plus connection setup (which is why it reads closer to 160k).

## Follow-ups not in this PR

- `select * from alert_rules where enabled = true` is cross-org and **no index supports it** (`packages/db/src/schema/alerts.ts:94-96` has only `(orgId)`, `(orgId, enabled)`, `(orgId, name)`) — a sequential scan on the hottest table every 60s. Wants a partial index; deferred because prod migrations are manual.
- `DigestService.reconcileSubscriptions` (~3.4k/hr), `ErrorsService` `SELECT actors` (1,610/hr at p50 **2,076ms**, the slowest shape in the service), redundant `SELECT DISTINCT` org enumerations, and the Cloudflare/PlanetScale poller N+1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788994741&installation_model_id=427786&pr_number=389&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F389&signature=7ef8a044842619aa294dd256b603891f8ec8e87d95a39a7be09119ae7b64d346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->