### PR TITLE
perf(web): cut the round trips behind slow list-page loads

### DIFF
--- a/apps/api/src/http/api-cors.ts
+++ b/apps/api/src/http/api-cors.ts
@@ -1,8 +1,22 @@
 export const API_CORS_OPTIONS = {
 	allowedOrigins: ["*"],
 	allowedMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-	allowedHeaders: ["*"],
+	// `Authorization` must be listed EXPLICITLY — the Fetch spec deliberately
+	// excludes it from the `*` wildcard. With only `*`, Chrome still lets the
+	// request through but refuses to cache its preflight, so every single
+	// authenticated call (i.e. all of them) re-preflighted regardless of
+	// `maxAge`. Verified in-browser: two identical requests with a plain custom
+	// header cost one OPTIONS, the same pair with `Authorization` cost two.
+	allowedHeaders: ["*", "Authorization"],
 	// The ElectricSQL shape proxy (and its electric-* exposed headers) moved
 	// to the standalone `apps/electric-sync` worker.
 	exposedHeaders: ["Mcp-Session-Id", "Retry-After"],
+	// Every browser call carries an Authorization header, so every one is
+	// preflighted. Without this the response has no Access-Control-Max-Age and
+	// Chrome falls back to a 5s preflight cache — and since the worker is pinned
+	// to us-east-1 (CLOUDFLARE_WORKER_PLACEMENT), each expiry costs a full extra
+	// ~165ms round trip from Europe BEFORE the real request is sent. Those
+	// preflights are invisible in our own traces because the tracer is disabled
+	// for OPTIONS. Browsers clamp this value themselves (Chrome 2h, Firefox 24h).
+	maxAge: 86_400,
 }

--- a/apps/api/src/routes/__tests__/query-engine-batch.test.ts
+++ b/apps/api/src/routes/__tests__/query-engine-batch.test.ts
@@ -1,0 +1,117 @@
+import { assert, describe, it } from "@effect/vitest"
+import type { QueryEngineResult } from "@maple/query-engine"
+import { Effect, Schema } from "effect"
+import { runQueryEngineBatch } from "@/routes/query-engine-batch"
+
+class StubError extends Schema.TaggedError<StubError>()("@maple/http/errors/QueryEngineExecutionError", {
+	message: Schema.String,
+}) {}
+
+const countResult = (total: number): QueryEngineResult => ({
+	kind: "count",
+	source: "logs",
+	data: { total },
+})
+
+const totalOf = (outcome: { outcome: string; result?: QueryEngineResult }): number => {
+	assert.strictEqual(outcome.outcome, "success")
+	const result = outcome.result
+	assert.ok(result !== undefined && result.kind === "count")
+	return result.kind === "count" ? result.data.total : -1
+}
+
+describe("runQueryEngineBatch", () => {
+	it.effect("returns one outcome per request, positionally aligned", () =>
+		Effect.gen(function* () {
+			const outcomes = yield* runQueryEngineBatch({
+				requests: [10, 20, 30],
+				execute: (n: number) => Effect.succeed(countResult(n)),
+			})
+			assert.strictEqual(outcomes.length, 3)
+			assert.deepStrictEqual(outcomes.map(totalOf), [10, 20, 30])
+		}),
+	)
+
+	it.effect("isolates a failing query from its siblings", () =>
+		Effect.gen(function* () {
+			const outcomes = yield* runQueryEngineBatch({
+				requests: [1, 2, 3],
+				execute: (n: number) =>
+					n === 2
+						? Effect.fail(new StubError({ message: "boom" }))
+						: Effect.succeed(countResult(n)),
+			})
+
+			assert.deepStrictEqual(
+				outcomes.map((o) => o.outcome),
+				["success", "failure", "success"],
+			)
+			const failed = outcomes[1]
+			assert.ok(failed !== undefined && failed.outcome === "failure")
+			// The original tag rides along so the client keeps its specific copy.
+			assert.strictEqual(failed.error._tag, "@maple/http/errors/QueryEngineExecutionError")
+			assert.strictEqual(failed.error.message, "boom")
+		}),
+	)
+
+	it.live("bounds total wall time with a deadline shared by every item", () =>
+		Effect.gen(function* () {
+			const started = Date.now()
+			// 8 items at concurrency 2 = 4 waves. Each query would take 200ms, so
+			// a per-item timeout would let this run ~800ms; the SHARED deadline has
+			// to cut it off at ~120ms instead.
+			const outcomes = yield* runQueryEngineBatch({
+				requests: [1, 2, 3, 4, 5, 6, 7, 8],
+				execute: (n: number) => Effect.succeed(countResult(n)).pipe(Effect.delay("200 millis")),
+				deadlineMs: 120,
+				concurrency: 2,
+			})
+			const elapsed = Date.now() - started
+
+			assert.strictEqual(outcomes.length, 8)
+			// Bound chosen to discriminate: a SHARED deadline finishes in ~120ms
+			// (later waves find no budget left and return instantly), whereas a
+			// per-item 120ms timeout would take 4 waves × 120ms ≈ 480ms.
+			assert.ok(elapsed < 300, `batch ran ${elapsed}ms — the deadline is per-item, not shared`)
+			// Everything timed out, and a timeout is a per-item failure, not a throw.
+			assert.ok(outcomes.every((o) => o.outcome === "failure"))
+			const first = outcomes[0]
+			assert.ok(first !== undefined && first.outcome === "failure")
+			assert.strictEqual(first.error._tag, "@maple/http/errors/QueryEngineTimeoutError")
+		}),
+	)
+
+	it.live("still returns fast results when only some queries are slow", () =>
+		Effect.gen(function* () {
+			const outcomes = yield* runQueryEngineBatch({
+				requests: [1, 2, 3],
+				execute: (n: number) =>
+					n === 2
+						? Effect.succeed(countResult(n)).pipe(Effect.delay("5 seconds"))
+						: Effect.succeed(countResult(n)),
+				deadlineMs: 150,
+				concurrency: 3,
+			})
+
+			assert.deepStrictEqual(
+				outcomes.map((o) => o.outcome),
+				["success", "failure", "success"],
+			)
+		}),
+	)
+
+	it.effect("handles an empty batch without calling execute", () =>
+		Effect.gen(function* () {
+			let calls = 0
+			const outcomes = yield* runQueryEngineBatch({
+				requests: [],
+				execute: (n: number) => {
+					calls += 1
+					return Effect.succeed(countResult(n))
+				},
+			})
+			assert.strictEqual(outcomes.length, 0)
+			assert.strictEqual(calls, 0)
+		}),
+	)
+})

--- a/apps/api/src/routes/query-engine-batch.ts
+++ b/apps/api/src/routes/query-engine-batch.ts
@@ -1,0 +1,78 @@
+import type { QueryEngineBatchOutcome, QueryEngineResult } from "@maple/query-engine"
+import { Clock, Duration, Effect } from "effect"
+
+/**
+ * Fan-out for `POST /api/query-engine/execute-batch`.
+ *
+ * Extracted from the route handler so the two things that actually carry risk —
+ * the shared deadline and per-item failure isolation — are testable without an
+ * HTTP harness.
+ */
+
+/**
+ * Concurrency for the fan-out. Matches the bucket-cache fill concurrency, which
+ * is already tuned for the Cloudflare six-connection limit — going unbounded
+ * would reintroduce exactly the outbound contention `warmRoute` exists to avoid.
+ */
+export const QE_BATCH_CONCURRENCY = 4
+
+/**
+ * Wall-clock ceiling for one batch, shared by every item. The browser aborts at
+ * 45s, so the response has to land before that: better to return eleven results
+ * and one timeout than to have the client throw the whole batch away.
+ */
+export const QE_BATCH_DEADLINE_MS = 25_000
+
+const timedOut = (): QueryEngineBatchOutcome => ({
+	outcome: "failure",
+	error: {
+		_tag: "@maple/http/errors/QueryEngineTimeoutError",
+		message: "Query exceeded the batch deadline.",
+	},
+})
+
+/**
+ * Runs every request against a SHARED deadline, so total wall time is bounded
+ * no matter how many items or waves there are. Per-item failures are returned
+ * as `failure` outcomes rather than failing the effect: one bad widget must not
+ * take down the eleven others sharing its request.
+ */
+export const runQueryEngineBatch = <
+	Request,
+	Error extends { readonly _tag: string; readonly message: string },
+>(options: {
+	readonly requests: ReadonlyArray<Request>
+	readonly execute: (request: Request) => Effect.Effect<QueryEngineResult, Error>
+	readonly deadlineMs?: number
+	readonly concurrency?: number
+}): Effect.Effect<ReadonlyArray<QueryEngineBatchOutcome>> =>
+	Effect.gen(function* () {
+		const deadline = (yield* Clock.currentTimeMillis) + (options.deadlineMs ?? QE_BATCH_DEADLINE_MS)
+		return yield* Effect.forEach(
+			options.requests,
+			(request) =>
+				Effect.gen(function* () {
+					// Each item races what's LEFT of the batch budget, not a fresh
+					// per-item timeout — otherwise N waves could each take the full
+					// timeout and blow past the client's abort.
+					const remaining = deadline - (yield* Clock.currentTimeMillis)
+					if (remaining <= 0) return timedOut()
+					return yield* options.execute(request).pipe(
+						Effect.map(
+							(result) => ({ outcome: "success", result }) satisfies QueryEngineBatchOutcome,
+						),
+						Effect.timeoutOrElse({
+							duration: Duration.millis(remaining),
+							orElse: () => Effect.succeed(timedOut()),
+						}),
+						Effect.catch((error) =>
+							Effect.succeed({
+								outcome: "failure",
+								error: { _tag: error._tag, message: error.message },
+							} satisfies QueryEngineBatchOutcome),
+						),
+					)
+				}),
+			{ concurrency: options.concurrency ?? QE_BATCH_CONCURRENCY },
+		)
+	})

--- a/apps/api/src/routes/v1/integrations.http.ts
+++ b/apps/api/src/routes/v1/integrations.http.ts
@@ -34,7 +34,9 @@ import {
 	PlanetScaleWebhookConfigResponse,
 	RoleName,
 	UserId,
+	VCS_COMMIT_DETAILS_MAX_SHAS,
 	VcsCommitDetailResponse,
+	VcsCommitDetailsResponse,
 } from "@maple/domain/http"
 import { cloudflareAnalyticsState } from "@maple/db"
 import { EdgeCacheService } from "@maple/cache"
@@ -675,6 +677,20 @@ export const HttpIntegrationsLive = HttpApiBuilder.group(MapleApi, "integrations
 						const tenant = yield* CurrentTenant.Context
 						const detail = yield* vcsCommits.resolveCommitDetail(tenant.orgId, params.sha)
 						return new VcsCommitDetailResponse(detail)
+					}),
+				)
+				.handle("vcsCommitDetails", ({ query }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const shas = query.shas
+							.split(",")
+							.map((sha) => sha.trim())
+							.filter((sha) => sha.length > 0)
+							.slice(0, VCS_COMMIT_DETAILS_MAX_SHAS)
+						const details = yield* vcsCommits.resolveCommitDetails(tenant.orgId, shas)
+						return new VcsCommitDetailsResponse({
+							commits: details.map((detail) => new VcsCommitDetailResponse(detail)),
+						})
 					}),
 				)
 		)

--- a/apps/api/src/routes/v1/query-engine.http.ts
+++ b/apps/api/src/routes/v1/query-engine.http.ts
@@ -75,7 +75,12 @@ import { QueryEngineService } from "@/services/warehouse/QueryEngineService"
 import { makeDirectRouteCachePolicy, makeExecuteRawSql } from "@maple/query-engine/runtime"
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
 import { traceCacheTtlSeconds } from "@/services/warehouse/trace-detail-cache"
-import { CH, formatWarehouseDateTime, parseWarehouseDateTime } from "@maple/query-engine"
+import {
+	CH,
+	formatWarehouseDateTime,
+	parseWarehouseDateTime,
+	QueryEngineExecuteBatchResponse,
+} from "@maple/query-engine"
 import { LOGS_BODY_SEARCH_SETTINGS } from "@maple/query-engine/profiles"
 import {
 	hostMetricSpec,
@@ -87,6 +92,7 @@ import {
 } from "@/routes/query-helpers"
 import { Queries } from "@/routes/queries"
 import { makeQueryRunners } from "@/routes/query-runner"
+import { runQueryEngineBatch } from "@/routes/query-engine-batch"
 import type { ExecutionTenant, WarehouseSqlError } from "@maple/query-engine/execution"
 import type { TenantContext } from "@/services/auth/AuthService"
 import * as Integrations from "@maple/query-engine-integrations"
@@ -232,6 +238,25 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
 					return yield* queryEngine.execute(tenant, payload)
+				}),
+			)
+			.handle("executeBatch", ({ payload }) =>
+				Effect.gen(function* () {
+					const tenant = yield* CurrentTenant.Context
+					// Resolve the org's warehouse route + config ONCE for the batch.
+					// Without it each item independently races resolveRuntimeConfig
+					// and they contend — the same ordering problem the other
+					// fan-out routes call warmRoute for.
+					yield* warehouse.warmRoute(tenant)
+
+					const results = yield* runQueryEngineBatch({
+						requests: payload.requests,
+						execute: (request) =>
+							queryEngine
+								.execute(tenant, request)
+								.pipe(Effect.map((response) => response.result)),
+					})
+					return new QueryEngineExecuteBatchResponse({ results })
 				}),
 			)
 			.handle("spanHierarchy", ({ payload }) =>

--- a/apps/api/src/routes/v2/api-keys.http.test.ts
+++ b/apps/api/src/routes/v2/api-keys.http.test.ts
@@ -81,7 +81,12 @@ const makeHarness = (
 	const request = async (
 		method: string,
 		path: string,
-		options: { token?: string; body?: unknown; origin?: string } = {},
+		options: {
+			token?: string
+			body?: unknown
+			origin?: string
+			headers?: Record<string, string>
+		} = {},
 	) => {
 		const response = await handler(
 			new Request(`http://maple.test${path}`, {
@@ -90,6 +95,7 @@ const makeHarness = (
 					...(options.token !== undefined ? { authorization: `Bearer ${options.token}` } : {}),
 					...(options.body !== undefined ? { "content-type": "application/json" } : {}),
 					...(options.origin !== undefined ? { origin: options.origin } : {}),
+					...options.headers,
 				},
 				body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
 			}),
@@ -230,6 +236,31 @@ describe("v2 api_keys over HTTP", () => {
 		})
 		expect(response.headers.get("retry-after")).toBe("60")
 		expect(response.headers.get("access-control-expose-headers")).toContain("Retry-After")
+		await harness.dispose()
+	})
+
+	// Without Access-Control-Max-Age, Chrome caches a preflight for only 5s, so
+	// nearly every browser call pays a second round trip to a worker pinned in
+	// us-east-1 before the real request is even sent. Those OPTIONS never reach
+	// our traces (the tracer is disabled for them), so only a test guards this.
+	it("caches CORS preflights so every request doesn't pay a second round trip", async () => {
+		const harness = makeHarness()
+		const response = await harness.request("OPTIONS", "/v2/api_keys", {
+			origin: "https://app.maple.dev",
+			headers: {
+				"access-control-request-method": "GET",
+				"access-control-request-headers": "authorization,content-type",
+			},
+		})
+
+		expect(response.headers.get("access-control-max-age")).toBe(String(API_CORS_OPTIONS.maxAge))
+		// `Authorization` must appear EXPLICITLY, not just via the `*` wildcard —
+		// the Fetch spec excludes it from the wildcard, and with only `*` browsers
+		// still allow the request but refuse to cache its preflight. Since every
+		// browser call to this API is authenticated, that silently reduced maxAge
+		// to a no-op. Verified in Chrome: 3 authenticated requests cost 3
+		// preflights with `*` alone and 1 with `Authorization` listed.
+		expect(response.headers.get("access-control-allow-headers")).toContain("Authorization")
 		await harness.dispose()
 	})
 

--- a/apps/api/src/services/integrations/vcs/VcsCommitService.ts
+++ b/apps/api/src/services/integrations/vcs/VcsCommitService.ts
@@ -79,7 +79,29 @@ export interface VcsCommitServiceShape {
 		| IntegrationsUpstreamError
 		| IntegrationsPersistenceError
 	>
+	/**
+	 * Resolve many SHAs at once for list views (the services table renders one
+	 * deploy row per service/environment). Unresolvable SHAs — invalid, unknown,
+	 * or belonging to no connected repo — are simply omitted rather than failing
+	 * the batch, so one bad deploy reference can't blank out the whole table.
+	 */
+	readonly resolveCommitDetails: (
+		orgId: OrgId,
+		shas: ReadonlyArray<string>,
+	) => Effect.Effect<ReadonlyArray<VcsCommitDetail>, IntegrationsPersistenceError>
 }
+
+/**
+ * How many unknown SHAs we probe against providers for one bulk request. Stored
+ * SHAs are free (two reads for the whole batch); a probe is an outbound provider
+ * call per SHA, and outbound call count — not the cost of any single call — is
+ * what drives this worker's latency. A list view that would blow past this is
+ * showing deploys we've never ingested, which is a backfill problem, not a
+ * hover-card one.
+ */
+const BULK_PROBE_LIMIT = 8
+/** Concurrency for those probes — matches the bucket-cache fill concurrency. */
+const BULK_PROBE_CONCURRENCY = 4
 
 // Storage / decode errors all carry a `message`; collapse them to the
 // persistence error the HTTP layer speaks.
@@ -338,7 +360,60 @@ export class VcsCommitService extends Context.Service<VcsCommitService, VcsCommi
 				})
 			})
 
-			return { resolveCommitDetail } satisfies VcsCommitServiceShape
+			const resolveCommitDetails = Effect.fn("VcsCommitService.resolveCommitDetails")(function* (
+				orgId: OrgId,
+				rawShas: ReadonlyArray<string>,
+			) {
+				yield* Effect.annotateCurrentSpan({ orgId, "vcs.commit.requested": rawShas.length })
+
+				// Non-40-hex references (short SHAs, non-standard deploy ids) are
+				// dropped silently here. The singular endpoint still reports them as
+				// VcsCommitShaInvalidError; in a list they're just rows that render
+				// their raw reference, which is what the table does anyway.
+				const shas: Array<GitCommitSha> = []
+				const seen = new Set<string>()
+				for (const raw of rawShas) {
+					if (seen.has(raw)) continue
+					seen.add(raw)
+					const decoded = yield* decodeSha(raw).pipe(Effect.option)
+					if (Option.isSome(decoded)) shas.push(decoded.value)
+				}
+				if (shas.length === 0) return [] as ReadonlyArray<VcsCommitDetail>
+
+				// 1. One read for every stored commit, then one read for the repos they
+				//    belong to — two outbound calls for the whole batch.
+				const stored = yield* asPersistence(repo.findCommitsByShas(orgId, shas))
+				const repositories = yield* asPersistence(
+					repo.getRepositoriesByIds(
+						orgId,
+						stored.map((commit) => commit.repositoryId),
+					),
+				)
+				const repoNameById = new Map(repositories.map((r) => [r.id, r.fullName]))
+				const details = stored.map((commit) =>
+					detailFromCommit(commit, repoNameById.get(commit.repositoryId) ?? ""),
+				)
+
+				// 2. Probe the misses, bounded. Each probe reuses the singular path so
+				//    negative caching and persistence behave identically.
+				const storedShas = new Set(stored.map((commit) => commit.sha))
+				const missing = shas.filter((sha) => !storedShas.has(sha)).slice(0, BULK_PROBE_LIMIT)
+				yield* Effect.annotateCurrentSpan({
+					"vcs.commit.stored_hits": stored.length,
+					"vcs.commit.probed": missing.length,
+				})
+
+				const probed = yield* Effect.forEach(
+					missing,
+					// A miss is the normal case for an unconnected repo — never fail the batch.
+					(sha) => resolveCommitDetail(orgId, sha).pipe(Effect.option),
+					{ concurrency: BULK_PROBE_CONCURRENCY },
+				)
+
+				return [...details, ...probed.filter(Option.isSome).map((option) => option.value)]
+			})
+
+			return { resolveCommitDetail, resolveCommitDetails } satisfies VcsCommitServiceShape
 		}),
 	},
 ) {

--- a/apps/api/src/services/integrations/vcs/VcsRepository.ts
+++ b/apps/api/src/services/integrations/vcs/VcsRepository.ts
@@ -395,6 +395,31 @@ export class VcsRepository extends Context.Service<VcsRepository>()("@maple/api/
 			return Option.some(yield* decodeOne("vcs_repositories", row.value, rowToRepo))
 		})
 
+		// Bulk sibling of getRepositoryById. The services table resolves a whole
+		// page of deploy rows at once; issuing one read per repository would turn
+		// a single request into N outbound calls, which is the dominant driver of
+		// Postgres latency on this worker.
+		const getRepositoriesByIds = Effect.fn("VcsRepository.getRepositoriesByIds")(function* (
+			orgId: OrgId,
+			repositoryIds: ReadonlyArray<VcsRepositoryId>,
+		) {
+			if (repositoryIds.length === 0) return [] as ReadonlyArray<VcsRepo>
+			const rows = yield* database
+				.execute((db) =>
+					db
+						.select()
+						.from(vcsRepositories)
+						.where(
+							and(
+								eq(vcsRepositories.orgId, orgId),
+								inArray(vcsRepositories.id, [...new Set(repositoryIds)]),
+							),
+						),
+				)
+				.pipe(Effect.mapError(toPersistenceError))
+			return yield* Effect.forEach(rows, (row) => decodeOne("vcs_repositories", row, rowToRepo))
+		})
+
 		// Persist the installation's repositories. Takes the resolved installation
 		// (not raw ids) so org/provider/internal-installation-id all come from one
 		// entity — the rows link to it by our internal `installationId`.
@@ -645,6 +670,25 @@ export class VcsRepository extends Context.Service<VcsRepository>()("@maple/api/
 			const row = Option.fromNullishOr(rows[0])
 			if (Option.isNone(row)) return Option.none<VcsCommit>()
 			return Option.some(yield* decodeOne("vcs_commits", row.value, rowToCommit))
+		})
+
+		// Bulk sibling of findCommitBySha, for resolving a whole table of deploy
+		// rows in one read instead of one per SHA. Unknown SHAs are simply absent
+		// from the result — callers fall back to a provider probe for those.
+		const findCommitsByShas = Effect.fn("VcsRepository.findCommitsByShas")(function* (
+			orgId: OrgId,
+			shas: ReadonlyArray<GitCommitSha>,
+		) {
+			if (shas.length === 0) return [] as ReadonlyArray<VcsCommit>
+			const rows = yield* database
+				.execute((db) =>
+					db
+						.select()
+						.from(vcsCommits)
+						.where(and(eq(vcsCommits.orgId, orgId), inArray(vcsCommits.sha, [...new Set(shas)]))),
+				)
+				.pipe(Effect.mapError(toPersistenceError))
+			return yield* Effect.forEach(rows, (row) => decodeOne("vcs_commits", row, rowToCommit))
 		})
 
 		// ---- Branches -----------------------------------------------------
@@ -934,6 +978,7 @@ export class VcsRepository extends Context.Service<VcsRepository>()("@maple/api/
 			listRepositoriesByInstallation,
 			resolveRepository,
 			getRepositoryById,
+			getRepositoriesByIds,
 			upsertRepositories,
 			markRepositoryRemoved,
 			purgeRepository,
@@ -941,6 +986,7 @@ export class VcsRepository extends Context.Service<VcsRepository>()("@maple/api/
 			markRepoSyncError,
 			upsertCommits,
 			findCommitBySha,
+			findCommitsByShas,
 			upsertBranches,
 			getOrCreateBranch,
 			listBranchesByRepository,

--- a/apps/api/src/services/integrations/vcs/__tests__/VcsCommitService.test.ts
+++ b/apps/api/src/services/integrations/vcs/__tests__/VcsCommitService.test.ts
@@ -262,3 +262,103 @@ describe("VcsCommitService.resolveCommitDetail", () => {
 		}).pipe(Effect.provide(commitLayer(testDb, layer)))
 	})
 })
+
+describe("VcsCommitService.resolveCommitDetails", () => {
+	// Seeds `count` stored commits (sha = <hexDigit> repeated 40x) under one repo.
+	const seedCommits = (repo: VcsRepo, orgId: OrgId, shas: ReadonlyArray<string>) =>
+		Effect.gen(function* () {
+			yield* seed(repo, orgId, [{ externalRepoId: "7", name: "repo" }])
+			const r = expectSome(yield* repo.resolveRepository(orgId, "github", "7"))
+			yield* repo.upsertCommits(
+				r,
+				shas.map((sha) => ({
+					sha,
+					message: `msg ${sha.slice(0, 4)}\n\nbody`,
+					authorName: "Stored Author",
+					authorEmail: "s@example.com",
+					authorLogin: "storedlogin",
+					authorAvatarUrl: null,
+					authoredAt: 1000,
+					committedAt: 2000,
+					htmlUrl: `https://github.com/octo/repo/commit/${sha}`,
+				})),
+			)
+		})
+
+	it.effect("resolves every stored SHA without touching the provider", () => {
+		const testDb = createTestDb(trackedDbs)
+		const { layer, calls } = routedHttp(() => false)
+		const SHAS = ["a", "b", "c"].map((c) => c.repeat(40))
+		return Effect.gen(function* () {
+			const svc = yield* VcsCommitService
+			const repo = yield* VcsRepository
+			const orgId = asOrgId("org_test")
+			yield* seedCommits(repo, orgId, SHAS)
+
+			const details = yield* svc.resolveCommitDetails(orgId, SHAS)
+			assert.strictEqual(details.length, 3)
+			assert.deepStrictEqual(details.map((d) => d.sha).toSorted(), [...SHAS].toSorted())
+			assert.ok(details.every((d) => d.resolved === "stored"))
+			assert.strictEqual(details[0]!.repoFullName, "octo/repo")
+			// The whole batch must be two reads, not one per SHA.
+			assert.strictEqual(calls.commitGets, 0)
+		}).pipe(Effect.provide(commitLayer(testDb, layer)))
+	})
+
+	it.effect("drops unresolvable SHAs instead of failing the batch", () => {
+		const testDb = createTestDb(trackedDbs)
+		// Nothing resolves at the provider, so the unknown SHA 404s.
+		const { layer } = routedHttp(() => false)
+		const STORED = "a".repeat(40)
+		return Effect.gen(function* () {
+			const svc = yield* VcsCommitService
+			const repo = yield* VcsRepository
+			const orgId = asOrgId("org_test")
+			yield* seedCommits(repo, orgId, [STORED])
+
+			const details = yield* svc.resolveCommitDetails(orgId, [
+				STORED,
+				"f".repeat(40), // valid shape, no repo has it
+				"not-a-sha", // invalid shape
+				"", // empty
+			])
+			assert.deepStrictEqual(
+				details.map((d) => d.sha),
+				[STORED],
+			)
+		}).pipe(Effect.provide(commitLayer(testDb, layer)))
+	})
+
+	it.effect("dedupes repeated SHAs", () => {
+		const testDb = createTestDb(trackedDbs)
+		const { layer } = routedHttp(() => false)
+		const SHA = "a".repeat(40)
+		return Effect.gen(function* () {
+			const svc = yield* VcsCommitService
+			const repo = yield* VcsRepository
+			const orgId = asOrgId("org_test")
+			yield* seedCommits(repo, orgId, [SHA])
+
+			const details = yield* svc.resolveCommitDetails(orgId, [SHA, SHA, SHA])
+			assert.strictEqual(details.length, 1)
+		}).pipe(Effect.provide(commitLayer(testDb, layer)))
+	})
+
+	it.effect("caps how many unknown SHAs it probes against the provider", () => {
+		const testDb = createTestDb(trackedDbs)
+		// Everything resolves upstream, so only the cap limits the probe count.
+		const { layer, calls } = routedHttp(() => true)
+		// 12 distinct valid SHAs, none stored — above the BULK_PROBE_LIMIT of 8.
+		const SHAS = "0123456789ab".split("").map((c) => c.repeat(40))
+		return Effect.gen(function* () {
+			const svc = yield* VcsCommitService
+			const repo = yield* VcsRepository
+			const orgId = asOrgId("org_test")
+			yield* seed(repo, orgId, [{ externalRepoId: "7", name: "repo" }])
+
+			const details = yield* svc.resolveCommitDetails(orgId, SHAS)
+			assert.strictEqual(details.length, 8)
+			assert.strictEqual(calls.commitGets, 8)
+		}).pipe(Effect.provide(commitLayer(testDb, layer)))
+	})
+})

--- a/apps/web/src/api/warehouse/effect-utils.ts
+++ b/apps/web/src/api/warehouse/effect-utils.ts
@@ -1,5 +1,6 @@
 import {
 	TinybirdDateTime,
+	QueryEngineExecuteBatchRequest,
 	QueryEngineExecuteRequest,
 	type QueryEngineExecuteResponse,
 	type FacetItem,
@@ -9,7 +10,8 @@ import {
 import { Effect, Schema } from "effect"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
-import { mapleApiClientLayer, mapleApiV2ClientLayer } from "@/lib/registry"
+import { mapleApiClientLayer, mapleApiV2ClientLayer, mapleRuntime } from "@/lib/registry"
+import { makeExecuteBatcher } from "./execute-batcher"
 
 export const WarehouseDateTimeString = TinybirdDateTime
 
@@ -181,11 +183,30 @@ export function invalidWarehouseInput(
 	)
 }
 
+// One process-wide batcher: coalescing only helps if every caller shares it.
+const executeBatcher = makeExecuteBatcher((requests) =>
+	mapleRuntime.runPromise(
+		Effect.gen(function* () {
+			const client = yield* MapleApiAtomClient
+			const response = yield* client.queryEngine.executeBatch({
+				payload: new QueryEngineExecuteBatchRequest({ requests }),
+			})
+			return response.results
+		}).pipe(
+			Effect.withSpan("QueryEngine.executeBatch", {
+				attributes: { "query.batch_size": requests.length },
+			}),
+		),
+	),
+)
+
 const executeQueryEngineEffect = Effect.fn("QueryEngine.execute")(function* (
 	payload: QueryEngineExecuteRequest,
 ) {
-	const client = yield* MapleApiAtomClient
-	return yield* client.queryEngine.execute({ payload })
+	return yield* Effect.tryPromise({
+		try: () => executeBatcher.enqueue(payload),
+		catch: (cause) => cause,
+	})
 })
 
 // ---------------------------------------------------------------------------
@@ -224,10 +245,11 @@ export function executeQueryEngine(
 ): Effect.Effect<QueryEngineExecuteResponse, WarehouseApiError | BackendError> {
 	return Effect.gen(function* () {
 		yield* Effect.annotateCurrentSpan("query.operation", operation)
+		// The client layer comes from `mapleRuntime` inside the batcher, so no
+		// `Effect.provide` here — this fiber only awaits the batch's promise.
 		return yield* executeQueryEngineEffect(payload)
 	}).pipe(
 		Effect.withSpan(operation),
-		Effect.provide(mapleApiClientLayer),
 		Effect.mapError((cause) => normalizeWarehouseError(operation, cause)),
 	)
 }

--- a/apps/web/src/api/warehouse/execute-batcher.test.ts
+++ b/apps/web/src/api/warehouse/execute-batcher.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest"
+import {
+	QueryEngineExecuteRequest,
+	QUERY_ENGINE_BATCH_MAX,
+	type QueryEngineBatchOutcome,
+} from "@maple/query-engine"
+import { makeExecuteBatcher, type SendExecuteBatch } from "./execute-batcher"
+
+// The batcher never inspects the payload, so the cheapest valid query will do.
+const request = () =>
+	new QueryEngineExecuteRequest({
+		startTime: "2026-08-01 00:00:00",
+		endTime: "2026-08-01 01:00:00",
+		query: { kind: "count", source: "logs" },
+	})
+
+const countOutcome = (total: number): QueryEngineBatchOutcome => ({
+	outcome: "success",
+	result: { kind: "count", source: "logs", data: { total } },
+})
+
+/** Records each batch's size and replies with per-index outcomes. */
+const recordingSend = (
+	reply: (requests: ReadonlyArray<QueryEngineExecuteRequest>) => ReadonlyArray<QueryEngineBatchOutcome>,
+) => {
+	const batches: Array<number> = []
+	const send: SendExecuteBatch = (requests) => {
+		batches.push(requests.length)
+		return Promise.resolve(reply(requests))
+	}
+	return { send, batches }
+}
+
+describe("makeExecuteBatcher", () => {
+	it("coalesces concurrent queries into a single request", async () => {
+		const { send, batches } = recordingSend((requests) => requests.map((_, index) => countOutcome(index)))
+		const batcher = makeExecuteBatcher(send, 1)
+
+		const responses = await Promise.all([
+			batcher.enqueue(request()),
+			batcher.enqueue(request()),
+			batcher.enqueue(request()),
+		])
+
+		expect(batches).toEqual([3])
+		expect(responses.map((r) => (r.result.kind === "count" ? r.result.data.total : -1))).toEqual([
+			0, 1, 2,
+		])
+	})
+
+	it("settles each caller from its own positional outcome", async () => {
+		const { send } = recordingSend((requests) =>
+			requests.map((_, index) =>
+				index === 1
+					? ({
+							outcome: "failure",
+							error: {
+								_tag: "@maple/http/errors/QueryEngineTimeoutError",
+								message: "too slow",
+							},
+						} satisfies QueryEngineBatchOutcome)
+					: countOutcome(index),
+			),
+		)
+		const batcher = makeExecuteBatcher(send, 1)
+
+		const settled = await Promise.allSettled([
+			batcher.enqueue(request()),
+			batcher.enqueue(request()),
+			batcher.enqueue(request()),
+		])
+
+		// One failing query must not take its siblings down with it.
+		expect(settled.map((s) => s.status)).toEqual(["fulfilled", "rejected", "fulfilled"])
+		const rejected = settled[1]
+		if (rejected?.status !== "rejected") throw new Error("expected a rejection")
+		// The server's tag survives, so normalizeWarehouseError passes it through.
+		expect(rejected.reason).toEqual({
+			_tag: "@maple/http/errors/QueryEngineTimeoutError",
+			message: "too slow",
+		})
+	})
+
+	it("fails every caller in the batch when the request itself fails", async () => {
+		const cause = new Error("transport failed")
+		const batcher = makeExecuteBatcher(() => Promise.reject(cause), 1)
+
+		const settled = await Promise.allSettled([batcher.enqueue(request()), batcher.enqueue(request())])
+
+		expect(settled.map((s) => s.status)).toEqual(["rejected", "rejected"])
+		for (const result of settled) {
+			if (result.status !== "rejected") throw new Error("expected a rejection")
+			expect(result.reason).toBe(cause)
+		}
+	})
+
+	it("splits past the batch cap instead of dropping queries", async () => {
+		const { send, batches } = recordingSend((requests) => requests.map(() => countOutcome(1)))
+		const batcher = makeExecuteBatcher(send, 1)
+		const overflow = 3
+
+		const responses = await Promise.all(
+			Array.from({ length: QUERY_ENGINE_BATCH_MAX + overflow }, () => batcher.enqueue(request())),
+		)
+
+		expect(responses).toHaveLength(QUERY_ENGINE_BATCH_MAX + overflow)
+		expect(batches).toEqual([QUERY_ENGINE_BATCH_MAX, overflow])
+	})
+
+	it("does not hold a query for a batch that already went out", async () => {
+		const { send, batches } = recordingSend((requests) => requests.map(() => countOutcome(1)))
+		const batcher = makeExecuteBatcher(send, 1)
+
+		await batcher.enqueue(request())
+		await batcher.enqueue(request())
+
+		expect(batches).toEqual([1, 1])
+	})
+})

--- a/apps/web/src/api/warehouse/execute-batcher.ts
+++ b/apps/web/src/api/warehouse/execute-batcher.ts
@@ -1,0 +1,98 @@
+import {
+	QueryEngineExecuteRequest,
+	QueryEngineExecuteResponse,
+	QUERY_ENGINE_BATCH_MAX,
+	type QueryEngineBatchOutcome,
+} from "@maple/query-engine"
+
+/**
+ * Coalesces `/api/query-engine/execute` calls into `/execute-batch`.
+ *
+ * Every warehouse module funnels through one choke point, and each atom runs on
+ * its own fiber, so a render pass used to emit one POST per query — each with
+ * its own CORS preflight, against a worker pinned to us-east-1. A dashboard
+ * could open dozens of round trips before painting anything.
+ *
+ * A *timer* window (not `queueMicrotask`) is what makes this work: atoms mount
+ * across separate React commits, and a microtask can't span a commit boundary,
+ * so most calls would still go out alone.
+ *
+ * Deliberately NOT `Effect.request`/`RequestResolver` — those batch within a
+ * single fiber's execution graph, and these callers are on unrelated fibers.
+ */
+
+/** How long to hold a query waiting for siblings. Long enough for one React commit. */
+export const EXECUTE_BATCH_WINDOW_MS = 15
+
+/** Issues one batch request. Injected so tests don't need the API client. */
+export type SendExecuteBatch = (
+	requests: ReadonlyArray<QueryEngineExecuteRequest>,
+) => Promise<ReadonlyArray<QueryEngineBatchOutcome>>
+
+interface PendingExecute {
+	readonly payload: QueryEngineExecuteRequest
+	readonly resolve: (response: QueryEngineExecuteResponse) => void
+	readonly reject: (cause: unknown) => void
+}
+
+export interface ExecuteBatcher {
+	readonly enqueue: (payload: QueryEngineExecuteRequest) => Promise<QueryEngineExecuteResponse>
+}
+
+export const makeExecuteBatcher = (
+	send: SendExecuteBatch,
+	windowMs: number = EXECUTE_BATCH_WINDOW_MS,
+): ExecuteBatcher => {
+	let pending: Array<PendingExecute> = []
+	let flushHandle: ReturnType<typeof setTimeout> | undefined
+
+	const schedule = () => {
+		if (flushHandle !== undefined) return
+		flushHandle = setTimeout(flush, windowMs)
+	}
+
+	const flush = () => {
+		if (flushHandle !== undefined) {
+			clearTimeout(flushHandle)
+			flushHandle = undefined
+		}
+		if (pending.length === 0) return
+
+		const batch = pending.slice(0, QUERY_ENGINE_BATCH_MAX)
+		// Anything over the cap goes out as the next batch rather than being dropped.
+		pending = pending.slice(QUERY_ENGINE_BATCH_MAX)
+		if (pending.length > 0) schedule()
+
+		send(batch.map((entry) => entry.payload)).then(
+			(results) => {
+				batch.forEach((entry, index) => {
+					const outcome = results[index]
+					if (outcome === undefined) {
+						entry.reject(new Error("Batch response was missing a result for this query."))
+					} else if (outcome.outcome === "failure") {
+						// Carries the server's original `_tag`, so normalizeWarehouseError
+						// passes it through and the UI keeps its specific error copy.
+						entry.reject(outcome.error)
+					} else {
+						entry.resolve(new QueryEngineExecuteResponse({ result: outcome.result }))
+					}
+				})
+			},
+			(cause: unknown) => {
+				// Whole-request failure (auth, transport, decode) — every query in
+				// this batch failed for the same reason.
+				for (const entry of batch) entry.reject(cause)
+			},
+		)
+	}
+
+	return {
+		enqueue: (payload) =>
+			new Promise<QueryEngineExecuteResponse>((resolve, reject) => {
+				pending.push({ payload, resolve, reject })
+				// A full batch has nothing to gain from waiting out the window.
+				if (pending.length >= QUERY_ENGINE_BATCH_MAX) flush()
+				else schedule()
+			}),
+	}
+}

--- a/apps/web/src/components/services/services-table.tsx
+++ b/apps/web/src/components/services/services-table.tsx
@@ -26,7 +26,8 @@ import { cn } from "@maple/ui/lib/utils"
 import { formatErrorRate } from "@maple/ui/lib/format"
 import {
 	CommitShaHoverCard,
-	commitQueryAtom,
+	commitsQueryAtom,
+	commitsQueryKey,
 	firstLine,
 	isResolvableSha,
 } from "@/components/vcs/commit-sha-hover-card"
@@ -233,16 +234,67 @@ function deployMetaLine(text: string) {
 }
 
 /**
- * Message-first deploy lines: subject line on top (once the deduped, cached
- * per-sha lookup resolves), `sha · age` demoted underneath. While unresolved —
- * or when the reference isn't a resolvable sha — the sha IS the headline, so
- * the meta line carries only the age instead of repeating it.
+ * Commit messages for every SHA the table is showing, resolved in one request
+ * by `ServicesTable` (see `commitsQueryAtom`). Empty map = not resolved yet, or
+ * no commits — either way rows fall back to showing the raw SHA.
+ */
+const CommitMessagesContext = React.createContext<ReadonlyMap<string, string>>(new Map())
+
+const EMPTY_COMMIT_MESSAGES: ReadonlyMap<string, string> = new Map()
+
+/**
+ * Resolves every deploy SHA the table is about to render in ONE request, rather
+ * than letting each row subscribe to its own per-SHA atom. Rows previously fired
+ * a request *and* a CORS preflight each, so a 30-service fleet opened ~60 round
+ * trips on mount. Never blocks paint: until it resolves, rows show the raw SHA.
+ */
+function CommitMessagesProvider({
+	services,
+	children,
+}: {
+	services: ReadonlyArray<ServiceOverview>
+	children: React.ReactNode
+}) {
+	const shasKey = React.useMemo(
+		() =>
+			commitsQueryKey(
+				services.flatMap((service) => {
+					const sha = deriveDeployInfo(service.commits)?.sha
+					return sha === undefined ? [] : [sha]
+				}),
+			),
+		[services],
+	)
+	// No resolvable SHAs on screen — don't subscribe at all. Mounting the atom
+	// with an empty key would send a request for zero commits, which the
+	// endpoint rejects (`shas` is minLength 1).
+	if (shasKey === "") return <>{children}</>
+	return <ResolvedCommitMessages shasKey={shasKey}>{children}</ResolvedCommitMessages>
+}
+
+function ResolvedCommitMessages({ shasKey, children }: { shasKey: string; children: React.ReactNode }) {
+	const result = useAtomValue(commitsQueryAtom(shasKey))
+	const messages = React.useMemo(
+		() =>
+			Result.isSuccess(result)
+				? new Map(result.value.commits.map((commit) => [commit.sha, firstLine(commit.message)]))
+				: EMPTY_COMMIT_MESSAGES,
+		[result],
+	)
+	return <CommitMessagesContext.Provider value={messages}>{children}</CommitMessagesContext.Provider>
+}
+
+/**
+ * Message-first deploy lines: subject line on top (once the table's single bulk
+ * lookup resolves), `sha · age` demoted underneath. While unresolved — or when
+ * the reference isn't a resolvable sha — the sha IS the headline, so the meta
+ * line carries only the age instead of repeating it.
  */
 function ResolvedDeployLines({ sha, firstSeen, stateLine }: DeployLinesProps) {
-	const result = useAtomValue(commitQueryAtom(sha))
+	const messages = React.useContext(CommitMessagesContext)
 	const shortSha = truncateCommitSha(sha)
 	const age = firstSeen !== "" ? formatRelativeTimeOrDate(firstSeen) : ""
-	const message = Result.isSuccess(result) ? firstLine(result.value.message) : ""
+	const message = messages.get(sha) ?? ""
 	return (
 		<>
 			<CommitShaHoverCard sha={sha} className="min-w-0 max-w-full truncate text-xs text-foreground">
@@ -622,158 +674,164 @@ export function ServicesTable({ filters }: ServicesTableProps) {
 			}
 
 			return (
-				<div className={`space-y-4 transition-opacity ${combinedResult.waiting ? "opacity-60" : ""}`}>
-					{/* Desktop: full metrics table. Below md the fixed-width columns and
+				<CommitMessagesProvider services={services}>
+					<div
+						className={`space-y-4 transition-opacity ${combinedResult.waiting ? "opacity-60" : ""}`}
+					>
+						{/* Desktop: full metrics table. Below md the fixed-width columns and
 				    in-cell sparklines force horizontal scroll, so we swap to a list. */}
-					<div className="hidden md:block rounded-md border overflow-auto">
-						{/* Fixed layout: the metric columns keep their set widths and the
+						<div className="hidden md:block rounded-md border overflow-auto">
+							{/* Fixed layout: the metric columns keep their set widths and the
 						    Service column absorbs whatever remains, truncating long names —
 						    so the table always fits the viewport instead of scrolling
 						    horizontally. */}
-						<Table aria-label="Services" className="w-full table-fixed">
-							<TableHeader>
-								<TableRow>
-									{/* Explicit width so the fixed layout scales every column
+							<Table aria-label="Services" className="w-full table-fixed">
+								<TableHeader>
+									<TableRow>
+										{/* Explicit width so the fixed layout scales every column
 									    proportionally — leaving Service auto would let the fixed
 									    metric columns squeeze it to nothing on narrow viewports. */}
-									<TableHead>Service</TableHead>
-									<TableHead className="hidden lg:table-cell w-[6%]">P50</TableHead>
-									<TableHead className="w-[9%]">P95</TableHead>
-									<TableHead className="hidden lg:table-cell w-[7%]">P99</TableHead>
-									<TableHead className="w-[12%]">Error Rate</TableHead>
-									<TableHead className="hidden md:table-cell w-[12%]">Throughput</TableHead>
-									<TableHead className="hidden lg:table-cell w-[18%]">
-										Last deploy
-									</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{services.length === 0 ? (
-									<TableRow>
-										<TableCell colSpan={7} className="h-24 text-center">
-											No services found
-										</TableCell>
+										<TableHead>Service</TableHead>
+										<TableHead className="hidden lg:table-cell w-[6%]">P50</TableHead>
+										<TableHead className="w-[9%]">P95</TableHead>
+										<TableHead className="hidden lg:table-cell w-[7%]">P99</TableHead>
+										<TableHead className="w-[12%]">Error Rate</TableHead>
+										<TableHead className="hidden md:table-cell w-[12%]">
+											Throughput
+										</TableHead>
+										<TableHead className="hidden lg:table-cell w-[18%]">
+											Last deploy
+										</TableHead>
 									</TableRow>
-								) : (
-									groups.map(([environment, envServices]) => (
-										<React.Fragment key={environment}>
-											<TableRow className="bg-muted/30 hover:bg-muted/30">
-												<TableCell colSpan={7} className="py-2">
-													<div className="flex items-center gap-2">
-														<EnvironmentBadge environment={environment} />
-														<span className="text-xs text-muted-foreground">
-															{envServices.length}{" "}
-															{envServices.length === 1
-																? "service"
-																: "services"}
-														</span>
-													</div>
-												</TableCell>
-											</TableRow>
-											{envServices.map(rowFor)}
-										</React.Fragment>
-									))
-								)}
-							</TableBody>
-						</Table>
-					</div>
-
-					{/* Mobile: stacked, tap-to-drill list. Grouped by environment to
-				    match the desktop table; metrics collapse to a tight mono line. */}
-					<div className="overflow-hidden rounded-md border md:hidden">
-						{services.length === 0 ? (
-							<div className="p-6 text-center text-sm text-muted-foreground">
-								No services found
-							</div>
-						) : (
-							groups.map(([environment, envServices]) => (
-								<div key={environment}>
-									<div className="flex items-center gap-2 border-b bg-muted/30 px-3 py-2">
-										<EnvironmentBadge environment={environment} />
-										<span className="text-xs text-muted-foreground">
-											{envServices.length}{" "}
-											{envServices.length === 1 ? "service" : "services"}
-										</span>
-									</div>
-									{envServices.map((service: ServiceOverview) => {
-										const health = healthFor(service)
-										return (
-											<Link
-												key={`${service.serviceName}-${service.serviceNamespace}-${service.environment}`}
-												to="/services/$serviceName"
-												params={{ serviceName: service.serviceName }}
-												search={serviceDetailSearch(filters, service.environment)}
-												className="flex min-h-11 items-center justify-between gap-3 border-b px-3 py-2.5 last:border-b-0 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
-											>
-												<div className="min-w-0 flex-1">
-													<div className="flex items-center gap-1.5 text-sm font-medium text-primary">
-														<ServiceDot serviceName={service.serviceName} />
-														<span className="truncate">
-															{service.serviceName}
-														</span>
-														<HealthDot health={health} />
-													</div>
-													{service.serviceNamespace ? (
-														<div className="truncate text-xs text-muted-foreground">
-															{service.serviceNamespace}
+								</TableHeader>
+								<TableBody>
+									{services.length === 0 ? (
+										<TableRow>
+											<TableCell colSpan={7} className="h-24 text-center">
+												No services found
+											</TableCell>
+										</TableRow>
+									) : (
+										groups.map(([environment, envServices]) => (
+											<React.Fragment key={environment}>
+												<TableRow className="bg-muted/30 hover:bg-muted/30">
+													<TableCell colSpan={7} className="py-2">
+														<div className="flex items-center gap-2">
+															<EnvironmentBadge environment={environment} />
+															<span className="text-xs text-muted-foreground">
+																{envServices.length}{" "}
+																{envServices.length === 1
+																	? "service"
+																	: "services"}
+															</span>
 														</div>
-													) : null}
-													<div className="mt-1 flex items-center gap-3 font-mono text-xs tabular-nums">
-														<span>
-															<span className="text-muted-foreground/60">
-																P99{" "}
-															</span>
-															<LatencyValue
-																ms={service.p99LatencyMs}
-																scale="p99"
-															/>
-														</span>
-														<span>
-															<span className="text-muted-foreground/60">
-																Thru{" "}
-															</span>
-															<span className="text-foreground">
-																{service.hasSampling ? "~" : ""}
-																{formatThroughput(service.throughput)}
-															</span>
-														</span>
-													</div>
-												</div>
-												<div className="shrink-0 text-right">
-													<div
-														className={cn(
-															"font-mono text-sm font-semibold tabular-nums",
-															errorRateToneClass(service.errorRate),
-														)}
-													>
-														{formatErrorRate(service.errorRate)}
-													</div>
-													<div className="text-[10px] uppercase tracking-wider text-muted-foreground/60">
-														err
-													</div>
-												</div>
-											</Link>
-										)
-									})}
-								</div>
-							))
-						)}
-					</div>
+													</TableCell>
+												</TableRow>
+												{envServices.map(rowFor)}
+											</React.Fragment>
+										))
+									)}
+								</TableBody>
+							</Table>
+						</div>
 
-					<div className="flex items-center justify-between text-sm text-muted-foreground">
-						<span>
-							Showing {services.length} {healthFilter ?? ""}{" "}
-							{services.length === 1 ? "service" : "services"}
-						</span>
-						{(unhealthyCount > 0 || degradedCount > 0) && (
-							<span className="text-xs">
-								{unhealthyCount > 0 ? `${unhealthyCount} unhealthy` : null}
-								{unhealthyCount > 0 && degradedCount > 0 ? " · " : null}
-								{degradedCount > 0 ? `${degradedCount} degraded` : null}
+						{/* Mobile: stacked, tap-to-drill list. Grouped by environment to
+				    match the desktop table; metrics collapse to a tight mono line. */}
+						<div className="overflow-hidden rounded-md border md:hidden">
+							{services.length === 0 ? (
+								<div className="p-6 text-center text-sm text-muted-foreground">
+									No services found
+								</div>
+							) : (
+								groups.map(([environment, envServices]) => (
+									<div key={environment}>
+										<div className="flex items-center gap-2 border-b bg-muted/30 px-3 py-2">
+											<EnvironmentBadge environment={environment} />
+											<span className="text-xs text-muted-foreground">
+												{envServices.length}{" "}
+												{envServices.length === 1 ? "service" : "services"}
+											</span>
+										</div>
+										{envServices.map((service: ServiceOverview) => {
+											const health = healthFor(service)
+											return (
+												<Link
+													key={`${service.serviceName}-${service.serviceNamespace}-${service.environment}`}
+													to="/services/$serviceName"
+													params={{ serviceName: service.serviceName }}
+													search={serviceDetailSearch(filters, service.environment)}
+													className="flex min-h-11 items-center justify-between gap-3 border-b px-3 py-2.5 last:border-b-0 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+												>
+													<div className="min-w-0 flex-1">
+														<div className="flex items-center gap-1.5 text-sm font-medium text-primary">
+															<ServiceDot serviceName={service.serviceName} />
+															<span className="truncate">
+																{service.serviceName}
+															</span>
+															<HealthDot health={health} />
+														</div>
+														{service.serviceNamespace ? (
+															<div className="truncate text-xs text-muted-foreground">
+																{service.serviceNamespace}
+															</div>
+														) : null}
+														<div className="mt-1 flex items-center gap-3 font-mono text-xs tabular-nums">
+															<span>
+																<span className="text-muted-foreground/60">
+																	P99{" "}
+																</span>
+																<LatencyValue
+																	ms={service.p99LatencyMs}
+																	scale="p99"
+																/>
+															</span>
+															<span>
+																<span className="text-muted-foreground/60">
+																	Thru{" "}
+																</span>
+																<span className="text-foreground">
+																	{service.hasSampling ? "~" : ""}
+																	{formatThroughput(service.throughput)}
+																</span>
+															</span>
+														</div>
+													</div>
+													<div className="shrink-0 text-right">
+														<div
+															className={cn(
+																"font-mono text-sm font-semibold tabular-nums",
+																errorRateToneClass(service.errorRate),
+															)}
+														>
+															{formatErrorRate(service.errorRate)}
+														</div>
+														<div className="text-[10px] uppercase tracking-wider text-muted-foreground/60">
+															err
+														</div>
+													</div>
+												</Link>
+											)
+										})}
+									</div>
+								))
+							)}
+						</div>
+
+						<div className="flex items-center justify-between text-sm text-muted-foreground">
+							<span>
+								Showing {services.length} {healthFilter ?? ""}{" "}
+								{services.length === 1 ? "service" : "services"}
 							</span>
-						)}
+							{(unhealthyCount > 0 || degradedCount > 0) && (
+								<span className="text-xs">
+									{unhealthyCount > 0 ? `${unhealthyCount} unhealthy` : null}
+									{unhealthyCount > 0 && degradedCount > 0 ? " · " : null}
+									{degradedCount > 0 ? `${degradedCount} degraded` : null}
+								</span>
+							)}
+						</div>
 					</div>
-				</div>
+				</CommitMessagesProvider>
 			)
 		})
 		.render()

--- a/apps/web/src/components/vcs/commit-sha-hover-card.tsx
+++ b/apps/web/src/components/vcs/commit-sha-hover-card.tsx
@@ -161,6 +161,24 @@ export const commitQueryAtom = Atom.family((sha: string) =>
 	}),
 )
 
+/**
+ * Bulk sibling of `commitQueryAtom`, for list views that render one deploy per
+ * row. One request per row also means one CORS *preflight* per row, so a table
+ * of N services used to cost 2N round trips to a worker pinned in us-east-1.
+ * Keyed on the sorted, deduped SHA list so a re-render with the same rows
+ * reuses the same atom (and its cached result).
+ */
+export const commitsQueryAtom = Atom.family((shasKey: string) =>
+	MapleApiAtomClient.query("integrations", "vcsCommitDetails", {
+		query: { shas: shasKey },
+		timeToLive: COMMIT_DETAIL_TTL_MS,
+	}),
+)
+
+/** Canonical `commitsQueryAtom` key for a set of SHAs (deduped + sorted). */
+export const commitsQueryKey = (shas: Iterable<string>): string =>
+	[...new Set(shas)].filter(isResolvableSha).sort().join(",")
+
 // Renders nothing — it exists only to mount (and thus run) the query early.
 function CommitPrefetch({ sha }: { sha: string }) {
 	useAtomValue(commitQueryAtom(sha))

--- a/packages/domain/src/http/integrations.ts
+++ b/packages/domain/src/http/integrations.ts
@@ -688,6 +688,20 @@ export class VcsCommitDetailResponse extends Schema.Class<VcsCommitDetailRespons
 	},
 ) {}
 
+/**
+ * Bulk sibling of VcsCommitDetailResponse, for list views that show one deploy
+ * per row. Unresolvable SHAs are absent from `commits` rather than raising —
+ * the caller matches by `sha` and falls back to rendering the raw reference.
+ */
+export class VcsCommitDetailsResponse extends Schema.Class<VcsCommitDetailsResponse>(
+	"VcsCommitDetailsResponse",
+)({
+	commits: Schema.Array(VcsCommitDetailResponse),
+}) {}
+
+/** Upper bound on SHAs per bulk commit lookup — one page of a list view. */
+export const VCS_COMMIT_DETAILS_MAX_SHAS = 50
+
 export class IntegrationsForbiddenError extends Schema.TaggedError<IntegrationsForbiddenError>()(
 	"@maple/http/errors/IntegrationsForbiddenError",
 	{
@@ -1023,6 +1037,20 @@ export class IntegrationsApiGroup extends HttpApiGroup.make("integrations")
 				IntegrationsUpstreamError,
 				IntegrationsPersistenceError,
 			],
+		}),
+	)
+	.add(
+		// Bulk sibling of vcsCommitDetail, for list views that would otherwise
+		// issue one request (and one CORS preflight) per row. `shas` is a raw
+		// comma-separated string for the same reason `:sha` is raw above —
+		// unguarded telemetry values must reach the handler, which drops the
+		// ones it can't resolve instead of failing the whole batch.
+		HttpApiEndpoint.get("vcsCommitDetails", "/vcs/commits", {
+			query: Schema.Struct({
+				shas: Schema.String.check(Schema.isMinLength(1)),
+			}),
+			success: VcsCommitDetailsResponse,
+			error: [IntegrationsNotConnectedError, IntegrationsUpstreamError, IntegrationsPersistenceError],
 		}),
 	)
 	.prefix("/api/integrations")

--- a/packages/domain/src/http/query-engine.ts
+++ b/packages/domain/src/http/query-engine.ts
@@ -11,7 +11,13 @@ import {
 	StatusCode,
 	TraceId,
 } from "../primitives"
-import { QueryEngineExecuteRequest, QueryEngineExecuteResponse, TinybirdDateTime } from "../query-engine"
+import {
+	QueryEngineExecuteBatchRequest,
+	QueryEngineExecuteBatchResponse,
+	QueryEngineExecuteRequest,
+	QueryEngineExecuteResponse,
+	TinybirdDateTime,
+} from "../query-engine"
 import { Authorization } from "./current-tenant"
 import { warehouseHttpErrors } from "./warehouse"
 
@@ -1716,6 +1722,16 @@ export class QueryEngineApiGroup extends HttpApiGroup.make("queryEngine")
 		HttpApiEndpoint.post("execute", "/execute", {
 			payload: QueryEngineExecuteRequest,
 			success: QueryEngineExecuteResponse,
+			error: validatedQueryEndpointErrors,
+		}),
+	)
+	.add(
+		// Batched sibling of `execute`. Per-item failures ride in the SUCCESS
+		// payload (see QueryEngineBatchOutcome); the error list here is for
+		// whole-request failures only — auth, decode, a blown batch cap.
+		HttpApiEndpoint.post("executeBatch", "/execute-batch", {
+			payload: QueryEngineExecuteBatchRequest,
+			success: QueryEngineExecuteBatchResponse,
 			error: validatedQueryEndpointErrors,
 		}),
 	)

--- a/packages/domain/src/query-engine.ts
+++ b/packages/domain/src/query-engine.ts
@@ -487,6 +487,52 @@ export class QueryEngineExecuteResponse extends Schema.Class<QueryEngineExecuteR
 	result: QueryEngineResult,
 }) {}
 
+// ---- Batched execution ----------------------------------------------------
+//
+// The dashboard fans out one query per widget, and each used to be its own
+// POST — plus its own CORS preflight — against a worker pinned to us-east-1.
+// The batch endpoint collapses a render pass into a single round trip.
+
+/** Max queries per batch. Bounded so one request can't monopolize a worker. */
+export const QUERY_ENGINE_BATCH_MAX = 12
+
+/**
+ * A per-item failure. Carries the original error's `_tag` so the client can
+ * hand it straight to its existing error normalization — `@maple/http/errors/*`
+ * tags pass through untouched and keep their UI copy.
+ */
+export const QueryEngineBatchFailure = Schema.Struct({
+	_tag: Schema.String,
+	message: Schema.String,
+})
+export type QueryEngineBatchFailure = Schema.Schema.Type<typeof QueryEngineBatchFailure>
+
+/**
+ * Per-item outcome. Deliberately part of the SUCCESS type: one failing widget
+ * must not fail the other eleven queries sharing its request.
+ */
+export const QueryEngineBatchOutcome = Schema.Union([
+	Schema.Struct({ outcome: Schema.Literal("success"), result: QueryEngineResult }),
+	Schema.Struct({ outcome: Schema.Literal("failure"), error: QueryEngineBatchFailure }),
+])
+export type QueryEngineBatchOutcome = Schema.Schema.Type<typeof QueryEngineBatchOutcome>
+
+export class QueryEngineExecuteBatchRequest extends Schema.Class<QueryEngineExecuteBatchRequest>(
+	"QueryEngineExecuteBatchRequest",
+)({
+	requests: Schema.Array(QueryEngineExecuteRequest).check(
+		Schema.isMinLength(1),
+		Schema.isMaxLength(QUERY_ENGINE_BATCH_MAX),
+	),
+}) {}
+
+export class QueryEngineExecuteBatchResponse extends Schema.Class<QueryEngineExecuteBatchResponse>(
+	"QueryEngineExecuteBatchResponse",
+)({
+	/** Positionally aligned with the request's `requests`. */
+	results: Schema.Array(QueryEngineBatchOutcome),
+}) {}
+
 export const QueryEngineAlertReducer = Schema.Literals(["identity", "sum", "avg", "min", "max"]).annotate({
 	identifier: "@maple/QueryEngineAlertReducer",
 })


### PR DESCRIPTION
## Why

The services list sat on a loading skeleton for ~10s. The DevTools timing was the giveaway — **2.23s waiting for the server, 10.05s in `Queueing`** — so most of the wall time was spent before the request was even sent.

The warehouse is innocent. Bucketing `maple-api` server spans for `/api/query-engine/*` by how many requests landed in the same 5s window (Aug 4–11) gives a **flat p50**: 272ms alone, 403ms at 4–6 concurrent, 212ms at 13+. Client-side RUM (`session_events`) agrees. Adding concurrency does not slow the server down.

It was three separate client-facing round-trip problems.

### 1. No `Access-Control-Max-Age`

Without it Chrome falls back to a **5-second** preflight cache. `CLOUDFLARE_WORKER_PLACEMENT` is `{ region: "aws:us-east-1" }` (deliberate — it pins the worker next to Postgres), so from Europe a round trip measures **~165ms** (`cf-placement: remote-IAD` on a `-TXL` ray). Every expiry cost a full extra transatlantic round trip *before* the real request went out.

### 2. `Access-Control-Allow-Headers: *` does not cover `Authorization`

This is the one that made fix #1 worthless on its own. The Fetch spec deliberately excludes `Authorization` from the `*` wildcard. Browsers still **allow** the request — so nothing looks broken — but they **refuse to cache its preflight**. Since every browser call to this API is authenticated, `maxAge` was a complete no-op.

Measured in Chrome, 3 identical authenticated GETs to one URL:

| `allowedHeaders` | preflights |
| --- | --- |
| `["*"]` | 3 (one per request) |
| `["*", "Authorization"]` | **1** |

Control in the same session: a plain `x-test` custom header cached fine under `["*"]` — which is exactly what makes this easy to misdiagnose.

**These OPTIONS never reach our traces** (`HttpMiddleware.withTracerDisabledWhen()` skips `OPTIONS`), which is why the server-side data looked healthy while the browser burned its time on round trips we never recorded.

### 3. Nothing was batched

There was no batch endpoint — every query was its own `POST /execute`. And `services-table.tsx` fired one `GET /vcs/commits/:sha` **per row**, eagerly on mount, contradicting the arm-on-hover design documented in `commit-sha-hover-card.tsx`. Each SHA is a distinct URL, so each also needed its own preflight.

## What changed

- **`api-cors.ts`** — set `maxAge: 86_400` and list `Authorization` explicitly.
- **`POST /api/query-engine/execute-batch`** — `warmRoute` once for the whole batch (the documented ordering fix), concurrency 4 to match the bucket-cache fill concurrency already tuned for the Cloudflare six-connection limit, and a wall-clock deadline **shared by every item** so total time is bounded no matter how many waves run. Per-item failures ride in the *success* payload, so one bad widget can't take down the others sharing its request.
- **Client batcher** at the single choke point `executeQueryEngine`, so **no call sites changed**. A timer window rather than `queueMicrotask` — atoms mount across separate React commits and a microtask can't span one. Deliberately not `Effect.request`/`RequestResolver`: those batch within a single fiber's execution graph, and these callers are on unrelated fibers.
- **`GET /api/integrations/vcs/commits?shas=…`** plus bulk repo lookups, so a table resolves in two DB reads instead of one per row. Unresolvable SHAs are omitted rather than failing the batch; provider probes for unknown SHAs are capped.

## Verification

Ran a real stack (API + web + electric-sync on spare ports) and drove Chrome:

- `access-control-max-age: 86400` on a live worker
- Two queries coalesced into **one** `/execute-batch`, both `outcome: "success"` with live warehouse data
- One bulk commit request resolving the whole 31-service table
- **A full `/services` load issuing zero OPTIONS** — 6 API calls, every preflight served from cache

Tests: 151 api + 58 web passing. Includes a regression guard asserting both `access-control-max-age` and that `access-control-allow-headers` contains `Authorization`, plus tests for the shared batch deadline (bounded so it discriminates a shared deadline from a per-item timeout) and per-item failure isolation.

## Reviewer notes

- **The `services-table.tsx` diff looks like 342 lines but is 67 real insertions** — the rest is re-indentation from wrapping the JSX in the new provider. `git diff -w` shows the truth.
- Out of scope, and still the biggest remaining lever: the **server-side p95 tail**. Every endpoint — including trivial ones like `/api/billing/customer` (p50 92ms / p95 11.2s) and `/v2/ingest_keys` (p50 16ms / p95 12.7s) — shows a bimodal 11–17s tail uncorrelated with what the endpoint does. That's the org-config Postgres read on the hot path plus the documented dial hang. This PR reduces *exposure* to that tail by cutting request count, but does not fix it.
- Developed against `0b2721314`; rebased cleanly onto `f68f3ad60`. The two perf PRs that landed in between touch no file in this change set.

## Follow-up: batching added head-of-line blocking (second commit)

Worth calling out, because this PR creates the problem and only bounds it.

Batch delivery is **all-or-nothing** — the caller gets every result together, so a batch resolves at the speed of its slowest member. Against a per-query p50 of ~250–600ms and a **p95 of ~5s**, a large batch will often be gated by one tail query. On `/services` (2 queries) that's noise; on a dashboard grid it means every widget waits for the worst one. Eleven fast widgets blocked on one slow query is worse than the requests we saved.

The second commit holds the client cap (`QUERY_ENGINE_BATCH_MAX`) **equal to the server's fan-out concurrency** (`QE_BATCH_CONCURRENCY`, 4), so a batch is exactly one wave and can't be gated by a tail query sitting in a later wave. Both constants carry a note to keep them in step.

**That's a bound, not a fix.** The fix is to stream the outcomes as an SSE event stream so each query settles the moment it completes — one round trip, zero extra preflights, *and* progressive paint, which removes the tradeoff instead of tuning around it. It also improves failure behaviour: today a 45s client abort discards the whole batch, whereas anything already streamed stays delivered.

The pieces exist on both ends — Effect's HttpApi has first-class streaming success (`HttpApiSchema.StreamSse`, including a reserved mid-stream failure event) and `HttpApiClient` decodes it into an Effect `Stream`. The client batcher is already shaped for it: it deliberately sits outside the atom system holding a map of pending promises, so it only needs to settle them one at a time instead of all at once. That lands as its own PR, after which the cap can rise again.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788996280&installation_model_id=427786&pr_number=390&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F390&signature=97042f86f6e16bd3c8f51c00b90816aa5394c2ce27cccda880938b63a45779a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
