### PR TITLE
perf(api): hold the execute batch to one server wave

### DIFF
--- a/apps/api/src/routes/query-engine-batch.ts
+++ b/apps/api/src/routes/query-engine-batch.ts
@@ -13,13 +13,17 @@ import { Clock, Duration, Effect } from "effect"
  * Concurrency for the fan-out. Matches the bucket-cache fill concurrency, which
  * is already tuned for the Cloudflare six-connection limit — going unbounded
  * would reintroduce exactly the outbound contention `warmRoute` exists to avoid.
+ *
+ * `QUERY_ENGINE_BATCH_MAX` (the client-side cap, in @maple/domain) is held equal
+ * to this on purpose, so a batch is exactly one wave and can't be gated by a
+ * tail query in a later wave. Keep them in step until outcomes stream.
  */
 export const QE_BATCH_CONCURRENCY = 4
 
 /**
  * Wall-clock ceiling for one batch, shared by every item. The browser aborts at
- * 45s, so the response has to land before that: better to return eleven results
- * and one timeout than to have the client throw the whole batch away.
+ * 45s, so the response has to land before that: better to return the results
+ * that finished plus one timeout than to have the client throw the batch away.
  */
 export const QE_BATCH_DEADLINE_MS = 25_000
 
@@ -35,7 +39,7 @@ const timedOut = (): QueryEngineBatchOutcome => ({
  * Runs every request against a SHARED deadline, so total wall time is bounded
  * no matter how many items or waves there are. Per-item failures are returned
  * as `failure` outcomes rather than failing the effect: one bad widget must not
- * take down the eleven others sharing its request.
+ * take down the others sharing its request.
  */
 export const runQueryEngineBatch = <
 	Request,

--- a/packages/domain/src/query-engine.ts
+++ b/packages/domain/src/query-engine.ts
@@ -493,8 +493,21 @@ export class QueryEngineExecuteResponse extends Schema.Class<QueryEngineExecuteR
 // POST — plus its own CORS preflight — against a worker pinned to us-east-1.
 // The batch endpoint collapses a render pass into a single round trip.
 
-/** Max queries per batch. Bounded so one request can't monopolize a worker. */
-export const QUERY_ENGINE_BATCH_MAX = 12
+/**
+ * Max queries per batch.
+ *
+ * Deliberately equal to the server's fan-out concurrency (`QE_BATCH_CONCURRENCY`
+ * in `apps/api/src/routes/query-engine-batch.ts`), so one batch is exactly ONE
+ * wave. That matters because delivery is currently all-or-nothing: the caller
+ * gets every result together, so a batch resolves at the speed of its slowest
+ * member. Per-query p95 is ~5s against a p50 of ~250-600ms, so the more queries
+ * share a batch, the likelier one tail query gates the whole render — a batch of
+ * 12 would run three waves and would very often be gated.
+ *
+ * Raise this only once `/execute-batch` streams its outcomes (per-query events
+ * settled as they complete), which removes the all-or-nothing coupling entirely.
+ */
+export const QUERY_ENGINE_BATCH_MAX = 4
 
 /**
  * A per-item failure. Carries the original error's `_tag` so the client can
@@ -509,7 +522,7 @@ export type QueryEngineBatchFailure = Schema.Schema.Type<typeof QueryEngineBatch
 
 /**
  * Per-item outcome. Deliberately part of the SUCCESS type: one failing widget
- * must not fail the other eleven queries sharing its request.
+ * must not fail the other queries sharing its request.
  */
 export const QueryEngineBatchOutcome = Schema.Union([
 	Schema.Struct({ outcome: Schema.Literal("success"), result: QueryEngineResult }),


### PR DESCRIPTION
Follow-up to #390, which merged before this could ride along.

## Why

#390 collapsed the query-engine fan-out into `POST /execute-batch`, which cut round trips — but batch delivery is **all-or-nothing**: the caller gets every result together, so a batch resolves at the speed of its slowest member.

Against a per-query p50 of ~250–600ms and a **p95 of ~5s**, a large batch will often contain one tail query that gates everything behind it. At the merged cap of 12 — three waves at the server's fan-out concurrency of 4 — that's likely on any real dashboard. Eleven fast widgets blocked on one slow query is worse than the requests we saved.

On `/services` (2 queries) this is noise. On a dashboard grid it's a visible regression.

## What

Hold `QUERY_ENGINE_BATCH_MAX` equal to the server's `QE_BATCH_CONCURRENCY` (4), so a batch is exactly **one wave** and can't be gated by a tail query sitting in a later wave. Both constants now carry a note explaining the coupling, since they live in different packages (`@maple/domain` can't import from `apps/api`) and would otherwise drift silently.

Round trips still drop ~4× versus one request per query; this only gives up the difference between a 4-batch and a 12-batch.

## This is a bound, not a fix

The real fix is to **stream the outcomes** — an SSE event per query, settled the moment it completes. That gives one round trip, zero extra preflights, *and* progressive paint, removing the tradeoff instead of tuning around it. It also improves failure behaviour: today a 45s client abort discards the whole batch, whereas anything already streamed stays delivered.

Both ends already support it — Effect's HttpApi has first-class streaming success (`HttpApiSchema.StreamSse`, including a reserved mid-stream failure event) and `HttpApiClient` decodes it into an Effect `Stream`. The client batcher is shaped for it too: it deliberately sits outside the atom system holding a map of pending promises, so it only needs to settle them one at a time rather than all at once.

Once that lands, this cap can rise again.

## Verification

`apps/api` batch tests (5) and `apps/web` batcher tests (5) pass — the cap test derives its expectation from the constant, so it follows the change. `packages/domain`, `apps/web`, and `apps/api` all typecheck.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788997035&installation_model_id=427786&pr_number=391&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F391&signature=d83ed8a0b41e57aba4f38cb08b158e72f3736f51fb994ac06e9202b59a6df45b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->