### PR TITLE
test Effect layer roots

### DIFF
--- a/apps/alerting/package.json
+++ b/apps/alerting/package.json
@@ -6,7 +6,7 @@
 		"dev": "portless",
 		"dev:app": "bun run ../../scripts/portless-wrangler.ts --env-file ../../.env.local --persist-to ../api/.wrangler/state --test-scheduled --port ${PORT:-8788} --inspector-port=$((${PORT:-8788} + 10000))",
 		"deploy": "wrangler deploy",
-		"test": "echo 'No tests yet'",
+		"test": "vitest run",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -18,9 +18,11 @@
 	"devDependencies": {
 		"@cloudflare/workers-types": "4.20260603.1",
 		"@effect/language-service": "catalog:effect",
+		"@effect/vitest": "4.0.0-beta.105",
 		"@maple/infra": "workspace:*",
 		"@types/node": "catalog:tooling",
 		"typescript": "catalog:tooling",
+		"vitest": "catalog:",
 		"wrangler": "^4.118.0"
 	},
 	"portless": {

--- a/apps/alerting/src/worker.test.ts
+++ b/apps/alerting/src/worker.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Cause, Effect, Exit, Layer } from "effect"
+import { env as workerEnv } from "../test/stubs/cloudflare-workers"
+import { buildLayer, catchTickFailure, selectScheduledProgram, type ScheduledTickPrograms } from "./worker"
+
+const cronCases = [
+	["*/5 * * * *", ["anomaly", "cloudflareAnalytics", "planetScale"]],
+	["*/15 * * * *", ["digest"]],
+	["0 * * * *", ["serviceMapRollup"]],
+	["* * * * *", ["alert", "error", "escalation"]],
+] as const
+
+describe("alerting Effect root", () => {
+	it.effect("acquires the production layer graph", () =>
+		Effect.scoped(Layer.build(buildLayer(workerEnv))).pipe(Effect.asVoid),
+	)
+
+	for (const [cron, expected] of cronCases) {
+		it.effect(`dispatches ${cron} to its characterized tick group`, () => {
+			const calls: Array<string> = []
+			const tick = (name: string) => Effect.sync(() => calls.push(name)).pipe(Effect.asVoid)
+			const ticks = {
+				alert: tick("alert"),
+				anomaly: tick("anomaly"),
+				cloudflareAnalytics: tick("cloudflareAnalytics"),
+				digest: tick("digest"),
+				error: tick("error"),
+				escalation: tick("escalation"),
+				planetScale: tick("planetScale"),
+				serviceMapRollup: tick("serviceMapRollup"),
+			} satisfies ScheduledTickPrograms
+
+			return selectScheduledProgram(cron, ticks).pipe(
+				Effect.tap(() =>
+					Effect.sync(() => expect(calls.toSorted()).toEqual([...expected].toSorted())),
+				),
+			)
+		})
+	}
+
+	it.effect("fails closed for an unknown cron", () => {
+		const calls: Array<string> = []
+		const tick = (name: string) => Effect.sync(() => calls.push(name)).pipe(Effect.asVoid)
+		const ticks = {
+			alert: tick("alert"),
+			anomaly: tick("anomaly"),
+			cloudflareAnalytics: tick("cloudflareAnalytics"),
+			digest: tick("digest"),
+			error: tick("error"),
+			escalation: tick("escalation"),
+			planetScale: tick("planetScale"),
+			serviceMapRollup: tick("serviceMapRollup"),
+		} satisfies ScheduledTickPrograms
+
+		return selectScheduledProgram("1 2 3 4 5", ticks).pipe(
+			Effect.tap(() => Effect.sync(() => expect(calls).toEqual([]))),
+		)
+	})
+
+	it.effect("isolates ordinary tick failures", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.fail("boom").pipe(
+				catchTickFailure("expected test failure"),
+				Effect.exit,
+			)
+			expect(Exit.isSuccess(exit)).toBe(true)
+		}),
+	)
+
+	it.effect("preserves interrupt-only causes for graceful worker teardown", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.interrupt.pipe(catchTickFailure("must not be logged"), Effect.exit)
+			expect(Exit.isFailure(exit)).toBe(true)
+			if (Exit.isFailure(exit)) {
+				expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true)
+			}
+		}),
+	)
+})

--- a/apps/alerting/src/worker.ts
+++ b/apps/alerting/src/worker.ts
@@ -44,7 +44,9 @@ interface AlertingWorkerEnv {
 	readonly [key: string]: unknown
 }
 
-const buildLayer = (env: AlertingWorkerEnv) => {
+export const buildLayer = (env: AlertingWorkerEnv) => {
+	// Keep config and binding services on the same invocation-scoped env record;
+	// scheduled handlers already receive the authoritative Cloudflare bindings.
 	const ConfigLive = layerFromEnv(env)
 	const WorkerEnvironmentLive = layerFromEnvRecord(env)
 	const EnvLive = Env.layer.pipe(Layer.provide(ConfigLive))
@@ -183,7 +185,7 @@ const buildLayer = (env: AlertingWorkerEnv) => {
  * `runScheduledEffect`'s `onInterrupt: "graceful"` handling instead of logging a phantom
  * tick failure. Mirrors the per-org guards inside the tick services.
  */
-const catchTickFailure = (label: string) =>
+export const catchTickFailure = (label: string) =>
 	Effect.catchCause((cause: Cause.Cause<unknown>) =>
 		Cause.hasInterruptsOnly(cause)
 			? Effect.interrupt
@@ -332,10 +334,70 @@ const planetScaleTick = makeTick(
 			: undefined,
 )
 
-const everyMinuteTick = Effect.all([alertTick, errorTick, escalationTick], {
-	concurrency: 2,
-	discard: true,
-})
+export interface ScheduledTickPrograms<R = never> {
+	readonly alert: Effect.Effect<void, never, R>
+	readonly anomaly: Effect.Effect<void, never, R>
+	readonly cloudflareAnalytics: Effect.Effect<void, never, R>
+	readonly digest: Effect.Effect<void, never, R>
+	readonly error: Effect.Effect<void, never, R>
+	readonly escalation: Effect.Effect<void, never, R>
+	readonly planetScale: Effect.Effect<void, never, R>
+	readonly serviceMapRollup: Effect.Effect<void, never, R>
+}
+
+/**
+ * Keep cron routing separate from the Worker shell so the schedule and its
+ * concurrency groups can be characterized without acquiring production
+ * drivers. The concrete tick Effects remain module-scoped and unchanged.
+ */
+export const selectScheduledProgram = <R>(
+	cron: string,
+	ticks: ScheduledTickPrograms<R>,
+): Effect.Effect<void, never, R> =>
+	Match.value(cron).pipe(
+		Match.when("*/5 * * * *", () =>
+			Effect.all([ticks.anomaly, ticks.cloudflareAnalytics, ticks.planetScale], {
+				concurrency: 3,
+				discard: true,
+			}),
+		),
+		Match.when("*/15 * * * *", () => ticks.digest),
+		Match.when("0 * * * *", () => ticks.serviceMapRollup),
+		Match.when("* * * * *", () =>
+			Effect.all([ticks.alert, ticks.error, ticks.escalation], {
+				concurrency: 2,
+				discard: true,
+			}),
+		),
+		// Fail closed: a newly configured cron must not silently inherit the
+		// every-minute alert/error/escalation fan-out.
+		Match.orElse((unknownCron) =>
+			Effect.logWarning("Skipping unknown alerting cron schedule").pipe(
+				Effect.annotateLogs({ cron: unknownCron }),
+			),
+		),
+	)
+
+type ScheduledServices =
+	| AlertsService
+	| AnomalyDetectionService
+	| CloudflareAnalyticsService
+	| DigestService
+	| ErrorsService
+	| EscalationService
+	| PlanetScaleService
+	| ServiceMapRollupService
+
+const scheduledTicks: ScheduledTickPrograms<ScheduledServices> = {
+	alert: alertTick,
+	anomaly: anomalyTick,
+	cloudflareAnalytics: cloudflareAnalyticsTick,
+	digest: digestTick,
+	error: errorTick,
+	escalation: escalationTick,
+	planetScale: planetScaleTick,
+	serviceMapRollup: serviceMapRollupTick,
+}
 
 interface ScheduledEventLike {
 	readonly cron: string
@@ -366,23 +428,7 @@ export default {
 			)
 			return
 		}
-		const program = Match.value(event.cron).pipe(
-			Match.when("*/5 * * * *", () =>
-				Effect.all([anomalyTick, cloudflareAnalyticsTick, planetScaleTick], {
-					concurrency: 3,
-					discard: true,
-				}),
-			),
-			Match.when("*/15 * * * *", () => digestTick),
-			Match.when("0 * * * *", () => serviceMapRollupTick),
-			Match.when("* * * * *", () => everyMinuteTick),
-			// Unknown schedules must not inherit the every-minute fan-out.
-			Match.orElse((cron) =>
-				Effect.logWarning("Skipping unknown alerting cron schedule").pipe(
-					Effect.annotateLogs({ cron }),
-				),
-			),
-		)
+		const program = selectScheduledProgram(event.cron, scheduledTicks)
 		try {
 			// Cron ticks cancel gracefully on isolate teardown — the schedule reruns
 			// anyway, and re-raised interrupts (see the per-org catchCause guards in the

--- a/apps/alerting/test/stubs/cloudflare-workers.ts
+++ b/apps/alerting/test/stubs/cloudflare-workers.ts
@@ -1,0 +1,8 @@
+/** Minimal bindings needed to acquire the alerting production layer in Node. */
+export const env: Record<string, unknown> = {
+	TINYBIRD_HOST: "https://api.tinybird.co",
+	TINYBIRD_TOKEN: "test-token",
+	MAPLE_ROOT_PASSWORD: "test-password",
+	MAPLE_INGEST_KEY_ENCRYPTION_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+	MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: "test-hmac-key",
+}

--- a/apps/alerting/vitest.config.ts
+++ b/apps/alerting/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from "node:url"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+	resolve: {
+		alias: {
+			"@": fileURLToPath(new URL("../api/src", import.meta.url)),
+			"cloudflare:workers": fileURLToPath(
+				new URL("./test/stubs/cloudflare-workers.ts", import.meta.url),
+			),
+		},
+	},
+	test: {
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+	},
+})

--- a/bun.lock
+++ b/bun.lock
@@ -34,9 +34,11 @@
       "devDependencies": {
         "@cloudflare/workers-types": "4.20260603.1",
         "@effect/language-service": "catalog:effect",
+        "@effect/vitest": "4.0.0-beta.105",
         "@maple/infra": "workspace:*",
         "@types/node": "catalog:tooling",
         "typescript": "catalog:tooling",
+        "vitest": "catalog:",
         "wrangler": "^4.118.0",
       },
     },


### PR DESCRIPTION
## Summary

- add a production-layer acquisition smoke test for the alerting worker
- characterize all four cron dispatch groups
- lock in ordinary-failure isolation and interrupt-only propagation
- replace the placeholder alerting test script with Vitest

## Why

The alerting deployable had no test that built its real Effect graph or checked its scheduled-entrypoint wiring. This is the guardrail layer for the structural PRs above it in this stack.

## Validation

- `bun run alchemy:build-deps`
- `bun run --cwd apps/alerting typecheck`
- `bun run --cwd apps/alerting test` — 8 passed
- targeted oxlint and diff checks

## Stack

1. This PR
2. #393 — share the web Effect runtime memo map
3. #394 — split API service and HTTP composition roots

<sub>Stack created with the GitHub Stacks CLI.</sub>
