### PR TITLE
fix shared web Effect runtime

### DIFF
--- a/apps/web/src/hooks/use-infinite-logs.ts
+++ b/apps/web/src/hooks/use-infinite-logs.ts
@@ -1,11 +1,11 @@
 import * as React from "react"
 import { Result } from "@/lib/effect-atom"
-import { Effect } from "effect"
 
 import { listLogs, type Log, type LogsResponse } from "@/api/warehouse/logs"
 import { listLogsResultAtom, type QueryAtomFailure } from "@/lib/services/atoms/warehouse-query-atoms"
 import { useRetainedRefreshableResultValue } from "@/hooks/use-retained-refreshable-result-value"
 import { useTableRefreshTimeRange } from "@/hooks/use-table-refresh-time-range"
+import { mapleRuntime } from "@/lib/registry"
 import type { LogsSearchParams } from "@/routes/logs"
 
 const PAGE_SIZE = 100
@@ -93,7 +93,8 @@ export function useInfiniteLogs(filters: LogsSearchParams | undefined): UseInfin
 
 		const currentKey = filterKeyRef.current
 
-		Effect.runPromise(listLogs({ data: { ...queryParams, cursor: lastCursor, limit: PAGE_SIZE } }))
+		mapleRuntime
+			.runPromise(listLogs({ data: { ...queryParams, cursor: lastCursor, limit: PAGE_SIZE } }))
 			.then((result) => {
 				if (filterKeyRef.current !== currentKey) return
 				setAdditionalPages((prev) => [...prev, result])

--- a/apps/web/src/hooks/use-infinite-replays.ts
+++ b/apps/web/src/hooks/use-infinite-replays.ts
@@ -1,11 +1,11 @@
 import * as React from "react"
-import { Effect } from "effect"
 import { Result, useAtomValue } from "@/lib/effect-atom"
 
 import { listReplays } from "@/api/warehouse/replays"
 import { listReplaysResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import type { SessionRow } from "@/components/replays/sessions-list"
 import { logClientError } from "@/lib/services/common/telemetry"
+import { mapleRuntime } from "@/lib/registry"
 
 /** Exported so the route loader prefetches the exact first-page key this hook reads. */
 export const REPLAYS_PAGE_SIZE = 50
@@ -92,7 +92,8 @@ export function useInfiniteReplays(filterInputs: ReplaysFilterInputs) {
 		const currentKey = filterKeyRef.current
 		const offset = allData.length
 
-		Effect.runPromise(listReplays({ data: { ...filterInputs, limit: PAGE_SIZE, offset } }))
+		mapleRuntime
+			.runPromise(listReplays({ data: { ...filterInputs, limit: PAGE_SIZE, offset } }))
 			.then((result) => {
 				if (filterKeyRef.current !== currentKey) return
 				setAdditionalPages((prev) => [...prev, { data: result.data }])

--- a/apps/web/src/hooks/use-infinite-traces.ts
+++ b/apps/web/src/hooks/use-infinite-traces.ts
@@ -1,6 +1,5 @@
 import * as React from "react"
 import { Result } from "@/lib/effect-atom"
-import { Effect } from "effect"
 
 import { listTraces, type Trace, type TracesResponse } from "@/api/warehouse/traces"
 import { listTracesResultAtom, type QueryAtomFailure } from "@/lib/services/atoms/warehouse-query-atoms"
@@ -8,6 +7,7 @@ import { useRetainedRefreshableResultValue } from "@/hooks/use-retained-refresha
 import { useTableRefreshTimeRange } from "@/hooks/use-table-refresh-time-range"
 import type { TracesSearchParams } from "@/routes/traces"
 import { logClientError } from "@/lib/services/common/telemetry"
+import { mapleRuntime } from "@/lib/registry"
 
 const PAGE_SIZE = 100
 const FETCH_THRESHOLD = 20
@@ -117,7 +117,8 @@ export function useInfiniteTraces(filters: TracesSearchParams | undefined): UseI
 		const currentKey = filterKeyRef.current
 		const offset = allData.length
 
-		Effect.runPromise(listTraces({ data: { ...queryParams, limit: PAGE_SIZE, offset } }))
+		mapleRuntime
+			.runPromise(listTraces({ data: { ...queryParams, limit: PAGE_SIZE, offset } }))
 			.then((result) => {
 				if (filterKeyRef.current !== currentKey) return
 				setAdditionalPages((prev) => [...prev, result])

--- a/apps/web/src/lib/make-app-runtime.test.ts
+++ b/apps/web/src/lib/make-app-runtime.test.ts
@@ -1,0 +1,32 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Context, Effect, Layer, ManagedRuntime } from "effect"
+import { makeAppRuntime } from "./make-app-runtime"
+
+class TestClient extends Context.Service<TestClient, { readonly acquisition: number }>()(
+	"@maple/web/test/TestClient",
+) {}
+
+describe("makeAppRuntime", () => {
+	it("reuses layers already acquired by the atom runtime", async () => {
+		let acquisitions = 0
+		const clientLayer = Layer.effect(
+			TestClient,
+			Effect.sync(() => ({ acquisition: ++acquisitions })),
+		)
+		const memoMap = Layer.makeMemoMapUnsafe()
+		const atomRuntime = ManagedRuntime.make(clientLayer, { memoMap })
+		const appRuntime = makeAppRuntime(clientLayer, memoMap)
+
+		try {
+			const atomClient = await atomRuntime.runPromise(TestClient)
+			const appClient = await appRuntime.runPromise(TestClient)
+
+			assert.strictEqual(appRuntime.memoMap, memoMap)
+			assert.strictEqual(appClient, atomClient)
+			assert.strictEqual(acquisitions, 1)
+		} finally {
+			await appRuntime.dispose()
+			await atomRuntime.dispose()
+		}
+	})
+})

--- a/apps/web/src/lib/make-app-runtime.ts
+++ b/apps/web/src/lib/make-app-runtime.ts
@@ -1,0 +1,11 @@
+import { Layer, ManagedRuntime } from "effect"
+
+/**
+ * Builds an imperative app runtime on the same memoization boundary as the
+ * atom registry. Any layer shared with atoms is acquired once and reused by
+ * both execution paths.
+ */
+export const makeAppRuntime = <R, E>(
+	layer: Layer.Layer<R, E, never>,
+	memoMap: Layer.MemoMap,
+): ManagedRuntime.ManagedRuntime<R, E> => ManagedRuntime.make(layer, { memoMap })

--- a/apps/web/src/lib/registry.ts
+++ b/apps/web/src/lib/registry.ts
@@ -1,10 +1,11 @@
 import { Atom, scheduleTask } from "@/lib/effect-atom"
-import { Layer, ManagedRuntime } from "effect"
+import { Layer } from "effect"
 import { AtomRegistry } from "effect/unstable/reactivity"
 import { MapleApiAtomClient } from "./services/common/atom-client"
 import { MapleFetchHttpClientLive } from "./services/common/http-client"
 import { mapleOtelLayer } from "./services/common/otel-layer"
 import { MapleApiV2AtomClient } from "./services/common/v2-atom-client"
+import { makeAppRuntime } from "./make-app-runtime"
 
 // Register the fetch layer FIRST so the Effect Layer memoMap caches
 // FetchHttpClient.layer with mapleFetch substituted. mapleOtelLayer's internal
@@ -38,4 +39,9 @@ export const mapleApiV2ClientLayer: Layer.Layer<MapleApiV2AtomClient> = appRegis
 // the `optimisticAction` atoms in @maple/effect-db. Building it once avoids
 // rebuilding the client layers on every call, and gives the
 // Effect-native collection factory a runtime for its handlers + backoff logging.
-export const mapleRuntime = ManagedRuntime.make(Layer.mergeAll(mapleApiClientLayer, mapleApiV2ClientLayer))
+// Sharing the registry memo map is load-bearing: nested `Effect.provide` calls
+// reuse the atom-owned client and tracer instances instead of rebuilding them.
+export const mapleRuntime = makeAppRuntime(
+	Layer.mergeAll(mapleApiClientLayer, mapleApiV2ClientLayer),
+	appMemoMap,
+)


### PR DESCRIPTION
## Summary

- build the imperative web runtime with the atom registry's shared `MemoMap`
- route logs, traces, and replays pagination through that persistent runtime
- add an acquisition-count regression test proving atom and imperative paths reuse the same layer instance

## Why

The pagination paths ran Effects outside the app runtime, while `mapleRuntime` owned a separate memoization boundary. That could rebuild API clients/tracing state and bypass the intended shared auth/runtime lifecycle.

## Validation

- `bun run --cwd apps/web typecheck`
- full web suite — 1,445 passed
- focused runtime regression — 1 passed
- React Doctor — 100/100
- oxfmt/diff check

## Stack

1. #392 — Effect root guardrails
2. This PR
3. #394 — split API service and HTTP composition roots

<sub>Stack created with the GitHub Stacks CLI.</sub>
