### PR TITLE
narrow API Effect entrypoint roots

### DIFF
--- a/apps/api/src/chat/turn-runner.ts
+++ b/apps/api/src/chat/turn-runner.ts
@@ -198,14 +198,14 @@ const CHAT_TURN_FAILED = "Maple couldn't complete this response."
  */
 export const runChatSessionTurn = async (input: RunChatSessionTurnInput): Promise<void> => {
 	const [
-		{ MainLive },
+		{ InvestigationServicesLive },
 		{ layerPg },
 		{ layerLlm, resolveTriageModel },
 		loop,
 		{ buildSubmitDiagnosisTool },
 		{ McpToolExecutor },
 	] = await Promise.all([
-		import("../runtime/service-graph"),
+		import("../runtime/mcp-service-graph"),
 		import("../platform/DatabasePgLive"),
 		import("../platform/Llm"),
 		import("./loop"),
@@ -215,7 +215,7 @@ export const runChatSessionTurn = async (input: RunChatSessionTurnInput): Promis
 	const { InvestigationService } = await import("@/services/errors/InvestigationService")
 
 	const runtime = ManagedRuntime.make(
-		MainLive.pipe(
+		InvestigationServicesLive.pipe(
 			Layer.provideMerge(layerLlm(input.env)),
 			Layer.provideMerge(layerPg),
 			Layer.provideMerge(layerFromEnvRecord(input.env)),

--- a/apps/api/src/mcp/__evals__/eval-runtime.ts
+++ b/apps/api/src/mcp/__evals__/eval-runtime.ts
@@ -1,6 +1,6 @@
 import { ConfigProvider, Effect, Layer, ManagedRuntime, Schema } from "effect"
 import { OrgId, UserId } from "@maple/domain/http"
-import { MainLive } from "@/runtime/service-graph"
+import { McpServicesLive } from "@/runtime/mcp-service-graph"
 import { Env } from "@/platform/Env"
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
 import { createTestDb } from "@/platform/test-pglite"
@@ -48,7 +48,7 @@ export const makeEvalRuntime = (): EvalRuntime => {
 	const databaseLive = testDb.layer
 	const workerEnvLive = Layer.succeed(WorkerEnvironment, env as Record<string, unknown>)
 
-	const layer = MainLive.pipe(
+	const layer = McpServicesLive.pipe(
 		Layer.provide(Layer.mergeAll(configLive, envLive, databaseLive, workerEnvLive)),
 	)
 	// `as any`: the residual requirement set is satisfied at runtime (same pattern

--- a/apps/api/src/runtime/graph-boundaries.test.ts
+++ b/apps/api/src/runtime/graph-boundaries.test.ts
@@ -6,6 +6,15 @@ const readModule = (path: string): string => readFileSync(new URL(path, import.m
 const importSpecifiers = (source: string): ReadonlyArray<string> =>
 	Array.from(source.matchAll(/(?:from\s+|import\s*\()["']([^"']+)["']/g), (match) => match[1]!)
 
+const layerMembers = (source: string, name: string): ReadonlyArray<string> => {
+	const block = new RegExp(`const ${name} = Layer\\.mergeAll\\(([\\s\\S]*?)\\n\\)`).exec(source)?.[1]
+	if (block === undefined) throw new Error(`Layer ${name} was not found`)
+	return block
+		.split("\n")
+		.map((line) => line.trim().replace(/,$/, ""))
+		.filter((line) => line !== "")
+}
+
 describe("API runtime graph boundaries", () => {
 	it("keeps the service composition root free of HTTP routes and schemas", () => {
 		const imports = importSpecifiers(readModule("./service-graph.ts"))
@@ -16,16 +25,72 @@ describe("API runtime graph boundaries", () => {
 	})
 
 	it("keeps runtime entrypoints off the compatibility facade", () => {
-		const runtimeEntrypoints: ReadonlyArray<readonly [source: string, expectedImport: string]> = [
-			[readModule("../chat/turn-runner.ts"), "../runtime/service-graph"],
-			[readModule("../mcp/__evals__/eval-runtime.ts"), "@/runtime/service-graph"],
-			[readModule("../worker.ts"), "./runtime/service-graph"],
-			[readModule("../workflows/InvestigationFanoutWorkflow.run.ts"), "../runtime/service-graph"],
+		const runtimeEntrypoints: ReadonlyArray<
+			readonly [
+				source: string,
+				expectedImports: ReadonlyArray<string>,
+				expectedRoots: ReadonlyArray<string>,
+			]
+		> = [
+			[
+				readModule("../chat/turn-runner.ts"),
+				["../runtime/mcp-service-graph"],
+				["InvestigationServicesLive"],
+			],
+			[
+				readModule("../mcp/__evals__/eval-runtime.ts"),
+				["@/runtime/mcp-service-graph"],
+				["McpServicesLive"],
+			],
+			[
+				readModule("../worker.ts"),
+				["./runtime/service-graph", "./runtime/mcp-service-graph"],
+				["HttpServicesLive", "InvestigationServicesLive"],
+			],
+			[
+				readModule("../workflows/InvestigationFanoutWorkflow.run.ts"),
+				["../runtime/mcp-service-graph"],
+				["McpServicesLive"],
+			],
 		]
 
-		for (const [source, expectedImport] of runtimeEntrypoints) {
-			expect(importSpecifiers(source)).toContain(expectedImport)
+		for (const [source, expectedImports, expectedRoots] of runtimeEntrypoints) {
+			for (const expectedImport of expectedImports)
+				expect(importSpecifiers(source)).toContain(expectedImport)
 			expect(importSpecifiers(source).some((specifier) => /(?:^|\/)app$/.test(specifier))).toBe(false)
+			for (const root of expectedRoots) expect(source).toContain(root)
+			expect(source).not.toMatch(/\{\s*MainLive\s*\}/)
+		}
+	})
+
+	it("keeps the headless MCP root limited to registered tool requirements", () => {
+		const source = readModule("./mcp-service-graph.ts")
+		const imports = importSpecifiers(source)
+
+		expect(layerMembers(source, "McpRuntimeServicesLive")).toEqual([
+			"AlertsServiceLive",
+			"DashboardPersistenceService.layer",
+			"ErrorsServiceLive",
+			"QueryEngineServiceLive",
+			"RecommendationIssueServiceLive",
+			"SetupAuditServiceLive",
+			"VcsSourceServiceLive",
+			"WarehouseQueryServiceLive",
+		])
+		expect(source).toContain(
+			"export const InvestigationServicesLive = Layer.mergeAll(McpServicesLive, InvestigationServiceLive)",
+		)
+		expect(imports).not.toContain("@/runtime/service-graph")
+		for (const routeOnlyService of [
+			"DailySpendService",
+			"CloudflareAnalyticsService",
+			"AnomalyDetectionService",
+			"AiTriageService",
+			"DigestService",
+			"DemoService",
+			"SlackIntegrationService",
+		]) {
+			expect(imports.some((specifier) => specifier.endsWith(`/${routeOnlyService}`))).toBe(false)
 		}
 	})
 })

--- a/apps/api/src/runtime/mcp-service-graph.ts
+++ b/apps/api/src/runtime/mcp-service-graph.ts
@@ -1,0 +1,114 @@
+import { EdgeCacheService } from "@maple/cache"
+import { BucketCacheService } from "@maple/query-engine/caching"
+import { Layer } from "effect"
+import { McpToolExecutor } from "@/mcp/dispatcher"
+import { CacheBackendLive } from "@/platform/CacheBackendLive"
+import { EmailService } from "@/platform/EmailService"
+import { Env } from "@/platform/Env"
+import { AlertRuntime, AlertsService } from "@/services/alerts/AlertsService"
+import { NotificationDispatcher } from "@/services/alerts/NotificationDispatcher"
+import { HazelOAuthService } from "@/services/auth/HazelOAuthService"
+import { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
+import { ErrorsService } from "@/services/errors/ErrorsService"
+import { InvestigationService } from "@/services/errors/InvestigationService"
+import { RecommendationIssueService } from "@/services/errors/RecommendationIssueService"
+import { TinybirdOrgTokenService } from "@/services/integrations/TinybirdOrgTokenService"
+import { VcsProviderRegistry } from "@/services/integrations/vcs/VcsProviderRegistry"
+import { VcsRepository } from "@/services/integrations/vcs/VcsRepository"
+import { VcsSourceService } from "@/services/integrations/vcs/VcsSourceService"
+import { GithubAppClient } from "@/services/integrations/vcs/vendor/github/GithubAppClient"
+import { GithubHttp } from "@/services/integrations/vcs/vendor/github/GithubHttp"
+import { GithubProvider } from "@/services/integrations/vcs/vendor/github/GithubProvider"
+import { OrgClickHouseSettingsService } from "@/services/org/OrgClickHouseSettingsService"
+import { OrgMembersService } from "@/services/org/OrgMembersService"
+import { SetupAuditService } from "@/services/org/SetupAuditService"
+import { QueryEngineService } from "@/services/warehouse/QueryEngineService"
+import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
+
+const InfraLive = Env.layer
+
+// MCP handlers use a finite service context (see runtime-requirements.ts).
+// Keep this graph independent from the HTTP composition root so headless
+// entrypoints do not evaluate or acquire route-only product services.
+const OrgClickHouseSettingsServiceLive = OrgClickHouseSettingsService.layer.pipe(Layer.provide(InfraLive))
+const TinybirdOrgTokenServiceLive = TinybirdOrgTokenService.layer.pipe(Layer.provide(InfraLive))
+const HazelOAuthServiceLive = HazelOAuthService.layer.pipe(Layer.provide(InfraLive))
+
+const WarehouseQueryServiceLive = WarehouseQueryService.layer.pipe(
+	Layer.provide(Layer.mergeAll(InfraLive, OrgClickHouseSettingsServiceLive, TinybirdOrgTokenServiceLive)),
+)
+
+const EdgeCacheServiceLive = EdgeCacheService.layer.pipe(Layer.provide(CacheBackendLive))
+const BucketCacheServiceLive = BucketCacheService.layer.pipe(Layer.provideMerge(EdgeCacheServiceLive))
+
+const QueryEngineServiceLive = QueryEngineService.layer.pipe(
+	Layer.provide(Layer.mergeAll(WarehouseQueryServiceLive, EdgeCacheServiceLive, BucketCacheServiceLive)),
+)
+
+const EmailServiceLive = EmailService.layer.pipe(Layer.provide(InfraLive))
+const OrgMembersServiceLive = OrgMembersService.layer.pipe(Layer.provide(InfraLive))
+
+const AlertsServiceLive = AlertsService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(
+			InfraLive,
+			QueryEngineServiceLive,
+			WarehouseQueryServiceLive,
+			AlertRuntime.layer,
+			HazelOAuthServiceLive,
+			EmailServiceLive,
+			OrgMembersServiceLive,
+			OrgClickHouseSettingsServiceLive,
+		),
+	),
+)
+
+const NotificationDispatcherLive = NotificationDispatcher.layer.pipe(
+	Layer.provide(Layer.mergeAll(InfraLive, EmailServiceLive)),
+)
+
+const ErrorsServiceLive = ErrorsService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(
+			InfraLive,
+			WarehouseQueryServiceLive,
+			EdgeCacheServiceLive,
+			NotificationDispatcherLive,
+		),
+	),
+)
+
+const RecommendationIssueServiceLive = RecommendationIssueService.layer.pipe(
+	Layer.provide(WarehouseQueryServiceLive),
+)
+
+const SetupAuditServiceLive = SetupAuditService.layer.pipe(Layer.provide(WarehouseQueryServiceLive))
+
+const GithubAppClientLive = GithubAppClient.layer.pipe(Layer.provide(GithubHttp.layer))
+const GithubProviderLive = GithubProvider.layer.pipe(Layer.provide(GithubAppClientLive))
+const VcsProviderRegistryLive = VcsProviderRegistry.layer.pipe(Layer.provide(GithubProviderLive))
+
+const VcsSourceServiceLive = VcsSourceService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(VcsRepository.layer, VcsProviderRegistryLive).pipe(Layer.provideMerge(InfraLive)),
+	),
+)
+
+const McpRuntimeServicesLive = Layer.mergeAll(
+	AlertsServiceLive,
+	DashboardPersistenceService.layer,
+	ErrorsServiceLive,
+	QueryEngineServiceLive,
+	RecommendationIssueServiceLive,
+	SetupAuditServiceLive,
+	VcsSourceServiceLive,
+	WarehouseQueryServiceLive,
+)
+
+/** MCP execution root used by headless fanout agents and direct tool evals. */
+export const McpServicesLive = McpToolExecutor.layer.pipe(Layer.provide(McpRuntimeServicesLive))
+
+const InvestigationServiceLive = InvestigationService.layer.pipe(Layer.provide(InfraLive))
+
+/** MCP execution plus diagnosis persistence for chat turns and internal RPC. */
+export const InvestigationServicesLive = Layer.mergeAll(McpServicesLive, InvestigationServiceLive)

--- a/apps/api/src/runtime/service-graph.ts
+++ b/apps/api/src/runtime/service-graph.ts
@@ -225,6 +225,3 @@ const MainServicesLive = Layer.mergeAll(
  * such as billing, demo, digest, OAuth, anomaly detection, and Slack integration.
  */
 export const HttpServicesLive = McpToolExecutor.layer.pipe(Layer.provideMerge(MainServicesLive))
-
-/** @deprecated Prefer an entrypoint-specific root. */
-export const MainLive = HttpServicesLive

--- a/apps/api/src/runtime/service-graph.ts
+++ b/apps/api/src/runtime/service-graph.ts
@@ -165,7 +165,7 @@ const AnomalyDetectionServiceLive = AnomalyDetectionService.layer.pipe(
 
 const AiTriageServiceLive = AiTriageService.layer.pipe(Layer.provideMerge(CoreServicesLive))
 
-const InvestigationServiceLive = InvestigationService.layer.pipe(Layer.provideMerge(CoreServicesLive))
+const InvestigationServiceLive = InvestigationService.layer.pipe(Layer.provide(InfraLive))
 
 const DigestServiceLive = DigestService.layer.pipe(
 	Layer.provideMerge(
@@ -216,4 +216,15 @@ const MainServicesLive = Layer.mergeAll(
 	SlackIntegrationServiceLive,
 )
 
-export const MainLive = McpToolExecutor.layer.pipe(Layer.provideMerge(MainServicesLive))
+/**
+ * Complete service graph for the HTTP worker.
+ *
+ * HTTP exposes every product surface plus MCP, so this is intentionally the
+ * broadest root. Non-HTTP entrypoints use the smaller roots in
+ * `mcp-service-graph.ts` instead of importing or acquiring route-only services
+ * such as billing, demo, digest, OAuth, anomaly detection, and Slack integration.
+ */
+export const HttpServicesLive = McpToolExecutor.layer.pipe(Layer.provideMerge(MainServicesLive))
+
+/** @deprecated Prefer an entrypoint-specific root. */
+export const MainLive = HttpServicesLive

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -94,13 +94,13 @@ const scoped = async <A, E, R>(program: Effect.Effect<A, E, R>) => {
 // the top level near-empty; the cost moves to the first request, which runs
 // under the far larger per-request CPU budget.
 const buildHandler = async () => {
-	const { MainLive } = await import("./runtime/service-graph")
+	const { HttpServicesLive } = await import("./runtime/service-graph")
 	const { AllRoutes, ApiAuthLive, ApiObservabilityLive } = await import("./runtime/http-graph")
 	const { layerPg } = await import("@/platform/DatabasePgLive")
 	const { pgConnectionMiddleware } = await import("@/platform/pg-connection-scope")
 	return HttpRouter.toWebHandler(
 		AllRoutes.pipe(
-			Layer.provideMerge(MainLive),
+			Layer.provideMerge(HttpServicesLive),
 			Layer.provideMerge(ApiAuthLive),
 			Layer.provideMerge(ApiObservabilityLive),
 			Layer.provideMerge(WorkerPlatformLive),
@@ -129,13 +129,13 @@ let handlerPromise: ReturnType<typeof buildHandler> | undefined
 const getHandler = () => (handlerPromise ??= buildHandler())
 
 // RPC has no HttpApi request to construct the application services for it, so
-// it gets a sibling isolate-wide ManagedRuntime. The heavy route/service graph
+// it gets a sibling isolate-wide ManagedRuntime. Its headless service graph
 // stays behind a dynamic import, preserving the worker's startup-CPU budget.
 const buildRpcRuntime = async (env: Record<string, unknown>) => {
-	const { MainLive } = await import("./runtime/service-graph")
+	const { InvestigationServicesLive } = await import("./runtime/mcp-service-graph")
 	const { layerPg } = await import("@/platform/DatabasePgLive")
 	return ManagedRuntime.make(
-		MainLive.pipe(
+		InvestigationServicesLive.pipe(
 			Layer.provideMerge(WorkerPlatformLive),
 			Layer.provideMerge(layerPg),
 			Layer.provideMerge(layerFromEnvRecord(env)),

--- a/apps/api/src/workflows/InvestigationFanoutWorkflow.run.ts
+++ b/apps/api/src/workflows/InvestigationFanoutWorkflow.run.ts
@@ -152,19 +152,19 @@ const fanoutTelemetry = MapleCloudflareSDK.make({
  * One runtime for the whole instance, built lazily and shared by every step.
  *
  * The dynamic-import gymnastics in this file and in `turn-runner.ts` exist
- * because building `MainLive` constructs hundreds of Schema ASTs and blows
+ * because building the service graph constructs hundreds of Schema ASTs and blows
  * Cloudflare's startup-CPU budget (error 10021). Building five of them
  * concurrently, one per lane step, would take that cost and multiply it against
  * a 30s per-step CPU limit — so the lane steps share one.
  */
 const makeRuntime = async (env: InvestigationFanoutWorkflowEnv) => {
-	const [{ MainLive }, { layerPg }, { layerLlm }] = await Promise.all([
-		import("../runtime/service-graph"),
+	const [{ McpServicesLive }, { layerPg }, { layerLlm }] = await Promise.all([
+		import("../runtime/mcp-service-graph"),
 		import("../platform/DatabasePgLive"),
 		import("../platform/Llm"),
 	])
 	return ManagedRuntime.make(
-		MainLive.pipe(
+		McpServicesLive.pipe(
 			Layer.provideMerge(layerLlm(env)),
 			Layer.provideMerge(layerPg),
 			Layer.provideMerge(layerFromEnvRecord(env)),


### PR DESCRIPTION
## Summary

- add distinct HTTP, MCP-only, and investigation/MCP service roots
- move headless MCP composition into a route-independent graph
- point chat, internal RPC, fanout workflows, and evals at the narrow roots
- retain `MainLive` as a compatibility alias for the complete HTTP graph
- extend graph-boundary tests to lock the entrypoint/root mapping and excluded service slices

## Why

The route-free split in #394 stopped non-HTTP entrypoints from evaluating route schemas, but they still acquired the entire product service graph. Headless MCP execution now excludes HTTP-only billing, demo, digest, OAuth, anomaly, AI-triage, and Slack-integration slices.

## Validation

- `bun run --cwd apps/api typecheck`
- full API suite — 1,637 passed, 184 skipped
- focused graph/internal-RPC tests — 6 passed
- `bun run lint:effect-boundaries`
- Worker startup — 113.3 ms active CPU / 400 ms budget on combined stack

## Stack

Builds on #394. Next: #397 and #398.

<sub>Stack created with the GitHub Stacks CLI.</sub>
