### PR TITLE
open Alchemy provider layer overrides

### DIFF
--- a/packages/alchemy-maple/README.md
+++ b/packages/alchemy-maple/README.md
@@ -71,7 +71,31 @@ Set `MAPLE_API_KEY` to a Maple API key (create one in the Maple dashboard, or wi
 - **Alert rules & destinations** need `alerts:write` **and** an org-admin key.
 - **API keys & ingest keys** need `api_keys:write` / `ingest_keys:read` **and** an org-admin key.
 
-`MAPLE_API_URL` overrides the API base URL (defaults to `https://api.maple.dev`). To source configuration differently, provide your own `Maple.MapleEnvironment` layer.
+`MAPLE_API_URL` overrides the API base URL (defaults to `https://api.maple.dev`).
+`Maple.providers()` reads those variables and uses the runtime's global `fetch`.
+
+To supply configuration or transport explicitly, compose the open provider
+layer with both services. These layers are used directly; no internal default
+overrides them:
+
+```typescript
+import * as Maple from "@maple-dev/alchemy"
+import { Layer, Redacted } from "effect"
+import { HttpClient } from "effect/unstable/http"
+
+const mapleProviders = Maple.providersWithDependencies().pipe(
+	Layer.provide(
+		Layer.succeed(Maple.MapleEnvironment, {
+			baseUrl: "https://maple.internal.example",
+			apiKey: Redacted.make("maple_ak_…"),
+		}),
+	),
+	Layer.provide(Layer.succeed(HttpClient.HttpClient, myHttpClient)),
+)
+```
+
+`Maple.MapleApiFromHttpClient()` exposes the same environment-and-transport
+seam when constructing the API client without the Alchemy provider collection.
 
 ## Resources
 

--- a/packages/alchemy-maple/src/MapleApi.ts
+++ b/packages/alchemy-maple/src/MapleApi.ts
@@ -137,8 +137,18 @@ export const make = Effect.gen(function* () {
 	}
 })
 
-/** Live client: {@link MapleEnvironment} + the runtime's global `fetch`. */
-export const MapleApiLive = () => Layer.effect(MapleApi, make).pipe(Layer.provide(FetchHttpClient.layer))
+/**
+ * Construct the Maple API client from caller-supplied {@link MapleEnvironment}
+ * and {@link HttpClient.HttpClient} services.
+ *
+ * This is the open composition seam used by `providersWithDependencies()`.
+ * Use {@link MapleApiLive} when the runtime's global `fetch` is the desired
+ * transport.
+ */
+export const MapleApiFromHttpClient = () => Layer.effect(MapleApi, make)
+
+/** Live client: caller-supplied {@link MapleEnvironment} + the runtime's global `fetch`. */
+export const MapleApiLive = () => MapleApiFromHttpClient().pipe(Layer.provide(FetchHttpClient.layer))
 
 /**
  * Fetch every page of a v2 list endpoint (`{ object: "list", data, has_more,

--- a/packages/alchemy-maple/src/MapleEnvironment.ts
+++ b/packages/alchemy-maple/src/MapleEnvironment.ts
@@ -9,8 +9,9 @@ import type * as Redacted from "effect/Redacted"
  *
  * Every Maple provider resolves its base URL and credential from this
  * service. `Maple.providers()` wires it from the environment by default
- * ({@link fromEnv}); provide your own layer to point at a different
- * deployment or to source the key from elsewhere.
+ * ({@link fromEnv}); use `Maple.providersWithDependencies()` when supplying
+ * your own layer to point at a different deployment or source the key from
+ * elsewhere.
  */
 export class MapleEnvironment extends Context.Service<
 	MapleEnvironment,

--- a/packages/alchemy-maple/src/Providers.ts
+++ b/packages/alchemy-maple/src/Providers.ts
@@ -1,11 +1,12 @@
 import * as Layer from "effect/Layer"
+import { FetchHttpClient } from "effect/unstable/http"
 import * as Provider from "alchemy/Provider"
 import { AlertDestination, AlertDestinationProvider } from "./AlertDestination"
 import { AlertRule, AlertRuleProvider } from "./AlertRule"
 import { ApiKey, ApiKeyProvider } from "./ApiKey"
 import { Dashboard, DashboardProvider } from "./Dashboard"
 import { IngestKeys, IngestKeysProvider } from "./IngestKeys"
-import { MapleApiLive } from "./MapleApi"
+import { MapleApiFromHttpClient } from "./MapleApi"
 import * as MapleEnvironment from "./MapleEnvironment"
 
 export class Providers extends Provider.ProviderCollection<Providers>()("Maple") {}
@@ -20,10 +21,32 @@ export class Providers extends Provider.ProviderCollection<Providers>()("Maple")
  * }, Effect.gen(function* () { ... }))
  * ```
  *
- * Credentials come from `MAPLE_API_KEY` / `MAPLE_API_URL` by default; provide
- * your own {@link MapleEnvironment.MapleEnvironment} layer to override.
+ * Credentials come from `MAPLE_API_KEY` / `MAPLE_API_URL` and requests use the
+ * runtime's global `fetch`. Use {@link providersWithDependencies} to supply a
+ * different environment or HTTP client.
  */
 export const providers = () =>
+	providersWithDependencies().pipe(
+		Layer.provide(FetchHttpClient.layer),
+		Layer.provide(MapleEnvironment.fromEnv()),
+	)
+
+/**
+ * Construct the Maple provider collection without choosing configuration or
+ * transport. The returned layer requires both
+ * {@link MapleEnvironment.MapleEnvironment} and Effect's `HttpClient` service,
+ * so layers supplied by the caller are the services the providers actually
+ * capture.
+ *
+ * @example
+ * ```typescript
+ * const mapleProviders = Maple.providersWithDependencies().pipe(
+ *   Layer.provide(myMapleEnvironment),
+ *   Layer.provide(myHttpClient),
+ * )
+ * ```
+ */
+export const providersWithDependencies = () =>
 	Layer.effect(
 		Providers,
 		Provider.collection([ApiKey, Dashboard, AlertDestination, AlertRule, IngestKeys]),
@@ -37,7 +60,6 @@ export const providers = () =>
 				IngestKeysProvider(),
 			),
 		),
-		Layer.provide(MapleApiLive()),
-		Layer.provide(MapleEnvironment.fromEnv()),
+		Layer.provide(MapleApiFromHttpClient()),
 		Layer.orDie,
 	)

--- a/packages/alchemy-maple/src/index.ts
+++ b/packages/alchemy-maple/src/index.ts
@@ -50,6 +50,6 @@ export {
 	type MapleError,
 } from "./errors"
 export { IngestKeys, IngestKeysProvider, type IngestKeysProps } from "./IngestKeys"
-export { listAll, MapleApi, MapleApiLive, type MapleApiShape } from "./MapleApi"
+export { listAll, MapleApi, MapleApiFromHttpClient, MapleApiLive, type MapleApiShape } from "./MapleApi"
 export { DEFAULT_BASE_URL, fromEnv, MapleEnvironment } from "./MapleEnvironment"
-export { Providers, providers } from "./Providers"
+export { Providers, providers, providersWithDependencies } from "./Providers"

--- a/packages/alchemy-maple/test/provider-layers.test.ts
+++ b/packages/alchemy-maple/test/provider-layers.test.ts
@@ -1,0 +1,111 @@
+import type { ScopedPlanStatusSession } from "alchemy/Cli/Cli"
+import { ConfigProvider, Effect, Layer, Redacted } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
+import { describe, expect, it } from "vitest"
+import { Dashboard, type Dashboard as DashboardResource } from "../src/Dashboard"
+import { MapleEnvironment } from "../src/MapleEnvironment"
+import { Providers, providers, providersWithDependencies } from "../src/Providers"
+
+const session: ScopedPlanStatusSession = {
+	emit: () => Effect.void,
+	done: () => Effect.void,
+	note: () => Effect.void,
+}
+
+const wireDashboard = {
+	id: "dash_override",
+	object: "dashboard",
+	name: "Override proof",
+	description: null,
+	tags: [],
+	time_range: { type: "relative", value: "12h" },
+	widgets: [],
+	variables: [],
+	created_at: "2026-08-11T12:00:00.000Z",
+	updated_at: "2026-08-11T12:00:00.000Z",
+}
+
+describe("Maple provider layers", () => {
+	it("uses the caller-supplied environment and HTTP client", async () => {
+		const requests: Array<{ url: string; authorization: string | undefined }> = []
+		const httpClient = HttpClient.make((request, url) => {
+			requests.push({
+				url: url.toString(),
+				authorization: request.headers.authorization,
+			})
+			return Effect.succeed(
+				HttpClientResponse.fromWeb(
+					request,
+					new Response(JSON.stringify(wireDashboard), {
+						status: 201,
+						headers: { "content-type": "application/json" },
+					}),
+				),
+			)
+		})
+
+		const customProviders = providersWithDependencies().pipe(
+			Layer.provide(
+				Layer.succeed(MapleEnvironment, {
+					baseUrl: "https://maple.override.test",
+					apiKey: Redacted.make("maple_ak_override"),
+				}),
+			),
+			Layer.provide(Layer.succeed(HttpClient.HttpClient, httpClient)),
+		)
+
+		const attributes = await Effect.runPromise(
+			Effect.gen(function* () {
+				const collection = yield* Providers
+				const provider = collection.get<DashboardResource>(Dashboard.Type)
+				if (provider === undefined) return yield* Effect.die("Dashboard provider is missing")
+				return yield* provider.reconcile({
+					id: "override-proof",
+					fqn: "test/override-proof",
+					instanceId: "i-1",
+					news: { name: "Override proof" },
+					olds: undefined,
+					output: undefined,
+					session,
+					bindings: [],
+				})
+			}).pipe(Effect.provide(customProviders)),
+		)
+
+		expect(attributes).toEqual({ dashboardId: "dash_override", name: "Override proof" })
+		expect(requests).toEqual([
+			{
+				url: "https://maple.override.test/v2/dashboards",
+				authorization: "Bearer maple_ak_override",
+			},
+		])
+	})
+
+	it("keeps providers() as a closed env-backed default", async () => {
+		const defaultProviders = providers().pipe(
+			Layer.provide(
+				ConfigProvider.layer(
+					ConfigProvider.fromUnknown({
+						MAPLE_API_KEY: "maple_ak_default",
+						MAPLE_API_URL: "https://api.default.test",
+					}),
+				),
+			),
+		)
+
+		const providerTypes = await Effect.runPromise(
+			Effect.gen(function* () {
+				const collection = yield* Providers
+				return Object.keys(collection.providers).sort()
+			}).pipe(Effect.provide(defaultProviders)),
+		)
+
+		expect(providerTypes).toEqual([
+			"Maple.AlertDestination",
+			"Maple.AlertRule",
+			"Maple.ApiKey",
+			"Maple.Dashboard",
+			"Maple.IngestKeys",
+		])
+	})
+})


### PR DESCRIPTION
## Summary

- add `providersWithDependencies()` as an open Alchemy provider layer
- add `MapleApiFromHttpClient()` as the open client constructor
- preserve the existing zero-argument `providers()` and `MapleApiLive()` defaults
- test that caller-supplied environment and HTTP services are actually captured
- correct README/JSDoc that previously promised an override the closed layer could not honor

## Why

The published provider root closed over environment configuration and global fetch, so wrapping it with alternate layers did not override those dependencies. The new API makes the dependency seam explicit without breaking existing consumers.

## Validation

- package typecheck
- 4 test files / 16 tests passed
- tsdown build
- oxfmt and oxlint with warnings denied

## Stack

Builds on #396. Next: #398.

<sub>Stack created with the GitHub Stacks CLI.</sub>
