### PR TITLE
simplify Tinybird project sync runtime

### DIFF
--- a/packages/domain/src/tinybird/project-sync.test.ts
+++ b/packages/domain/src/tinybird/project-sync.test.ts
@@ -1,24 +1,14 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { datasources, pipes, projectRevision } from "../generated/tinybird-project-manifest"
 import {
-	cleanupOwnedTinybirdDeployment,
-	cleanupStaleTinybirdDeployments,
-	fetchInstanceHealth,
 	getCurrentTinybirdProjectRevision,
-	getTinybirdDeploymentStatus,
-	pollTinybirdDeploymentStep,
-	setTinybirdDeploymentLiveStep,
-	startTinybirdDeploymentStep,
+	makeTinybirdProjectSyncRuntime,
 	TinybirdDeploymentNotReadyError,
 	TinybirdSyncRejectedError,
 	TinybirdSyncUnavailableError,
 } from "./project-sync"
 
-const originalFetch = globalThis.fetch
-
-afterEach(() => {
-	globalThis.fetch = originalFetch
-})
+const makeRuntime = (fetch: typeof globalThis.fetch) => makeTinybirdProjectSyncRuntime({ fetch })
 
 const jsonResponse = (body: unknown, status = 200) =>
 	new Response(JSON.stringify(body), {
@@ -31,36 +21,58 @@ describe("Tinybird project sync", () => {
 		expect(await getCurrentTinybirdProjectRevision()).toBe(projectRevision)
 	})
 
+	it("reuses one injected transport across Promise operations", async () => {
+		const fetch = vi.fn(async () => jsonResponse({ deployment: { status: "data_ready" } }))
+		const runtime = makeRuntime(fetch as unknown as typeof globalThis.fetch)
+		const params = {
+			baseUrl: "https://customer.tinybird.co",
+			token: "token",
+			deploymentId: "dep-1",
+		} as const
+
+		const first = await runtime.getTinybirdDeploymentStatus(params)
+		const second = await runtime.getTinybirdDeploymentStatus(params)
+
+		expect(first).toEqual(second)
+		expect(fetch).toHaveBeenCalledTimes(2)
+	})
+
 	describe("startTinybirdDeploymentStep", () => {
 		it("uploads the bundled Tinybird resources without building from disk at runtime", async () => {
 			let requestBody: FormData | null = null
 			let authorizationHeader = ""
 
-			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-				const isRequest = input instanceof Request
-				const url =
-					typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
-				const method = init?.method ?? (isRequest ? input.method : "GET")
-				const headers =
-					init?.headers instanceof Headers
-						? init.headers
-						: isRequest
-							? input.headers
-							: new Headers(init?.headers as HeadersInit | undefined)
-				authorizationHeader = headers.get("Authorization") ?? ""
+			const runtime = makeRuntime(
+				vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+					const isRequest = input instanceof Request
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url
+					const method = init?.method ?? (isRequest ? input.method : "GET")
+					const headers =
+						init?.headers instanceof Headers
+							? init.headers
+							: isRequest
+								? input.headers
+								: new Headers(init?.headers as HeadersInit | undefined)
+					authorizationHeader = headers.get("Authorization") ?? ""
 
-				if (url.includes("/v1/deploy") && method === "POST") {
-					requestBody = (init?.body ?? (isRequest ? input.body : null)) as FormData
-					return jsonResponse({
-						result: "no_changes",
-						deployment: { id: "dep-1", status: "live" },
-					})
-				}
+					if (url.includes("/v1/deploy") && method === "POST") {
+						requestBody = (init?.body ?? (isRequest ? input.body : null)) as FormData
+						return jsonResponse({
+							result: "no_changes",
+							deployment: { id: "dep-1", status: "live" },
+						})
+					}
 
-				throw new Error(`Unexpected request: ${method} ${url}`)
-			}) as unknown as typeof fetch
+					throw new Error(`Unexpected request: ${method} ${url}`)
+				}) as unknown as typeof fetch,
+			)
 
-			const result = await startTinybirdDeploymentStep({
+			const result = await runtime.startTinybirdDeploymentStep({
 				baseUrl: "https://customer.tinybird.co/",
 				token: "customer-token",
 			})
@@ -85,14 +97,16 @@ describe("Tinybird project sync", () => {
 		})
 
 		it("returns a successful-in-progress deployment when Tinybird accepts the request", async () => {
-			globalThis.fetch = vi.fn(async () =>
-				jsonResponse({
-					result: "success",
-					deployment: { id: "dep-2", status: "deploying" },
-				}),
-			) as unknown as typeof fetch
+			const runtime = makeRuntime(
+				vi.fn(async () =>
+					jsonResponse({
+						result: "success",
+						deployment: { id: "dep-2", status: "deploying" },
+					}),
+				) as unknown as typeof fetch,
+			)
 
-			const result = await startTinybirdDeploymentStep({
+			const result = await runtime.startTinybirdDeploymentStep({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 			})
@@ -103,12 +117,14 @@ describe("Tinybird project sync", () => {
 		})
 
 		it("classifies Tinybird deploy rejections as user-fixable upstream errors", async () => {
-			globalThis.fetch = vi.fn(
-				async () => new Response("bad credentials", { status: 401 }),
-			) as unknown as typeof fetch
+			const runtime = makeRuntime(
+				vi.fn(
+					async () => new Response("bad credentials", { status: 401 }),
+				) as unknown as typeof fetch,
+			)
 
 			await expect(
-				startTinybirdDeploymentStep({
+				runtime.startTinybirdDeploymentStep({
 					baseUrl: "https://customer.tinybird.co",
 					token: "bad-token",
 				}),
@@ -116,29 +132,31 @@ describe("Tinybird project sync", () => {
 		})
 
 		it("extracts structured Tinybird feedback instead of showing the raw deploy response body", async () => {
-			globalThis.fetch = vi.fn(async () =>
-				jsonResponse(
-					{
-						result: "failed",
-						deployment: {
-							id: "59",
-							status: "calculating",
-							feedback: [
-								{
-									resource: null,
-									level: "ERROR",
-									message:
-										"There's already a deployment in progress.\n\nYou can check the status of your deployments with `tb deployment ls`.",
-								},
-							],
+			const runtime = makeRuntime(
+				vi.fn(async () =>
+					jsonResponse(
+						{
+							result: "failed",
+							deployment: {
+								id: "59",
+								status: "calculating",
+								feedback: [
+									{
+										resource: null,
+										level: "ERROR",
+										message:
+											"There's already a deployment in progress.\n\nYou can check the status of your deployments with `tb deployment ls`.",
+									},
+								],
+							},
 						},
-					},
-					400,
-				),
-			) as unknown as typeof fetch
+						400,
+					),
+				) as unknown as typeof fetch,
+			)
 
 			await expect(
-				startTinybirdDeploymentStep({
+				runtime.startTinybirdDeploymentStep({
 					baseUrl: "https://customer.tinybird.co",
 					token: "token",
 				}),
@@ -150,16 +168,18 @@ describe("Tinybird project sync", () => {
 		})
 
 		it("treats invalid Tinybird JSON as an upstream availability problem", async () => {
-			globalThis.fetch = vi.fn(
-				async () =>
-					new Response("not-json", {
-						status: 200,
-						headers: { "content-type": "application/json" },
-					}),
-			) as unknown as typeof fetch
+			const runtime = makeRuntime(
+				vi.fn(
+					async () =>
+						new Response("not-json", {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						}),
+				) as unknown as typeof fetch,
+			)
 
 			await expect(
-				startTinybirdDeploymentStep({
+				runtime.startTinybirdDeploymentStep({
 					baseUrl: "https://customer.tinybird.co",
 					token: "token",
 				}),
@@ -169,11 +189,13 @@ describe("Tinybird project sync", () => {
 
 	describe("pollTinybirdDeploymentStep", () => {
 		it("resolves when Tinybird reports data_ready", async () => {
-			globalThis.fetch = vi.fn(async () =>
-				jsonResponse({ deployment: { status: "data_ready" } }),
-			) as unknown as typeof fetch
+			const runtime = makeRuntime(
+				vi.fn(async () =>
+					jsonResponse({ deployment: { status: "data_ready" } }),
+				) as unknown as typeof fetch,
+			)
 
-			const result = await pollTinybirdDeploymentStep({
+			const result = await runtime.pollTinybirdDeploymentStep({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 				deploymentId: "dep-1",
@@ -185,11 +207,13 @@ describe("Tinybird project sync", () => {
 		})
 
 		it("resolves when Tinybird reports live", async () => {
-			globalThis.fetch = vi.fn(async () =>
-				jsonResponse({ deployment: { status: "live" } }),
-			) as unknown as typeof fetch
+			const runtime = makeRuntime(
+				vi.fn(async () =>
+					jsonResponse({ deployment: { status: "live" } }),
+				) as unknown as typeof fetch,
+			)
 
-			const result = await pollTinybirdDeploymentStep({
+			const result = await runtime.pollTinybirdDeploymentStep({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 				deploymentId: "dep-1",
@@ -201,12 +225,14 @@ describe("Tinybird project sync", () => {
 		})
 
 		it("throws TinybirdDeploymentNotReadyError for non-terminal non-ready statuses so workflow steps retry", async () => {
-			globalThis.fetch = vi.fn(async () =>
-				jsonResponse({ deployment: { status: "deploying" } }),
-			) as unknown as typeof fetch
+			const runtime = makeRuntime(
+				vi.fn(async () =>
+					jsonResponse({ deployment: { status: "deploying" } }),
+				) as unknown as typeof fetch,
+			)
 
 			await expect(
-				pollTinybirdDeploymentStep({
+				runtime.pollTinybirdDeploymentStep({
 					baseUrl: "https://customer.tinybird.co",
 					token: "token",
 					deploymentId: "dep-1",
@@ -215,14 +241,16 @@ describe("Tinybird project sync", () => {
 		})
 
 		it("rejects with a TinybirdSyncRejectedError when Tinybird reaches a terminal error state", async () => {
-			globalThis.fetch = vi.fn(async () =>
-				jsonResponse({
-					deployment: { status: "failed", errors: ["broken pipe"] },
-				}),
-			) as unknown as typeof fetch
+			const runtime = makeRuntime(
+				vi.fn(async () =>
+					jsonResponse({
+						deployment: { status: "failed", errors: ["broken pipe"] },
+					}),
+				) as unknown as typeof fetch,
+			)
 
 			await expect(
-				pollTinybirdDeploymentStep({
+				runtime.pollTinybirdDeploymentStep({
 					baseUrl: "https://customer.tinybird.co",
 					token: "token",
 					deploymentId: "dep-1",
@@ -233,11 +261,13 @@ describe("Tinybird project sync", () => {
 
 	describe("getTinybirdDeploymentStatus", () => {
 		it("treats data_ready as ready to promote, not as terminal", async () => {
-			globalThis.fetch = vi.fn(async () =>
-				jsonResponse({ deployment: { status: "data_ready" } }),
-			) as unknown as typeof fetch
+			const runtime = makeRuntime(
+				vi.fn(async () =>
+					jsonResponse({ deployment: { status: "data_ready" } }),
+				) as unknown as typeof fetch,
+			)
 
-			const result = await getTinybirdDeploymentStatus({
+			const result = await runtime.getTinybirdDeploymentStatus({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 				deploymentId: "dep-1",
@@ -250,11 +280,13 @@ describe("Tinybird project sync", () => {
 		})
 
 		it("treats live as the successful terminal deployment state", async () => {
-			globalThis.fetch = vi.fn(async () =>
-				jsonResponse({ deployment: { status: "live" } }),
-			) as unknown as typeof fetch
+			const runtime = makeRuntime(
+				vi.fn(async () =>
+					jsonResponse({ deployment: { status: "live" } }),
+				) as unknown as typeof fetch,
+			)
 
-			const result = await getTinybirdDeploymentStatus({
+			const result = await runtime.getTinybirdDeploymentStatus({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 				deploymentId: "dep-1",
@@ -270,15 +302,21 @@ describe("Tinybird project sync", () => {
 		it("POSTs to /v1/deployments/:id/set-live", async () => {
 			const calls: Array<{ url: string; method: string }> = []
 
-			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-				const url =
-					typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
-				const method = init?.method ?? "GET"
-				calls.push({ url, method })
-				return new Response("", { status: 200 })
-			}) as unknown as typeof fetch
+			const runtime = makeRuntime(
+				vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url
+					const method = init?.method ?? "GET"
+					calls.push({ url, method })
+					return new Response("", { status: 200 })
+				}) as unknown as typeof fetch,
+			)
 
-			await setTinybirdDeploymentLiveStep({
+			await runtime.setTinybirdDeploymentLiveStep({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 				deploymentId: "dep-1",
@@ -294,31 +332,37 @@ describe("Tinybird project sync", () => {
 		it("deletes only deployments in terminal failed states", async () => {
 			const calls: Array<{ method: string; url: string }> = []
 
-			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-				const url =
-					typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
-				const method = init?.method ?? "GET"
-				calls.push({ method, url })
+			const runtime = makeRuntime(
+				vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url
+					const method = init?.method ?? "GET"
+					calls.push({ method, url })
 
-				if (method === "GET" && url.includes("/v1/deployments")) {
-					return jsonResponse({
-						deployments: [
-							{ id: "live-1", status: "live", live: true },
-							// In-flight states must not be deleted — these are active
-							// deployments about to be promoted.
-							{ id: "in-flight-1", status: "deploying", live: false },
-							{ id: "in-flight-2", status: "data_ready", live: false },
-							// Terminal failed states are safe to clean up.
-							{ id: "failed-1", status: "failed", live: false },
-							{ id: "failed-2", status: "error", live: false },
-						],
-					})
-				}
+					if (method === "GET" && url.includes("/v1/deployments")) {
+						return jsonResponse({
+							deployments: [
+								{ id: "live-1", status: "live", live: true },
+								// In-flight states must not be deleted — these are active
+								// deployments about to be promoted.
+								{ id: "in-flight-1", status: "deploying", live: false },
+								{ id: "in-flight-2", status: "data_ready", live: false },
+								// Terminal failed states are safe to clean up.
+								{ id: "failed-1", status: "failed", live: false },
+								{ id: "failed-2", status: "error", live: false },
+							],
+						})
+					}
 
-				return new Response("", { status: 200 })
-			}) as unknown as typeof fetch
+					return new Response("", { status: 200 })
+				}) as unknown as typeof fetch,
+			)
 
-			await cleanupStaleTinybirdDeployments({
+			await runtime.cleanupStaleTinybirdDeployments({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 			})
@@ -331,18 +375,24 @@ describe("Tinybird project sync", () => {
 		it("is a no-op when there are no stale deployments", async () => {
 			const calls: Array<{ method: string; url: string }> = []
 
-			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-				const url =
-					typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
-				const method = init?.method ?? "GET"
-				calls.push({ method, url })
+			const runtime = makeRuntime(
+				vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url
+					const method = init?.method ?? "GET"
+					calls.push({ method, url })
 
-				return jsonResponse({
-					deployments: [{ id: "live-1", status: "live", live: true }],
-				})
-			}) as unknown as typeof fetch
+					return jsonResponse({
+						deployments: [{ id: "live-1", status: "live", live: true }],
+					})
+				}) as unknown as typeof fetch,
+			)
 
-			await cleanupStaleTinybirdDeployments({
+			await runtime.cleanupStaleTinybirdDeployments({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 			})
@@ -360,27 +410,33 @@ describe("Tinybird project sync", () => {
 				releaseGate = resolve
 			})
 
-			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-				const url =
-					typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
-				const method = init?.method ?? "GET"
-				if (method === "GET") {
-					return jsonResponse({
-						deployments: staleIds.map((id) => ({ id, status: "failed", live: false })),
-					})
-				}
+			const runtime = makeRuntime(
+				vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url
+					const method = init?.method ?? "GET"
+					if (method === "GET") {
+						return jsonResponse({
+							deployments: staleIds.map((id) => ({ id, status: "failed", live: false })),
+						})
+					}
 
-				const id = url.match(/\/v1\/deployments\/([^?]+)/)?.[1]
-				if (id === undefined) throw new Error(`Unexpected deletion URL: ${url}`)
-				attempted.push(id)
-				active += 1
-				peak = Math.max(peak, active)
-				await gate
-				active -= 1
-				return new Response("", { status: 200 })
-			}) as unknown as typeof fetch
+					const id = url.match(/\/v1\/deployments\/([^?]+)/)?.[1]
+					if (id === undefined) throw new Error(`Unexpected deletion URL: ${url}`)
+					attempted.push(id)
+					active += 1
+					peak = Math.max(peak, active)
+					await gate
+					active -= 1
+					return new Response("", { status: 200 })
+				}) as unknown as typeof fetch,
+			)
 
-			const cleanup = cleanupStaleTinybirdDeployments({
+			const cleanup = runtime.cleanupStaleTinybirdDeployments({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 			})
@@ -398,20 +454,26 @@ describe("Tinybird project sync", () => {
 		it("does not delete active or in-progress deployments", async () => {
 			const requests: string[] = []
 
-			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-				const url =
-					typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
-				const method = init?.method ?? "GET"
-				requests.push(`${method} ${url}`)
+			const runtime = makeRuntime(
+				vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url
+					const method = init?.method ?? "GET"
+					requests.push(`${method} ${url}`)
 
-				if (method === "GET") {
-					return jsonResponse({ deployment: { status: "deploying" } })
-				}
+					if (method === "GET") {
+						return jsonResponse({ deployment: { status: "deploying" } })
+					}
 
-				return new Response("", { status: 200 })
-			}) as unknown as typeof fetch
+					return new Response("", { status: 200 })
+				}) as unknown as typeof fetch,
+			)
 
-			await cleanupOwnedTinybirdDeployment({
+			await runtime.cleanupOwnedTinybirdDeployment({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 				deploymentId: "dep-1",
@@ -423,36 +485,42 @@ describe("Tinybird project sync", () => {
 
 	describe("fetchInstanceHealth", () => {
 		it("treats non-JSON health probe responses as missing metrics instead of failing", async () => {
-			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-				const isRequest = input instanceof Request
-				const url =
-					typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
-				const method = init?.method ?? (isRequest ? input.method : "GET")
+			const runtime = makeRuntime(
+				vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+					const isRequest = input instanceof Request
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url
+					const method = init?.method ?? (isRequest ? input.method : "GET")
 
-				if (url.includes("/v1/workspace") && method === "GET") {
-					return new Response("<html>not json</html>", {
-						status: 200,
-						headers: { "content-type": "text/html" },
-					})
-				}
+					if (url.includes("/v1/workspace") && method === "GET") {
+						return new Response("<html>not json</html>", {
+							status: 200,
+							headers: { "content-type": "text/html" },
+						})
+					}
 
-				const parsedUrl = new URL(url)
-				const query = parsedUrl.searchParams.get("q") ?? ""
+					const parsedUrl = new URL(url)
+					const query = parsedUrl.searchParams.get("q") ?? ""
 
-				if (parsedUrl.pathname === "/v0/sql" && query.includes("datasources_storage")) {
-					return new Response("datasource probe exploded", { status: 502 })
-				}
-				if (parsedUrl.pathname === "/v0/sql" && query.includes("endpoint_errors")) {
-					return jsonResponse({ data: [{ cnt: 4 }] })
-				}
-				if (parsedUrl.pathname === "/v0/sql" && query.includes("pipe_stats_rt")) {
-					return jsonResponse({ data: [{ avg_ms: "0.0974" }] })
-				}
+					if (parsedUrl.pathname === "/v0/sql" && query.includes("datasources_storage")) {
+						return new Response("datasource probe exploded", { status: 502 })
+					}
+					if (parsedUrl.pathname === "/v0/sql" && query.includes("endpoint_errors")) {
+						return jsonResponse({ data: [{ cnt: 4 }] })
+					}
+					if (parsedUrl.pathname === "/v0/sql" && query.includes("pipe_stats_rt")) {
+						return jsonResponse({ data: [{ avg_ms: "0.0974" }] })
+					}
 
-				throw new Error(`Unexpected request: ${method} ${url}`)
-			}) as unknown as typeof fetch
+					throw new Error(`Unexpected request: ${method} ${url}`)
+				}) as unknown as typeof fetch,
+			)
 
-			const result = await fetchInstanceHealth({
+			const result = await runtime.fetchInstanceHealth({
 				baseUrl: "https://customer.tinybird.co",
 				token: "token",
 			})

--- a/packages/domain/src/tinybird/project-sync.ts
+++ b/packages/domain/src/tinybird/project-sync.ts
@@ -1,6 +1,6 @@
 import { datasources, pipes, projectRevision } from "../generated/tinybird-project-manifest"
 import { TinybirdApi, TinybirdApiError } from "@tinybirdco/sdk"
-import { Duration, Effect, Layer, Schema, Context } from "effect"
+import { Duration, Effect, Schema } from "effect"
 import {
 	applyRawTtlOverrides,
 	computeEffectiveRevision,
@@ -260,11 +260,15 @@ const toNumberOrNull = (value: unknown): number | null => {
 	return null
 }
 
-const makeApi = (params: TinybirdProjectSyncParams) =>
+export interface TinybirdProjectSyncOptions {
+	readonly fetch: typeof globalThis.fetch
+}
+
+const makeApi = (params: TinybirdProjectSyncParams, fetch: typeof globalThis.fetch) =>
 	new TinybirdApi({
 		baseUrl: normalizeBaseUrl(params.baseUrl),
 		token: params.token,
-		fetch: globalThis.fetch,
+		fetch,
 		timeout: Duration.toMillis(REQUEST_TIMEOUT),
 	})
 
@@ -319,445 +323,435 @@ export interface TinybirdProjectSyncShape {
 	readonly getCurrentProjectRevision: () => Effect.Effect<string>
 }
 
-export class TinybirdProjectSync extends Context.Service<TinybirdProjectSync, TinybirdProjectSyncShape>()(
-	"@maple/domain/tinybird/TinybirdProjectSync",
-	{
-		make: Effect.gen(function* () {
-			const fetchDeploymentStatusInternal = Effect.fn("TinybirdProjectSync.fetchDeploymentStatus")(
-				function* (params: TinybirdProjectSyncParams & { readonly deploymentId: string }) {
-					yield* Effect.annotateCurrentSpan("deploymentId", params.deploymentId)
-					const api = makeApi(params)
-					const response = yield* Effect.tryPromise({
-						try: () => api.request(`/v1/deployments/${params.deploymentId}`),
-						catch: (error) => mapApiFailure(error, "Deployment status check failed"),
-					})
+export const makeTinybirdProjectSync = (options: TinybirdProjectSyncOptions): TinybirdProjectSyncShape => {
+	const fetchDeploymentStatusInternal = Effect.fn("TinybirdProjectSync.fetchDeploymentStatus")(function* (
+		params: TinybirdProjectSyncParams & { readonly deploymentId: string },
+	) {
+		yield* Effect.annotateCurrentSpan("deploymentId", params.deploymentId)
+		const api = makeApi(params, options.fetch)
+		const response = yield* Effect.tryPromise({
+			try: () => api.request(`/v1/deployments/${params.deploymentId}`),
+			catch: (error) => mapApiFailure(error, "Deployment status check failed"),
+		})
 
-					const rawBody = yield* Effect.promise(() => response.text()).pipe(
-						Effect.orElseSucceed(() => ""),
-					)
+		const rawBody = yield* Effect.promise(() => response.text()).pipe(Effect.orElseSucceed(() => ""))
 
-					if (response.status === 404) {
-						return {
-							deploymentId: params.deploymentId,
-							status: "deleted",
-							isTerminal: true,
-							isReady: false,
-							errorMessage: `Deployment ${params.deploymentId} was deleted.\nResponse: ${rawBody}`,
-						} satisfies TinybirdDeploymentReadiness
-					}
-					if (response.status >= 400) {
-						return yield* Effect.fail(
-							classifyHttpError(
-								response.status,
-								`Deployment status check failed (HTTP ${response.status}).\nResponse: ${rawBody}`,
-							),
-						)
-					}
-
-					const body = yield* Schema.decodeEffect(DeploymentStatusBodyFromJson)(rawBody).pipe(
-						Effect.mapError(() =>
-							toUnavailableError(
-								`Tinybird returned invalid JSON from deployment status.\nResponse: ${rawBody}`,
-								response.status,
-							),
-						),
-					)
-					const status = body.deployment?.status ?? "unknown"
-					const isReady = READY_STATUSES.has(status)
-					const isTerminal = status === "live" || FAILURE_STATUSES.has(status)
-					const errorMessage = extractStatusErrorMessage(body, status)
-
-					return {
-						deploymentId: params.deploymentId,
-						status,
-						isTerminal,
-						isReady,
-						errorMessage,
-					} satisfies TinybirdDeploymentReadiness
-				},
+		if (response.status === 404) {
+			return {
+				deploymentId: params.deploymentId,
+				status: "deleted",
+				isTerminal: true,
+				isReady: false,
+				errorMessage: `Deployment ${params.deploymentId} was deleted.\nResponse: ${rawBody}`,
+			} satisfies TinybirdDeploymentReadiness
+		}
+		if (response.status >= 400) {
+			return yield* Effect.fail(
+				classifyHttpError(
+					response.status,
+					`Deployment status check failed (HTTP ${response.status}).\nResponse: ${rawBody}`,
+				),
 			)
+		}
 
-			const cleanupStaleDeployments = Effect.fn("TinybirdProjectSync.cleanupStaleDeployments")(
-				function* (params: TinybirdProjectSyncParams) {
-					yield* Effect.annotateCurrentSpan("baseUrl", params.baseUrl)
-					const api = makeApi(params)
+		const body = yield* Schema.decodeEffect(DeploymentStatusBodyFromJson)(rawBody).pipe(
+			Effect.mapError(() =>
+				toUnavailableError(
+					`Tinybird returned invalid JSON from deployment status.\nResponse: ${rawBody}`,
+					response.status,
+				),
+			),
+		)
+		const status = body.deployment?.status ?? "unknown"
+		const isReady = READY_STATUSES.has(status)
+		const isTerminal = status === "live" || FAILURE_STATUSES.has(status)
+		const errorMessage = extractStatusErrorMessage(body, status)
 
-					const listResponse = yield* Effect.tryPromise({
-						try: () => api.request(`/v1/deployments`),
-						catch: (error) => mapApiFailure(error, "Deployments list failed"),
-					})
+		return {
+			deploymentId: params.deploymentId,
+			status,
+			isTerminal,
+			isReady,
+			errorMessage,
+		} satisfies TinybirdDeploymentReadiness
+	})
 
-					if (listResponse.status === 404) return
-					const rawBody = yield* Effect.promise(() => listResponse.text()).pipe(
-						Effect.orElseSucceed(() => ""),
-					)
-					if (listResponse.status >= 400) {
-						return yield* Effect.fail(
-							classifyHttpError(
-								listResponse.status,
-								`Deployments list failed (HTTP ${listResponse.status}).\nResponse: ${rawBody}`,
-							),
-						)
-					}
+	const cleanupStaleDeployments = Effect.fn("TinybirdProjectSync.cleanupStaleDeployments")(function* (
+		params: TinybirdProjectSyncParams,
+	) {
+		yield* Effect.annotateCurrentSpan("baseUrl", params.baseUrl)
+		const api = makeApi(params, options.fetch)
 
-					const body = yield* Schema.decodeEffect(DeploymentsListBodyFromJson)(rawBody).pipe(
-						Effect.mapError(() =>
-							toUnavailableError(
-								`Tinybird returned invalid JSON from deployments list.\nResponse: ${rawBody}`,
-								listResponse.status,
-							),
-						),
-					)
+		const listResponse = yield* Effect.tryPromise({
+			try: () => api.request(`/v1/deployments`),
+			catch: (error) => mapApiFailure(error, "Deployments list failed"),
+		})
 
-					// Only delete deployments in known terminal-failed states. The
-					// previous filter (`!d.live && d.status !== "live"`) also matched
-					// in-flight states like `deploying`, `data_ready`, and any
-					// unrecognised status string from a future Tinybird release —
-					// deleting an active deployment that's still being promoted
-					// disrupts schema rollout. Restrict to `failed` / `error` and
-					// require `live === false` (or unset) as defense in depth.
-					const TERMINAL_FAILED_STATUSES = new Set(["failed", "error"])
-					const stale = body.deployments.filter(
-						(d) =>
-							d.live !== true &&
-							typeof d.status === "string" &&
-							TERMINAL_FAILED_STATUSES.has(d.status),
-					)
-					if (stale.length === 0) return
-
-					yield* Effect.forEach(
-						stale,
-						(deployment) =>
-							Effect.tryPromise({
-								try: () =>
-									api.request(`/v1/deployments/${deployment.id}`, { method: "DELETE" }),
-								catch: (error) => (error instanceof Error ? error : new Error(String(error))),
-							}).pipe(
-								Effect.tapError((error) =>
-									Effect.logWarning("Tinybird stale-deployment cleanup failed").pipe(
-										Effect.annotateLogs({
-											deploymentId: deployment.id,
-											deploymentStatus: deployment.status ?? "unknown",
-											error: error.message,
-										}),
-									),
-								),
-								Effect.ignore,
-							),
-						{ concurrency: STALE_DEPLOYMENT_DELETE_CONCURRENCY, discard: true },
-					)
-				},
+		if (listResponse.status === 404) return
+		const rawBody = yield* Effect.promise(() => listResponse.text()).pipe(Effect.orElseSucceed(() => ""))
+		if (listResponse.status >= 400) {
+			return yield* Effect.fail(
+				classifyHttpError(
+					listResponse.status,
+					`Deployments list failed (HTTP ${listResponse.status}).\nResponse: ${rawBody}`,
+				),
 			)
+		}
 
-			const startDeployment = Effect.fn("TinybirdProjectSync.startDeployment")(function* (
-				params: TinybirdDeployParams,
-			) {
-				yield* Effect.annotateCurrentSpan("baseUrl", params.baseUrl)
-				const api = makeApi(params)
-				const overrides = params.overrides ?? EMPTY_TTL_OVERRIDES
-				const formData = buildDeployFormData(overrides)
-				const effectiveRevision = computeEffectiveRevision(projectRevision, overrides)
+		const body = yield* Schema.decodeEffect(DeploymentsListBodyFromJson)(rawBody).pipe(
+			Effect.mapError(() =>
+				toUnavailableError(
+					`Tinybird returned invalid JSON from deployments list.\nResponse: ${rawBody}`,
+					listResponse.status,
+				),
+			),
+		)
 
-				const deployResponse = yield* Effect.tryPromise({
-					try: () =>
-						api.request("/v1/deploy?allow_destructive_operations=true", {
-							method: "POST",
-							body: formData,
-						}),
-					catch: (error) => mapApiFailure(error, "Tinybird project sync failed"),
-				})
+		// Only delete deployments in known terminal-failed states. The
+		// previous filter (`!d.live && d.status !== "live"`) also matched
+		// in-flight states like `deploying`, `data_ready`, and any
+		// unrecognised status string from a future Tinybird release —
+		// deleting an active deployment that's still being promoted
+		// disrupts schema rollout. Restrict to `failed` / `error` and
+		// require `live === false` (or unset) as defense in depth.
+		const TERMINAL_FAILED_STATUSES = new Set(["failed", "error"])
+		const stale = body.deployments.filter(
+			(d) => d.live !== true && typeof d.status === "string" && TERMINAL_FAILED_STATUSES.has(d.status),
+		)
+		if (stale.length === 0) return
 
-				const deployRawBody = yield* Effect.promise(() => deployResponse.text()).pipe(
-					Effect.orElseSucceed(() => ""),
-				)
-
-				if (deployResponse.status >= 400) {
-					const parsedDeployBody = yield* parseJsonSafe(DeployResponseSchema)(deployRawBody)
-					return yield* Effect.fail(
-						classifyHttpError(
-							deployResponse.status,
-							parsedDeployBody
-								? toDeployErrorMessage(
-										parsedDeployBody,
-										`Tinybird project sync failed (HTTP ${deployResponse.status}).\nResponse: ${deployRawBody}`,
-									)
-								: `Tinybird project sync failed (HTTP ${deployResponse.status}).\nResponse: ${deployRawBody}`,
-						),
-					)
-				}
-
-				const deployBody = yield* Schema.decodeEffect(DeployResponseFromJson)(deployRawBody).pipe(
-					Effect.mapError(() =>
-						toUnavailableError(
-							`Tinybird returned invalid JSON from /v1/deploy.\nResponse: ${deployRawBody}`,
-							deployResponse.status,
+		yield* Effect.forEach(
+			stale,
+			(deployment) =>
+				Effect.tryPromise({
+					try: () => api.request(`/v1/deployments/${deployment.id}`, { method: "DELETE" }),
+					catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+				}).pipe(
+					Effect.tapError((error) =>
+						Effect.logWarning("Tinybird stale-deployment cleanup failed").pipe(
+							Effect.annotateLogs({
+								deploymentId: deployment.id,
+								deploymentStatus: deployment.status ?? "unknown",
+								error: error.message,
+							}),
 						),
 					),
-				)
+					Effect.ignore,
+				),
+			{ concurrency: STALE_DEPLOYMENT_DELETE_CONCURRENCY, discard: true },
+		)
+	})
 
-				if (deployBody.result === "failed") {
-					return yield* Effect.fail(
-						toRejectedError(
-							toDeployErrorMessage(
-								deployBody,
-								`Tinybird project sync failed.\nResponse: ${deployRawBody}`,
-							),
-							deployResponse.status,
-						),
-					)
-				}
+	const startDeployment = Effect.fn("TinybirdProjectSync.startDeployment")(function* (
+		params: TinybirdDeployParams,
+	) {
+		yield* Effect.annotateCurrentSpan("baseUrl", params.baseUrl)
+		const api = makeApi(params, options.fetch)
+		const overrides = params.overrides ?? EMPTY_TTL_OVERRIDES
+		const formData = buildDeployFormData(overrides)
+		const effectiveRevision = computeEffectiveRevision(projectRevision, overrides)
 
-				const feedback = deployBody.deployment?.feedback ?? []
+		const deployResponse = yield* Effect.tryPromise({
+			try: () =>
+				api.request("/v1/deploy?allow_destructive_operations=true", {
+					method: "POST",
+					body: formData,
+				}),
+			catch: (error) => mapApiFailure(error, "Tinybird project sync failed"),
+		})
 
-				return {
-					projectRevision: effectiveRevision,
-					result: deployBody.result,
-					deploymentId: deployBody.deployment?.id ?? null,
-					deploymentStatus: deployBody.deployment?.status ?? null,
-					errorMessage: formatFeedback(feedback),
-				} satisfies TinybirdStartDeploymentResult
-			})
+		const deployRawBody = yield* Effect.promise(() => deployResponse.text()).pipe(
+			Effect.orElseSucceed(() => ""),
+		)
 
-			const pollDeployment = Effect.fn("TinybirdProjectSync.pollDeployment")(function* (
-				params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-			) {
-				const status = yield* fetchDeploymentStatusInternal(params)
-
-				if (status.isReady) return status
-
-				if (status.isTerminal) {
-					return yield* Effect.fail(
-						toRejectedError(
-							status.errorMessage
-								? `Tinybird deployment ${status.status}: ${status.errorMessage}`
-								: `Tinybird deployment ${status.status} before reaching data_ready.`,
-						),
-					)
-				}
-
-				return yield* Effect.fail(
-					TinybirdDeploymentNotReadyError.from(params.deploymentId, status.status),
-				)
-			})
-
-			const setDeploymentLive = Effect.fn("TinybirdProjectSync.setDeploymentLive")(function* (
-				params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-			) {
-				yield* Effect.annotateCurrentSpan("deploymentId", params.deploymentId)
-				const api = makeApi(params)
-				const liveResponse = yield* Effect.tryPromise({
-					try: () =>
-						api.request(`/v1/deployments/${params.deploymentId}/set-live`, {
-							method: "POST",
-						}),
-					catch: (error) =>
-						mapApiFailure(error, `Failed to set Tinybird deployment ${params.deploymentId} live`),
-				})
-
-				if (liveResponse.status >= 400) {
-					const liveRawBody = yield* Effect.promise(() => liveResponse.text()).pipe(
-						Effect.orElseSucceed(() => ""),
-					)
-					return yield* Effect.fail(
-						classifyHttpError(
-							liveResponse.status,
-							`Failed to set Tinybird deployment ${params.deploymentId} live (HTTP ${liveResponse.status}).\nResponse: ${liveRawBody}`,
-						),
-					)
-				}
-			})
-
-			const cleanupOwnedDeployment = Effect.fn("TinybirdProjectSync.cleanupOwnedDeployment")(function* (
-				params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-			) {
-				yield* Effect.annotateCurrentSpan("deploymentId", params.deploymentId)
-				const status = yield* fetchDeploymentStatusInternal(params)
-				if (!status.isTerminal || status.status === "live" || status.status === "data_ready") {
-					return
-				}
-				if (status.status === "deleted") {
-					return
-				}
-
-				const api = makeApi(params)
-				const response = yield* Effect.tryPromise({
-					try: () =>
-						api.request(`/v1/deployments/${params.deploymentId}`, {
-							method: "DELETE",
-						}),
-					catch: (error) =>
-						mapApiFailure(error, `Failed to delete Tinybird deployment ${params.deploymentId}`),
-				})
-
-				if (response.status === 404) return
-				if (response.status >= 400) {
-					const rawBody = yield* Effect.promise(() => response.text()).pipe(
-						Effect.orElseSucceed(() => ""),
-					)
-					return yield* Effect.fail(
-						classifyHttpError(
-							response.status,
-							`Failed to delete Tinybird deployment ${params.deploymentId} (HTTP ${response.status}).\nResponse: ${rawBody}`,
-						),
-					)
-				}
-			})
-
-			const fetchInstanceHealth = Effect.fn("TinybirdProjectSync.fetchInstanceHealth")(function* (
-				params: TinybirdProjectSyncParams,
-			) {
-				yield* Effect.annotateCurrentSpan("baseUrl", params.baseUrl)
-				const api = makeApi(params)
-
-				const requestJsonBestEffort = <A, I>(
-					schema: Schema.Codec<A, I>,
-					path: string,
-					init?: RequestInit,
-				): Effect.Effect<A | null> => {
-					const parse = parseJsonSafe(schema)
-					return Effect.promise(() => api.request(path, init)).pipe(
-						Effect.flatMap((response) =>
-							Effect.promise(() => response.text()).pipe(
-								Effect.flatMap((rawBody) =>
-									response.ok ? parse(rawBody) : Effect.succeed(null),
-								),
-							),
-						),
-						Effect.orElseSucceed(() => null),
-					)
-				}
-
-				const querySql = (sql: string) =>
-					requestJsonBestEffort(
-						SqlResponseSchema,
-						`/v0/sql?q=${encodeURIComponent(`${sql} FORMAT JSON`)}`,
-					)
-
-				// Raw SQL against Tinybird's `tinybird.*` admin schema — fixed strings,
-				// no interpolation. Kept raw because @maple/domain cannot depend on
-				// @maple/query-engine (the DSL) without inverting the existing
-				// query-engine → domain dependency. These three queries have no
-				// dynamic input, so there's no injection surface to protect.
-				const DATASOURCES_STORAGE_SQL =
-					"SELECT datasource_name, bytes, rows FROM tinybird.datasources_storage WHERE timestamp = (SELECT max(timestamp) FROM tinybird.datasources_storage) ORDER BY bytes DESC"
-				const ENDPOINT_ERRORS_24H_SQL =
-					"SELECT count() as cnt FROM tinybird.endpoint_errors WHERE start_datetime >= now() - interval 1 day"
-				const PIPE_LATENCY_24H_SQL =
-					"SELECT avg(duration) as avg_ms FROM tinybird.pipe_stats_rt WHERE start_datetime >= now() - interval 1 day"
-
-				const [workspace, datasourcesResult, errorsResult, latencyResult] = yield* Effect.all(
-					[
-						requestJsonBestEffort(WorkspaceProbeSchema, "/v1/workspace"),
-						querySql(DATASOURCES_STORAGE_SQL),
-						querySql(ENDPOINT_ERRORS_24H_SQL),
-						querySql(PIPE_LATENCY_24H_SQL),
-					],
-					{ concurrency: "unbounded" },
-				)
-
-				const ds = (datasourcesResult?.data ?? []).map((row) => ({
-					name: String(row.datasource_name ?? ""),
-					rowCount: Number(row.rows ?? 0),
-					bytes: Number(row.bytes ?? 0),
-				}))
-
-				const totalRows = ds.reduce((sum, d) => sum + d.rowCount, 0)
-				const totalBytes = ds.reduce((sum, d) => sum + d.bytes, 0)
-
-				const recentErrorCount = Number(errorsResult?.data?.[0]?.cnt ?? 0)
-				const avgLatencyRaw = toNumberOrNull(latencyResult?.data?.[0]?.avg_ms)
-				const avgQueryLatencyMs = avgLatencyRaw == null ? null : avgLatencyRaw * 1000
-
-				return {
-					workspaceName: workspace?.name ?? null,
-					datasources: ds,
-					totalRows,
-					totalBytes,
-					recentErrorCount,
-					avgQueryLatencyMs,
-				}
-			})
-
-			const getCurrentProjectRevision = Effect.fn("TinybirdProjectSync.getCurrentProjectRevision")(
-				function* () {
-					return projectRevision
-				},
+		if (deployResponse.status >= 400) {
+			const parsedDeployBody = yield* parseJsonSafe(DeployResponseSchema)(deployRawBody)
+			return yield* Effect.fail(
+				classifyHttpError(
+					deployResponse.status,
+					parsedDeployBody
+						? toDeployErrorMessage(
+								parsedDeployBody,
+								`Tinybird project sync failed (HTTP ${deployResponse.status}).\nResponse: ${deployRawBody}`,
+							)
+						: `Tinybird project sync failed (HTTP ${deployResponse.status}).\nResponse: ${deployRawBody}`,
+				),
 			)
+		}
 
-			return {
-				cleanupStaleDeployments,
-				startDeployment,
-				pollDeployment,
-				getDeploymentStatus: fetchDeploymentStatusInternal,
-				setDeploymentLive,
-				cleanupOwnedDeployment,
-				fetchInstanceHealth,
-				getCurrentProjectRevision,
-			} satisfies TinybirdProjectSyncShape
-		}),
-	},
-) {
-	static readonly layer = Layer.effect(this, this.make)
+		const deployBody = yield* Schema.decodeEffect(DeployResponseFromJson)(deployRawBody).pipe(
+			Effect.mapError(() =>
+				toUnavailableError(
+					`Tinybird returned invalid JSON from /v1/deploy.\nResponse: ${deployRawBody}`,
+					deployResponse.status,
+				),
+			),
+		)
 
-	static readonly cleanupStaleDeployments = (params: TinybirdProjectSyncParams) =>
-		this.use((service) => service.cleanupStaleDeployments(params))
+		if (deployBody.result === "failed") {
+			return yield* Effect.fail(
+				toRejectedError(
+					toDeployErrorMessage(
+						deployBody,
+						`Tinybird project sync failed.\nResponse: ${deployRawBody}`,
+					),
+					deployResponse.status,
+				),
+			)
+		}
 
-	static readonly startDeployment = (params: TinybirdDeployParams) =>
-		this.use((service) => service.startDeployment(params))
+		const feedback = deployBody.deployment?.feedback ?? []
 
-	static readonly pollDeployment = (
+		return {
+			projectRevision: effectiveRevision,
+			result: deployBody.result,
+			deploymentId: deployBody.deployment?.id ?? null,
+			deploymentStatus: deployBody.deployment?.status ?? null,
+			errorMessage: formatFeedback(feedback),
+		} satisfies TinybirdStartDeploymentResult
+	})
+
+	const pollDeployment = Effect.fn("TinybirdProjectSync.pollDeployment")(function* (
 		params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-	) => this.use((service) => service.pollDeployment(params))
+	) {
+		const status = yield* fetchDeploymentStatusInternal(params)
 
-	static readonly getDeploymentStatus = (
+		if (status.isReady) return status
+
+		if (status.isTerminal) {
+			return yield* Effect.fail(
+				toRejectedError(
+					status.errorMessage
+						? `Tinybird deployment ${status.status}: ${status.errorMessage}`
+						: `Tinybird deployment ${status.status} before reaching data_ready.`,
+				),
+			)
+		}
+
+		return yield* Effect.fail(TinybirdDeploymentNotReadyError.from(params.deploymentId, status.status))
+	})
+
+	const setDeploymentLive = Effect.fn("TinybirdProjectSync.setDeploymentLive")(function* (
 		params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-	) => this.use((service) => service.getDeploymentStatus(params))
+	) {
+		yield* Effect.annotateCurrentSpan("deploymentId", params.deploymentId)
+		const api = makeApi(params, options.fetch)
+		const liveResponse = yield* Effect.tryPromise({
+			try: () =>
+				api.request(`/v1/deployments/${params.deploymentId}/set-live`, {
+					method: "POST",
+				}),
+			catch: (error) =>
+				mapApiFailure(error, `Failed to set Tinybird deployment ${params.deploymentId} live`),
+		})
 
-	static readonly setDeploymentLive = (
+		if (liveResponse.status >= 400) {
+			const liveRawBody = yield* Effect.promise(() => liveResponse.text()).pipe(
+				Effect.orElseSucceed(() => ""),
+			)
+			return yield* Effect.fail(
+				classifyHttpError(
+					liveResponse.status,
+					`Failed to set Tinybird deployment ${params.deploymentId} live (HTTP ${liveResponse.status}).\nResponse: ${liveRawBody}`,
+				),
+			)
+		}
+	})
+
+	const cleanupOwnedDeployment = Effect.fn("TinybirdProjectSync.cleanupOwnedDeployment")(function* (
 		params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-	) => this.use((service) => service.setDeploymentLive(params))
+	) {
+		yield* Effect.annotateCurrentSpan("deploymentId", params.deploymentId)
+		const status = yield* fetchDeploymentStatusInternal(params)
+		if (!status.isTerminal || status.status === "live" || status.status === "data_ready") {
+			return
+		}
+		if (status.status === "deleted") {
+			return
+		}
 
-	static readonly cleanupOwnedDeployment = (
-		params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-	) => this.use((service) => service.cleanupOwnedDeployment(params))
+		const api = makeApi(params, options.fetch)
+		const response = yield* Effect.tryPromise({
+			try: () =>
+				api.request(`/v1/deployments/${params.deploymentId}`, {
+					method: "DELETE",
+				}),
+			catch: (error) =>
+				mapApiFailure(error, `Failed to delete Tinybird deployment ${params.deploymentId}`),
+		})
 
-	static readonly fetchInstanceHealth = (params: TinybirdProjectSyncParams) =>
-		this.use((service) => service.fetchInstanceHealth(params))
+		if (response.status === 404) return
+		if (response.status >= 400) {
+			const rawBody = yield* Effect.promise(() => response.text()).pipe(Effect.orElseSucceed(() => ""))
+			return yield* Effect.fail(
+				classifyHttpError(
+					response.status,
+					`Failed to delete Tinybird deployment ${params.deploymentId} (HTTP ${response.status}).\nResponse: ${rawBody}`,
+				),
+			)
+		}
+	})
 
-	static readonly getCurrentProjectRevision = () =>
-		this.use((service) => service.getCurrentProjectRevision())
+	const fetchInstanceHealth = Effect.fn("TinybirdProjectSync.fetchInstanceHealth")(function* (
+		params: TinybirdProjectSyncParams,
+	) {
+		yield* Effect.annotateCurrentSpan("baseUrl", params.baseUrl)
+		const api = makeApi(params, options.fetch)
+
+		const requestJsonBestEffort = <A, I>(
+			schema: Schema.Codec<A, I>,
+			path: string,
+			init?: RequestInit,
+		): Effect.Effect<A | null> => {
+			const parse = parseJsonSafe(schema)
+			return Effect.promise(() => api.request(path, init)).pipe(
+				Effect.flatMap((response) =>
+					Effect.promise(() => response.text()).pipe(
+						Effect.flatMap((rawBody) => (response.ok ? parse(rawBody) : Effect.succeed(null))),
+					),
+				),
+				Effect.orElseSucceed(() => null),
+			)
+		}
+
+		const querySql = (sql: string) =>
+			requestJsonBestEffort(SqlResponseSchema, `/v0/sql?q=${encodeURIComponent(`${sql} FORMAT JSON`)}`)
+
+		// Raw SQL against Tinybird's `tinybird.*` admin schema — fixed strings,
+		// no interpolation. Kept raw because @maple/domain cannot depend on
+		// @maple/query-engine (the DSL) without inverting the existing
+		// query-engine → domain dependency. These three queries have no
+		// dynamic input, so there's no injection surface to protect.
+		const DATASOURCES_STORAGE_SQL =
+			"SELECT datasource_name, bytes, rows FROM tinybird.datasources_storage WHERE timestamp = (SELECT max(timestamp) FROM tinybird.datasources_storage) ORDER BY bytes DESC"
+		const ENDPOINT_ERRORS_24H_SQL =
+			"SELECT count() as cnt FROM tinybird.endpoint_errors WHERE start_datetime >= now() - interval 1 day"
+		const PIPE_LATENCY_24H_SQL =
+			"SELECT avg(duration) as avg_ms FROM tinybird.pipe_stats_rt WHERE start_datetime >= now() - interval 1 day"
+
+		const [workspace, datasourcesResult, errorsResult, latencyResult] = yield* Effect.all(
+			[
+				requestJsonBestEffort(WorkspaceProbeSchema, "/v1/workspace"),
+				querySql(DATASOURCES_STORAGE_SQL),
+				querySql(ENDPOINT_ERRORS_24H_SQL),
+				querySql(PIPE_LATENCY_24H_SQL),
+			],
+			{ concurrency: "unbounded" },
+		)
+
+		const ds = (datasourcesResult?.data ?? []).map((row) => ({
+			name: String(row.datasource_name ?? ""),
+			rowCount: Number(row.rows ?? 0),
+			bytes: Number(row.bytes ?? 0),
+		}))
+
+		const totalRows = ds.reduce((sum, d) => sum + d.rowCount, 0)
+		const totalBytes = ds.reduce((sum, d) => sum + d.bytes, 0)
+
+		const recentErrorCount = Number(errorsResult?.data?.[0]?.cnt ?? 0)
+		const avgLatencyRaw = toNumberOrNull(latencyResult?.data?.[0]?.avg_ms)
+		const avgQueryLatencyMs = avgLatencyRaw == null ? null : avgLatencyRaw * 1000
+
+		return {
+			workspaceName: workspace?.name ?? null,
+			datasources: ds,
+			totalRows,
+			totalBytes,
+			recentErrorCount,
+			avgQueryLatencyMs,
+		}
+	})
+
+	const getCurrentProjectRevision = Effect.fn("TinybirdProjectSync.getCurrentProjectRevision")(
+		function* () {
+			return projectRevision
+		},
+	)
+
+	return {
+		cleanupStaleDeployments,
+		startDeployment,
+		pollDeployment,
+		getDeploymentStatus: fetchDeploymentStatusInternal,
+		setDeploymentLive,
+		cleanupOwnedDeployment,
+		fetchInstanceHealth,
+		getCurrentProjectRevision,
+	} satisfies TinybirdProjectSyncShape
 }
 
 // Promise-returning wrappers for non-Effect callers (Cloudflare Workflow steps)
 
-const provideSync = <A, E>(effect: Effect.Effect<A, E, TinybirdProjectSync>): Promise<A> =>
-	Effect.runPromise(Effect.provide(effect, TinybirdProjectSync.layer))
+export interface TinybirdProjectSyncRuntime {
+	readonly cleanupStaleTinybirdDeployments: (params: TinybirdProjectSyncParams) => Promise<void>
+	readonly startTinybirdDeploymentStep: (
+		params: TinybirdDeployParams,
+	) => Promise<TinybirdStartDeploymentResult>
+	readonly pollTinybirdDeploymentStep: (
+		params: TinybirdProjectSyncParams & { readonly deploymentId: string },
+	) => Promise<TinybirdDeploymentReadiness>
+	readonly getTinybirdDeploymentStatus: (
+		params: TinybirdProjectSyncParams & { readonly deploymentId: string },
+	) => Promise<TinybirdDeploymentReadiness>
+	readonly setTinybirdDeploymentLiveStep: (
+		params: TinybirdProjectSyncParams & { readonly deploymentId: string },
+	) => Promise<void>
+	readonly cleanupOwnedTinybirdDeployment: (
+		params: TinybirdProjectSyncParams & { readonly deploymentId: string },
+	) => Promise<void>
+	readonly fetchInstanceHealth: (params: TinybirdProjectSyncParams) => Promise<TinybirdInstanceHealth>
+	readonly getCurrentTinybirdProjectRevision: () => Promise<string>
+}
+
+export const makeTinybirdProjectSyncRuntime = (
+	options: TinybirdProjectSyncOptions,
+): TinybirdProjectSyncRuntime => {
+	const sync = makeTinybirdProjectSync(options)
+	const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> => Effect.runPromise(effect)
+
+	return {
+		cleanupStaleTinybirdDeployments: (params) => run(sync.cleanupStaleDeployments(params)),
+		startTinybirdDeploymentStep: (params) => run(sync.startDeployment(params)),
+		pollTinybirdDeploymentStep: (params) => run(sync.pollDeployment(params)),
+		getTinybirdDeploymentStatus: (params) => run(sync.getDeploymentStatus(params)),
+		setTinybirdDeploymentLiveStep: (params) => run(sync.setDeploymentLive(params)),
+		cleanupOwnedTinybirdDeployment: (params) => run(sync.cleanupOwnedDeployment(params)),
+		fetchInstanceHealth: (params) => run(sync.fetchInstanceHealth(params)),
+		getCurrentTinybirdProjectRevision: () => run(sync.getCurrentProjectRevision()),
+	} satisfies TinybirdProjectSyncRuntime
+}
+
+// Resolve the platform fetch at call time so runtimes that install it after
+// module evaluation still use the platform implementation.
+const defaultRuntime = makeTinybirdProjectSyncRuntime({
+	fetch: (input, init) => globalThis.fetch(input, init),
+})
 
 export const cleanupStaleTinybirdDeployments = (params: TinybirdProjectSyncParams): Promise<void> =>
-	provideSync(TinybirdProjectSync.cleanupStaleDeployments(params))
+	defaultRuntime.cleanupStaleTinybirdDeployments(params)
 
 export const startTinybirdDeploymentStep = (
 	params: TinybirdDeployParams,
-): Promise<TinybirdStartDeploymentResult> => provideSync(TinybirdProjectSync.startDeployment(params))
+): Promise<TinybirdStartDeploymentResult> => defaultRuntime.startTinybirdDeploymentStep(params)
 
 export const pollTinybirdDeploymentStep = (
 	params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-): Promise<TinybirdDeploymentReadiness> => provideSync(TinybirdProjectSync.pollDeployment(params))
+): Promise<TinybirdDeploymentReadiness> => defaultRuntime.pollTinybirdDeploymentStep(params)
 
 export const getTinybirdDeploymentStatus = (
 	params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-): Promise<TinybirdDeploymentReadiness> => provideSync(TinybirdProjectSync.getDeploymentStatus(params))
+): Promise<TinybirdDeploymentReadiness> => defaultRuntime.getTinybirdDeploymentStatus(params)
 
 export const setTinybirdDeploymentLiveStep = (
 	params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-): Promise<void> => provideSync(TinybirdProjectSync.setDeploymentLive(params))
+): Promise<void> => defaultRuntime.setTinybirdDeploymentLiveStep(params)
 
 export const cleanupOwnedTinybirdDeployment = (
 	params: TinybirdProjectSyncParams & { readonly deploymentId: string },
-): Promise<void> => provideSync(TinybirdProjectSync.cleanupOwnedDeployment(params))
+): Promise<void> => defaultRuntime.cleanupOwnedTinybirdDeployment(params)
 
 export const fetchInstanceHealth = (params: TinybirdProjectSyncParams): Promise<TinybirdInstanceHealth> =>
-	provideSync(TinybirdProjectSync.fetchInstanceHealth(params))
+	defaultRuntime.fetchInstanceHealth(params)
 
 export const getCurrentTinybirdProjectRevision = (): Promise<string> =>
-	provideSync(TinybirdProjectSync.getCurrentProjectRevision())
+	defaultRuntime.getCurrentTinybirdProjectRevision()


### PR DESCRIPTION
## Summary

- remove the unused `TinybirdProjectSync` `Context.Service` and Layer
- expose `makeTinybirdProjectSync({ fetch })` for injectable Effect operations
- expose `makeTinybirdProjectSyncRuntime({ fetch })` for reusable Promise callers
- preserve every existing named Promise export through one module-level compatibility runtime
- replace global fetch mutation in tests with injected transports

## Why

Every wrapper previously built and immediately provided a fresh service layer, while the implementation still read global fetch. That was DI-shaped ceremony with neither reuse nor a real test seam.

## Validation

- domain typecheck
- focused project-sync suite — 19 passed
- full domain suite — 472 passed
- clickhouse-builder prerequisite build
- oxfmt, oxlint, and diff checks

The default compatibility runtime still resolves `globalThis.fetch` at call time; new code should use one of the injectable factories.

## Stack

Builds on #397.

<sub>Stack created with the GitHub Stacks CLI.</sub>
