### PR TITLE
extract alert destinations service

### DIFF
--- a/apps/alerting/src/worker.ts
+++ b/apps/alerting/src/worker.ts
@@ -1,5 +1,6 @@
 import {
 	ANTICIPATED_ERROR_IDENTIFIERS,
+	AlertDestinationsService,
 	AlertsService,
 	AnomalyDetectionService,
 	BucketCacheService,
@@ -85,6 +86,12 @@ export const buildLayer = (env: AlertingWorkerEnv) => {
 
 	const OrgMembersServiceLive = OrgMembersService.layer.pipe(Layer.provide(EnvLive))
 
+	const AlertDestinationsServiceLive = AlertDestinationsService.layer.pipe(
+		Layer.provide(
+			Layer.mergeAll(BaseLive, HazelOAuthServiceLive, EmailServiceLive, OrgMembersServiceLive),
+		),
+	)
+
 	// WorkerEnvironment is merged in so the incident-open issue-hub hook can see
 	// the cross-script investigation workflow binding.
 	// AlertRuntime is a Context.Reference with defaults, so it needs no wiring here.
@@ -97,7 +104,7 @@ export const buildLayer = (env: AlertingWorkerEnv) => {
 				OrgClickHouseSettingsLive,
 				HazelOAuthServiceLive,
 				EmailServiceLive,
-				OrgMembersServiceLive,
+				AlertDestinationsServiceLive,
 				WorkerEnvironmentLive,
 			),
 		),

--- a/apps/api/src/alerting.ts
+++ b/apps/api/src/alerting.ts
@@ -1,5 +1,6 @@
 export { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
 export { AlertRuntime, AlertsService } from "./services/alerts/AlertsService"
+export { AlertDestinationsService } from "./services/alerts/AlertDestinationsService"
 export { AnomalyDetectionService } from "./services/alerts/AnomalyDetectionService"
 export { BucketCacheService } from "@maple/query-engine/caching"
 export { CacheBackendLive } from "@/platform/CacheBackendLive"

--- a/apps/api/src/platform/describe-cause.ts
+++ b/apps/api/src/platform/describe-cause.ts
@@ -1,0 +1,11 @@
+/** Render an unknown nested cause for logs and serialized persistence errors. */
+export const describeCause = (cause: unknown): string | undefined => {
+	if (cause == null) return undefined
+	if (cause instanceof Error) return cause.stack ?? cause.message
+	if (typeof cause === "string") return cause
+	try {
+		return JSON.stringify(cause)
+	} catch {
+		return String(cause)
+	}
+}

--- a/apps/api/src/routes/v2/alchemy-provider.integration.test.ts
+++ b/apps/api/src/routes/v2/alchemy-provider.integration.test.ts
@@ -34,6 +34,7 @@ import { ApiKeysService } from "@/services/org/ApiKeysService"
 import { AuthService } from "@/services/auth/AuthService"
 import { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
 import { AlertRuntime, AlertsService } from "@/services/alerts/AlertsService"
+import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
 import { HazelOAuthService } from "@/services/auth/HazelOAuthService"
 import { OrgClickHouseSettingsService } from "@/services/org/OrgClickHouseSettingsService"
 import { OrgMembersService } from "@/services/org/OrgMembersService"
@@ -123,6 +124,11 @@ const makeHarness = () => {
 	const orgChSettingsLive = OrgClickHouseSettingsService.layer.pipe(
 		Layer.provide(Layer.mergeAll(envLive, testDb.layer)),
 	)
+	const alertDestinationsLive = AlertDestinationsService.layer.pipe(
+		Layer.provide(
+			Layer.mergeAll(envLive, testDb.layer, runtimeLive, hazelOAuthLive, emailLive, orgMembersLive),
+		),
+	)
 	const alertsLive = AlertsService.layer.pipe(
 		Layer.provide(
 			Layer.mergeAll(
@@ -136,6 +142,7 @@ const makeHarness = () => {
 				orgMembersLive,
 				orgChSettingsLive,
 				investigationsLive,
+				alertDestinationsLive,
 			),
 		),
 	)
@@ -143,6 +150,7 @@ const makeHarness = () => {
 		ApiKeysService.layer,
 		AuthService.layer,
 		DashboardPersistenceService.layer,
+		alertDestinationsLive,
 		alertsLive,
 	).pipe(Layer.provideMerge(Layer.mergeAll(envLive, testDb.layer)))
 

--- a/apps/api/src/routes/v2/alert-destinations.http.ts
+++ b/apps/api/src/routes/v2/alert-destinations.http.ts
@@ -17,7 +17,7 @@ import type {
 } from "@maple/domain/http/v2"
 import { MapleApiV2, paginateArray, resourceNotFound } from "@maple/domain/http/v2"
 import { Effect } from "effect"
-import { AlertsService } from "@/services/alerts/AlertsService"
+import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
 import { mapAlertError } from "./alerts-error-map"
 
 const toV2Destination = (doc: AlertDestinationDocument): V2AlertDestination => ({
@@ -156,13 +156,13 @@ const toUpdateRequest = (params: V2AlertDestinationUpdateParams): AlertDestinati
 
 export const HttpV2AlertDestinationsLive = HttpApiBuilder.group(MapleApiV2, "alertDestinations", (handlers) =>
 	Effect.gen(function* () {
-		const alerts = yield* AlertsService
+		const destinations = yield* AlertDestinationsService
 
 		return handlers
 			.handle("list", ({ query }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					const response = yield* alerts
+					const response = yield* destinations
 						.listDestinations(tenant.orgId)
 						.pipe(mapAlertError("destination_list"))
 					const page = yield* paginateArray(response.destinations.map(toV2Destination), query)
@@ -172,7 +172,7 @@ export const HttpV2AlertDestinationsLive = HttpApiBuilder.group(MapleApiV2, "ale
 			.handle("retrieve", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					const response = yield* alerts
+					const response = yield* destinations
 						.listDestinations(tenant.orgId)
 						.pipe(mapAlertError("destination_list"))
 					const destination = response.destinations.find((doc) => doc.id === params.id)
@@ -186,7 +186,7 @@ export const HttpV2AlertDestinationsLive = HttpApiBuilder.group(MapleApiV2, "ale
 			.handle("create", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					const created = yield* alerts
+					const created = yield* destinations
 						.createDestination(
 							tenant.orgId,
 							tenant.userId,
@@ -200,7 +200,7 @@ export const HttpV2AlertDestinationsLive = HttpApiBuilder.group(MapleApiV2, "ale
 			.handle("update", ({ params, payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					const updated = yield* alerts
+					const updated = yield* destinations
 						.updateDestination(
 							tenant.orgId,
 							tenant.userId,
@@ -215,7 +215,7 @@ export const HttpV2AlertDestinationsLive = HttpApiBuilder.group(MapleApiV2, "ale
 			.handle("delete", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					const deleted = yield* alerts
+					const deleted = yield* destinations
 						.deleteDestination(tenant.orgId, tenant.roles, params.id)
 						.pipe(mapAlertError("destination_delete"))
 					return {
@@ -229,7 +229,7 @@ export const HttpV2AlertDestinationsLive = HttpApiBuilder.group(MapleApiV2, "ale
 			.handle("test", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					const result = yield* alerts
+					const result = yield* destinations
 						.testDestination(tenant.orgId, tenant.userId, tenant.roles, params.id)
 						.pipe(mapAlertError("destination_test"))
 					return {

--- a/apps/api/src/routes/v2/alerts.http.test.ts
+++ b/apps/api/src/routes/v2/alerts.http.test.ts
@@ -17,6 +17,7 @@ import { ApiKeysService } from "@/services/org/ApiKeysService"
 import { AuthService } from "@/services/auth/AuthService"
 import { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
 import { AlertRuntime, AlertsService } from "@/services/alerts/AlertsService"
+import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
 import { HazelOAuthService } from "@/services/auth/HazelOAuthService"
 import { OrgClickHouseSettingsService } from "@/services/org/OrgClickHouseSettingsService"
 import { OrgMembersService } from "@/services/org/OrgMembersService"
@@ -100,6 +101,11 @@ const makeHarness = (warehouseService: WarehouseQueryServiceShape = warehouseStu
 	const orgChSettingsLive = OrgClickHouseSettingsService.layer.pipe(
 		Layer.provide(Layer.mergeAll(envLive, testDb.layer)),
 	)
+	const alertDestinationsLive = AlertDestinationsService.layer.pipe(
+		Layer.provide(
+			Layer.mergeAll(envLive, testDb.layer, runtimeLive, hazelOAuthLive, emailLive, orgMembersLive),
+		),
+	)
 	const alertsLive = AlertsService.layer.pipe(
 		Layer.provide(
 			Layer.mergeAll(
@@ -113,6 +119,7 @@ const makeHarness = (warehouseService: WarehouseQueryServiceShape = warehouseStu
 				orgMembersLive,
 				orgChSettingsLive,
 				investigationsLive,
+				alertDestinationsLive,
 			),
 		),
 	)
@@ -120,6 +127,7 @@ const makeHarness = (warehouseService: WarehouseQueryServiceShape = warehouseStu
 		ApiKeysService.layer,
 		AuthService.layer,
 		DashboardPersistenceService.layer,
+		alertDestinationsLive,
 		alertsLive,
 	).pipe(Layer.provideMerge(Layer.mergeAll(envLive, testDb.layer)))
 

--- a/apps/api/src/routes/v2/v2-test-support.ts
+++ b/apps/api/src/routes/v2/v2-test-support.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer } from "effect"
 import { EdgeCacheService, MemoryCacheBackendLive } from "@maple/cache"
 import { AlertsService } from "@/services/alerts/AlertsService"
+import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
 import { AnomalyDetectionService } from "@/services/alerts/AnomalyDetectionService"
 import { ErrorsService } from "@/services/errors/ErrorsService"
 import { IngestAttributeMappingService } from "@/services/org/IngestAttributeMappingService"
@@ -265,23 +266,36 @@ export const SlackIntegrationServiceStubLayer = Layer.succeed(
 	}),
 )
 
-/** Inert AlertsService for harnesses that never touch the alert groups. */
-export const AlertsServiceStubLayer = Layer.succeed(AlertsService, {
+const alertDestinationStubs = {
 	listDestinations: die,
 	createDestination: die,
 	updateDestination: die,
 	deleteDestination: die,
 	testDestination: die,
-	listRules: die,
-	createRule: die,
-	updateRule: die,
-	deleteRule: die,
-	testRule: die,
-	previewRule: die,
-	listIncidents: die,
-	getIncident: die,
-	listRuleChecks: die,
-	summarizeRuleChecks: die,
-	listDeliveryEvents: die,
-	runSchedulerTick: die,
-})
+}
+
+/** Inert destination capability for harnesses that never touch the alert destination group. */
+export const AlertDestinationsServiceStubLayer = Layer.succeed(
+	AlertDestinationsService,
+	alertDestinationStubs,
+)
+
+/** Inert AlertsService facade for harnesses that never touch the alert groups. */
+export const AlertsServiceStubLayer = Layer.mergeAll(
+	AlertDestinationsServiceStubLayer,
+	Layer.succeed(AlertsService, {
+		...alertDestinationStubs,
+		listRules: die,
+		createRule: die,
+		updateRule: die,
+		deleteRule: die,
+		testRule: die,
+		previewRule: die,
+		listIncidents: die,
+		getIncident: die,
+		listRuleChecks: die,
+		summarizeRuleChecks: die,
+		listDeliveryEvents: die,
+		runSchedulerTick: die,
+	}),
+)

--- a/apps/api/src/runtime/mcp-service-graph.ts
+++ b/apps/api/src/runtime/mcp-service-graph.ts
@@ -6,6 +6,7 @@ import { CacheBackendLive } from "@/platform/CacheBackendLive"
 import { EmailService } from "@/platform/EmailService"
 import { Env } from "@/platform/Env"
 import { AlertRuntime, AlertsService } from "@/services/alerts/AlertsService"
+import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
 import { NotificationDispatcher } from "@/services/alerts/NotificationDispatcher"
 import { HazelOAuthService } from "@/services/auth/HazelOAuthService"
 import { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
@@ -48,6 +49,18 @@ const QueryEngineServiceLive = QueryEngineService.layer.pipe(
 const EmailServiceLive = EmailService.layer.pipe(Layer.provide(InfraLive))
 const OrgMembersServiceLive = OrgMembersService.layer.pipe(Layer.provide(InfraLive))
 
+const AlertDestinationsServiceLive = AlertDestinationsService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(
+			InfraLive,
+			AlertRuntime.layer,
+			HazelOAuthServiceLive,
+			EmailServiceLive,
+			OrgMembersServiceLive,
+		),
+	),
+)
+
 const AlertsServiceLive = AlertsService.layer.pipe(
 	Layer.provide(
 		Layer.mergeAll(
@@ -59,6 +72,7 @@ const AlertsServiceLive = AlertsService.layer.pipe(
 			EmailServiceLive,
 			OrgMembersServiceLive,
 			OrgClickHouseSettingsServiceLive,
+			AlertDestinationsServiceLive,
 		),
 	),
 )

--- a/apps/api/src/runtime/service-graph.ts
+++ b/apps/api/src/runtime/service-graph.ts
@@ -6,6 +6,7 @@ import { CacheBackendLive } from "@/platform/CacheBackendLive"
 import { EmailService } from "@/platform/EmailService"
 import { Env } from "@/platform/Env"
 import { AlertRuntime, AlertsService } from "@/services/alerts/AlertsService"
+import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
 import { AnomalyDetectionService } from "@/services/alerts/AnomalyDetectionService"
 import { NotificationDispatcher } from "@/services/alerts/NotificationDispatcher"
 import { PlanetScaleOAuthService } from "@/services/auth/PlanetScaleOAuthService"
@@ -116,6 +117,12 @@ const EmailServiceLive = EmailService.layer.pipe(Layer.provide(Env.layer))
 
 const OrgMembersServiceLive = OrgMembersService.layer.pipe(Layer.provide(Env.layer))
 
+const AlertDestinationsServiceLive = AlertDestinationsService.layer.pipe(
+	Layer.provide(
+		Layer.mergeAll(CoreServicesLive, AlertRuntime.layer, EmailServiceLive, OrgMembersServiceLive),
+	),
+)
+
 const AlertsServiceLive = AlertsService.layer.pipe(
 	Layer.provideMerge(
 		Layer.mergeAll(
@@ -124,6 +131,7 @@ const AlertsServiceLive = AlertsService.layer.pipe(
 			AlertRuntime.layer,
 			EmailServiceLive,
 			OrgMembersServiceLive,
+			AlertDestinationsServiceLive,
 		),
 	),
 )
@@ -203,6 +211,7 @@ const MainServicesLive = Layer.mergeAll(
 	WarehouseQueryServiceLive,
 	EdgeCacheServiceLive,
 	QueryEngineServiceLive,
+	AlertDestinationsServiceLive,
 	AlertsServiceLive,
 	AnomalyDetectionServiceLive,
 	AiTriageServiceLive,

--- a/apps/api/src/services/alerts/AlertDestinationDelivery.ts
+++ b/apps/api/src/services/alerts/AlertDestinationDelivery.ts
@@ -1,0 +1,192 @@
+import {
+	AlertDeliveryError,
+	AlertValidationError,
+	type AlertNotificationTemplate,
+	type AlertIncidentId,
+	type AlertRuleId,
+} from "@maple/domain/http"
+import type { AlertDestinationRow } from "@maple/db"
+import { Effect } from "effect"
+import { parseBase64Aes256GcmKey } from "@/platform/Crypto"
+import type { EmailServiceShape } from "@/platform/EmailService"
+import type { SlackBotTokenResolverShape } from "@/services/integrations/slack-bot-token"
+import {
+	buildAlertChatUrl,
+	dispatchDelivery as dispatchDeliveryImpl,
+	type DispatchContext as DeliveryDispatchContext,
+	type DispatchResult,
+} from "./AlertDeliveryDispatch"
+import {
+	hydrateDestinationRow,
+	type DestinationSecretConfig,
+	type EnrichedDestinationSecretConfig,
+} from "./AlertDestinationHydration"
+import type { AlertRuntimeShape } from "./AlertRuntime"
+
+export type AlertDispatchContext = Omit<
+	DeliveryDispatchContext,
+	"ruleId" | "incidentId" | "incidentStatus" | "sentAtMs"
+> & {
+	readonly ruleId: AlertRuleId
+	readonly incidentId: AlertIncidentId | null
+	readonly incidentStatus: DeliveryDispatchContext["incidentStatus"]
+	readonly linkUrl: string
+	readonly sentAtMs: number
+}
+
+export type AlertDeliveryPayloadContext = Omit<
+	AlertDispatchContext,
+	"deliveryKey" | "destination" | "publicConfig" | "secretConfig"
+>
+
+export const parseAlertDestinationEncryptionKey = (
+	raw: string,
+): Effect.Effect<Buffer, AlertValidationError> =>
+	parseBase64Aes256GcmKey(
+		raw,
+		(message) =>
+			new AlertValidationError({
+				message:
+					message === "Expected a non-empty base64 encryption key"
+						? "MAPLE_INGEST_KEY_ENCRYPTION_KEY is required"
+						: message === "Expected base64 for exactly 32 bytes"
+							? "MAPLE_INGEST_KEY_ENCRYPTION_KEY must be base64 for exactly 32 bytes"
+							: message,
+				details: [],
+			}),
+	)
+
+export const makeAlertDestinationDelivery = (options: {
+	readonly encryptionKey: Buffer
+	readonly appBaseUrl: string
+	readonly runtime: AlertRuntimeShape
+	readonly email: EmailServiceShape
+	readonly resolveSlackBotToken: SlackBotTokenResolverShape["resolve"]
+}) => {
+	const hydrateDestination = Effect.fn("AlertsService.hydrateDestination")(function* (
+		row: AlertDestinationRow,
+	) {
+		const { publicConfig, secretConfig } = yield* hydrateDestinationRow(row, options.encryptionKey, {
+			onPublicConfigInvalid: (cause) =>
+				new AlertValidationError({
+					message: "Stored destination config is invalid",
+					details: [],
+					cause,
+				}),
+			onDecryptFailure: () =>
+				new AlertValidationError({
+					message: "Failed to decrypt destination secret",
+					details: [],
+				}),
+			onSecretConfigInvalid: (cause) =>
+				new AlertValidationError({
+					message: "Stored destination secret is invalid",
+					details: [],
+					cause,
+				}),
+		})
+		return { row, publicConfig, secretConfig } as const
+	})
+
+	const enrichSecretForDispatch = (
+		_row: AlertDestinationRow,
+		secretConfig: DestinationSecretConfig,
+	): Effect.Effect<EnrichedDestinationSecretConfig, AlertDeliveryError> =>
+		// Hazel-OAuth webhooks embed their delivery token in the URL path, so
+		// there's nothing to enrich at dispatch time.
+		Effect.succeed(secretConfig)
+
+	const composeLinkUrl = (serviceLinkName: string | null) =>
+		serviceLinkName
+			? `${options.appBaseUrl}/services/${encodeURIComponent(serviceLinkName)}`
+			: `${options.appBaseUrl}/alerts`
+
+	const composeChatUrl = (context: AlertDispatchContext): string =>
+		buildAlertChatUrl(options.appBaseUrl, context)
+
+	const sendEmail = (to: string, subject: string, html: string) =>
+		options.email
+			.send(to, subject, html)
+			.pipe(
+				Effect.mapError(
+					(error) => new AlertDeliveryError({ message: error.message, destinationType: "email" }),
+				),
+			)
+
+	const dispatchDelivery = (
+		context: AlertDispatchContext,
+		payloadJson: string,
+	): Effect.Effect<DispatchResult, AlertDeliveryError> =>
+		dispatchDeliveryImpl(
+			context,
+			payloadJson,
+			options.runtime.fetch,
+			options.runtime.deliveryTimeoutMs(),
+			context.linkUrl,
+			composeChatUrl(context),
+			{ sendEmail, resolveSlackBotToken: options.resolveSlackBotToken },
+		)
+
+	const buildPayload = (context: AlertDeliveryPayloadContext) =>
+		({
+			eventType: context.eventType,
+			incidentId: context.incidentId,
+			incidentStatus: context.incidentStatus,
+			dedupeKey: context.dedupeKey,
+			rule: {
+				id: context.ruleId,
+				name: context.ruleName,
+				signalType: context.signalType,
+				severity: context.severity,
+				groupKey: context.groupKey,
+				comparator: context.comparator,
+				threshold: context.threshold,
+				thresholdUpper: context.thresholdUpper,
+				windowMinutes: context.windowMinutes,
+			},
+			observed: {
+				value: context.value,
+				sampleCount: context.sampleCount,
+			},
+			template: context.template ?? null,
+			linkUrl: context.linkUrl,
+			chatUrl: buildAlertChatUrl(options.appBaseUrl, context),
+			sentAt: new Date(context.sentAtMs).toISOString(),
+		}) satisfies {
+			readonly eventType: AlertDeliveryPayloadContext["eventType"]
+			readonly incidentId: AlertIncidentId | null
+			readonly incidentStatus: AlertDeliveryPayloadContext["incidentStatus"]
+			readonly dedupeKey: string
+			readonly rule: Record<string, unknown>
+			readonly observed: Record<string, unknown>
+			readonly template: AlertNotificationTemplate | null
+			readonly linkUrl: string
+			readonly chatUrl: string
+			readonly sentAt: string
+		}
+
+	const sendImmediateNotification = Effect.fn("AlertsService.sendImmediateNotification")(function* (
+		destinationRow: AlertDestinationRow,
+		context: Omit<AlertDispatchContext, "destination" | "publicConfig" | "secretConfig">,
+	) {
+		const hydrated = yield* hydrateDestination(destinationRow)
+		const enrichedSecret = yield* enrichSecretForDispatch(hydrated.row, hydrated.secretConfig)
+		const fullContext: AlertDispatchContext = {
+			destination: hydrated.row,
+			publicConfig: hydrated.publicConfig,
+			secretConfig: enrichedSecret,
+			...context,
+		}
+		const payload = buildPayload(fullContext)
+		return yield* dispatchDelivery(fullContext, JSON.stringify(payload))
+	})
+
+	return {
+		hydrateDestination,
+		enrichSecretForDispatch,
+		composeLinkUrl,
+		dispatchDelivery,
+		buildPayload,
+		sendImmediateNotification,
+	} as const
+}

--- a/apps/api/src/services/alerts/AlertDestinationsService.boundary.test.ts
+++ b/apps/api/src/services/alerts/AlertDestinationsService.boundary.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const readModule = (path: string): string => readFileSync(new URL(path, import.meta.url), "utf8")
+
+const importSpecifiers = (source: string): ReadonlyArray<string> =>
+	Array.from(source.matchAll(/(?:from\s+|import\s*\()["']([^"']+)["']/g), (match) => match[1]!)
+
+describe("AlertDestinationsService boundary", () => {
+	it("stays independent from alert evaluation and warehouse services", () => {
+		const source = readModule("./AlertDestinationsService.ts")
+		const imports = importSpecifiers(source)
+
+		expect(imports.filter((specifier) => specifier.startsWith("@maple/query-engine"))).toEqual([])
+		for (const forbidden of [
+			"QueryEngineService",
+			"WarehouseQueryService",
+			"OrgClickHouseSettingsService",
+			"AnomalyDetectionService",
+			"ErrorsService",
+		]) {
+			expect(imports.some((specifier) => specifier.endsWith(`/${forbidden}`))).toBe(false)
+		}
+		expect(source).not.toContain("WorkerEnvironment")
+	})
+
+	it("is the capability consumed by the destination HTTP group", () => {
+		const source = readModule("../../routes/v2/alert-destinations.http.ts")
+		const imports = importSpecifiers(source)
+
+		expect(imports).toContain("@/services/alerts/AlertDestinationsService")
+		expect(imports).not.toContain("@/services/alerts/AlertsService")
+	})
+})

--- a/apps/api/src/services/alerts/AlertDestinationsService.ts
+++ b/apps/api/src/services/alerts/AlertDestinationsService.ts
@@ -1,0 +1,801 @@
+import {
+	AlertDeliveryError,
+	AlertDestinationDeleteResponse,
+	AlertDestinationDocument,
+	AlertDestinationType as AlertDestinationTypeSchema,
+	AlertDestinationInUseError,
+	AlertDestinationTestResponse,
+	AlertDestinationsListResponse,
+	AlertForbiddenError,
+	AlertNotFoundError,
+	AlertPersistenceError,
+	AlertRuleDocument,
+	AlertValidationError,
+	RoleName,
+	type AlertDestinationCreateRequest,
+	type AlertDestinationType,
+	type AlertDestinationUpdateRequest,
+	type OrgId,
+	type UserId,
+} from "@maple/domain/http"
+import { alertDestinations, alertRules, type AlertDestinationRow } from "@maple/db"
+import { and, desc, eq } from "drizzle-orm"
+import { Context, Effect, Layer, Match, Option, Redacted, Schema } from "effect"
+import { encryptAes256Gcm, type EncryptedValue } from "@/platform/Crypto"
+import { Database, type DatabaseClient } from "@/platform/DatabaseLive"
+import { EmailService } from "@/platform/EmailService"
+import { Env } from "@/platform/Env"
+import { readTxid, txidColumn } from "@/platform/electric-txid"
+import { validateExternalUrl } from "@/http/url-validator"
+import { HazelOAuthService } from "@/services/auth/HazelOAuthService"
+import { describeCause } from "@/platform/describe-cause"
+import { OrgMembersService, type OrgMember } from "@/services/org/OrgMembersService"
+import { SlackBotTokenResolver } from "@/services/integrations/slack-bot-token"
+import { PAGERDUTY_ROUTING_KEY_PATTERN, verifyPagerDutyRoutingKey } from "./AlertDeliveryDispatch"
+import {
+	DestinationPublicConfigSchema,
+	type DestinationPublicConfig,
+	type DestinationSecretConfig,
+} from "./AlertDestinationHydration"
+import { makeAlertDestinationDelivery, parseAlertDestinationEncryptionKey } from "./AlertDestinationDelivery"
+import { AlertRuntime } from "./AlertRuntime"
+
+const StringArraySchema = Schema.Array(Schema.String)
+const decodeAlertDestinationIdSync = Schema.decodeUnknownSync(AlertDestinationDocument.fields.id)
+const decodeAlertDestinationTypeSync = Schema.decodeUnknownSync(AlertDestinationTypeSchema)
+const decodeAlertRuleIdSync = Schema.decodeUnknownSync(AlertRuleDocument.fields.id)
+const decodeIsoDateTimeStringSync = Schema.decodeUnknownSync(AlertDestinationDocument.fields.createdAt)
+const decodeRoleNameSync = Schema.decodeUnknownSync(RoleName)
+
+const adminRoles = [decodeRoleNameSync("root"), decodeRoleNameSync("org:admin")]
+
+const makePersistenceError = (error: unknown) => {
+	const cause = describeCause(error instanceof Error ? error.cause : error)
+	return new AlertPersistenceError({
+		message: error instanceof Error ? error.message : "Alert persistence failed",
+		...(cause === undefined ? {} : { cause }),
+	})
+}
+
+const makeValidationError = (message: string, details: ReadonlyArray<string> = [], cause?: unknown) =>
+	new AlertValidationError({ message, details, ...(cause === undefined ? {} : { cause }) })
+
+const makeDeliveryError = (message: string, destinationType?: AlertDestinationType, cause?: unknown) =>
+	new AlertDeliveryError({
+		message,
+		destinationType,
+		...(cause === undefined ? {} : { cause }),
+	})
+
+const normalizeOptionalString = (value: string | null | undefined) => {
+	const trimmed = value?.trim()
+	return trimmed && trimmed.length > 0 ? trimmed : null
+}
+
+const validateDestinationUrl = (rawUrl: string, field: string): Effect.Effect<string, AlertValidationError> =>
+	validateExternalUrl(rawUrl).pipe(
+		Effect.as(rawUrl.trim()),
+		Effect.mapError((error) => makeValidationError(`${field}: ${error.message}`, [], error)),
+	)
+
+const summarizeMembers = (members: ReadonlyArray<OrgMember>): string => {
+	const first = members[0]
+	if (first === undefined) return "Email"
+	const label = first.name ?? first.email
+	return members.length === 1 ? label : `${label} +${members.length - 1} more`
+}
+
+const emailPublicConfig = (members: ReadonlyArray<OrgMember>): DestinationPublicConfig => ({
+	summary: summarizeMembers(members),
+	channelLabel: members[0]?.email ?? null,
+	memberUserIds: members.map((member) => member.userId),
+})
+
+const emailSecretConfig = (members: ReadonlyArray<OrgMember>): DestinationSecretConfig => ({
+	type: "email",
+	members: members.map((member) => ({
+		userId: member.userId,
+		email: member.email,
+		name: member.name,
+	})),
+})
+
+const encryptSecret = (
+	plaintext: string,
+	encryptionKey: Buffer,
+): Effect.Effect<EncryptedValue, AlertValidationError> =>
+	encryptAes256Gcm(plaintext, encryptionKey, () =>
+		makeValidationError("Failed to encrypt destination secret"),
+	)
+
+const summarizeWebhookUrl = (url: string) =>
+	Option.match(Option.liftThrowable(() => new URL(url))(), {
+		onNone: () => "Webhook endpoint",
+		onSome: (parsed) => `POST ${parsed.host}`,
+	})
+
+const buildPublicConfig = (
+	request: Exclude<AlertDestinationCreateRequest, { readonly type: "email" }>,
+): DestinationPublicConfig =>
+	Match.value(request).pipe(
+		Match.discriminatorsExhaustive("type")({
+			"slack-bot": (r) => ({
+				summary: r.channelName?.trim() ? `#${r.channelName.trim()}` : "Slack channel",
+				channelLabel: r.channelName?.trim() ? `#${r.channelName.trim()}` : null,
+			}),
+			pagerduty: () => ({ summary: "PagerDuty Events API v2", channelLabel: null }),
+			webhook: (r) => ({ summary: summarizeWebhookUrl(r.url), channelLabel: null }),
+			"hazel-oauth": (r) => ({
+				summary: `${r.hazelOrganizationName} · #${r.hazelChannelName}`,
+				channelLabel: `#${r.hazelChannelName}`,
+				hazelOrganizationId: r.hazelOrganizationId,
+				hazelOrganizationName: r.hazelOrganizationName,
+				hazelOrganizationLogoUrl: r.hazelOrganizationLogoUrl ?? null,
+				hazelChannelId: r.hazelChannelId,
+				hazelChannelName: r.hazelChannelName,
+			}),
+			discord: (r) => ({ summary: summarizeWebhookUrl(r.webhookUrl), channelLabel: null }),
+		}),
+	)
+
+const buildSecretConfig = (
+	request: Exclude<AlertDestinationCreateRequest, { readonly type: "hazel-oauth" | "email" }>,
+): DestinationSecretConfig =>
+	Match.value(request).pipe(
+		Match.discriminatorsExhaustive("type")({
+			"slack-bot": (r) => ({
+				type: "slack-bot" as const,
+				channelId: r.channelId.trim(),
+				channelName: normalizeOptionalString(r.channelName),
+			}),
+			pagerduty: (r) => ({ type: "pagerduty" as const, integrationKey: r.integrationKey.trim() }),
+			webhook: (r) => ({
+				type: "webhook" as const,
+				url: r.url.trim(),
+				signingSecret: normalizeOptionalString(r.signingSecret),
+			}),
+			discord: (r) => ({ type: "discord" as const, webhookUrl: r.webhookUrl.trim() }),
+		}),
+	)
+
+const safeParsePublicConfig = (row: AlertDestinationRow): DestinationPublicConfig =>
+	Option.getOrElse(Schema.decodeUnknownOption(DestinationPublicConfigSchema)(row.configJson), () => ({
+		summary: "Invalid destination config",
+		channelLabel: null,
+	}))
+
+const safeParseStringArray = (value: unknown): ReadonlyArray<string> =>
+	Option.getOrElse(Schema.decodeUnknownOption(StringArraySchema)(value), () => [])
+
+const rowToDestinationDocument = (row: AlertDestinationRow, publicConfig: DestinationPublicConfig) =>
+	new AlertDestinationDocument({
+		id: decodeAlertDestinationIdSync(row.id),
+		name: row.name,
+		type: decodeAlertDestinationTypeSync(row.type),
+		enabled: row.enabled,
+		summary: publicConfig.summary,
+		channelLabel: publicConfig.channelLabel,
+		memberUserIds: publicConfig.memberUserIds != null ? [...publicConfig.memberUserIds] : null,
+		lastTestedAt:
+			row.lastTestedAt == null ? null : decodeIsoDateTimeStringSync(row.lastTestedAt.toISOString()),
+		lastTestError: row.lastTestError,
+		createdAt: decodeIsoDateTimeStringSync(row.createdAt.toISOString()),
+		updatedAt: decodeIsoDateTimeStringSync(row.updatedAt.toISOString()),
+	})
+
+export interface AlertDestinationsServiceShape {
+	readonly listDestinations: (
+		orgId: OrgId,
+	) => Effect.Effect<AlertDestinationsListResponse, AlertPersistenceError>
+	readonly createDestination: (
+		orgId: OrgId,
+		userId: UserId,
+		roles: ReadonlyArray<RoleName>,
+		request: AlertDestinationCreateRequest,
+	) => Effect.Effect<
+		AlertDestinationDocument,
+		AlertForbiddenError | AlertValidationError | AlertPersistenceError | AlertDeliveryError
+	>
+	readonly updateDestination: (
+		orgId: OrgId,
+		userId: UserId,
+		roles: ReadonlyArray<RoleName>,
+		destinationId: AlertDestinationDocument["id"],
+		request: AlertDestinationUpdateRequest,
+	) => Effect.Effect<
+		AlertDestinationDocument,
+		AlertForbiddenError | AlertValidationError | AlertPersistenceError | AlertNotFoundError
+	>
+	readonly deleteDestination: (
+		orgId: OrgId,
+		roles: ReadonlyArray<RoleName>,
+		destinationId: AlertDestinationDocument["id"],
+	) => Effect.Effect<
+		AlertDestinationDeleteResponse,
+		AlertForbiddenError | AlertPersistenceError | AlertNotFoundError | AlertDestinationInUseError
+	>
+	readonly testDestination: (
+		orgId: OrgId,
+		userId: UserId,
+		roles: ReadonlyArray<RoleName>,
+		destinationId: AlertDestinationDocument["id"],
+	) => Effect.Effect<
+		AlertDestinationTestResponse,
+		| AlertForbiddenError
+		| AlertPersistenceError
+		| AlertNotFoundError
+		| AlertDeliveryError
+		| AlertValidationError
+	>
+}
+
+export class AlertDestinationsService extends Context.Service<
+	AlertDestinationsService,
+	AlertDestinationsServiceShape
+>()("@maple/api/services/alerts/AlertDestinationsService", {
+	make: Effect.gen(function* () {
+		const database = yield* Database
+		const env = yield* Env
+		const runtime = yield* AlertRuntime
+		const hazelOAuth = yield* HazelOAuthService
+		const email = yield* EmailService
+		const orgMembers = yield* OrgMembersService
+		const slackBotToken = yield* SlackBotTokenResolver
+		const encryptionKey = yield* parseAlertDestinationEncryptionKey(
+			Redacted.value(env.MAPLE_INGEST_KEY_ENCRYPTION_KEY),
+		)
+		const delivery = makeAlertDestinationDelivery({
+			encryptionKey,
+			appBaseUrl: env.MAPLE_APP_BASE_URL,
+			runtime,
+			email,
+			resolveSlackBotToken: slackBotToken.resolve,
+		})
+
+		const dbExecute = <T>(fn: (db: DatabaseClient) => Promise<T>) =>
+			database.execute(fn).pipe(
+				Effect.tapError((error) =>
+					Effect.logError("AlertsService dbExecute failed").pipe(
+						Effect.annotateLogs({
+							message: error.message,
+							cause: describeCause(error.cause) ?? "(none)",
+						}),
+					),
+				),
+				Effect.mapError(makePersistenceError),
+			)
+
+		const requireAdmin = Effect.fn("AlertsService.requireAdmin")(function* (
+			roles: ReadonlyArray<RoleName>,
+		) {
+			if (roles.some((role) => adminRoles.includes(role))) return
+			return yield* Effect.fail(
+				new AlertForbiddenError({
+					message: "Only org admins can manage alerts",
+					...(roles.length > 0 ? { roles: [...roles] } : {}),
+				}),
+			)
+		})
+
+		const requireDestinationRow = Effect.fn("AlertsService.requireDestinationRow")(function* (
+			orgId: OrgId,
+			destinationId: AlertDestinationDocument["id"],
+		) {
+			const rows = yield* dbExecute((db) =>
+				db
+					.select()
+					.from(alertDestinations)
+					.where(and(eq(alertDestinations.orgId, orgId), eq(alertDestinations.id, destinationId)))
+					.limit(1),
+			)
+			if (rows[0]) return rows[0]
+			return yield* Effect.fail(
+				new AlertNotFoundError({
+					message: "Alert destination not found",
+					resourceType: "destination",
+					resourceId: destinationId,
+				}),
+			)
+		})
+
+		const resolveEmailMembers = (
+			orgId: OrgId,
+			memberUserIds: ReadonlyArray<string>,
+		): Effect.Effect<ReadonlyArray<OrgMember>, AlertValidationError> =>
+			orgMembers.resolveMembers(orgId, memberUserIds).pipe(
+				Effect.mapError((error) => makeValidationError(error.message, error.unknownUserIds ?? [])),
+				Effect.flatMap((members) =>
+					members.length === 0
+						? Effect.fail(makeValidationError("At least one workspace member is required"))
+						: Effect.succeed(members),
+				),
+			)
+
+		const markDestinationTest = Effect.fn("AlertsService.markDestinationTest")(function* (
+			orgId: OrgId,
+			destinationId: AlertDestinationDocument["id"],
+			errorMessage: string | null,
+		) {
+			const timestamp = yield* runtime.now
+			yield* dbExecute((db) =>
+				db
+					.update(alertDestinations)
+					.set({
+						lastTestedAt: new Date(timestamp),
+						lastTestError: errorMessage,
+						updatedAt: new Date(timestamp),
+					})
+					.where(and(eq(alertDestinations.orgId, orgId), eq(alertDestinations.id, destinationId))),
+			)
+		})
+
+		const listDestinations = Effect.fn("AlertsService.listDestinations")(function* (orgId: OrgId) {
+			const rows = yield* dbExecute((db) =>
+				db
+					.select()
+					.from(alertDestinations)
+					.where(eq(alertDestinations.orgId, orgId))
+					.orderBy(desc(alertDestinations.createdAt), desc(alertDestinations.id)),
+			)
+			return new AlertDestinationsListResponse({
+				destinations: rows.map((row) => rowToDestinationDocument(row, safeParsePublicConfig(row))),
+			})
+		})
+
+		const validatePagerDutyKey = Effect.fn("AlertsService.validatePagerDutyKey")(function* (
+			integrationKey: string,
+		) {
+			if (!PAGERDUTY_ROUTING_KEY_PATTERN.test(integrationKey)) {
+				return yield* Effect.fail(
+					makeValidationError(
+						"PagerDuty integration key must be a 32-character Events API v2 routing key — a REST API token won't work.",
+					),
+				)
+			}
+			const result = yield* verifyPagerDutyRoutingKey(
+				integrationKey,
+				runtime.fetch,
+				runtime.deliveryTimeoutMs(),
+				`maple-keycheck-${runtime.makeUuid()}`,
+			)
+			if (result.status === "invalid") {
+				return yield* Effect.fail(
+					makeValidationError(`PagerDuty rejected this routing key: ${result.reason}`),
+				)
+			}
+		})
+
+		const createDestination: AlertDestinationsServiceShape["createDestination"] = Effect.fn(
+			"AlertsService.createDestination",
+		)(function* (orgId, userId, roles, request) {
+			yield* requireAdmin(roles)
+			if (request.type === "webhook") yield* validateDestinationUrl(request.url, "url")
+			else if (request.type === "discord") {
+				yield* validateDestinationUrl(request.webhookUrl, "webhookUrl")
+			}
+			const destinationId = decodeAlertDestinationIdSync(runtime.makeUuid())
+			let publicConfig: DestinationPublicConfig
+			let secretConfig: DestinationSecretConfig
+			if (request.type === "email") {
+				const members = yield* resolveEmailMembers(orgId, request.memberUserIds)
+				publicConfig = emailPublicConfig(members)
+				secretConfig = emailSecretConfig(members)
+			} else {
+				publicConfig = buildPublicConfig(request)
+				secretConfig =
+					request.type === "hazel-oauth"
+						? yield* hazelOAuth
+								.createChannelWebhook(orgId, {
+									channelId: request.hazelChannelId.trim(),
+									name: request.name.trim(),
+								})
+								.pipe(
+									Effect.map((webhook) => ({
+										type: "hazel-oauth" as const,
+										hazelOrganizationId: request.hazelOrganizationId.trim(),
+										hazelOrganizationName: request.hazelOrganizationName.trim(),
+										hazelChannelId: request.hazelChannelId.trim(),
+										hazelChannelName: request.hazelChannelName.trim(),
+										webhookId: webhook.id,
+										webhookUrl: webhook.webhookUrl,
+										webhookToken: webhook.token,
+									})),
+									Effect.catchTags({
+										"@maple/http/errors/IntegrationsNotConnectedError": (error) =>
+											Effect.fail(
+												makeValidationError(
+													`Could not provision Hazel channel webhook: ${error.message}`,
+												),
+											),
+										"@maple/http/errors/IntegrationsRevokedError": (error) =>
+											Effect.fail(
+												makeValidationError(
+													`Could not provision Hazel channel webhook: ${error.message}`,
+												),
+											),
+										"@maple/http/errors/IntegrationsValidationError": (error) =>
+											Effect.fail(
+												makeValidationError(
+													`Could not provision Hazel channel webhook: ${error.message}`,
+												),
+											),
+										"@maple/http/errors/IntegrationsPersistenceError": (error) =>
+											Effect.fail(makePersistenceError(error)),
+										"@maple/http/errors/IntegrationsUpstreamError": (error) =>
+											Effect.fail(
+												makeDeliveryError(
+													"Could not provision Hazel channel webhook",
+													"hazel-oauth",
+													error,
+												),
+											),
+									}),
+								)
+						: buildSecretConfig(request)
+			}
+			if (secretConfig.type === "pagerduty") yield* validatePagerDutyKey(secretConfig.integrationKey)
+			const encryptedSecret = yield* encryptSecret(JSON.stringify(secretConfig), encryptionKey)
+			const timestamp = yield* runtime.now
+			const row = {
+				id: destinationId,
+				orgId,
+				name: request.name.trim(),
+				type: request.type,
+				enabled: request.enabled !== false,
+				configJson: publicConfig,
+				secretCiphertext: encryptedSecret.ciphertext,
+				secretIv: encryptedSecret.iv,
+				secretTag: encryptedSecret.tag,
+				lastTestedAt: null,
+				lastTestError: null,
+				createdAt: new Date(timestamp),
+				updatedAt: new Date(timestamp),
+				createdBy: userId,
+				updatedBy: userId,
+			}
+			const writeRows = yield* dbExecute((db) =>
+				db.insert(alertDestinations).values(row).returning(txidColumn),
+			)
+			const txid = readTxid(writeRows)
+			const document = rowToDestinationDocument(row, publicConfig)
+			return txid === undefined ? document : new AlertDestinationDocument({ ...document, txid })
+		})
+
+		const updateDestination: AlertDestinationsServiceShape["updateDestination"] = Effect.fn(
+			"AlertsService.updateDestination",
+		)(function* (orgId, userId, roles, destinationId, request) {
+			yield* requireAdmin(roles)
+			const existing = yield* requireDestinationRow(orgId, destinationId)
+			if (existing.type !== request.type) {
+				return yield* Effect.fail(makeValidationError("Destination type cannot be changed"))
+			}
+			const hydrated = yield* delivery.hydrateDestination(existing)
+			if (request.type === "webhook" && request.url != null && request.url.trim().length > 0) {
+				yield* validateDestinationUrl(request.url, "url")
+			} else if (
+				request.type === "discord" &&
+				request.webhookUrl != null &&
+				request.webhookUrl.trim().length > 0
+			) {
+				yield* validateDestinationUrl(request.webhookUrl, "webhookUrl")
+			}
+
+			const { nextPublicConfig, nextSecretConfig } = yield* Match.value(request).pipe(
+				Match.discriminatorsExhaustive("type")({
+					"slack-bot": (r) => {
+						const channelName = normalizeOptionalString(r.channelName)
+						return Effect.succeed({
+							nextPublicConfig: {
+								summary:
+									channelName != null ? `#${channelName}` : hydrated.publicConfig.summary,
+								channelLabel:
+									channelName != null
+										? `#${channelName}`
+										: hydrated.publicConfig.channelLabel,
+							} satisfies DestinationPublicConfig,
+							nextSecretConfig: {
+								type: "slack-bot" as const,
+								channelId:
+									normalizeOptionalString(r.channelId) ??
+									(hydrated.secretConfig.type === "slack-bot"
+										? hydrated.secretConfig.channelId
+										: ""),
+								channelName:
+									r.channelName === undefined
+										? hydrated.secretConfig.type === "slack-bot"
+											? hydrated.secretConfig.channelName
+											: null
+										: channelName,
+							} satisfies DestinationSecretConfig,
+						})
+					},
+					pagerduty: (r) =>
+						Effect.succeed({
+							nextPublicConfig: hydrated.publicConfig,
+							nextSecretConfig: {
+								type: "pagerduty" as const,
+								integrationKey:
+									normalizeOptionalString(r.integrationKey) ??
+									(hydrated.secretConfig.type === "pagerduty"
+										? hydrated.secretConfig.integrationKey
+										: ""),
+							} satisfies DestinationSecretConfig,
+						}),
+					webhook: (r) =>
+						Effect.succeed({
+							nextPublicConfig: {
+								summary:
+									r.url != null && r.url.trim().length > 0
+										? summarizeWebhookUrl(r.url)
+										: hydrated.publicConfig.summary,
+								channelLabel: null,
+							} satisfies DestinationPublicConfig,
+							nextSecretConfig: {
+								type: "webhook" as const,
+								url:
+									normalizeOptionalString(r.url) ??
+									(hydrated.secretConfig.type === "webhook"
+										? hydrated.secretConfig.url
+										: ""),
+								signingSecret:
+									r.signingSecret === undefined
+										? hydrated.secretConfig.type === "webhook"
+											? hydrated.secretConfig.signingSecret
+											: null
+										: normalizeOptionalString(r.signingSecret),
+							} satisfies DestinationSecretConfig,
+						}),
+					"hazel-oauth": (r) =>
+						Effect.gen(function* () {
+							const previousSecret =
+								hydrated.secretConfig.type === "hazel-oauth" ? hydrated.secretConfig : null
+							const nextOrganizationId =
+								normalizeOptionalString(r.hazelOrganizationId) ??
+								previousSecret?.hazelOrganizationId ??
+								""
+							const nextOrganizationName =
+								normalizeOptionalString(r.hazelOrganizationName) ??
+								previousSecret?.hazelOrganizationName ??
+								""
+							const nextOrganizationLogoUrl =
+								r.hazelOrganizationLogoUrl === undefined
+									? (hydrated.publicConfig.hazelOrganizationLogoUrl ?? null)
+									: r.hazelOrganizationLogoUrl
+							const nextChannelId =
+								normalizeOptionalString(r.hazelChannelId) ??
+								previousSecret?.hazelChannelId ??
+								""
+							const nextChannelName =
+								normalizeOptionalString(r.hazelChannelName) ??
+								previousSecret?.hazelChannelName ??
+								""
+							const nextName = normalizeOptionalString(r.name) ?? existing.name
+							const channelChanged =
+								previousSecret == null || previousSecret.hazelChannelId !== nextChannelId
+							const provisioned = channelChanged
+								? yield* hazelOAuth
+										.createChannelWebhook(orgId, {
+											channelId: nextChannelId,
+											name: nextName,
+										})
+										.pipe(
+											Effect.mapError((error) =>
+												makeValidationError(
+													`Could not provision Hazel channel webhook: ${error.message}`,
+												),
+											),
+										)
+								: null
+							return {
+								nextPublicConfig: {
+									summary: `${nextOrganizationName} · #${nextChannelName}`,
+									channelLabel: `#${nextChannelName}`,
+									hazelOrganizationId: nextOrganizationId,
+									hazelOrganizationName: nextOrganizationName,
+									hazelOrganizationLogoUrl: nextOrganizationLogoUrl,
+									hazelChannelId: nextChannelId,
+									hazelChannelName: nextChannelName,
+								} satisfies DestinationPublicConfig,
+								nextSecretConfig: {
+									type: "hazel-oauth" as const,
+									hazelOrganizationId: nextOrganizationId,
+									hazelOrganizationName: nextOrganizationName,
+									hazelChannelId: nextChannelId,
+									hazelChannelName: nextChannelName,
+									webhookId: provisioned?.id ?? previousSecret!.webhookId,
+									webhookUrl: provisioned?.webhookUrl ?? previousSecret!.webhookUrl,
+									webhookToken: provisioned?.token ?? previousSecret!.webhookToken,
+								} satisfies DestinationSecretConfig,
+							}
+						}),
+					discord: (r) =>
+						Effect.succeed({
+							nextPublicConfig: {
+								summary:
+									r.webhookUrl != null && r.webhookUrl.trim().length > 0
+										? summarizeWebhookUrl(r.webhookUrl)
+										: hydrated.publicConfig.summary,
+								channelLabel: null,
+							} satisfies DestinationPublicConfig,
+							nextSecretConfig: {
+								type: "discord" as const,
+								webhookUrl:
+									normalizeOptionalString(r.webhookUrl) ??
+									(hydrated.secretConfig.type === "discord"
+										? hydrated.secretConfig.webhookUrl
+										: ""),
+							} satisfies DestinationSecretConfig,
+						}),
+					email: (r) =>
+						Effect.gen(function* () {
+							const supplied =
+								r.memberUserIds != null && r.memberUserIds.length > 0 ? r.memberUserIds : null
+							if (supplied === null) {
+								return {
+									nextPublicConfig: hydrated.publicConfig,
+									nextSecretConfig:
+										hydrated.secretConfig.type === "email"
+											? hydrated.secretConfig
+											: emailSecretConfig([]),
+								}
+							}
+							const members = yield* resolveEmailMembers(orgId, supplied)
+							return {
+								nextPublicConfig: emailPublicConfig(members),
+								nextSecretConfig: emailSecretConfig(members),
+							}
+						}),
+				}),
+			)
+			if (
+				request.type === "pagerduty" &&
+				normalizeOptionalString(request.integrationKey) != null &&
+				nextSecretConfig.type === "pagerduty"
+			) {
+				yield* validatePagerDutyKey(nextSecretConfig.integrationKey)
+			}
+			const encryptedSecret = yield* encryptSecret(JSON.stringify(nextSecretConfig), encryptionKey)
+			const timestamp = yield* runtime.now
+			const nextName = normalizeOptionalString(request.name) ?? existing.name
+			const nextEnabled = request.enabled === undefined ? existing.enabled : request.enabled
+			const writeRows = yield* dbExecute((db) =>
+				db
+					.update(alertDestinations)
+					.set({
+						name: nextName,
+						enabled: nextEnabled,
+						configJson: nextPublicConfig,
+						secretCiphertext: encryptedSecret.ciphertext,
+						secretIv: encryptedSecret.iv,
+						secretTag: encryptedSecret.tag,
+						updatedAt: new Date(timestamp),
+						updatedBy: userId,
+					})
+					.where(and(eq(alertDestinations.orgId, orgId), eq(alertDestinations.id, destinationId)))
+					.returning(txidColumn),
+			)
+			const txid = readTxid(writeRows)
+			const document = rowToDestinationDocument(
+				{
+					...existing,
+					name: nextName,
+					enabled: nextEnabled,
+					configJson: nextPublicConfig,
+					secretCiphertext: encryptedSecret.ciphertext,
+					secretIv: encryptedSecret.iv,
+					secretTag: encryptedSecret.tag,
+					updatedAt: new Date(timestamp),
+					updatedBy: userId,
+				},
+				nextPublicConfig,
+			)
+			return txid === undefined ? document : new AlertDestinationDocument({ ...document, txid })
+		})
+
+		const deleteDestination: AlertDestinationsServiceShape["deleteDestination"] = Effect.fn(
+			"AlertsService.deleteDestination",
+		)(function* (orgId, roles, destinationId) {
+			yield* requireAdmin(roles)
+			yield* requireDestinationRow(orgId, destinationId)
+			const dependentRules = yield* dbExecute((db) =>
+				db
+					.select({
+						id: alertRules.id,
+						name: alertRules.name,
+						destinationIdsJson: alertRules.destinationIdsJson,
+					})
+					.from(alertRules)
+					.where(eq(alertRules.orgId, orgId)),
+			).pipe(
+				Effect.map((rows) =>
+					rows.filter((row) =>
+						safeParseStringArray(row.destinationIdsJson).includes(destinationId),
+					),
+				),
+			)
+			if (dependentRules.length > 0) {
+				const ruleIds = dependentRules.map((row) => decodeAlertRuleIdSync(row.id))
+				const ruleNames = dependentRules.map((row) => row.name)
+				return yield* Effect.fail(
+					new AlertDestinationInUseError({
+						message: `Destination is still used by alert rules: ${ruleNames.join(", ")}`,
+						destinationId,
+						ruleIds,
+						ruleNames,
+					}),
+				)
+			}
+			const deleted = yield* dbExecute((db) =>
+				db
+					.delete(alertDestinations)
+					.where(and(eq(alertDestinations.orgId, orgId), eq(alertDestinations.id, destinationId)))
+					.returning(txidColumn),
+			)
+			const txid = readTxid(deleted)
+			return new AlertDestinationDeleteResponse({
+				id: destinationId,
+				...(txid !== undefined && { txid }),
+			})
+		})
+
+		const testDestination: AlertDestinationsServiceShape["testDestination"] = Effect.fn(
+			"AlertsService.testDestination",
+		)(function* (orgId, _userId, roles, destinationId) {
+			yield* requireAdmin(roles)
+			const row = yield* requireDestinationRow(orgId, destinationId)
+			yield* delivery
+				.sendImmediateNotification(row, {
+					deliveryKey: `${orgId}:${destinationId}:test`,
+					ruleId: decodeAlertRuleIdSync(runtime.makeUuid()),
+					ruleName: "Test alert",
+					groupKey: null,
+					signalType: "throughput",
+					severity: "warning",
+					comparator: "lt",
+					threshold: 1,
+					thresholdUpper: null,
+					windowMinutes: 5,
+					eventType: "test",
+					incidentId: null,
+					incidentStatus: "resolved",
+					dedupeKey: `${orgId}:${destinationId}:test`,
+					value: 0,
+					sampleCount: 0,
+					linkUrl: delivery.composeLinkUrl(null),
+					sentAtMs: yield* runtime.now,
+				})
+				.pipe(
+					Effect.tapError((error) =>
+						markDestinationTest(
+							orgId,
+							destinationId,
+							error instanceof Error ? error.message : "Destination test failed",
+						),
+					),
+					Effect.mapError((error) =>
+						error instanceof AlertDeliveryError
+							? error
+							: makeDeliveryError(
+									error instanceof Error ? error.message : "Destination test failed",
+									decodeAlertDestinationTypeSync(row.type),
+								),
+					),
+				)
+			yield* markDestinationTest(orgId, destinationId, null)
+			return new AlertDestinationTestResponse({
+				success: true,
+				message: "Test notification sent",
+			})
+		})
+
+		return {
+			listDestinations,
+			createDestination,
+			updateDestination,
+			deleteDestination,
+			testDestination,
+		} satisfies AlertDestinationsServiceShape
+	}),
+}) {
+	static readonly layer = Layer.effect(this, this.make).pipe(Layer.provide(SlackBotTokenResolver.layer))
+}

--- a/apps/api/src/services/alerts/AlertRuntime.ts
+++ b/apps/api/src/services/alerts/AlertRuntime.ts
@@ -1,0 +1,25 @@
+import { randomUUID } from "node:crypto"
+import { Clock, Context, Effect, Layer } from "effect"
+
+const DELIVERY_TIMEOUT_MS_DEFAULT = 15_000
+
+export interface AlertRuntimeShape {
+	/** Current wall-clock time in epoch ms, sourced from Effect's `Clock` so tests drive it via `TestClock`. */
+	readonly now: Effect.Effect<number>
+	readonly makeUuid: () => string
+	readonly fetch: typeof fetch
+	readonly deliveryTimeoutMs: () => number
+}
+
+export class AlertRuntime extends Context.Reference<AlertRuntimeShape>("@maple/api/services/AlertRuntime", {
+	defaultValue: (): AlertRuntimeShape => ({
+		now: Clock.currentTimeMillis,
+		makeUuid: () => randomUUID(),
+		fetch: globalThis.fetch,
+		deliveryTimeoutMs: () => DELIVERY_TIMEOUT_MS_DEFAULT,
+	}),
+}) {
+	// Reference defaults make explicit wiring optional; kept for hosts that
+	// still merge it into their layer stack.
+	static readonly layer = Layer.succeed(this, this.defaultValue())
+}

--- a/apps/api/src/services/alerts/AlertsService.test.ts
+++ b/apps/api/src/services/alerts/AlertsService.test.ts
@@ -22,6 +22,7 @@ import {
 	type AlertsServiceShape,
 	interleaveAlertRulesByOrg,
 } from "./AlertsService"
+import { AlertDestinationsService } from "./AlertDestinationsService"
 import { BucketCacheService } from "@maple/query-engine/caching"
 import { EdgeCacheService } from "@maple/cache"
 import { baselineWarehouseCapabilities } from "@maple/query-engine"
@@ -212,8 +213,13 @@ const makeLayer = (
 	const orgChSettingsLive = OrgClickHouseSettingsService.layer.pipe(
 		Layer.provide(Layer.mergeAll(envLive, databaseLive)),
 	)
+	const alertDestinationsLive = AlertDestinationsService.layer.pipe(
+		Layer.provide(
+			Layer.mergeAll(envLive, databaseLive, runtimeLive, hazelOAuthLive, emailLive, orgMembersLive),
+		),
+	)
 
-	return AlertsService.layer.pipe(
+	const alertsLive = AlertsService.layer.pipe(
 		Layer.provide(
 			Layer.mergeAll(
 				envLive,
@@ -226,9 +232,11 @@ const makeLayer = (
 				orgMembersLive,
 				orgChSettingsLive,
 				investigationsLive,
+				alertDestinationsLive,
 			),
 		),
 	)
+	return Layer.mergeAll(alertDestinationsLive, alertsLive)
 }
 
 const asOrgId = Schema.decodeUnknownSync(OrgId)
@@ -351,6 +359,19 @@ const insertDeliveryEventRow = async (
 }
 
 describe("AlertsService", () => {
+	it.effect("delegates the legacy destination methods to AlertDestinationsService", () => {
+		const testDb = createTestDb(trackedDbs)
+		return Effect.gen(function* () {
+			const alerts = yield* AlertsService
+			const destinations = yield* AlertDestinationsService
+			assert.strictEqual(alerts.listDestinations, destinations.listDestinations)
+			assert.strictEqual(alerts.createDestination, destinations.createDestination)
+			assert.strictEqual(alerts.updateDestination, destinations.updateDestination)
+			assert.strictEqual(alerts.deleteDestination, destinations.deleteDestination)
+			assert.strictEqual(alerts.testDestination, destinations.testDestination)
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub({}))))
+	})
+
 	it.effect("caps active alert rules per organization", () => {
 		const testDb = createTestDb(trackedDbs)
 		return Effect.gen(function* () {

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto"
 import {
 	CompiledAlertQueryPlan,
 	QueryEngineAlertReducer,
@@ -16,11 +15,7 @@ import {
 	AlertDeliveryEventDocument,
 	AlertDeliveryEventsListResponse,
 	AlertDeliveryStatus,
-	AlertDestinationDeleteResponse,
 	AlertDestinationDocument,
-	AlertDestinationInUseError,
-	AlertDestinationTestResponse,
-	AlertDestinationsListResponse,
 	AlertEvaluationResult,
 	AlertEventType as AlertEventTypeSchema,
 	AlertForbiddenError,
@@ -49,9 +44,7 @@ import {
 	AlertNotificationTemplate,
 	type AlertComparator,
 	AlertDestinationType as AlertDestinationTypeSchema,
-	type AlertDestinationCreateRequest,
 	type AlertDestinationType,
-	type AlertDestinationUpdateRequest,
 	type AlertEventType as AlertEventTypeValue,
 	type AlertRuleUpsertRequest,
 	type QueryBuilderQueryDraftPayload,
@@ -113,38 +106,24 @@ import { upsertAlertIssue } from "@/services/errors/issue-hub"
 import { probeLiveness } from "@/services/alerts/telemetry-liveness"
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
 import type { TenantContext } from "@/services/auth/AuthService"
-import { encryptAes256Gcm, parseBase64Aes256GcmKey, type EncryptedValue } from "@/platform/Crypto"
 import { Database, type DatabaseClient } from "@/platform/DatabaseLive"
 import { readTxid, txidColumn } from "@/platform/electric-txid"
-import {
-	buildAlertChatUrl,
-	dispatchDelivery as dispatchDeliveryImpl,
-	formatComparator,
-	PAGERDUTY_ROUTING_KEY_PATTERN,
-	type DispatchContext as DeliveryDispatchContext,
-	type DispatchResult,
-	verifyPagerDutyRoutingKey,
-} from "./AlertDeliveryDispatch"
+import { formatComparator } from "./AlertDeliveryDispatch"
 import { EmailService } from "@/platform/EmailService"
 import { Env } from "@/platform/Env"
 import { OrgClickHouseSettingsService } from "@/services/org/OrgClickHouseSettingsService"
-import { OrgMembersService, type OrgMember } from "@/services/org/OrgMembersService"
-import { describeCause } from "@/services/errors/ErrorsService"
-import { HazelOAuthService } from "@/services/auth/HazelOAuthService"
+import { describeCause } from "@/platform/describe-cause"
 import { QueryEngineService } from "@/services/warehouse/QueryEngineService"
 import type { GroupedAlertObservation } from "@maple/query-engine/runtime"
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
-import { validateExternalUrl } from "@/http/url-validator"
 import type { AlertChecksRow } from "@maple/domain/tinybird"
-import {
-	DestinationPublicConfigSchema,
-	hydrateDestinationRow,
-	type DestinationPublicConfig,
-	type DestinationSecretConfig,
-	type EnrichedDestinationSecretConfig,
-} from "./AlertDestinationHydration"
 import { SlackBotTokenResolver } from "@/services/integrations/slack-bot-token"
 import { dateToMs } from "@/platform/time"
+import { AlertRuntime } from "./AlertRuntime"
+import { AlertDestinationsService, type AlertDestinationsServiceShape } from "./AlertDestinationsService"
+import { makeAlertDestinationDelivery, parseAlertDestinationEncryptionKey } from "./AlertDestinationDelivery"
+
+export { AlertRuntime, type AlertRuntimeShape } from "./AlertRuntime"
 
 /**
  * Persisted evaluation-failure category per warehouse tag (`ErrorCategory` on
@@ -215,22 +194,6 @@ interface EvaluatedRule {
 	readonly derivedFromNoData: boolean
 }
 
-type DispatchContext = Omit<
-	DeliveryDispatchContext,
-	"ruleId" | "incidentId" | "incidentStatus" | "sentAtMs"
-> & {
-	readonly ruleId: AlertRuleId
-	readonly incidentId: AlertIncidentId | null
-	readonly incidentStatus: Schema.Schema.Type<typeof AlertIncidentStatus>
-	readonly linkUrl: string
-	readonly sentAtMs: number
-}
-
-type DeliveryPayloadContext = Omit<
-	DispatchContext,
-	"deliveryKey" | "destination" | "publicConfig" | "secretConfig"
->
-
 interface DeliveryAttemptFailure {
 	readonly message: string
 	readonly kind: "transport" | "timeout" | "payload" | "destination" | "unknown"
@@ -243,7 +206,6 @@ const ALERT_CHECK_INGEST_CONCURRENCY = 4
 // Storm fuse: cap issue-hub upserts per scheduler tick so a pathological
 // group-by rule opening hundreds of incidents can't stall the per-minute tick.
 const ISSUE_UPSERTS_PER_TICK = 50
-const DELIVERY_TIMEOUT_MS_DEFAULT = 15_000
 const DELIVERY_LEASE_TTL_MS = 30_000
 
 type DatabaseTransaction = Parameters<Parameters<DatabaseClient["transaction"]>[0]>[0]
@@ -383,27 +345,6 @@ type IsoDateTimeValue = Schema.Schema.Type<typeof AlertDestinationDocument.field
 
 const adminRoles = [decodeRoleNameSync("root"), decodeRoleNameSync("org:admin")]
 
-export interface AlertRuntimeShape {
-	/** Current wall-clock time in epoch ms, sourced from Effect's `Clock` so tests drive it via `TestClock`. */
-	readonly now: Effect.Effect<number>
-	readonly makeUuid: () => string
-	readonly fetch: typeof fetch
-	readonly deliveryTimeoutMs: () => number
-}
-
-export class AlertRuntime extends Context.Reference<AlertRuntimeShape>("@maple/api/services/AlertRuntime", {
-	defaultValue: (): AlertRuntimeShape => ({
-		now: Clock.currentTimeMillis,
-		makeUuid: () => randomUUID(),
-		fetch: globalThis.fetch,
-		deliveryTimeoutMs: () => DELIVERY_TIMEOUT_MS_DEFAULT,
-	}),
-}) {
-	// Reference defaults make explicit wiring optional; kept for hosts that
-	// still merge it into their layer stack.
-	static readonly layer = Layer.succeed(this, this.defaultValue())
-}
-
 const toIso = (value: Date | null | undefined): IsoDateTimeValue | null =>
 	value == null ? null : decodeIsoDateTimeStringSync(value.toISOString())
 
@@ -488,54 +429,6 @@ const makeDeliveryError = (message: string, destinationType?: AlertDestinationTy
 
 const isAdmin = (roles: ReadonlyArray<RoleName>) => roles.some((role) => adminRoles.includes(role))
 
-const validateDestinationUrl = (rawUrl: string, field: string): Effect.Effect<string, AlertValidationError> =>
-	validateExternalUrl(rawUrl).pipe(
-		Effect.as(rawUrl.trim()),
-		Effect.mapError((error) => makeValidationError(`${field}: ${error.message}`, [], error)),
-	)
-
-/** Resolved member recipients — display label from names, address in channelLabel. */
-const summarizeMembers = (members: ReadonlyArray<OrgMember>): string => {
-	const first = members[0]
-	if (first === undefined) return "Email"
-	const label = first.name ?? first.email
-	return members.length === 1 ? label : `${label} +${members.length - 1} more`
-}
-
-const emailPublicConfig = (members: ReadonlyArray<OrgMember>): DestinationPublicConfig => ({
-	summary: summarizeMembers(members),
-	channelLabel: members[0]?.email ?? null,
-	memberUserIds: members.map((member) => member.userId),
-})
-
-const emailSecretConfig = (members: ReadonlyArray<OrgMember>): DestinationSecretConfig => ({
-	type: "email" as const,
-	members: members.map((member) => ({
-		userId: member.userId,
-		email: member.email,
-		name: member.name,
-	})),
-})
-
-const parseEncryptionKey = (raw: string): Effect.Effect<Buffer, AlertValidationError> =>
-	parseBase64Aes256GcmKey(raw, (message) =>
-		makeValidationError(
-			message === "Expected a non-empty base64 encryption key"
-				? "MAPLE_INGEST_KEY_ENCRYPTION_KEY is required"
-				: message === "Expected base64 for exactly 32 bytes"
-					? "MAPLE_INGEST_KEY_ENCRYPTION_KEY must be base64 for exactly 32 bytes"
-					: message,
-		),
-	)
-
-const encryptSecret = (
-	plaintext: string,
-	encryptionKey: Buffer,
-): Effect.Effect<EncryptedValue, AlertValidationError> =>
-	encryptAes256Gcm(plaintext, encryptionKey, () =>
-		makeValidationError("Failed to encrypt destination secret"),
-	)
-
 type StoredDeliveryPayloadType = Schema.Schema.Type<typeof StoredDeliveryPayloadSchema>
 
 const parseDeliveryPayload = (
@@ -544,83 +437,6 @@ const parseDeliveryPayload = (
 	Schema.decodeUnknownEffect(StoredDeliveryPayloadSchema)(value).pipe(
 		Effect.mapError((cause) => makeValidationError("Stored delivery payload is invalid", [], cause)),
 	)
-
-const summarizeWebhookUrl = (url: string) =>
-	Option.match(Option.liftThrowable(() => new URL(url))(), {
-		onNone: () => "Webhook endpoint",
-		onSome: (parsed) => `POST ${parsed.host}`,
-	})
-
-// Email requires resolving member ids → emails via the auth provider first, so
-// its public/secret configs are built inline (emailPublicConfig/emailSecretConfig)
-// after that effect — the type excludes it here, like hazel-oauth below.
-const buildPublicConfig = (
-	request: Exclude<AlertDestinationCreateRequest, { readonly type: "email" }>,
-): DestinationPublicConfig =>
-	Match.value(request).pipe(
-		Match.discriminatorsExhaustive("type")({
-			"slack-bot": (r) => ({
-				summary: r.channelName?.trim() ? `#${r.channelName.trim()}` : "Slack channel",
-				channelLabel: r.channelName?.trim() ? `#${r.channelName.trim()}` : null,
-			}),
-			pagerduty: () => ({
-				summary: "PagerDuty Events API v2" as string,
-				channelLabel: null,
-			}),
-			webhook: (r) => ({
-				summary: summarizeWebhookUrl(r.url),
-				channelLabel: null,
-			}),
-			"hazel-oauth": (r) => ({
-				summary: `${r.hazelOrganizationName} · #${r.hazelChannelName}`,
-				channelLabel: `#${r.hazelChannelName}`,
-				hazelOrganizationId: r.hazelOrganizationId,
-				hazelOrganizationName: r.hazelOrganizationName,
-				hazelOrganizationLogoUrl: r.hazelOrganizationLogoUrl ?? null,
-				hazelChannelId: r.hazelChannelId,
-				hazelChannelName: r.hazelChannelName,
-			}),
-			discord: (r) => ({
-				summary: summarizeWebhookUrl(r.webhookUrl),
-				channelLabel: null,
-			}),
-		}),
-	)
-
-// Hazel-OAuth requires provisioning a channel webhook on Hazel first, so its
-// secret config is built inline after that side effect — the type excludes it
-// here so this stays a pure, total function over the remaining variants.
-const buildSecretConfig = (
-	request: Exclude<AlertDestinationCreateRequest, { readonly type: "hazel-oauth" | "email" }>,
-): DestinationSecretConfig =>
-	Match.value(request).pipe(
-		Match.discriminatorsExhaustive("type")({
-			"slack-bot": (r) => ({
-				type: "slack-bot" as const,
-				channelId: r.channelId.trim(),
-				channelName: normalizeOptionalString(r.channelName) ?? null,
-			}),
-			pagerduty: (r) => ({
-				type: "pagerduty" as const,
-				integrationKey: r.integrationKey.trim(),
-			}),
-			webhook: (r) => ({
-				type: "webhook" as const,
-				url: r.url.trim(),
-				signingSecret: normalizeOptionalString(r.signingSecret),
-			}),
-			discord: (r) => ({
-				type: "discord" as const,
-				webhookUrl: r.webhookUrl.trim(),
-			}),
-		}),
-	)
-
-const safeParsePublicConfig = (row: AlertDestinationRow): DestinationPublicConfig =>
-	Option.getOrElse(Schema.decodeUnknownOption(DestinationPublicConfigSchema)(row.configJson), () => ({
-		summary: "Invalid destination config",
-		channelLabel: null,
-	}))
 
 const safeParseStringArray = (value: unknown): ReadonlyArray<string> =>
 	Option.getOrElse(Schema.decodeUnknownOption(StringArraySchema)(value), () => [] as ReadonlyArray<string>)
@@ -834,21 +650,6 @@ const parseCompiledPlan = (
 	)
 }
 
-const rowToDestinationDocument = (row: AlertDestinationRow, publicConfig: DestinationPublicConfig) =>
-	new AlertDestinationDocument({
-		id: decodeAlertDestinationIdSync(row.id),
-		name: row.name,
-		type: decodeAlertDestinationTypeSync(row.type),
-		enabled: row.enabled,
-		summary: publicConfig.summary,
-		channelLabel: publicConfig.channelLabel,
-		memberUserIds: publicConfig.memberUserIds != null ? [...publicConfig.memberUserIds] : null,
-		lastTestedAt: toIso(row.lastTestedAt),
-		lastTestError: row.lastTestError,
-		createdAt: decodeIsoDateTimeStringSync(row.createdAt.toISOString()),
-		updatedAt: decodeIsoDateTimeStringSync(row.updatedAt.toISOString()),
-	})
-
 const serviceNamesFromRow = (row: AlertRuleRow): ReadonlyArray<string> =>
 	row.serviceNamesJson ? safeParseStringArray(row.serviceNamesJson) : []
 
@@ -954,50 +755,7 @@ const rowToIncidentDocument = (row: AlertIncidentRow) =>
 
 // Formatting helpers imported from AlertDeliveryDispatch
 
-export interface AlertsServiceShape {
-	readonly listDestinations: (
-		orgId: OrgId,
-	) => Effect.Effect<AlertDestinationsListResponse, AlertPersistenceError>
-	readonly createDestination: (
-		orgId: OrgId,
-		userId: UserId,
-		roles: ReadonlyArray<RoleName>,
-		request: AlertDestinationCreateRequest,
-	) => Effect.Effect<
-		AlertDestinationDocument,
-		AlertForbiddenError | AlertValidationError | AlertPersistenceError | AlertDeliveryError
-	>
-	readonly updateDestination: (
-		orgId: OrgId,
-		userId: UserId,
-		roles: ReadonlyArray<RoleName>,
-		destinationId: AlertDestinationDocument["id"],
-		request: AlertDestinationUpdateRequest,
-	) => Effect.Effect<
-		AlertDestinationDocument,
-		AlertForbiddenError | AlertValidationError | AlertPersistenceError | AlertNotFoundError
-	>
-	readonly deleteDestination: (
-		orgId: OrgId,
-		roles: ReadonlyArray<RoleName>,
-		destinationId: AlertDestinationDocument["id"],
-	) => Effect.Effect<
-		AlertDestinationDeleteResponse,
-		AlertForbiddenError | AlertPersistenceError | AlertNotFoundError | AlertDestinationInUseError
-	>
-	readonly testDestination: (
-		orgId: OrgId,
-		userId: UserId,
-		roles: ReadonlyArray<RoleName>,
-		destinationId: AlertDestinationDocument["id"],
-	) => Effect.Effect<
-		AlertDestinationTestResponse,
-		| AlertForbiddenError
-		| AlertPersistenceError
-		| AlertNotFoundError
-		| AlertDeliveryError
-		| AlertValidationError
-	>
+export interface AlertsServiceShape extends AlertDestinationsServiceShape {
 	readonly listRules: (orgId: OrgId) => Effect.Effect<AlertRulesListResponse, AlertPersistenceError>
 	readonly createRule: (
 		orgId: OrgId,
@@ -1150,32 +908,31 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 		make: Effect.gen(function* () {
 			const database = yield* Database
 			const env = yield* Env
+			const destinations = yield* AlertDestinationsService
 			const queryEngine = yield* QueryEngineService
 			const warehouse = yield* WarehouseQueryService
 			const runtime = yield* AlertRuntime
-			const hazelOAuth = yield* HazelOAuthService
 			const email = yield* EmailService
-			const orgMembers = yield* OrgMembersService
 			const orgChSettings = yield* OrgClickHouseSettingsService
 			const slackBotToken = yield* SlackBotTokenResolver
-
-			const resolveEmailMembers = (
-				orgId: OrgId,
-				memberUserIds: ReadonlyArray<string>,
-			): Effect.Effect<ReadonlyArray<OrgMember>, AlertValidationError> =>
-				orgMembers.resolveMembers(orgId, memberUserIds).pipe(
-					Effect.mapError((error) =>
-						makeValidationError(error.message, error.unknownUserIds ?? []),
-					),
-					Effect.flatMap((members) =>
-						members.length === 0
-							? Effect.fail(makeValidationError("At least one workspace member is required"))
-							: Effect.succeed(members),
-					),
-				)
-			const encryptionKey = yield* parseEncryptionKey(
+			const encryptionKey = yield* parseAlertDestinationEncryptionKey(
 				Redacted.value(env.MAPLE_INGEST_KEY_ENCRYPTION_KEY),
 			)
+			const destinationDelivery = makeAlertDestinationDelivery({
+				encryptionKey,
+				appBaseUrl: env.MAPLE_APP_BASE_URL,
+				runtime,
+				email,
+				resolveSlackBotToken: slackBotToken.resolve,
+			})
+			const {
+				hydrateDestination,
+				enrichSecretForDispatch,
+				composeLinkUrl,
+				dispatchDelivery,
+				buildPayload,
+				sendImmediateNotification,
+			} = destinationDelivery
 			// Optional: present only inside a Worker isolate. Used to kick off the
 			// AI triage Workflow for issues created from freshly opened incidents.
 			const workerEnv = yield* Effect.serviceOption(WorkerEnvironment)
@@ -1185,7 +942,6 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 			})
 			const now = runtime.now
 			const makeUuid = () => runtime.makeUuid()
-			const deliveryTimeoutMs = () => runtime.deliveryTimeoutMs()
 			const workerId = makeUuid()
 
 			const dbExecute = <T>(fn: (db: DatabaseClient) => Promise<T>) =>
@@ -1212,55 +968,6 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					}),
 				)
 			})
-
-			const requireDestinationRow = Effect.fn("AlertsService.requireDestinationRow")(function* (
-				orgId: OrgId,
-				destinationId: AlertDestinationDocument["id"],
-			) {
-				const rows = yield* dbExecute((db) =>
-					db
-						.select()
-						.from(alertDestinations)
-						.where(
-							and(eq(alertDestinations.orgId, orgId), eq(alertDestinations.id, destinationId)),
-						)
-						.limit(1),
-				)
-				if (rows[0]) return rows[0]
-				return yield* Effect.fail(
-					new AlertNotFoundError({
-						message: "Alert destination not found",
-						resourceType: "destination",
-						resourceId: destinationId,
-					}),
-				)
-			})
-
-			const hydrateDestination = Effect.fn("AlertsService.hydrateDestination")(function* (
-				row: AlertDestinationRow,
-			) {
-				const { publicConfig, secretConfig } = yield* hydrateDestinationRow(row, encryptionKey, {
-					onPublicConfigInvalid: (cause) =>
-						makeValidationError("Stored destination config is invalid", [], cause),
-					onDecryptFailure: () => makeValidationError("Failed to decrypt destination secret"),
-					onSecretConfigInvalid: (cause) =>
-						makeValidationError("Stored destination secret is invalid", [], cause),
-				})
-				return {
-					row,
-					publicConfig,
-					secretConfig,
-					document: rowToDestinationDocument(row, publicConfig),
-				} as const
-			})
-
-			const enrichSecretForDispatch = (
-				_row: AlertDestinationRow,
-				secretConfig: DestinationSecretConfig,
-			): Effect.Effect<EnrichedDestinationSecretConfig, AlertDeliveryError> =>
-				// Hazel-OAuth webhooks embed their delivery token in the URL path, so
-				// there's nothing to enrich at dispatch time.
-				Effect.succeed(secretConfig)
 
 			const requireRuleRow = Effect.fn("AlertsService.requireRuleRow")(function* (
 				orgId: OrgId,
@@ -1773,83 +1480,10 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				)
 			})
 
-			const markDestinationTest = Effect.fn("AlertsService.markDestinationTest")(function* (
-				orgId: OrgId,
-				destinationId: AlertDestinationId,
-				errorMessage: string | null,
-			) {
-				const timestamp = yield* now
-				yield* dbExecute((db) =>
-					db
-						.update(alertDestinations)
-						.set({
-							lastTestedAt: new Date(timestamp),
-							lastTestError: errorMessage,
-							updatedAt: new Date(timestamp),
-						})
-						.where(
-							and(eq(alertDestinations.orgId, orgId), eq(alertDestinations.id, destinationId)),
-						),
-				)
-			})
-
-			const composeLinkUrl = (serviceLinkName: string | null) =>
-				serviceLinkName
-					? `${env.MAPLE_APP_BASE_URL}/services/${encodeURIComponent(serviceLinkName)}`
-					: `${env.MAPLE_APP_BASE_URL}/alerts`
-
 			const resolveNotificationLinkUrl = (
 				rule: Pick<NormalizedRule, "serviceNames" | "groupBy">,
 				groupKey: string | null,
 			) => composeLinkUrl(resolveServiceLinkName(rule, groupKey))
-
-			const composeChatUrl = (context: DispatchContext): string =>
-				buildAlertChatUrl(env.MAPLE_APP_BASE_URL, context)
-
-			const sendEmail = (to: string, subject: string, html: string) =>
-				email
-					.send(to, subject, html)
-					.pipe(Effect.mapError((error) => makeDeliveryError(error.message, "email")))
-
-			const dispatchDelivery = (
-				context: DispatchContext,
-				payloadJson: string,
-			): Effect.Effect<DispatchResult, AlertDeliveryError> =>
-				dispatchDeliveryImpl(
-					context,
-					payloadJson,
-					runtime.fetch,
-					deliveryTimeoutMs(),
-					context.linkUrl,
-					composeChatUrl(context),
-					{ sendEmail, resolveSlackBotToken: slackBotToken.resolve },
-				)
-
-			const buildPayload = (context: DeliveryPayloadContext) => ({
-				eventType: context.eventType,
-				incidentId: context.incidentId,
-				incidentStatus: context.incidentStatus,
-				dedupeKey: context.dedupeKey,
-				rule: {
-					id: context.ruleId,
-					name: context.ruleName,
-					signalType: context.signalType,
-					severity: context.severity,
-					groupKey: context.groupKey,
-					comparator: context.comparator,
-					threshold: context.threshold,
-					thresholdUpper: context.thresholdUpper,
-					windowMinutes: context.windowMinutes,
-				},
-				observed: {
-					value: context.value,
-					sampleCount: context.sampleCount,
-				},
-				template: context.template ?? null,
-				linkUrl: context.linkUrl,
-				chatUrl: buildAlertChatUrl(env.MAPLE_APP_BASE_URL, context),
-				sentAt: new Date(context.sentAtMs).toISOString(),
-			})
 
 			const toDeliveryAttemptFailure = (
 				error: AlertValidationError | AlertDeliveryError | AlertNotFoundError | AlertPersistenceError,
@@ -1880,23 +1514,6 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 						}),
 					}),
 				)
-
-			const sendImmediateNotification = Effect.fn("AlertsService.sendImmediateNotification")(function* (
-				destinationRow: AlertDestinationRow,
-				context: Omit<DispatchContext, "destination" | "publicConfig" | "secretConfig">,
-			) {
-				const hydrated = yield* hydrateDestination(destinationRow)
-				const enrichedSecret = yield* enrichSecretForDispatch(hydrated.row, hydrated.secretConfig)
-				const fullContext: DispatchContext = {
-					destination: hydrated.row,
-					publicConfig: hydrated.publicConfig,
-					secretConfig: enrichedSecret,
-					...context,
-				}
-				const payload = buildPayload(fullContext)
-				const payloadJson = JSON.stringify(payload)
-				return yield* dispatchDelivery(fullContext, payloadJson)
-			})
 
 			const queueIncidentNotifications = Effect.fn("AlertsService.queueIncidentNotifications")(
 				function* (
@@ -1979,528 +1596,6 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				const base = Math.min(60_000 * Math.pow(2, attemptNumber - 1), 15 * 60_000)
 				const jitter = yield* Random.nextIntBetween(0, 1_000)
 				return base + jitter
-			})
-
-			const listDestinations = Effect.fn("AlertsService.listDestinations")(function* (orgId: OrgId) {
-				const rows = yield* dbExecute((db) =>
-					db
-						.select()
-						.from(alertDestinations)
-						.where(eq(alertDestinations.orgId, orgId))
-						.orderBy(desc(alertDestinations.createdAt), desc(alertDestinations.id)),
-				)
-
-				const destinations = rows.map((row) =>
-					rowToDestinationDocument(row, safeParsePublicConfig(row)),
-				)
-
-				return new AlertDestinationsListResponse({ destinations })
-			})
-
-			// Reject a PagerDuty routing key that can't possibly work before we persist
-			// it, so a wrong key surfaces at connect time instead of at first page.
-			// Format check is instant; the live check enqueues a no-op resolve event and
-			// only rejects on a definitive "invalid key" — it fails open on outages.
-			const validatePagerDutyKey = Effect.fn("AlertsService.validatePagerDutyKey")(function* (
-				integrationKey: string,
-			) {
-				if (!PAGERDUTY_ROUTING_KEY_PATTERN.test(integrationKey)) {
-					return yield* Effect.fail(
-						makeValidationError(
-							"PagerDuty integration key must be a 32-character Events API v2 routing key — a REST API token won't work.",
-						),
-					)
-				}
-				const result = yield* verifyPagerDutyRoutingKey(
-					integrationKey,
-					runtime.fetch,
-					deliveryTimeoutMs(),
-					`maple-keycheck-${makeUuid()}`,
-				)
-				if (result.status === "invalid") {
-					return yield* Effect.fail(
-						makeValidationError(`PagerDuty rejected this routing key: ${result.reason}`),
-					)
-				}
-			})
-
-			const createDestination = Effect.fn("AlertsService.createDestination")(function* (
-				orgId: OrgId,
-				userId: UserId,
-				roles: ReadonlyArray<RoleName>,
-				request: AlertDestinationCreateRequest,
-			) {
-				yield* requireAdmin(roles)
-				// Reject URLs pointing at internal/loopback/metadata networks before we
-				// persist them. The dispatcher will later POST to whatever we store.
-				if (request.type === "webhook") {
-					yield* validateDestinationUrl(request.url, "url")
-				} else if (request.type === "discord") {
-					yield* validateDestinationUrl(request.webhookUrl, "webhookUrl")
-				}
-				const destinationId = decodeAlertDestinationIdSync(makeUuid())
-				let publicConfig: DestinationPublicConfig
-				let secretConfig: DestinationSecretConfig
-				if (request.type === "email") {
-					// Email recipients are workspace members: resolve the selected ids
-					// to emails via the auth provider so clients can never route alerts
-					// to arbitrary addresses.
-					const members = yield* resolveEmailMembers(orgId, request.memberUserIds)
-					publicConfig = emailPublicConfig(members)
-					secretConfig = emailSecretConfig(members)
-				} else {
-					publicConfig = buildPublicConfig(request)
-					secretConfig =
-						request.type === "hazel-oauth"
-							? yield* hazelOAuth
-									.createChannelWebhook(orgId, {
-										channelId: request.hazelChannelId.trim(),
-										name: request.name.trim(),
-									})
-									.pipe(
-										Effect.map((webhook) => ({
-											type: "hazel-oauth" as const,
-											hazelOrganizationId: request.hazelOrganizationId.trim(),
-											hazelOrganizationName: request.hazelOrganizationName.trim(),
-											hazelChannelId: request.hazelChannelId.trim(),
-											hazelChannelName: request.hazelChannelName.trim(),
-											webhookId: webhook.id,
-											webhookUrl: webhook.webhookUrl,
-											webhookToken: webhook.token,
-										})),
-										Effect.catchTags({
-											"@maple/http/errors/IntegrationsNotConnectedError": (error) =>
-												Effect.fail(
-													makeValidationError(
-														`Could not provision Hazel channel webhook: ${error.message}`,
-													),
-												),
-											"@maple/http/errors/IntegrationsRevokedError": (error) =>
-												Effect.fail(
-													makeValidationError(
-														`Could not provision Hazel channel webhook: ${error.message}`,
-													),
-												),
-											"@maple/http/errors/IntegrationsValidationError": (error) =>
-												Effect.fail(
-													makeValidationError(
-														`Could not provision Hazel channel webhook: ${error.message}`,
-													),
-												),
-											"@maple/http/errors/IntegrationsPersistenceError": (error) =>
-												Effect.fail(makePersistenceError(error)),
-											"@maple/http/errors/IntegrationsUpstreamError": (error) =>
-												Effect.fail(
-													makeDeliveryError(
-														"Could not provision Hazel channel webhook",
-														"hazel-oauth",
-														error,
-													),
-												),
-										}),
-									)
-							: buildSecretConfig(request)
-				}
-				if (secretConfig.type === "pagerduty") {
-					yield* validatePagerDutyKey(secretConfig.integrationKey)
-				}
-				const encryptedSecret = yield* encryptSecret(JSON.stringify(secretConfig), encryptionKey)
-				const timestamp = yield* now
-
-				const row = {
-					id: destinationId,
-					orgId,
-					name: request.name.trim(),
-					type: request.type,
-					enabled: request.enabled !== false,
-					configJson: publicConfig,
-					secretCiphertext: encryptedSecret.ciphertext,
-					secretIv: encryptedSecret.iv,
-					secretTag: encryptedSecret.tag,
-					lastTestedAt: null,
-					lastTestError: null,
-					createdAt: new Date(timestamp),
-					updatedAt: new Date(timestamp),
-					createdBy: userId,
-					updatedBy: userId,
-				}
-
-				const writeRows = yield* dbExecute((db) =>
-					db.insert(alertDestinations).values(row).returning(txidColumn),
-				)
-				const txid = readTxid(writeRows)
-				const document = rowToDestinationDocument(row, publicConfig)
-				return txid === undefined ? document : new AlertDestinationDocument({ ...document, txid })
-			})
-
-			const updateDestination = Effect.fn("AlertsService.updateDestination")(function* (
-				orgId: OrgId,
-				userId: UserId,
-				roles: ReadonlyArray<RoleName>,
-				destinationId: AlertDestinationDocument["id"],
-				request: AlertDestinationUpdateRequest,
-			) {
-				yield* requireAdmin(roles)
-				const existing = yield* requireDestinationRow(orgId, destinationId)
-				if (existing.type !== request.type) {
-					return yield* Effect.fail(makeValidationError("Destination type cannot be changed"))
-				}
-
-				const hydrated = yield* hydrateDestination(existing)
-
-				// Validate any URL the request supplies before we persist it. Each
-				// branch only validates when the field is non-empty so the existing
-				// (already-validated) stored URL can stay unchanged on partial updates.
-				if (request.type === "webhook" && request.url != null && request.url.trim().length > 0) {
-					yield* validateDestinationUrl(request.url, "url")
-				} else if (
-					request.type === "discord" &&
-					request.webhookUrl != null &&
-					request.webhookUrl.trim().length > 0
-				) {
-					yield* validateDestinationUrl(request.webhookUrl, "webhookUrl")
-				}
-
-				const { nextPublicConfig, nextSecretConfig } = yield* Match.value(request).pipe(
-					Match.discriminatorsExhaustive("type")({
-						"slack-bot": (r) => {
-							const channelName = normalizeOptionalString(r.channelName)
-							return Effect.succeed({
-								nextPublicConfig: {
-									summary:
-										channelName != null
-											? `#${channelName}`
-											: hydrated.publicConfig.summary,
-									channelLabel:
-										channelName != null
-											? `#${channelName}`
-											: hydrated.publicConfig.channelLabel,
-								} satisfies DestinationPublicConfig,
-								nextSecretConfig: {
-									type: "slack-bot" as const,
-									channelId:
-										normalizeOptionalString(r.channelId) ??
-										(hydrated.secretConfig.type === "slack-bot"
-											? hydrated.secretConfig.channelId
-											: ""),
-									channelName:
-										r.channelName === undefined
-											? hydrated.secretConfig.type === "slack-bot"
-												? hydrated.secretConfig.channelName
-												: null
-											: (channelName ?? null),
-								} satisfies DestinationSecretConfig,
-							})
-						},
-						pagerduty: (r) =>
-							Effect.succeed({
-								nextPublicConfig: hydrated.publicConfig,
-								nextSecretConfig: {
-									type: "pagerduty" as const,
-									integrationKey:
-										normalizeOptionalString(r.integrationKey) ??
-										(hydrated.secretConfig.type === "pagerduty"
-											? hydrated.secretConfig.integrationKey
-											: ""),
-								} satisfies DestinationSecretConfig,
-							}),
-						webhook: (r) =>
-							Effect.succeed({
-								nextPublicConfig: {
-									summary:
-										r.url != null && r.url.trim().length > 0
-											? summarizeWebhookUrl(r.url)
-											: hydrated.publicConfig.summary,
-									channelLabel: null,
-								} satisfies DestinationPublicConfig,
-								nextSecretConfig: {
-									type: "webhook" as const,
-									url:
-										normalizeOptionalString(r.url) ??
-										(hydrated.secretConfig.type === "webhook"
-											? hydrated.secretConfig.url
-											: ""),
-									signingSecret:
-										r.signingSecret === undefined
-											? hydrated.secretConfig.type === "webhook"
-												? hydrated.secretConfig.signingSecret
-												: null
-											: normalizeOptionalString(r.signingSecret),
-								} satisfies DestinationSecretConfig,
-							}),
-						"hazel-oauth": (r) =>
-							Effect.gen(function* () {
-								const previousSecret =
-									hydrated.secretConfig.type === "hazel-oauth"
-										? hydrated.secretConfig
-										: null
-								const nextOrganizationId =
-									normalizeOptionalString(r.hazelOrganizationId) ??
-									previousSecret?.hazelOrganizationId ??
-									""
-								const nextOrganizationName =
-									normalizeOptionalString(r.hazelOrganizationName) ??
-									previousSecret?.hazelOrganizationName ??
-									""
-								const requestLogoUrl = r.hazelOrganizationLogoUrl
-								const nextOrganizationLogoUrl =
-									requestLogoUrl === undefined
-										? (hydrated.publicConfig.hazelOrganizationLogoUrl ?? null)
-										: requestLogoUrl
-								const nextChannelId =
-									normalizeOptionalString(r.hazelChannelId) ??
-									previousSecret?.hazelChannelId ??
-									""
-								const nextChannelName =
-									normalizeOptionalString(r.hazelChannelName) ??
-									previousSecret?.hazelChannelName ??
-									""
-								const nextName = normalizeOptionalString(r.name) ?? existing.name
-								const channelChanged =
-									previousSecret == null || previousSecret.hazelChannelId !== nextChannelId
-
-								// TODO: when Hazel exposes DELETE /api/v1/channel-webhooks/:id,
-								// revoke the old webhook here on channel change.
-								const provisioned = channelChanged
-									? yield* hazelOAuth
-											.createChannelWebhook(orgId, {
-												channelId: nextChannelId,
-												name: nextName,
-											})
-											.pipe(
-												Effect.mapError((error) =>
-													makeValidationError(
-														`Could not provision Hazel channel webhook: ${error.message}`,
-													),
-												),
-											)
-									: null
-
-								const webhookId = provisioned?.id ?? previousSecret!.webhookId
-								const webhookUrl = provisioned?.webhookUrl ?? previousSecret!.webhookUrl
-								const webhookToken = provisioned?.token ?? previousSecret!.webhookToken
-
-								return {
-									nextPublicConfig: {
-										summary: `${nextOrganizationName} · #${nextChannelName}`,
-										channelLabel: `#${nextChannelName}`,
-										hazelOrganizationId: nextOrganizationId,
-										hazelOrganizationName: nextOrganizationName,
-										hazelOrganizationLogoUrl: nextOrganizationLogoUrl,
-										hazelChannelId: nextChannelId,
-										hazelChannelName: nextChannelName,
-									} satisfies DestinationPublicConfig,
-									nextSecretConfig: {
-										type: "hazel-oauth" as const,
-										hazelOrganizationId: nextOrganizationId,
-										hazelOrganizationName: nextOrganizationName,
-										hazelChannelId: nextChannelId,
-										hazelChannelName: nextChannelName,
-										webhookId,
-										webhookUrl,
-										webhookToken,
-									} satisfies DestinationSecretConfig,
-								}
-							}),
-						discord: (r) =>
-							Effect.succeed({
-								nextPublicConfig: {
-									summary:
-										r.webhookUrl != null && r.webhookUrl.trim().length > 0
-											? summarizeWebhookUrl(r.webhookUrl)
-											: hydrated.publicConfig.summary,
-									channelLabel: null,
-								} satisfies DestinationPublicConfig,
-								nextSecretConfig: {
-									type: "discord" as const,
-									webhookUrl:
-										normalizeOptionalString(r.webhookUrl) ??
-										(hydrated.secretConfig.type === "discord"
-											? hydrated.secretConfig.webhookUrl
-											: ""),
-								} satisfies DestinationSecretConfig,
-							}),
-						email: (r) =>
-							Effect.gen(function* () {
-								// Member ids supplied → re-resolve via the auth provider and
-								// replace wholesale; omitted (or empty) → keep the stored
-								// recipient snapshot.
-								const supplied =
-									r.memberUserIds != null && r.memberUserIds.length > 0
-										? r.memberUserIds
-										: null
-								if (supplied === null) {
-									return {
-										nextPublicConfig: hydrated.publicConfig,
-										nextSecretConfig:
-											hydrated.secretConfig.type === "email"
-												? hydrated.secretConfig
-												: emailSecretConfig([]),
-									}
-								}
-								const members = yield* resolveEmailMembers(orgId, supplied)
-								return {
-									nextPublicConfig: emailPublicConfig(members),
-									nextSecretConfig: emailSecretConfig(members),
-								}
-							}),
-					}),
-				)
-
-				// Validate only a newly-supplied key; a blank key keeps the stored one.
-				if (
-					request.type === "pagerduty" &&
-					normalizeOptionalString(request.integrationKey) != null &&
-					nextSecretConfig.type === "pagerduty"
-				) {
-					yield* validatePagerDutyKey(nextSecretConfig.integrationKey)
-				}
-				const encryptedSecret = yield* encryptSecret(JSON.stringify(nextSecretConfig), encryptionKey)
-				const timestamp = yield* now
-				const nextName = normalizeOptionalString(request.name) ?? existing.name
-				const nextEnabled = request.enabled === undefined ? existing.enabled : request.enabled
-
-				const writeRows = yield* dbExecute((db) =>
-					db
-						.update(alertDestinations)
-						.set({
-							name: nextName,
-							enabled: nextEnabled,
-							configJson: nextPublicConfig,
-							secretCiphertext: encryptedSecret.ciphertext,
-							secretIv: encryptedSecret.iv,
-							secretTag: encryptedSecret.tag,
-							updatedAt: new Date(timestamp),
-							updatedBy: userId,
-						})
-						.where(
-							and(eq(alertDestinations.orgId, orgId), eq(alertDestinations.id, destinationId)),
-						)
-						.returning(txidColumn),
-				)
-
-				const txid = readTxid(writeRows)
-				const document = rowToDestinationDocument(
-					{
-						...existing,
-						name: nextName,
-						enabled: nextEnabled,
-						configJson: nextPublicConfig,
-						secretCiphertext: encryptedSecret.ciphertext,
-						secretIv: encryptedSecret.iv,
-						secretTag: encryptedSecret.tag,
-						updatedAt: new Date(timestamp),
-						updatedBy: userId,
-					},
-					nextPublicConfig,
-				)
-				return txid === undefined ? document : new AlertDestinationDocument({ ...document, txid })
-			})
-
-			const deleteDestination = Effect.fn("AlertsService.deleteDestination")(function* (
-				orgId: OrgId,
-				roles: ReadonlyArray<RoleName>,
-				destinationId: AlertDestinationDocument["id"],
-			) {
-				yield* requireAdmin(roles)
-				yield* requireDestinationRow(orgId, destinationId)
-				const dependentRules = yield* dbExecute((db) =>
-					db
-						.select({
-							id: alertRules.id,
-							name: alertRules.name,
-							destinationIdsJson: alertRules.destinationIdsJson,
-						})
-						.from(alertRules)
-						.where(eq(alertRules.orgId, orgId)),
-				).pipe(
-					Effect.map((rows) =>
-						rows.filter((row) =>
-							safeParseStringArray(row.destinationIdsJson).includes(destinationId),
-						),
-					),
-				)
-
-				if (dependentRules.length > 0) {
-					const ruleIds = dependentRules.map((row) => decodeAlertRuleIdSync(row.id))
-					const ruleNames = dependentRules.map((row) => row.name)
-					return yield* Effect.fail(
-						new AlertDestinationInUseError({
-							message: `Destination is still used by alert rules: ${ruleNames.join(", ")}`,
-							destinationId,
-							ruleIds,
-							ruleNames,
-						}),
-					)
-				}
-
-				const deleted = yield* dbExecute((db) =>
-					db
-						.delete(alertDestinations)
-						.where(
-							and(eq(alertDestinations.orgId, orgId), eq(alertDestinations.id, destinationId)),
-						)
-						.returning(txidColumn),
-				)
-				const txid = readTxid(deleted)
-				return new AlertDestinationDeleteResponse({
-					id: destinationId,
-					...(txid !== undefined && { txid }),
-				})
-			})
-
-			const testDestination = Effect.fn("AlertsService.testDestination")(function* (
-				orgId: OrgId,
-				userId: UserId,
-				roles: ReadonlyArray<RoleName>,
-				destinationId: AlertDestinationDocument["id"],
-			) {
-				yield* requireAdmin(roles)
-				const row = yield* requireDestinationRow(orgId, destinationId)
-				yield* sendImmediateNotification(row, {
-					deliveryKey: `${orgId}:${destinationId}:test`,
-					ruleId: decodeAlertRuleIdSync(makeUuid()),
-					ruleName: "Test alert",
-					groupKey: null,
-					signalType: "throughput",
-					severity: "warning",
-					comparator: "lt",
-					threshold: 1,
-					thresholdUpper: null,
-					windowMinutes: 5,
-					eventType: "test",
-					incidentId: null,
-					incidentStatus: "resolved",
-					dedupeKey: `${orgId}:${destinationId}:test`,
-					value: 0,
-					sampleCount: 0,
-					linkUrl: composeLinkUrl(null),
-					sentAtMs: yield* now,
-				}).pipe(
-					Effect.tapError((error) => {
-						const message =
-							error instanceof AlertDeliveryError
-								? error.message
-								: error instanceof Error
-									? error.message
-									: "Destination test failed"
-						return markDestinationTest(orgId, destinationId, message)
-					}),
-					Effect.mapError((error) =>
-						error instanceof AlertDeliveryError
-							? error
-							: makeDeliveryError(
-									error instanceof Error ? error.message : "Destination test failed",
-									decodeAlertDestinationTypeSync(row.type),
-								),
-					),
-				)
-
-				yield* markDestinationTest(orgId, destinationId, null)
-				return new AlertDestinationTestResponse({
-					success: true,
-					message: "Test notification sent",
-				})
 			})
 
 			const upsertRuleRow = Effect.fn("AlertsService.upsertRuleRow")(function* (
@@ -5297,11 +4392,11 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 			// `AlertsService.of(...)` can't be used here — referencing the class inside
 			// its own `make` is a TS2506 circular base-expression error.
 			return {
-				listDestinations,
-				createDestination,
-				updateDestination,
-				deleteDestination,
-				testDestination,
+				listDestinations: destinations.listDestinations,
+				createDestination: destinations.createDestination,
+				updateDestination: destinations.updateDestination,
+				deleteDestination: destinations.deleteDestination,
+				testDestination: destinations.testDestination,
 				listRules,
 				createRule,
 				updateRule,
@@ -5318,8 +4413,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 		}),
 	},
 ) {
-	// The resolver is self-provided (it needs only Database + Env, which every
-	// caller already supplies) so wiring stays unchanged in app.ts and the
-	// alerting worker.
+	// The resolver remains private to alert delivery; the destination capability
+	// is explicit so composition roots can expose it without the evaluator graph.
 	static readonly layer = Layer.effect(this, this.make).pipe(Layer.provide(SlackBotTokenResolver.layer))
 }

--- a/apps/api/src/services/errors/ErrorsService.ts
+++ b/apps/api/src/services/errors/ErrorsService.ts
@@ -113,6 +113,7 @@ import { selectDistinctOrgIds } from "@/platform/distinct-org-ids"
 import { readTxid, txidColumn } from "@/platform/electric-txid"
 import { Env } from "@/platform/Env"
 import { dateToMs, msToDate } from "@/platform/time"
+import { describeCause } from "@/platform/describe-cause"
 import { NotificationDispatcher, type NotificationRequest } from "@/services/alerts/NotificationDispatcher"
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
 import { EdgeCacheService } from "@maple/cache"
@@ -232,16 +233,7 @@ const severitySortRank = (severity: IssueSeverity | null): number =>
 		Match.exhaustive,
 	)
 
-export const describeCause = (cause: unknown): string | undefined => {
-	if (cause == null) return undefined
-	if (cause instanceof Error) return cause.stack ?? cause.message
-	if (typeof cause === "string") return cause
-	try {
-		return JSON.stringify(cause)
-	} catch {
-		return String(cause)
-	}
-}
+export { describeCause } from "@/platform/describe-cause"
 
 export const makePersistenceError = (error: unknown): ErrorPersistenceError => {
 	const baseFor = (message: string, raw: unknown) => {


### PR DESCRIPTION
## Summary

- extract destination list/create/update/delete/test into `AlertDestinationsService`
- factor shared delivery, encryption, hydration, and provider payload logic without forking scheduler behavior
- keep `AlertsServiceShape` source-compatible through exact-reference delegation
- migrate the v2 destination routes to the narrow service
- wire the capability into HTTP, MCP-under-facade, and alerting roots

## Dependency reduction

The destination layer requires Database, Env, AlertRuntime, Hazel OAuth, Email, and Org Members; Slack token resolution stays private. It excludes QueryEngine, Warehouse, org ClickHouse settings, WorkerEnvironment, anomaly detection, and rule evaluation/scheduling.

## Validation

- API and alerting production typechecks
- focused API regressions — 112 passed
- alerting root suite — 8 passed on the combined stack
- full combined API suite — 1,635 passed, 184 skipped
- Effect boundary lint, oxlint, formatting, and diff checks
- combined Worker startup — 130 ms active CPU / 400 ms budget

## Compatibility

The legacy `AlertsService` facade retains all five destination methods and delegates the exact function references. No destination-only MCP tool exists yet, so MCP keeps the facade but receives the narrow layer underneath it.

<sub>Stack created with the GitHub Stacks CLI.</sub>
