### PR TITLE
extract alert read models service

### DIFF
--- a/apps/alerting/src/worker.ts
+++ b/apps/alerting/src/worker.ts
@@ -1,6 +1,7 @@
 import {
 	ANTICIPATED_ERROR_IDENTIFIERS,
 	AlertDestinationsService,
+	AlertReadModelsService,
 	AlertsService,
 	AnomalyDetectionService,
 	BucketCacheService,
@@ -93,6 +94,10 @@ export const buildLayer = (env: AlertingWorkerEnv) => {
 		),
 	)
 
+	const AlertReadModelsServiceLive = AlertReadModelsService.layer.pipe(
+		Layer.provide(Layer.mergeAll(DatabaseLive, WarehouseQueryServiceLive)),
+	)
+
 	// WorkerEnvironment is merged in so the incident-open issue-hub hook can see
 	// the cross-script investigation workflow binding.
 	// AlertRuntime is a Context.Reference with defaults, so it needs no wiring here.
@@ -106,6 +111,7 @@ export const buildLayer = (env: AlertingWorkerEnv) => {
 				HazelOAuthServiceLive,
 				EmailServiceLive,
 				AlertDestinationsServiceLive,
+				AlertReadModelsServiceLive,
 				WorkerEnvironmentLive,
 			),
 		),

--- a/apps/api/src/alerting.ts
+++ b/apps/api/src/alerting.ts
@@ -1,6 +1,7 @@
 export { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
 export { AlertRuntime, AlertsService } from "./services/alerts/AlertsService"
 export { AlertDestinationsService } from "./services/alerts/AlertDestinationsService"
+export { AlertReadModelsService } from "./services/alerts/AlertReadModelsService"
 export { AnomalyDetectionService } from "./services/alerts/AnomalyDetectionService"
 export { BucketCacheService } from "@maple/query-engine/caching"
 export { CacheBackendLive } from "@/platform/CacheBackendLive"

--- a/apps/api/src/mcp/tools/get-incident-timeline.ts
+++ b/apps/api/src/mcp/tools/get-incident-timeline.ts
@@ -3,7 +3,7 @@ import { formatNextSteps } from "@/mcp/lib/next-steps"
 import { Effect, Schema } from "effect"
 import { createDualContent } from "@/mcp/lib/structured-output"
 import { resolveTenant } from "@/mcp/lib/query-warehouse"
-import { AlertsService } from "@/services/alerts/AlertsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 
 const comparatorLabel: Record<string, string> = {
 	gt: ">",
@@ -42,9 +42,9 @@ export function registerGetIncidentTimelineTool(server: McpToolRegistrar) {
 		}),
 		Effect.fn("McpTool.getIncidentTimeline")(function* ({ rule_id, status, severity, group_key, limit }) {
 			const tenant = yield* resolveTenant
-			const alerts = yield* AlertsService
+			const readModels = yield* AlertReadModelsService
 
-			const result = yield* alerts.listIncidents(tenant.orgId).pipe(
+			const result = yield* readModels.listIncidents(tenant.orgId).pipe(
 				Effect.mapError(
 					(error) =>
 						new McpQueryError({

--- a/apps/api/src/mcp/tools/list-alert-checks.ts
+++ b/apps/api/src/mcp/tools/list-alert-checks.ts
@@ -10,7 +10,7 @@ import { formatNextSteps } from "@/mcp/lib/next-steps"
 import { Effect, Schema } from "effect"
 import { createDualContent } from "@/mcp/lib/structured-output"
 import { resolveTenant } from "@/mcp/lib/query-warehouse"
-import { AlertsService } from "@/services/alerts/AlertsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 import { AlertRuleId } from "@maple/domain/http"
 
 const decodeRuleId = Schema.decodeUnknownSync(AlertRuleId)
@@ -29,7 +29,7 @@ export function registerListAlertChecksTool(server: McpToolRegistrar) {
 		}),
 		Effect.fn("McpTool.listAlertChecks")(function* ({ rule_id, group_key, status, since, until, limit }) {
 			const tenant = yield* resolveTenant
-			const alerts = yield* AlertsService
+			const readModels = yield* AlertReadModelsService
 
 			const ruleId = yield* Effect.try({
 				try: () => decodeRuleId(rule_id),
@@ -41,7 +41,7 @@ export function registerListAlertChecksTool(server: McpToolRegistrar) {
 					}),
 			})
 
-			const result = yield* alerts
+			const result = yield* readModels
 				.listRuleChecks(tenant.orgId, ruleId, {
 					groupKey: group_key,
 					since,

--- a/apps/api/src/mcp/tools/list-alert-incidents.ts
+++ b/apps/api/src/mcp/tools/list-alert-incidents.ts
@@ -4,7 +4,7 @@ import { formatNextSteps } from "@/mcp/lib/next-steps"
 import { Effect, Schema } from "effect"
 import { createDualContent } from "@/mcp/lib/structured-output"
 import { resolveTenant } from "@/mcp/lib/query-warehouse"
-import { AlertsService } from "@/services/alerts/AlertsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 
 const comparatorLabel: Record<string, string> = {
 	gt: ">",
@@ -25,9 +25,9 @@ export function registerListAlertIncidentsTool(server: McpToolRegistrar) {
 		}),
 		Effect.fn("McpTool.listAlertIncidents")(function* ({ status, severity, group_key, limit }) {
 			const tenant = yield* resolveTenant
-			const alerts = yield* AlertsService
+			const readModels = yield* AlertReadModelsService
 
-			const result = yield* alerts.listIncidents(tenant.orgId).pipe(
+			const result = yield* readModels.listIncidents(tenant.orgId).pipe(
 				Effect.mapError(
 					(error) =>
 						new McpQueryError({

--- a/apps/api/src/mcp/tools/runtime-requirements.ts
+++ b/apps/api/src/mcp/tools/runtime-requirements.ts
@@ -1,4 +1,5 @@
 import type { AlertsService } from "@/services/alerts/AlertsService"
+import type { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 import type { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
 import type { ErrorActorsService } from "@/services/errors/ErrorActorsService"
 import type { ErrorsService } from "@/services/errors/ErrorsService"
@@ -16,6 +17,7 @@ import type { CurrentMcpTenant } from "../lib/query-warehouse"
  */
 export type McpToolRuntimeRequirements =
 	| AlertsService
+	| AlertReadModelsService
 	| DashboardPersistenceService
 	| ErrorActorsService
 	| ErrorsService

--- a/apps/api/src/routes/v2/alchemy-provider.integration.test.ts
+++ b/apps/api/src/routes/v2/alchemy-provider.integration.test.ts
@@ -35,6 +35,7 @@ import { AuthService } from "@/services/auth/AuthService"
 import { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
 import { AlertRuntime, AlertsService } from "@/services/alerts/AlertsService"
 import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 import { HazelOAuthService } from "@/services/auth/HazelOAuthService"
 import { OrgClickHouseSettingsService } from "@/services/org/OrgClickHouseSettingsService"
 import { OrgMembersService } from "@/services/org/OrgMembersService"
@@ -129,6 +130,9 @@ const makeHarness = () => {
 			Layer.mergeAll(envLive, testDb.layer, runtimeLive, hazelOAuthLive, emailLive, orgMembersLive),
 		),
 	)
+	const alertReadModelsLive = AlertReadModelsService.layer.pipe(
+		Layer.provide(Layer.mergeAll(testDb.layer, warehouseLive)),
+	)
 	const alertsLive = AlertsService.layer.pipe(
 		Layer.provide(
 			Layer.mergeAll(
@@ -143,6 +147,7 @@ const makeHarness = () => {
 				orgChSettingsLive,
 				investigationsLive,
 				alertDestinationsLive,
+				alertReadModelsLive,
 			),
 		),
 	)
@@ -151,6 +156,7 @@ const makeHarness = () => {
 		AuthService.layer,
 		DashboardPersistenceService.layer,
 		alertDestinationsLive,
+		alertReadModelsLive,
 		alertsLive,
 	).pipe(Layer.provideMerge(Layer.mergeAll(envLive, testDb.layer)))
 

--- a/apps/api/src/routes/v2/alert-deliveries.http.ts
+++ b/apps/api/src/routes/v2/alert-deliveries.http.ts
@@ -4,7 +4,7 @@ import { CurrentTenant } from "@maple/domain/http"
 import type { V2AlertDelivery } from "@maple/domain/http/v2"
 import { MapleApiV2, paginateOffsetQuery, timestamp, timestampOrNull } from "@maple/domain/http/v2"
 import { Effect } from "effect"
-import { AlertsService } from "@/services/alerts/AlertsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 import { mapAlertError } from "./alerts-error-map"
 
 const toV2Delivery = (doc: AlertDeliveryEventDocument): V2AlertDelivery => ({
@@ -29,12 +29,12 @@ const toV2Delivery = (doc: AlertDeliveryEventDocument): V2AlertDelivery => ({
 
 export const HttpV2AlertDeliveriesLive = HttpApiBuilder.group(MapleApiV2, "alertDeliveries", (handlers) =>
 	Effect.gen(function* () {
-		const alerts = yield* AlertsService
+		const readModels = yield* AlertReadModelsService
 		return handlers.handle("list", ({ query }) =>
 			Effect.gen(function* () {
 				const tenant = yield* CurrentTenant.Context
 				const page = yield* paginateOffsetQuery(query, ({ limit, offset }) =>
-					alerts.listDeliveryEvents(tenant.orgId, { limit, offset }).pipe(
+					readModels.listDeliveryEvents(tenant.orgId, { limit, offset }).pipe(
 						mapAlertError("delivery_list"),
 						Effect.map((response) => response.events.map(toV2Delivery)),
 					),

--- a/apps/api/src/routes/v2/alert-incidents.http.ts
+++ b/apps/api/src/routes/v2/alert-incidents.http.ts
@@ -4,7 +4,7 @@ import { CurrentTenant } from "@maple/domain/http"
 import type { V2AlertIncident } from "@maple/domain/http/v2"
 import { MapleApiV2, paginateOffsetQuery } from "@maple/domain/http/v2"
 import { Effect } from "effect"
-import { AlertsService } from "@/services/alerts/AlertsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 import { mapAlertError } from "./alerts-error-map"
 
 const toV2Incident = (doc: AlertIncidentDocument): V2AlertIncident => ({
@@ -32,14 +32,14 @@ const toV2Incident = (doc: AlertIncidentDocument): V2AlertIncident => ({
 
 export const HttpV2AlertIncidentsLive = HttpApiBuilder.group(MapleApiV2, "alertIncidents", (handlers) =>
 	Effect.gen(function* () {
-		const alerts = yield* AlertsService
+		const readModels = yield* AlertReadModelsService
 
 		return handlers
 			.handle("list", ({ query }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
 					const page = yield* paginateOffsetQuery(query, ({ limit, offset }) =>
-						alerts
+						readModels
 							.listIncidents(tenant.orgId, {
 								...(query.status !== undefined ? { status: query.status } : {}),
 								...(query.rule_id !== undefined ? { ruleId: query.rule_id } : {}),
@@ -57,7 +57,7 @@ export const HttpV2AlertIncidentsLive = HttpApiBuilder.group(MapleApiV2, "alertI
 			.handle("retrieve", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					const incident = yield* alerts
+					const incident = yield* readModels
 						.getIncident(tenant.orgId, params.id)
 						.pipe(mapAlertError("incident_retrieve"))
 					return toV2Incident(incident)

--- a/apps/api/src/routes/v2/alert-rules.http.ts
+++ b/apps/api/src/routes/v2/alert-rules.http.ts
@@ -27,6 +27,7 @@ import {
 import { AlertForbiddenError } from "@maple/domain/http"
 import { Effect, Encoding, Result, Schema } from "effect"
 import { AlertsService } from "@/services/alerts/AlertsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 import { mapAlertError } from "./alerts-error-map"
 
 const decodeIsoDateTime = Schema.decodeUnknownSync(IsoDateTimeString)
@@ -293,6 +294,7 @@ const toV2PreviewResult = (preview: AlertRulePreviewResponse): V2AlertRulePrevie
 export const HttpV2AlertRulesLive = HttpApiBuilder.group(MapleApiV2, "alertRules", (handlers) =>
 	Effect.gen(function* () {
 		const alerts = yield* AlertsService
+		const readModels = yield* AlertReadModelsService
 
 		const findRule = (orgId: Parameters<typeof alerts.listRules>[0], ruleId: AlertRuleDocument["id"]) =>
 			Effect.gen(function* () {
@@ -410,7 +412,7 @@ export const HttpV2AlertRulesLive = HttpApiBuilder.group(MapleApiV2, "alertRules
 					const tenant = yield* CurrentTenant.Context
 					const cursor = yield* decodeChecksCursor(query.cursor)
 					const limit = query.limit ?? 20
-					const response = yield* alerts
+					const response = yield* readModels
 						.listRuleChecks(tenant.orgId, params.id, {
 							...(query.group_key !== undefined ? { groupKey: query.group_key } : {}),
 							...(query.status !== undefined ? { status: query.status } : {}),
@@ -436,7 +438,7 @@ export const HttpV2AlertRulesLive = HttpApiBuilder.group(MapleApiV2, "alertRules
 			.handle("checksSummary", ({ params, query }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					const summary = yield* alerts
+					const summary = yield* readModels
 						.summarizeRuleChecks(tenant.orgId, params.id, {
 							since: query.since,
 							until: query.until,

--- a/apps/api/src/routes/v2/alerts.http.test.ts
+++ b/apps/api/src/routes/v2/alerts.http.test.ts
@@ -18,6 +18,7 @@ import { AuthService } from "@/services/auth/AuthService"
 import { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
 import { AlertRuntime, AlertsService } from "@/services/alerts/AlertsService"
 import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 import { HazelOAuthService } from "@/services/auth/HazelOAuthService"
 import { OrgClickHouseSettingsService } from "@/services/org/OrgClickHouseSettingsService"
 import { OrgMembersService } from "@/services/org/OrgMembersService"
@@ -106,6 +107,9 @@ const makeHarness = (warehouseService: WarehouseQueryServiceShape = warehouseStu
 			Layer.mergeAll(envLive, testDb.layer, runtimeLive, hazelOAuthLive, emailLive, orgMembersLive),
 		),
 	)
+	const alertReadModelsLive = AlertReadModelsService.layer.pipe(
+		Layer.provide(Layer.mergeAll(testDb.layer, warehouseLive)),
+	)
 	const alertsLive = AlertsService.layer.pipe(
 		Layer.provide(
 			Layer.mergeAll(
@@ -120,6 +124,7 @@ const makeHarness = (warehouseService: WarehouseQueryServiceShape = warehouseStu
 				orgChSettingsLive,
 				investigationsLive,
 				alertDestinationsLive,
+				alertReadModelsLive,
 			),
 		),
 	)
@@ -128,6 +133,7 @@ const makeHarness = (warehouseService: WarehouseQueryServiceShape = warehouseStu
 		AuthService.layer,
 		DashboardPersistenceService.layer,
 		alertDestinationsLive,
+		alertReadModelsLive,
 		alertsLive,
 	).pipe(Layer.provideMerge(Layer.mergeAll(envLive, testDb.layer)))
 

--- a/apps/api/src/routes/v2/v2-test-support.ts
+++ b/apps/api/src/routes/v2/v2-test-support.ts
@@ -2,6 +2,7 @@ import { Effect, Layer } from "effect"
 import { EdgeCacheService, MemoryCacheBackendLive } from "@maple/cache"
 import { AlertsService } from "@/services/alerts/AlertsService"
 import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 import { AnomalyDetectionService } from "@/services/alerts/AnomalyDetectionService"
 import { ErrorsService } from "@/services/errors/ErrorsService"
 import { IngestAttributeMappingService } from "@/services/org/IngestAttributeMappingService"
@@ -280,22 +281,30 @@ export const AlertDestinationsServiceStubLayer = Layer.succeed(
 	alertDestinationStubs,
 )
 
+const alertReadModelStubs = {
+	listIncidents: die,
+	getIncident: die,
+	listRuleChecks: die,
+	summarizeRuleChecks: die,
+	listDeliveryEvents: die,
+}
+
+/** Inert read-model capability for harnesses that never touch alert history. */
+export const AlertReadModelsServiceStubLayer = Layer.succeed(AlertReadModelsService, alertReadModelStubs)
+
 /** Inert AlertsService facade for harnesses that never touch the alert groups. */
 export const AlertsServiceStubLayer = Layer.mergeAll(
 	AlertDestinationsServiceStubLayer,
+	AlertReadModelsServiceStubLayer,
 	Layer.succeed(AlertsService, {
 		...alertDestinationStubs,
+		...alertReadModelStubs,
 		listRules: die,
 		createRule: die,
 		updateRule: die,
 		deleteRule: die,
 		testRule: die,
 		previewRule: die,
-		listIncidents: die,
-		getIncident: die,
-		listRuleChecks: die,
-		summarizeRuleChecks: die,
-		listDeliveryEvents: die,
 		runSchedulerTick: die,
 	}),
 )

--- a/apps/api/src/runtime/graph-boundaries.test.ts
+++ b/apps/api/src/runtime/graph-boundaries.test.ts
@@ -68,6 +68,7 @@ describe("API runtime graph boundaries", () => {
 		const imports = importSpecifiers(source)
 
 		expect(layerMembers(source, "McpRuntimeServicesLive")).toEqual([
+			"AlertReadModelsServiceLive",
 			"AlertsServiceLive",
 			"DashboardPersistenceService.layer",
 			"ErrorActorsServiceLive",

--- a/apps/api/src/runtime/mcp-service-graph.ts
+++ b/apps/api/src/runtime/mcp-service-graph.ts
@@ -7,6 +7,7 @@ import { EmailService } from "@/platform/EmailService"
 import { Env } from "@/platform/Env"
 import { AlertRuntime, AlertsService } from "@/services/alerts/AlertsService"
 import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 import { NotificationDispatcher } from "@/services/alerts/NotificationDispatcher"
 import { HazelOAuthService } from "@/services/auth/HazelOAuthService"
 import { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
@@ -62,6 +63,10 @@ const AlertDestinationsServiceLive = AlertDestinationsService.layer.pipe(
 	),
 )
 
+const AlertReadModelsServiceLive = AlertReadModelsService.layer.pipe(
+	Layer.provide(Layer.mergeAll(InfraLive, WarehouseQueryServiceLive)),
+)
+
 const AlertsServiceLive = AlertsService.layer.pipe(
 	Layer.provide(
 		Layer.mergeAll(
@@ -74,6 +79,7 @@ const AlertsServiceLive = AlertsService.layer.pipe(
 			OrgMembersServiceLive,
 			OrgClickHouseSettingsServiceLive,
 			AlertDestinationsServiceLive,
+			AlertReadModelsServiceLive,
 		),
 	),
 )
@@ -113,6 +119,7 @@ const VcsSourceServiceLive = VcsSourceService.layer.pipe(
 )
 
 const McpRuntimeServicesLive = Layer.mergeAll(
+	AlertReadModelsServiceLive,
 	AlertsServiceLive,
 	DashboardPersistenceService.layer,
 	ErrorActorsServiceLive,

--- a/apps/api/src/runtime/service-graph.ts
+++ b/apps/api/src/runtime/service-graph.ts
@@ -7,6 +7,7 @@ import { EmailService } from "@/platform/EmailService"
 import { Env } from "@/platform/Env"
 import { AlertRuntime, AlertsService } from "@/services/alerts/AlertsService"
 import { AlertDestinationsService } from "@/services/alerts/AlertDestinationsService"
+import { AlertReadModelsService } from "@/services/alerts/AlertReadModelsService"
 import { AnomalyDetectionService } from "@/services/alerts/AnomalyDetectionService"
 import { NotificationDispatcher } from "@/services/alerts/NotificationDispatcher"
 import { PlanetScaleOAuthService } from "@/services/auth/PlanetScaleOAuthService"
@@ -124,6 +125,10 @@ const AlertDestinationsServiceLive = AlertDestinationsService.layer.pipe(
 	),
 )
 
+const AlertReadModelsServiceLive = AlertReadModelsService.layer.pipe(
+	Layer.provide(Layer.mergeAll(CoreServicesLive, WarehouseQueryServiceLive)),
+)
+
 const AlertsServiceLive = AlertsService.layer.pipe(
 	Layer.provideMerge(
 		Layer.mergeAll(
@@ -133,6 +138,7 @@ const AlertsServiceLive = AlertsService.layer.pipe(
 			EmailServiceLive,
 			OrgMembersServiceLive,
 			AlertDestinationsServiceLive,
+			AlertReadModelsServiceLive,
 		),
 	),
 )
@@ -216,6 +222,7 @@ const MainServicesLive = Layer.mergeAll(
 	EdgeCacheServiceLive,
 	QueryEngineServiceLive,
 	AlertDestinationsServiceLive,
+	AlertReadModelsServiceLive,
 	AlertsServiceLive,
 	AnomalyDetectionServiceLive,
 	AiTriageServiceLive,

--- a/apps/api/src/services/alerts/AlertReadModelsService.boundary.test.ts
+++ b/apps/api/src/services/alerts/AlertReadModelsService.boundary.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const readModule = (path: string): string => readFileSync(new URL(path, import.meta.url), "utf8")
+
+const importSpecifiers = (source: string): ReadonlyArray<string> =>
+	Array.from(source.matchAll(/(?:from\s+|import\s*\()["']([^"']+)["']/g), (match) => match[1]!)
+
+describe("AlertReadModelsService boundary", () => {
+	it("depends on persistence and warehouse reads, not scheduler or delivery capabilities", () => {
+		const imports = importSpecifiers(readModule("./AlertReadModelsService.ts"))
+
+		expect(imports).toContain("@/platform/DatabaseLive")
+		expect(imports).toContain("@/services/warehouse/WarehouseQueryService")
+		for (const forbidden of [
+			"AlertDestinationsService",
+			"AlertRuntime",
+			"EmailService",
+			"Env",
+			"OrgClickHouseSettingsService",
+			"QueryEngineService",
+			"SlackBotTokenResolver",
+		]) {
+			expect(imports.some((specifier) => specifier.endsWith(`/${forbidden}`))).toBe(false)
+		}
+	})
+
+	it("is the capability consumed by incident, delivery, and check read handlers", () => {
+		for (const path of [
+			"../../routes/v2/alert-incidents.http.ts",
+			"../../routes/v2/alert-deliveries.http.ts",
+			"../../mcp/tools/list-alert-incidents.ts",
+			"../../mcp/tools/get-incident-timeline.ts",
+			"../../mcp/tools/list-alert-checks.ts",
+		]) {
+			const imports = importSpecifiers(readModule(path))
+			expect(imports).toContain("@/services/alerts/AlertReadModelsService")
+			expect(imports).not.toContain("@/services/alerts/AlertsService")
+		}
+
+		const alertRulesImports = importSpecifiers(readModule("../../routes/v2/alert-rules.http.ts"))
+		expect(alertRulesImports).toContain("@/services/alerts/AlertReadModelsService")
+		expect(alertRulesImports).toContain("@/services/alerts/AlertsService")
+	})
+})

--- a/apps/api/src/services/alerts/AlertReadModelsService.test.ts
+++ b/apps/api/src/services/alerts/AlertReadModelsService.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, assert, describe, expect, it } from "@effect/vitest"
+import { AlertDestinationId, AlertIncidentId, AlertRuleId, OrgId } from "@maple/domain/http"
+import { Effect, Layer, Schema } from "effect"
+import { Database } from "@/platform/DatabaseLive"
+import { cleanupTestDbs, createTestDb, executeSql, type TestDb } from "@/platform/test-pglite"
+import {
+	WarehouseQueryService,
+	type WarehouseQueryServiceShape,
+} from "@/services/warehouse/WarehouseQueryService"
+import { AlertReadModelsService } from "./AlertReadModelsService"
+
+// Compile-time guard: scheduler, delivery, Env, cache, and query-engine
+// capabilities cannot enter this layer without making the assignment fail.
+const readModelRequirements: Layer.Layer<AlertReadModelsService, never, Database | WarehouseQueryService> =
+	AlertReadModelsService.layer
+
+const asOrgId = Schema.decodeUnknownSync(OrgId)
+const asRuleId = Schema.decodeUnknownSync(AlertRuleId)
+const asIncidentId = Schema.decodeUnknownSync(AlertIncidentId)
+const asDestinationId = Schema.decodeUnknownSync(AlertDestinationId)
+
+const ORG = asOrgId("org_alert_read_models")
+const OTHER_ORG = asOrgId("org_alert_read_models_other")
+const RULE = asRuleId("00000000-0000-4000-8000-000000000010")
+const INCIDENT_OLD = asIncidentId("00000000-0000-4000-8000-000000000011")
+const INCIDENT_NEW = asIncidentId("00000000-0000-4000-8000-000000000012")
+const DESTINATION = asDestinationId("00000000-0000-4000-8000-000000000013")
+const DELIVERY = "00000000-0000-4000-8000-000000000014"
+
+const createdDbs: TestDb[] = []
+
+afterEach(() => cleanupTestDbs(createdDbs))
+
+const makeWarehouseStub = (contexts: Array<string>): WarehouseQueryServiceShape => ({
+	query: () => Effect.die(new Error("unexpected pipe query")),
+	sqlQuery: () => Effect.die(new Error("unexpected raw SQL query")),
+	rawSqlQuery: () => Effect.die(new Error("unexpected raw SQL query")),
+	compiledQuery: (_tenant, compiled, options) =>
+		Effect.sync(() => contexts.push(options?.context ?? "")).pipe(
+			Effect.andThen(compiled.decodeRows([])),
+		),
+	compiledQueryFirst: () => Effect.die(new Error("unexpected first-row query")),
+	ingest: () => Effect.void,
+	asExecutor: () => {
+		throw new Error("asExecutor is not supported by this test stub")
+	},
+})
+
+const makeLayer = (testDb: TestDb, contexts: Array<string>) =>
+	readModelRequirements.pipe(
+		Layer.provide(
+			Layer.mergeAll(testDb.layer, Layer.succeed(WarehouseQueryService, makeWarehouseStub(contexts))),
+		),
+	)
+
+const seedReadModels = async (testDb: TestDb) => {
+	const created = new Date("2026-08-01T10:00:00.000Z")
+	await executeSql(
+		testDb,
+		`INSERT INTO alert_destinations
+		   (id, org_id, name, type, enabled, config_json, secret_ciphertext, secret_iv, secret_tag,
+		    created_at, updated_at, created_by, updated_by)
+		 VALUES ($1, $2, 'Primary webhook', 'webhook', true, '{}'::jsonb, '', '', '',
+		         $3, $3, 'user_read_models', 'user_read_models')`,
+		[DESTINATION, ORG, created],
+	)
+	await executeSql(
+		testDb,
+		`INSERT INTO alert_rules
+		   (id, org_id, name, enabled, severity, signal_type, comparator, threshold, window_minutes,
+		    destination_ids_json, reducer, no_data_behavior, created_at, updated_at, created_by, updated_by)
+		 VALUES ($1, $2, 'Read model rule', true, 'warning', 'error_rate', 'gt', 5, 5,
+		         '[]'::jsonb, 'avg', 'skip', $3, $3, 'user_read_models', 'user_read_models')`,
+		[RULE, ORG, created],
+	)
+	await executeSql(
+		testDb,
+		`INSERT INTO alert_incidents
+		   (id, org_id, rule_id, incident_key, rule_name, group_key, signal_type, severity, status,
+		    comparator, threshold, first_triggered_at, last_triggered_at, resolved_at,
+		    last_observed_value, last_sample_count, dedupe_key, created_at, updated_at)
+		 VALUES
+		   ($1, $3, $4, 'read-old', 'Read model rule', 'api', 'error_rate', 'warning', 'resolved',
+		    'gt', 5, '2026-08-01T10:00:00Z', '2026-08-01T10:05:00Z', '2026-08-01T10:06:00Z',
+		    7, 20, 'dedupe-old', $5, $5),
+		   ($2, $3, $4, 'read-new', 'Read model rule', 'worker', 'error_rate', 'critical', 'open',
+		    'gt', 5, '2026-08-01T10:10:00Z', '2026-08-01T10:15:00Z', null,
+		    9, 30, 'dedupe-new', $5, $5)`,
+		[INCIDENT_OLD, INCIDENT_NEW, ORG, RULE, created],
+	)
+	await executeSql(
+		testDb,
+		`INSERT INTO alert_delivery_events
+		   (id, org_id, incident_id, rule_id, destination_id, delivery_key, event_type,
+		    attempt_number, status, scheduled_at, attempted_at, response_code, payload_json,
+		    created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, 'delivery-read-model', 'trigger', 1, 'success',
+		         '2026-08-01T10:16:00Z', '2026-08-01T10:16:01Z', 204, '{}'::jsonb,
+		         '2026-08-01T10:16:00Z', '2026-08-01T10:16:01Z')`,
+		[DELIVERY, ORG, INCIDENT_NEW, RULE, DESTINATION],
+	)
+}
+
+describe("AlertReadModelsService", () => {
+	it.effect("reads incident and delivery projections without the scheduler graph", () => {
+		const testDb = createTestDb(createdDbs)
+		const contexts: Array<string> = []
+		return Effect.gen(function* () {
+			yield* Effect.promise(() => seedReadModels(testDb))
+			const readModels = yield* AlertReadModelsService
+
+			const incidents = yield* readModels.listIncidents(ORG)
+			assert.deepStrictEqual(
+				incidents.incidents.map((incident) => incident.id),
+				[INCIDENT_NEW, INCIDENT_OLD],
+			)
+			const open = yield* readModels.listIncidents(ORG, { status: "open", limit: 1 })
+			assert.deepStrictEqual(
+				open.incidents.map((incident) => incident.id),
+				[INCIDENT_NEW],
+			)
+			assert.strictEqual((yield* readModels.getIncident(ORG, INCIDENT_NEW)).groupKey, "worker")
+
+			const deliveries = yield* readModels.listDeliveryEvents(ORG)
+			assert.strictEqual(deliveries.events[0]?.id, DELIVERY)
+			assert.strictEqual(deliveries.events[0]?.destinationName, "Primary webhook")
+			assert.strictEqual(deliveries.events[0]?.responseCode, 204)
+			assert.deepStrictEqual(contexts, [])
+		}).pipe(Effect.provide(makeLayer(testDb, contexts)))
+	})
+
+	it.effect("enforces org ownership before warehouse-backed check reads", () => {
+		const testDb = createTestDb(createdDbs)
+		const contexts: Array<string> = []
+		return Effect.gen(function* () {
+			yield* Effect.promise(() => seedReadModels(testDb))
+			const readModels = yield* AlertReadModelsService
+
+			const missingIncident = yield* Effect.flip(readModels.getIncident(OTHER_ORG, INCIDENT_NEW))
+			assert.strictEqual(missingIncident._tag, "@maple/http/errors/AlertNotFoundError")
+
+			const missingChecks = yield* Effect.flip(readModels.listRuleChecks(OTHER_ORG, RULE, {}))
+			assert.strictEqual(missingChecks._tag, "@maple/http/errors/AlertNotFoundError")
+			assert.deepStrictEqual(contexts, [])
+
+			const checks = yield* readModels.listRuleChecks(ORG, RULE, { limit: 20 })
+			assert.deepStrictEqual(checks.checks, [])
+			const summary = yield* readModels.summarizeRuleChecks(ORG, RULE, {
+				since: "2026-08-01T00:00:00.000Z",
+				until: "2026-08-02T00:00:00.000Z",
+			})
+			expect(summary).toMatchObject({
+				topGroupKeys: [],
+				points: [],
+				totals: { total: 0, breached: 0, healthy: 0, skipped: 0, error: 0, transitions: 0 },
+			})
+			assert.deepStrictEqual(contexts, [
+				"listAlertChecks",
+				"alertCheckSummaryGroups",
+				"alertCheckSummary",
+			])
+		}).pipe(Effect.provide(makeLayer(testDb, contexts)))
+	})
+})

--- a/apps/api/src/services/alerts/AlertReadModelsService.ts
+++ b/apps/api/src/services/alerts/AlertReadModelsService.ts
@@ -1,0 +1,569 @@
+import * as CH from "@maple/query-engine/ch"
+import {
+	AlertCheckDocument,
+	AlertChecksListResponse,
+	AlertComparator as AlertComparatorSchema,
+	AlertDeliveryEventDocument,
+	AlertDeliveryEventsListResponse,
+	AlertDeliveryStatus,
+	AlertDestinationDocument,
+	AlertDestinationType as AlertDestinationTypeSchema,
+	AlertEventType as AlertEventTypeSchema,
+	AlertIncidentDocument,
+	AlertIncidentsListResponse,
+	AlertIncidentStatus,
+	AlertIncidentTransition as AlertIncidentTransitionSchema,
+	AlertNotFoundError,
+	AlertPersistenceError,
+	AlertRuleDocument,
+	AlertSeverity as AlertSeveritySchema,
+	AlertSignalType as AlertSignalTypeSchema,
+	AlertCheckStatus as AlertCheckStatusSchema,
+	AlertValidationError,
+	OrgId,
+	RoleName,
+	UserId,
+	type AlertIncidentId,
+	type AlertRuleId,
+} from "@maple/domain/http"
+import {
+	alertDeliveryEvents,
+	alertDestinations,
+	alertIncidents,
+	alertRules,
+	type AlertIncidentRow,
+} from "@maple/db"
+import { and, desc, eq } from "drizzle-orm"
+import { Context, Effect, Layer, Schema } from "effect"
+import { Database, type DatabaseClient } from "@/platform/DatabaseLive"
+import { describeCause } from "@/platform/describe-cause"
+import type { TenantContext } from "@/services/auth/AuthService"
+import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
+
+export interface AlertChecksSummaryPoint {
+	readonly bucket: string
+	readonly groupKey: string
+	readonly totalCount: number
+	readonly breachedCount: number
+	readonly healthyCount: number
+	readonly skippedCount: number
+	readonly errorCount: number
+	readonly transitionCount: number
+	readonly observedValue: number | null
+	readonly threshold: number
+}
+
+export interface AlertChecksSummary {
+	readonly bucketSeconds: number
+	readonly topGroupKeys: ReadonlyArray<string>
+	readonly points: ReadonlyArray<AlertChecksSummaryPoint>
+	readonly totals: {
+		readonly total: number
+		readonly breached: number
+		readonly healthy: number
+		readonly skipped: number
+		readonly error: number
+		readonly transitions: number
+	}
+}
+
+export interface ListAlertIncidentsOptions {
+	readonly status?: AlertIncidentStatus
+	readonly ruleId?: AlertRuleId
+	readonly limit?: number
+	readonly offset?: number
+}
+
+export interface ListAlertDeliveryEventsOptions {
+	readonly limit?: number
+	readonly offset?: number
+}
+
+export interface AlertReadModelsServiceShape {
+	readonly listIncidents: (
+		orgId: OrgId,
+		options?: ListAlertIncidentsOptions,
+	) => Effect.Effect<AlertIncidentsListResponse, AlertPersistenceError>
+	readonly getIncident: (
+		orgId: OrgId,
+		incidentId: AlertIncidentId,
+	) => Effect.Effect<AlertIncidentDocument, AlertPersistenceError | AlertNotFoundError>
+	readonly listRuleChecks: (
+		orgId: OrgId,
+		ruleId: AlertRuleId,
+		options: {
+			readonly groupKey?: string
+			readonly status?: AlertCheckDocument["status"]
+			readonly since?: string
+			readonly until?: string
+			readonly limit?: number
+			readonly beforeTimestamp?: string
+			readonly beforeGroupKey?: string
+		},
+	) => Effect.Effect<AlertChecksListResponse, AlertPersistenceError | AlertNotFoundError>
+	readonly summarizeRuleChecks: (
+		orgId: OrgId,
+		ruleId: AlertRuleId,
+		options: {
+			readonly since: string
+			readonly until: string
+		},
+	) => Effect.Effect<AlertChecksSummary, AlertPersistenceError | AlertNotFoundError | AlertValidationError>
+	readonly listDeliveryEvents: (
+		orgId: OrgId,
+		options?: ListAlertDeliveryEventsOptions,
+	) => Effect.Effect<AlertDeliveryEventsListResponse, AlertPersistenceError>
+}
+
+const decodeAlertIncidentIdSync = Schema.decodeUnknownSync(AlertIncidentDocument.fields.id)
+const decodeAlertRuleIdSync = Schema.decodeUnknownSync(AlertRuleDocument.fields.id)
+const decodeAlertDeliveryEventIdSync = Schema.decodeUnknownSync(AlertDeliveryEventDocument.fields.id)
+const decodeAlertDestinationIdSync = Schema.decodeUnknownSync(AlertDestinationDocument.fields.id)
+const decodeIsoDateTimeStringSync = Schema.decodeUnknownSync(AlertDestinationDocument.fields.createdAt)
+const decodeAlertDestinationTypeSync = Schema.decodeUnknownSync(AlertDestinationTypeSchema)
+const decodeAlertSeveritySync = Schema.decodeUnknownSync(AlertSeveritySchema)
+const decodeAlertSignalTypeSync = Schema.decodeUnknownSync(AlertSignalTypeSchema)
+const decodeAlertComparatorSync = Schema.decodeUnknownSync(AlertComparatorSchema)
+const decodeAlertCheckStatusSync = Schema.decodeUnknownSync(AlertCheckStatusSchema)
+const decodeAlertIncidentTransitionSync = Schema.decodeUnknownSync(AlertIncidentTransitionSchema)
+const decodeAlertIncidentStatusSync = Schema.decodeUnknownSync(AlertIncidentStatus)
+const decodeAlertEventTypeSync = Schema.decodeUnknownSync(AlertEventTypeSchema)
+const decodeErrorIssueIdSync = Schema.decodeUnknownSync(AlertIncidentDocument.fields.errorIssueId)
+const decodeAlertDeliveryStatusSync = Schema.decodeUnknownSync(AlertDeliveryStatus)
+const decodeRoleNameSync = Schema.decodeUnknownSync(RoleName)
+const decodeUserIdSync = Schema.decodeUnknownSync(UserId)
+
+type IsoDateTimeValue = Schema.Schema.Type<typeof AlertDestinationDocument.fields.createdAt>
+
+const toIso = (value: Date | null | undefined): IsoDateTimeValue | null =>
+	value == null ? null : decodeIsoDateTimeStringSync(value.toISOString())
+
+const makePersistenceError = (error: unknown) => {
+	const cause = describeCause(error instanceof Error ? error.cause : error)
+	return new AlertPersistenceError({
+		message: error instanceof Error ? error.message : "Alert persistence failed",
+		...(cause === undefined ? {} : { cause }),
+	})
+}
+
+const makeValidationError = (message: string) => new AlertValidationError({ message, details: [] })
+
+const rowToIncidentDocument = (row: AlertIncidentRow) =>
+	new AlertIncidentDocument({
+		id: decodeAlertIncidentIdSync(row.id),
+		ruleId: decodeAlertRuleIdSync(row.ruleId),
+		ruleName: row.ruleName,
+		groupKey: row.groupKey,
+		signalType: decodeAlertSignalTypeSync(row.signalType),
+		severity: decodeAlertSeveritySync(row.severity),
+		status: decodeAlertIncidentStatusSync(row.status),
+		comparator: decodeAlertComparatorSync(row.comparator),
+		threshold: row.threshold,
+		thresholdUpper: row.thresholdUpper,
+		firstTriggeredAt: decodeIsoDateTimeStringSync(row.firstTriggeredAt.toISOString()),
+		lastTriggeredAt: decodeIsoDateTimeStringSync(row.lastTriggeredAt.toISOString()),
+		resolvedAt: toIso(row.resolvedAt),
+		lastObservedValue: row.lastObservedValue,
+		lastSampleCount: row.lastSampleCount,
+		dedupeKey: row.dedupeKey,
+		lastDeliveredEventType:
+			row.lastDeliveredEventType != null ? decodeAlertEventTypeSync(row.lastDeliveredEventType) : null,
+		lastNotifiedAt: toIso(row.lastNotifiedAt),
+		errorIssueId: row.errorIssueId != null ? decodeErrorIssueIdSync(row.errorIssueId) : null,
+	})
+
+const toTinybirdSqlDateTime64 = (iso: string) => {
+	const d = new Date(iso)
+	if (Number.isNaN(d.getTime())) return null
+	const pad = (n: number, w = 2) => n.toString().padStart(w, "0")
+	return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}.${pad(d.getUTCMilliseconds(), 3)}`
+}
+
+export class AlertReadModelsService extends Context.Service<
+	AlertReadModelsService,
+	AlertReadModelsServiceShape
+>()("@maple/api/services/alerts/AlertReadModelsService", {
+	make: Effect.gen(function* () {
+		const database = yield* Database
+		const warehouse = yield* WarehouseQueryService
+
+		const dbExecute = <T>(fn: (db: DatabaseClient) => Promise<T>) =>
+			database.execute(fn).pipe(
+				Effect.tapError((error) =>
+					Effect.logError("AlertsService dbExecute failed").pipe(
+						Effect.annotateLogs({
+							message: error.message,
+							cause: describeCause(error.cause) ?? "(none)",
+						}),
+					),
+				),
+				Effect.mapError(makePersistenceError),
+			)
+
+		const systemTenant = (orgId: OrgId): TenantContext => ({
+			orgId,
+			userId: decodeUserIdSync("system-alerting"),
+			roles: [decodeRoleNameSync("root")],
+			authMode: "self_hosted",
+		})
+
+		const listIncidents = Effect.fn("AlertsService.listIncidents")(function* (
+			orgId: OrgId,
+			options: ListAlertIncidentsOptions = {},
+		) {
+			yield* Effect.annotateCurrentSpan({
+				orgId,
+				...(options.status !== undefined ? { status: options.status } : {}),
+				...(options.ruleId !== undefined ? { ruleId: options.ruleId } : {}),
+			})
+			const conditions = [
+				eq(alertIncidents.orgId, orgId),
+				options.status ? eq(alertIncidents.status, options.status) : undefined,
+				options.ruleId ? eq(alertIncidents.ruleId, options.ruleId) : undefined,
+			].filter((condition): condition is NonNullable<typeof condition> => condition !== undefined)
+			const rows = yield* dbExecute((db) =>
+				db
+					.select()
+					.from(alertIncidents)
+					.where(and(...conditions))
+					.orderBy(desc(alertIncidents.lastTriggeredAt), desc(alertIncidents.id))
+					.limit(options.limit ?? 100)
+					.offset(options.offset ?? 0),
+			)
+			yield* Effect.annotateCurrentSpan("result.rowCount", rows.length)
+			return new AlertIncidentsListResponse({
+				incidents: rows.map(rowToIncidentDocument),
+			})
+		})
+
+		const getIncident = Effect.fn("AlertsService.getIncident")(function* (
+			orgId: OrgId,
+			incidentId: AlertIncidentId,
+		) {
+			yield* Effect.annotateCurrentSpan({ orgId, incidentId })
+			const rows = yield* dbExecute((db) =>
+				db
+					.select()
+					.from(alertIncidents)
+					.where(and(eq(alertIncidents.orgId, orgId), eq(alertIncidents.id, incidentId)))
+					.limit(1),
+			)
+			const incident = rows[0]
+			if (incident === undefined) {
+				return yield* new AlertNotFoundError({
+					message: `No such alert incident: '${incidentId}'`,
+					resourceType: "alert_incident",
+					resourceId: incidentId,
+				})
+			}
+			return rowToIncidentDocument(incident)
+		})
+
+		const listRuleChecks = Effect.fn("AlertsService.listRuleChecks")(function* (
+			orgId: OrgId,
+			ruleId: AlertRuleId,
+			options: {
+				readonly groupKey?: string
+				readonly status?: AlertCheckDocument["status"]
+				readonly since?: string
+				readonly until?: string
+				readonly limit?: number
+				readonly beforeTimestamp?: string
+				readonly beforeGroupKey?: string
+			},
+		) {
+			// Verify the rule exists and belongs to this org before querying Tinybird.
+			const ruleRow = yield* dbExecute((db) =>
+				db
+					.select({ id: alertRules.id })
+					.from(alertRules)
+					.where(and(eq(alertRules.orgId, orgId), eq(alertRules.id, ruleId)))
+					.limit(1),
+			)
+			if (ruleRow.length === 0) {
+				return yield* new AlertNotFoundError({
+					message: "Alert rule not found",
+					resourceType: "alert_rule",
+					resourceId: ruleId,
+				})
+			}
+
+			const clamp = (n: number | undefined, min: number, max: number, fallback: number) => {
+				if (n == null || Number.isNaN(n)) return fallback
+				return Math.min(max, Math.max(min, Math.trunc(n)))
+			}
+			const limit = clamp(options.limit, 1, 2000, 500)
+
+			const since = options.since != null ? toTinybirdSqlDateTime64(options.since) : null
+			const until = options.until != null ? toTinybirdSqlDateTime64(options.until) : null
+			const beforeTimestamp =
+				options.beforeTimestamp != null ? toTinybirdSqlDateTime64(options.beforeTimestamp) : null
+			const hasGroupKey = options.groupKey != null && options.groupKey !== ""
+
+			const compiled = CH.compile(
+				CH.listRuleChecksQuery({
+					limit,
+					groupKey: hasGroupKey ? options.groupKey : undefined,
+					status: options.status,
+					since: since ?? undefined,
+					until: until ?? undefined,
+					beforeTimestamp: beforeTimestamp ?? undefined,
+					beforeGroupKey: beforeTimestamp != null ? (options.beforeGroupKey ?? "") : undefined,
+				}),
+				{
+					orgId,
+					ruleId,
+					...(hasGroupKey ? { groupKey: options.groupKey } : {}),
+					...(options.status != null ? { status: options.status } : {}),
+					...(since != null ? { since } : {}),
+					...(until != null ? { until } : {}),
+					...(beforeTimestamp != null
+						? {
+								beforeTimestamp,
+								beforeGroupKey: options.beforeGroupKey ?? "",
+							}
+						: {}),
+				},
+			)
+
+			const rows = yield* warehouse
+				// listRuleChecksQuery declares .routing("ingest") — alert_checks only
+				// exists in the managed Tinybird pipeline.
+				.compiledQuery(systemTenant(orgId), compiled, {
+					profile: "list",
+					context: "listAlertChecks",
+				})
+				.pipe(
+					Effect.mapError(
+						(error) =>
+							new AlertPersistenceError({
+								message: `Failed to list alert checks: ${error.message}`,
+							}),
+					),
+				)
+
+			const checks = yield* Effect.try({
+				try: () =>
+					rows.map((r) => {
+						const rawTransition =
+							r.incidentTransition == null || r.incidentTransition === ""
+								? "none"
+								: String(r.incidentTransition)
+						return new AlertCheckDocument({
+							timestamp: decodeIsoDateTimeStringSync(String(r.timestamp)),
+							groupKey: String(r.groupKey ?? ""),
+							status: decodeAlertCheckStatusSync(String(r.status)),
+							signalType: decodeAlertSignalTypeSync(String(r.signalType)),
+							comparator: decodeAlertComparatorSync(String(r.comparator)),
+							threshold: Number(r.threshold),
+							// thresholdUpper not yet recorded in the Tinybird alert_checks
+							// datasource — schema column will be backfilled with the
+							// datasource update; for now always null in the audit log.
+							thresholdUpper: null,
+							observedValue: r.observedValue == null ? null : Number(r.observedValue),
+							sampleCount: Number(r.sampleCount ?? 0),
+							windowMinutes: Number(r.windowMinutes ?? 0),
+							windowStart: decodeIsoDateTimeStringSync(String(r.windowStart)),
+							windowEnd: decodeIsoDateTimeStringSync(String(r.windowEnd)),
+							consecutiveBreaches: Number(r.consecutiveBreaches ?? 0),
+							consecutiveHealthy: Number(r.consecutiveHealthy ?? 0),
+							incidentId:
+								r.incidentId == null || r.incidentId === ""
+									? null
+									: decodeAlertIncidentIdSync(String(r.incidentId)),
+							incidentTransition: decodeAlertIncidentTransitionSync(rawTransition),
+							evaluationDurationMs: Number(r.evaluationDurationMs ?? 0),
+							errorMessage:
+								r.errorMessage == null || r.errorMessage === ""
+									? null
+									: String(r.errorMessage),
+							errorCategory:
+								r.errorCategory == null || r.errorCategory === ""
+									? null
+									: String(r.errorCategory),
+						})
+					}),
+				catch: (error) =>
+					new AlertPersistenceError({
+						message: `Failed to decode alert check row: ${error instanceof Error ? error.message : String(error)}`,
+					}),
+			})
+
+			return new AlertChecksListResponse({ checks })
+		})
+
+		const summarizeRuleChecks = Effect.fn("AlertsService.summarizeRuleChecks")(function* (
+			orgId: OrgId,
+			ruleId: AlertRuleId,
+			options: { readonly since: string; readonly until: string },
+		) {
+			const ruleRow = yield* dbExecute((db) =>
+				db
+					.select({ id: alertRules.id })
+					.from(alertRules)
+					.where(and(eq(alertRules.orgId, orgId), eq(alertRules.id, ruleId)))
+					.limit(1),
+			)
+			if (ruleRow.length === 0) {
+				return yield* new AlertNotFoundError({
+					message: "Alert rule not found",
+					resourceType: "alert_rule",
+					resourceId: ruleId,
+				})
+			}
+
+			const startMs = Date.parse(options.since)
+			const endMs = Date.parse(options.until)
+			const maxRangeMs = 365 * 24 * 60 * 60 * 1000
+			if (
+				!Number.isFinite(startMs) ||
+				!Number.isFinite(endMs) ||
+				endMs <= startMs ||
+				endMs - startMs > maxRangeMs
+			) {
+				return yield* Effect.fail(
+					makeValidationError("Alert check summaries require a valid range of at most 365 days"),
+				)
+			}
+			const since = toTinybirdSqlDateTime64(options.since)
+			const until = toTinybirdSqlDateTime64(options.until)
+			if (since == null || until == null) {
+				return yield* Effect.fail(makeValidationError("Invalid alert check summary range"))
+			}
+
+			// At most 720 time buckets; minute alignment keeps the boundaries
+			// stable across refreshes and matches alert evaluation granularity.
+			const bucketSeconds = Math.max(1, Math.ceil((endMs - startMs) / 1000 / 720 / 60)) * 60
+			const tenant = systemTenant(orgId)
+			const groupRows = yield* warehouse
+				.compiledQuery(
+					tenant,
+					CH.compile(CH.alertCheckGroupTotalsQuery({ since, until, limit: 20 }), {
+						orgId,
+						ruleId,
+						since,
+						until,
+					}),
+					{ profile: "aggregation", context: "alertCheckSummaryGroups" },
+				)
+				.pipe(
+					Effect.mapError(
+						(error) =>
+							new AlertPersistenceError({
+								message: `Failed to summarize alert check groups: ${error.message}`,
+							}),
+					),
+				)
+			const topGroupKeys = groupRows.map((row) => String(row.groupKey ?? ""))
+			const rows = yield* warehouse
+				.compiledQuery(
+					tenant,
+					CH.compile(CH.alertChecksSummaryQuery({ topGroupKeys }), {
+						orgId,
+						ruleId,
+						since,
+						until,
+						bucketSeconds,
+					}),
+					{ profile: "aggregation", context: "alertCheckSummary" },
+				)
+				.pipe(
+					Effect.mapError(
+						(error) =>
+							new AlertPersistenceError({
+								message: `Failed to summarize alert checks: ${error.message}`,
+							}),
+					),
+				)
+
+			const points: AlertChecksSummaryPoint[] = rows.map((row) => ({
+				bucket: String(row.bucket),
+				groupKey: String(row.groupKey ?? ""),
+				totalCount: Number(row.totalCount ?? 0),
+				breachedCount: Number(row.breachedCount ?? 0),
+				healthyCount: Number(row.healthyCount ?? 0),
+				skippedCount: Number(row.skippedCount ?? 0),
+				errorCount: Number(row.errorCount ?? 0),
+				transitionCount: Number(row.transitionCount ?? 0),
+				observedValue: row.observedValue == null ? null : Number(row.observedValue),
+				threshold: Number(row.threshold ?? 0),
+			}))
+			const totals = points.reduce(
+				(acc, point) => ({
+					total: acc.total + point.totalCount,
+					breached: acc.breached + point.breachedCount,
+					healthy: acc.healthy + point.healthyCount,
+					skipped: acc.skipped + point.skippedCount,
+					error: acc.error + point.errorCount,
+					transitions: acc.transitions + point.transitionCount,
+				}),
+				{ total: 0, breached: 0, healthy: 0, skipped: 0, error: 0, transitions: 0 },
+			)
+			return { bucketSeconds, topGroupKeys, points, totals } satisfies AlertChecksSummary
+		})
+
+		const listDeliveryEvents = Effect.fn("AlertsService.listDeliveryEvents")(function* (
+			orgId: OrgId,
+			options: ListAlertDeliveryEventsOptions = {},
+		) {
+			const rows = yield* dbExecute((db) =>
+				db
+					.select()
+					.from(alertDeliveryEvents)
+					.where(eq(alertDeliveryEvents.orgId, orgId))
+					.orderBy(desc(alertDeliveryEvents.createdAt), desc(alertDeliveryEvents.id))
+					.limit(options.limit ?? 100)
+					.offset(options.offset ?? 0),
+			)
+
+			const destinationRows = yield* dbExecute((db) =>
+				db
+					.select({
+						id: alertDestinations.id,
+						name: alertDestinations.name,
+						type: alertDestinations.type,
+					})
+					.from(alertDestinations)
+					.where(eq(alertDestinations.orgId, orgId)),
+			)
+			const destinationMap = new Map(destinationRows.map((row) => [row.id, row]))
+
+			const events = rows.map((row) => {
+				const destination = destinationMap.get(row.destinationId)
+				return new AlertDeliveryEventDocument({
+					id: decodeAlertDeliveryEventIdSync(row.id),
+					incidentId: row.incidentId ? decodeAlertIncidentIdSync(row.incidentId) : null,
+					ruleId: decodeAlertRuleIdSync(row.ruleId),
+					destinationId: decodeAlertDestinationIdSync(row.destinationId),
+					destinationName: destination?.name ?? "Deleted destination",
+					destinationType:
+						destination?.type != null
+							? decodeAlertDestinationTypeSync(destination.type)
+							: decodeAlertDestinationTypeSync("webhook"),
+					deliveryKey: row.deliveryKey,
+					eventType: decodeAlertEventTypeSync(row.eventType),
+					attemptNumber: row.attemptNumber,
+					status: decodeAlertDeliveryStatusSync(row.status),
+					scheduledAt: decodeIsoDateTimeStringSync(row.scheduledAt.toISOString()),
+					attemptedAt: toIso(row.attemptedAt),
+					providerMessage: row.providerMessage,
+					providerReference: row.providerReference,
+					responseCode: row.responseCode,
+					errorMessage: row.errorMessage,
+				})
+			})
+
+			return new AlertDeliveryEventsListResponse({ events })
+		})
+
+		return {
+			listIncidents,
+			getIncident,
+			listRuleChecks,
+			summarizeRuleChecks,
+			listDeliveryEvents,
+		} satisfies AlertReadModelsServiceShape
+	}),
+}) {
+	static readonly layer = Layer.effect(this, this.make)
+}

--- a/apps/api/src/services/alerts/AlertsService.test.ts
+++ b/apps/api/src/services/alerts/AlertsService.test.ts
@@ -23,6 +23,7 @@ import {
 	interleaveAlertRulesByOrg,
 } from "./AlertsService"
 import { AlertDestinationsService } from "./AlertDestinationsService"
+import { AlertReadModelsService } from "./AlertReadModelsService"
 import { BucketCacheService } from "@maple/query-engine/caching"
 import { EdgeCacheService } from "@maple/cache"
 import { baselineWarehouseCapabilities } from "@maple/query-engine"
@@ -218,6 +219,9 @@ const makeLayer = (
 			Layer.mergeAll(envLive, databaseLive, runtimeLive, hazelOAuthLive, emailLive, orgMembersLive),
 		),
 	)
+	const alertReadModelsLive = AlertReadModelsService.layer.pipe(
+		Layer.provide(Layer.mergeAll(databaseLive, warehouseLive)),
+	)
 
 	const alertsLive = AlertsService.layer.pipe(
 		Layer.provide(
@@ -233,10 +237,11 @@ const makeLayer = (
 				orgChSettingsLive,
 				investigationsLive,
 				alertDestinationsLive,
+				alertReadModelsLive,
 			),
 		),
 	)
-	return Layer.mergeAll(alertDestinationsLive, alertsLive)
+	return Layer.mergeAll(alertDestinationsLive, alertReadModelsLive, alertsLive)
 }
 
 const asOrgId = Schema.decodeUnknownSync(OrgId)
@@ -369,6 +374,19 @@ describe("AlertsService", () => {
 			assert.strictEqual(alerts.updateDestination, destinations.updateDestination)
 			assert.strictEqual(alerts.deleteDestination, destinations.deleteDestination)
 			assert.strictEqual(alerts.testDestination, destinations.testDestination)
+		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub({}))))
+	})
+
+	it.effect("delegates the legacy read methods to AlertReadModelsService", () => {
+		const testDb = createTestDb(trackedDbs)
+		return Effect.gen(function* () {
+			const alerts = yield* AlertsService
+			const readModels = yield* AlertReadModelsService
+			assert.strictEqual(alerts.listIncidents, readModels.listIncidents)
+			assert.strictEqual(alerts.getIncident, readModels.getIncident)
+			assert.strictEqual(alerts.listRuleChecks, readModels.listRuleChecks)
+			assert.strictEqual(alerts.summarizeRuleChecks, readModels.summarizeRuleChecks)
+			assert.strictEqual(alerts.listDeliveryEvents, readModels.listDeliveryEvents)
 		}).pipe(Effect.provide(makeLayer(testDb, makeWarehouseStub({}))))
 	})
 

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -6,27 +6,19 @@ import {
 	QuerySpec,
 	formatWarehouseDateTime,
 } from "@maple/query-engine"
-import * as CH from "@maple/query-engine/ch"
 import { buildTimeseriesQuerySpec, resolveGroupBy } from "@maple/query-engine/query-builder"
 import { prepareRawSql, type AlertBucketSource } from "@maple/query-engine/runtime"
 import {
 	AlertComparator as AlertComparatorSchema,
 	AlertDeliveryError,
 	AlertDeliveryEventDocument,
-	AlertDeliveryEventsListResponse,
-	AlertDeliveryStatus,
 	AlertDestinationDocument,
 	AlertEvaluationResult,
 	AlertEventType as AlertEventTypeSchema,
 	AlertForbiddenError,
 	AlertGroupBy as AlertGroupBySchema,
-	AlertCheckDocument,
-	AlertChecksListResponse,
-	AlertCheckStatus as AlertCheckStatusSchema,
 	AlertIncidentDocument,
-	AlertIncidentsListResponse,
 	AlertIncidentStatus,
-	AlertIncidentTransition as AlertIncidentTransitionSchema,
 	AlertNotFoundError,
 	AlertPersistenceError,
 	AlertRuleDeleteResponse,
@@ -43,7 +35,6 @@ import {
 	QueryBuilderQueryDraftSchema,
 	AlertNotificationTemplate,
 	type AlertComparator,
-	AlertDestinationType as AlertDestinationTypeSchema,
 	type AlertDestinationType,
 	type AlertEventType as AlertEventTypeValue,
 	type AlertRuleUpsertRequest,
@@ -82,7 +73,6 @@ import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, s
 import {
 	Array as Arr,
 	Cause,
-	Clock,
 	Chunk,
 	Effect,
 	HashSet,
@@ -122,6 +112,7 @@ import { dateToMs } from "@/platform/time"
 import { AlertRuntime } from "./AlertRuntime"
 import { AlertDestinationsService, type AlertDestinationsServiceShape } from "./AlertDestinationsService"
 import { makeAlertDestinationDelivery, parseAlertDestinationEncryptionKey } from "./AlertDestinationDelivery"
+import { AlertReadModelsService, type AlertReadModelsServiceShape } from "./AlertReadModelsService"
 
 export { AlertRuntime, type AlertRuntimeShape } from "./AlertRuntime"
 
@@ -255,16 +246,11 @@ const decodeQuerySpecSync = Schema.decodeUnknownSync(QuerySpec)
 const decodeIsoDateTimeStringSync = Schema.decodeUnknownSync(AlertDestinationDocument.fields.createdAt)
 const decodeRoleNameSync = Schema.decodeUnknownSync(RoleName)
 const decodeUserIdSync = Schema.decodeUnknownSync(UserIdSchema)
-const decodeAlertDestinationTypeSync = Schema.decodeUnknownSync(AlertDestinationTypeSchema)
 const decodeAlertSeveritySync = Schema.decodeUnknownSync(AlertSeveritySchema)
 const decodeAlertSignalTypeSync = Schema.decodeUnknownSync(AlertSignalTypeSchema)
 const decodeAlertComparatorSync = Schema.decodeUnknownSync(AlertComparatorSchema)
-const decodeAlertCheckStatusSync = Schema.decodeUnknownSync(AlertCheckStatusSchema)
-const decodeAlertIncidentTransitionSync = Schema.decodeUnknownSync(AlertIncidentTransitionSchema)
 const decodeAlertIncidentStatusSync = Schema.decodeUnknownSync(AlertIncidentStatus)
 const decodeAlertEventTypeSync = Schema.decodeUnknownSync(AlertEventTypeSchema)
-const decodeErrorIssueIdSync = Schema.decodeUnknownSync(AlertIncidentDocument.fields.errorIssueId)
-const decodeAlertDeliveryStatusSync = Schema.decodeUnknownSync(AlertDeliveryStatus)
 
 const decodeAlertGroupByFromJsonSync = Schema.decodeUnknownSync(AlertGroupByFromJson)
 const decodeOrgIdSync = Schema.decodeUnknownSync(OrgId)
@@ -729,33 +715,9 @@ const rowToRuleDocument = (
 	})
 }
 
-const rowToIncidentDocument = (row: AlertIncidentRow) =>
-	new AlertIncidentDocument({
-		id: decodeAlertIncidentIdSync(row.id),
-		ruleId: decodeAlertRuleIdSync(row.ruleId),
-		ruleName: row.ruleName,
-		groupKey: row.groupKey,
-		signalType: decodeAlertSignalTypeSync(row.signalType),
-		severity: decodeAlertSeveritySync(row.severity),
-		status: decodeAlertIncidentStatusSync(row.status),
-		comparator: decodeAlertComparatorSync(row.comparator),
-		threshold: row.threshold,
-		thresholdUpper: row.thresholdUpper,
-		firstTriggeredAt: decodeIsoDateTimeStringSync(row.firstTriggeredAt.toISOString()),
-		lastTriggeredAt: decodeIsoDateTimeStringSync(row.lastTriggeredAt.toISOString()),
-		resolvedAt: toIso(row.resolvedAt),
-		lastObservedValue: row.lastObservedValue,
-		lastSampleCount: row.lastSampleCount,
-		dedupeKey: row.dedupeKey,
-		lastDeliveredEventType:
-			row.lastDeliveredEventType != null ? decodeAlertEventTypeSync(row.lastDeliveredEventType) : null,
-		lastNotifiedAt: toIso(row.lastNotifiedAt),
-		errorIssueId: row.errorIssueId != null ? decodeErrorIssueIdSync(row.errorIssueId) : null,
-	})
-
 // Formatting helpers imported from AlertDeliveryDispatch
 
-export interface AlertsServiceShape extends AlertDestinationsServiceShape {
+export interface AlertsServiceShape extends AlertDestinationsServiceShape, AlertReadModelsServiceShape {
 	readonly listRules: (orgId: OrgId) => Effect.Effect<AlertRulesListResponse, AlertPersistenceError>
 	readonly createRule: (
 		orgId: OrgId,
@@ -816,39 +778,6 @@ export interface AlertsServiceShape extends AlertDestinationsServiceShape {
 		| AlertPersistenceError
 		| WarehouseError
 	>
-	readonly listIncidents: (
-		orgId: OrgId,
-		options?: ListAlertIncidentsOptions,
-	) => Effect.Effect<AlertIncidentsListResponse, AlertPersistenceError>
-	readonly getIncident: (
-		orgId: OrgId,
-		incidentId: AlertIncidentId,
-	) => Effect.Effect<AlertIncidentDocument, AlertPersistenceError | AlertNotFoundError>
-	readonly listRuleChecks: (
-		orgId: OrgId,
-		ruleId: AlertRuleId,
-		options: {
-			readonly groupKey?: string
-			readonly status?: AlertCheckDocument["status"]
-			readonly since?: string
-			readonly until?: string
-			readonly limit?: number
-			readonly beforeTimestamp?: string
-			readonly beforeGroupKey?: string
-		},
-	) => Effect.Effect<AlertChecksListResponse, AlertPersistenceError | AlertNotFoundError>
-	readonly summarizeRuleChecks: (
-		orgId: OrgId,
-		ruleId: AlertRuleId,
-		options: {
-			readonly since: string
-			readonly until: string
-		},
-	) => Effect.Effect<AlertChecksSummary, AlertPersistenceError | AlertNotFoundError | AlertValidationError>
-	readonly listDeliveryEvents: (
-		orgId: OrgId,
-		options?: ListAlertDeliveryEventsOptions,
-	) => Effect.Effect<AlertDeliveryEventsListResponse, AlertPersistenceError>
 	readonly runSchedulerTick: () => Effect.Effect<
 		{
 			readonly evaluatedCount: number
@@ -863,45 +792,6 @@ export interface AlertsServiceShape extends AlertDestinationsServiceShape {
 	>
 }
 
-export interface AlertChecksSummaryPoint {
-	readonly bucket: string
-	readonly groupKey: string
-	readonly totalCount: number
-	readonly breachedCount: number
-	readonly healthyCount: number
-	readonly skippedCount: number
-	readonly errorCount: number
-	readonly transitionCount: number
-	readonly observedValue: number | null
-	readonly threshold: number
-}
-
-export interface AlertChecksSummary {
-	readonly bucketSeconds: number
-	readonly topGroupKeys: ReadonlyArray<string>
-	readonly points: ReadonlyArray<AlertChecksSummaryPoint>
-	readonly totals: {
-		readonly total: number
-		readonly breached: number
-		readonly healthy: number
-		readonly skipped: number
-		readonly error: number
-		readonly transitions: number
-	}
-}
-
-export interface ListAlertIncidentsOptions {
-	readonly status?: AlertIncidentStatus
-	readonly ruleId?: AlertRuleId
-	readonly limit?: number
-	readonly offset?: number
-}
-
-export interface ListAlertDeliveryEventsOptions {
-	readonly limit?: number
-	readonly offset?: number
-}
-
 export class AlertsService extends Context.Service<AlertsService, AlertsServiceShape>()(
 	"@maple/api/services/AlertsService",
 	{
@@ -909,6 +799,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 			const database = yield* Database
 			const env = yield* Env
 			const destinations = yield* AlertDestinationsService
+			const readModels = yield* AlertReadModelsService
 			const queryEngine = yield* QueryEngineService
 			const warehouse = yield* WarehouseQueryService
 			const runtime = yield* AlertRuntime
@@ -2199,365 +2090,6 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					series,
 					wouldFire,
 				})
-			})
-
-			const listIncidents = Effect.fn("AlertsService.listIncidents")(function* (
-				orgId: OrgId,
-				options: ListAlertIncidentsOptions = {},
-			) {
-				yield* Effect.annotateCurrentSpan({
-					orgId,
-					...(options.status !== undefined ? { status: options.status } : {}),
-					...(options.ruleId !== undefined ? { ruleId: options.ruleId } : {}),
-				})
-				const conditions = [
-					eq(alertIncidents.orgId, orgId),
-					options.status ? eq(alertIncidents.status, options.status) : undefined,
-					options.ruleId ? eq(alertIncidents.ruleId, options.ruleId) : undefined,
-				].filter((condition): condition is NonNullable<typeof condition> => condition !== undefined)
-				const rows = yield* dbExecute((db) =>
-					db
-						.select()
-						.from(alertIncidents)
-						.where(and(...conditions))
-						.orderBy(desc(alertIncidents.lastTriggeredAt), desc(alertIncidents.id))
-						.limit(options.limit ?? 100)
-						.offset(options.offset ?? 0),
-				)
-				yield* Effect.annotateCurrentSpan("result.rowCount", rows.length)
-				return new AlertIncidentsListResponse({
-					incidents: rows.map(rowToIncidentDocument),
-				})
-			})
-
-			const getIncident = Effect.fn("AlertsService.getIncident")(function* (
-				orgId: OrgId,
-				incidentId: AlertIncidentId,
-			) {
-				yield* Effect.annotateCurrentSpan({ orgId, incidentId })
-				const rows = yield* dbExecute((db) =>
-					db
-						.select()
-						.from(alertIncidents)
-						.where(and(eq(alertIncidents.orgId, orgId), eq(alertIncidents.id, incidentId)))
-						.limit(1),
-				)
-				const incident = rows[0]
-				if (incident === undefined) {
-					return yield* new AlertNotFoundError({
-						message: `No such alert incident: '${incidentId}'`,
-						resourceType: "alert_incident",
-						resourceId: incidentId,
-					})
-				}
-				return rowToIncidentDocument(incident)
-			})
-
-			const toTinybirdSqlDateTime64 = (iso: string) => {
-				const d = new Date(iso)
-				if (Number.isNaN(d.getTime())) return null
-				const pad = (n: number, w = 2) => n.toString().padStart(w, "0")
-				return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}.${pad(d.getUTCMilliseconds(), 3)}`
-			}
-
-			const listRuleChecks = Effect.fn("AlertsService.listRuleChecks")(function* (
-				orgId: OrgId,
-				ruleId: AlertRuleId,
-				options: {
-					readonly groupKey?: string
-					readonly status?: AlertCheckDocument["status"]
-					readonly since?: string
-					readonly until?: string
-					readonly limit?: number
-					readonly beforeTimestamp?: string
-					readonly beforeGroupKey?: string
-				},
-			) {
-				// Verify the rule exists and belongs to this org before querying Tinybird.
-				const ruleRow = yield* dbExecute((db) =>
-					db
-						.select({ id: alertRules.id })
-						.from(alertRules)
-						.where(and(eq(alertRules.orgId, orgId), eq(alertRules.id, ruleId)))
-						.limit(1),
-				)
-				if (ruleRow.length === 0) {
-					return yield* new AlertNotFoundError({
-						message: "Alert rule not found",
-						resourceType: "alert_rule",
-						resourceId: ruleId,
-					})
-				}
-
-				const clamp = (n: number | undefined, min: number, max: number, fallback: number) => {
-					if (n == null || Number.isNaN(n)) return fallback
-					return Math.min(max, Math.max(min, Math.trunc(n)))
-				}
-				const limit = clamp(options.limit, 1, 2000, 500)
-
-				const since = options.since != null ? toTinybirdSqlDateTime64(options.since) : null
-				const until = options.until != null ? toTinybirdSqlDateTime64(options.until) : null
-				const beforeTimestamp =
-					options.beforeTimestamp != null ? toTinybirdSqlDateTime64(options.beforeTimestamp) : null
-				const hasGroupKey = options.groupKey != null && options.groupKey !== ""
-
-				const compiled = CH.compile(
-					CH.listRuleChecksQuery({
-						limit,
-						groupKey: hasGroupKey ? options.groupKey : undefined,
-						status: options.status,
-						since: since ?? undefined,
-						until: until ?? undefined,
-						beforeTimestamp: beforeTimestamp ?? undefined,
-						beforeGroupKey: beforeTimestamp != null ? (options.beforeGroupKey ?? "") : undefined,
-					}),
-					{
-						orgId,
-						ruleId,
-						...(hasGroupKey ? { groupKey: options.groupKey } : {}),
-						...(options.status != null ? { status: options.status } : {}),
-						...(since != null ? { since } : {}),
-						...(until != null ? { until } : {}),
-						...(beforeTimestamp != null
-							? {
-									beforeTimestamp,
-									beforeGroupKey: options.beforeGroupKey ?? "",
-								}
-							: {}),
-					},
-				)
-
-				const tenant = systemTenant(orgId)
-				const rows = yield* warehouse
-					// listRuleChecksQuery declares .routing("ingest") — alert_checks only
-					// exists in the managed Tinybird pipeline.
-					.compiledQuery(tenant, compiled, {
-						profile: "list",
-						context: "listAlertChecks",
-					})
-					.pipe(
-						Effect.mapError(
-							(error) =>
-								new AlertPersistenceError({
-									message: `Failed to list alert checks: ${error.message}`,
-								}),
-						),
-					)
-
-				const checks = yield* Effect.try({
-					try: () =>
-						rows.map((r) => {
-							const rawTransition =
-								r.incidentTransition == null || r.incidentTransition === ""
-									? "none"
-									: String(r.incidentTransition)
-							return new AlertCheckDocument({
-								timestamp: decodeIsoDateTimeStringSync(String(r.timestamp)),
-								groupKey: String(r.groupKey ?? ""),
-								status: decodeAlertCheckStatusSync(String(r.status)),
-								signalType: decodeAlertSignalTypeSync(String(r.signalType)),
-								comparator: decodeAlertComparatorSync(String(r.comparator)),
-								threshold: Number(r.threshold),
-								// thresholdUpper not yet recorded in the Tinybird alert_checks
-								// datasource — schema column will be backfilled with the
-								// datasource update; for now always null in the audit log.
-								thresholdUpper: null,
-								observedValue: r.observedValue == null ? null : Number(r.observedValue),
-								sampleCount: Number(r.sampleCount ?? 0),
-								windowMinutes: Number(r.windowMinutes ?? 0),
-								windowStart: decodeIsoDateTimeStringSync(String(r.windowStart)),
-								windowEnd: decodeIsoDateTimeStringSync(String(r.windowEnd)),
-								consecutiveBreaches: Number(r.consecutiveBreaches ?? 0),
-								consecutiveHealthy: Number(r.consecutiveHealthy ?? 0),
-								incidentId:
-									r.incidentId == null || r.incidentId === ""
-										? null
-										: decodeAlertIncidentIdSync(String(r.incidentId)),
-								incidentTransition: decodeAlertIncidentTransitionSync(rawTransition),
-								evaluationDurationMs: Number(r.evaluationDurationMs ?? 0),
-								errorMessage:
-									r.errorMessage == null || r.errorMessage === ""
-										? null
-										: String(r.errorMessage),
-								errorCategory:
-									r.errorCategory == null || r.errorCategory === ""
-										? null
-										: String(r.errorCategory),
-							})
-						}),
-					catch: (error) =>
-						new AlertPersistenceError({
-							message: `Failed to decode alert check row: ${error instanceof Error ? error.message : String(error)}`,
-						}),
-				})
-
-				return new AlertChecksListResponse({ checks })
-			})
-
-			const summarizeRuleChecks = Effect.fn("AlertsService.summarizeRuleChecks")(function* (
-				orgId: OrgId,
-				ruleId: AlertRuleId,
-				options: { readonly since: string; readonly until: string },
-			) {
-				const ruleRow = yield* dbExecute((db) =>
-					db
-						.select({ id: alertRules.id })
-						.from(alertRules)
-						.where(and(eq(alertRules.orgId, orgId), eq(alertRules.id, ruleId)))
-						.limit(1),
-				)
-				if (ruleRow.length === 0) {
-					return yield* new AlertNotFoundError({
-						message: "Alert rule not found",
-						resourceType: "alert_rule",
-						resourceId: ruleId,
-					})
-				}
-
-				const startMs = Date.parse(options.since)
-				const endMs = Date.parse(options.until)
-				const maxRangeMs = 365 * 24 * 60 * 60 * 1000
-				if (
-					!Number.isFinite(startMs) ||
-					!Number.isFinite(endMs) ||
-					endMs <= startMs ||
-					endMs - startMs > maxRangeMs
-				) {
-					return yield* Effect.fail(
-						makeValidationError(
-							"Alert check summaries require a valid range of at most 365 days",
-						),
-					)
-				}
-				const since = toTinybirdSqlDateTime64(options.since)
-				const until = toTinybirdSqlDateTime64(options.until)
-				if (since == null || until == null) {
-					return yield* Effect.fail(makeValidationError("Invalid alert check summary range"))
-				}
-
-				// At most 720 time buckets; minute alignment keeps the boundaries
-				// stable across refreshes and matches alert evaluation granularity.
-				const bucketSeconds = Math.max(1, Math.ceil((endMs - startMs) / 1000 / 720 / 60)) * 60
-				const tenant = systemTenant(orgId)
-				const groupRows = yield* warehouse
-					.compiledQuery(
-						tenant,
-						CH.compile(CH.alertCheckGroupTotalsQuery({ since, until, limit: 20 }), {
-							orgId,
-							ruleId,
-							since,
-							until,
-						}),
-						{ profile: "aggregation", context: "alertCheckSummaryGroups" },
-					)
-					.pipe(
-						Effect.mapError(
-							(error) =>
-								new AlertPersistenceError({
-									message: `Failed to summarize alert check groups: ${error.message}`,
-								}),
-						),
-					)
-				const topGroupKeys = groupRows.map((row) => String(row.groupKey ?? ""))
-				const rows = yield* warehouse
-					.compiledQuery(
-						tenant,
-						CH.compile(CH.alertChecksSummaryQuery({ topGroupKeys }), {
-							orgId,
-							ruleId,
-							since,
-							until,
-							bucketSeconds,
-						}),
-						{ profile: "aggregation", context: "alertCheckSummary" },
-					)
-					.pipe(
-						Effect.mapError(
-							(error) =>
-								new AlertPersistenceError({
-									message: `Failed to summarize alert checks: ${error.message}`,
-								}),
-						),
-					)
-
-				const points: AlertChecksSummaryPoint[] = rows.map((row) => ({
-					bucket: String(row.bucket),
-					groupKey: String(row.groupKey ?? ""),
-					totalCount: Number(row.totalCount ?? 0),
-					breachedCount: Number(row.breachedCount ?? 0),
-					healthyCount: Number(row.healthyCount ?? 0),
-					skippedCount: Number(row.skippedCount ?? 0),
-					errorCount: Number(row.errorCount ?? 0),
-					transitionCount: Number(row.transitionCount ?? 0),
-					observedValue: row.observedValue == null ? null : Number(row.observedValue),
-					threshold: Number(row.threshold ?? 0),
-				}))
-				const totals = points.reduce(
-					(acc, point) => ({
-						total: acc.total + point.totalCount,
-						breached: acc.breached + point.breachedCount,
-						healthy: acc.healthy + point.healthyCount,
-						skipped: acc.skipped + point.skippedCount,
-						error: acc.error + point.errorCount,
-						transitions: acc.transitions + point.transitionCount,
-					}),
-					{ total: 0, breached: 0, healthy: 0, skipped: 0, error: 0, transitions: 0 },
-				)
-				return { bucketSeconds, topGroupKeys, points, totals } satisfies AlertChecksSummary
-			})
-
-			const listDeliveryEvents = Effect.fn("AlertsService.listDeliveryEvents")(function* (
-				orgId: OrgId,
-				options: ListAlertDeliveryEventsOptions = {},
-			) {
-				const rows = yield* dbExecute((db) =>
-					db
-						.select()
-						.from(alertDeliveryEvents)
-						.where(eq(alertDeliveryEvents.orgId, orgId))
-						.orderBy(desc(alertDeliveryEvents.createdAt), desc(alertDeliveryEvents.id))
-						.limit(options.limit ?? 100)
-						.offset(options.offset ?? 0),
-				)
-
-				const destinationRows = yield* dbExecute((db) =>
-					db
-						.select({
-							id: alertDestinations.id,
-							name: alertDestinations.name,
-							type: alertDestinations.type,
-						})
-						.from(alertDestinations)
-						.where(eq(alertDestinations.orgId, orgId)),
-				)
-				const destinationMap = new Map(destinationRows.map((row) => [row.id, row]))
-
-				const events = rows.map((row) => {
-					const destination = destinationMap.get(row.destinationId)
-					return new AlertDeliveryEventDocument({
-						id: decodeAlertDeliveryEventIdSync(row.id),
-						incidentId: row.incidentId ? decodeAlertIncidentIdSync(row.incidentId) : null,
-						ruleId: decodeAlertRuleIdSync(row.ruleId),
-						destinationId: decodeAlertDestinationIdSync(row.destinationId),
-						destinationName: destination?.name ?? "Deleted destination",
-						destinationType:
-							destination?.type != null
-								? decodeAlertDestinationTypeSync(destination.type)
-								: decodeAlertDestinationTypeSync("webhook"),
-						deliveryKey: row.deliveryKey,
-						eventType: decodeAlertEventTypeSync(row.eventType),
-						attemptNumber: row.attemptNumber,
-						status: decodeAlertDeliveryStatusSync(row.status),
-						scheduledAt: decodeIsoDateTimeStringSync(row.scheduledAt.toISOString()),
-						attemptedAt: toIso(row.attemptedAt),
-						providerMessage: row.providerMessage,
-						providerReference: row.providerReference,
-						responseCode: row.responseCode,
-						errorMessage: row.errorMessage,
-					})
-				})
-
-				return new AlertDeliveryEventsListResponse({ events })
 			})
 
 			const claimableDeliveryWhere = (currentTime: number) =>
@@ -4403,11 +3935,11 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				deleteRule,
 				testRule,
 				previewRule,
-				listIncidents,
-				getIncident,
-				listRuleChecks,
-				summarizeRuleChecks,
-				listDeliveryEvents,
+				listIncidents: readModels.listIncidents,
+				getIncident: readModels.getIncident,
+				listRuleChecks: readModels.listRuleChecks,
+				summarizeRuleChecks: readModels.summarizeRuleChecks,
+				listDeliveryEvents: readModels.listDeliveryEvents,
 				runSchedulerTick,
 			} satisfies AlertsServiceShape
 		}),


### PR DESCRIPTION
## Summary

- extract alert incident, delivery-event, and rule-check reads into `AlertReadModelsService`
- require exactly `Database | WarehouseQueryService`, leaving destination delivery, query evaluation, scheduler, and worker environment out of read-only consumers
- migrate v2 incident/delivery/check handlers and the three read-only MCP tools to the narrow capability
- keep `AlertsService` source-compatible by delegating the same five function references

## Verification

- API and alerting production typechecks
- full API suite: 1,640 tests passed before the final no-behavior cleanup
- alerting suite: 8 tests passed
- focused read-model, boundary, and graph tests
- Effect boundary lint, Knip, formatting, and diff checks

## Stack

Depends on #400. Part of stack #395.

