### PR TITLE
extract error policy service

### DIFF
--- a/apps/alerting/src/worker.ts
+++ b/apps/alerting/src/worker.ts
@@ -16,6 +16,7 @@ import {
 	Env,
 	ErrorActorsService,
 	ErrorIssueWorkflowService,
+	ErrorPolicyService,
 	ErrorsService,
 	EscalationService,
 	HazelOAuthService,
@@ -140,6 +141,7 @@ export const buildLayer = (env: AlertingWorkerEnv) => {
 	const ErrorIssueWorkflowServiceLive = ErrorIssueWorkflowService.layer.pipe(
 		Layer.provide(Layer.mergeAll(BaseLive, ErrorActorsServiceLive)),
 	)
+	const ErrorPolicyServiceLive = ErrorPolicyService.layer.pipe(Layer.provide(BaseLive))
 
 	// WorkerEnvironment is merged in so incident-open investigations can see the
 	// cross-script fan-out workflow binding.
@@ -152,6 +154,7 @@ export const buildLayer = (env: AlertingWorkerEnv) => {
 				NotificationDispatcherLive,
 				ErrorActorsServiceLive,
 				ErrorIssueWorkflowServiceLive,
+				ErrorPolicyServiceLive,
 				WorkerEnvironmentLive,
 			),
 		),

--- a/apps/api/src/alerting.ts
+++ b/apps/api/src/alerting.ts
@@ -10,6 +10,7 @@ export { CloudflareAnalyticsService } from "./services/integrations/CloudflareAn
 export { CloudflareOAuthService } from "./services/auth/CloudflareOAuthService"
 export { ErrorActorsService } from "./services/errors/ErrorActorsService"
 export { ErrorIssueWorkflowService } from "./services/errors/ErrorIssueWorkflowService"
+export { ErrorPolicyService } from "./services/errors/ErrorPolicyService"
 export { ErrorsService } from "./services/errors/ErrorsService"
 export { NotificationDispatcher } from "./services/alerts/NotificationDispatcher"
 export { Database } from "@/platform/DatabaseLive"

--- a/apps/api/src/mcp/tools/runtime-requirements.ts
+++ b/apps/api/src/mcp/tools/runtime-requirements.ts
@@ -4,6 +4,7 @@ import type { AlertRulesService } from "@/services/alerts/AlertRulesService"
 import type { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
 import type { ErrorActorsService } from "@/services/errors/ErrorActorsService"
 import type { ErrorIssueWorkflowService } from "@/services/errors/ErrorIssueWorkflowService"
+import type { ErrorPolicyService } from "@/services/errors/ErrorPolicyService"
 import type { ErrorsService } from "@/services/errors/ErrorsService"
 import type { RecommendationIssueService } from "@/services/errors/RecommendationIssueService"
 import type { VcsSourceService } from "@/services/integrations/vcs/VcsSourceService"
@@ -24,6 +25,7 @@ export type McpToolRuntimeRequirements =
 	| DashboardPersistenceService
 	| ErrorActorsService
 	| ErrorIssueWorkflowService
+	| ErrorPolicyService
 	| ErrorsService
 	| QueryEngineService
 	| RecommendationIssueService

--- a/apps/api/src/mcp/tools/update-error-notification-policy.ts
+++ b/apps/api/src/mcp/tools/update-error-notification-policy.ts
@@ -9,7 +9,7 @@ import {
 import { Effect, Option, Schema } from "effect"
 import { createDualContent } from "@/mcp/lib/structured-output"
 import { resolveTenant } from "@/mcp/lib/query-warehouse"
-import { ErrorsService } from "@/services/errors/ErrorsService"
+import { ErrorPolicyService } from "@/services/errors/ErrorPolicyService"
 import { AlertDestinationId, AlertSeverity, ErrorNotificationPolicyUpsertRequest } from "@maple/domain/http"
 
 const decodeSeverity = Schema.decodeUnknownOption(AlertSeverity)
@@ -55,7 +55,7 @@ export function registerUpdateErrorNotificationPolicyTool(server: McpToolRegistr
 			const decodedSeverity = Option.getOrUndefined(parsedSeverity)
 
 			const tenant = yield* resolveTenant
-			const errors = yield* ErrorsService
+			const policies = yield* ErrorPolicyService
 
 			const patch: Partial<{
 				enabled: boolean
@@ -102,7 +102,7 @@ export function registerUpdateErrorNotificationPolicyTool(server: McpToolRegistr
 				),
 			)
 
-			const policy = yield* errors
+			const policy = yield* policies
 				.upsertNotificationPolicy(tenant.orgId, tenant.userId, decodedPatch)
 				.pipe(
 					Effect.catchTags({

--- a/apps/api/src/routes/v1/errors.http.ts
+++ b/apps/api/src/routes/v1/errors.http.ts
@@ -3,6 +3,7 @@ import { CurrentTenant, ErrorForbiddenError, MapleApi } from "@maple/domain/http
 import { Effect } from "effect"
 import { ErrorActorsService } from "@/services/errors/ErrorActorsService"
 import { ErrorIssueWorkflowService } from "@/services/errors/ErrorIssueWorkflowService"
+import { ErrorPolicyService } from "@/services/errors/ErrorPolicyService"
 import { ErrorsService } from "@/services/errors/ErrorsService"
 import { requireAdmin } from "@/services/auth/auth"
 
@@ -10,6 +11,7 @@ export const HttpErrorsLive = HttpApiBuilder.group(MapleApi, "errors", (handlers
 	Effect.gen(function* () {
 		const actors = yield* ErrorActorsService
 		const workflow = yield* ErrorIssueWorkflowService
+		const policies = yield* ErrorPolicyService
 		const errors = yield* ErrorsService
 
 		return handlers
@@ -227,7 +229,7 @@ export const HttpErrorsLive = HttpApiBuilder.group(MapleApi, "errors", (handlers
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
 					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
-					return yield* errors.getNotificationPolicy(tenant.orgId)
+					return yield* policies.getNotificationPolicy(tenant.orgId)
 				}).pipe(Effect.withSpan("HttpErrors.getNotificationPolicy")),
 			)
 			.handle("upsertNotificationPolicy", ({ payload }) =>
@@ -241,14 +243,14 @@ export const HttpErrorsLive = HttpApiBuilder.group(MapleApi, "errors", (handlers
 								message: "Only org admins can manage error notification policy",
 							}),
 					)
-					return yield* errors.upsertNotificationPolicy(tenant.orgId, tenant.userId, payload)
+					return yield* policies.upsertNotificationPolicy(tenant.orgId, tenant.userId, payload)
 				}).pipe(Effect.withSpan("HttpErrors.upsertNotificationPolicy")),
 			)
 			.handle("getEscalationPolicy", () =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
 					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
-					return yield* errors.getEscalationPolicy(tenant.orgId)
+					return yield* policies.getEscalationPolicy(tenant.orgId)
 				}).pipe(Effect.withSpan("HttpErrors.getEscalationPolicy")),
 			)
 			.handle("upsertEscalationPolicy", ({ payload }) =>
@@ -262,14 +264,14 @@ export const HttpErrorsLive = HttpApiBuilder.group(MapleApi, "errors", (handlers
 								message: "Only org admins can manage the escalation policy",
 							}),
 					)
-					return yield* errors.upsertEscalationPolicy(tenant.orgId, tenant.userId, payload)
+					return yield* policies.upsertEscalationPolicy(tenant.orgId, tenant.userId, payload)
 				}).pipe(Effect.withSpan("HttpErrors.upsertEscalationPolicy")),
 			)
 			.handle("evaluateEscalationPolicy", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
 					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
-					return yield* errors.evaluateEscalationPolicy(tenant.orgId, payload)
+					return yield* policies.evaluateEscalationPolicy(tenant.orgId, payload)
 				}).pipe(Effect.withSpan("HttpErrors.evaluateEscalationPolicy")),
 			)
 			.handle("listIssueEscalations", ({ params }) =>
@@ -279,14 +281,14 @@ export const HttpErrorsLive = HttpApiBuilder.group(MapleApi, "errors", (handlers
 						orgId: tenant.orgId,
 						"maple.issue.id": params.issueId,
 					})
-					return yield* errors.listIssueEscalations(tenant.orgId, params.issueId)
+					return yield* policies.listIssueEscalations(tenant.orgId, params.issueId)
 				}).pipe(Effect.withSpan("HttpErrors.listIssueEscalations")),
 			)
 			.handle("listRecentEscalations", ({ query }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
 					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
-					return yield* errors.listRecentEscalations(tenant.orgId, query.limit)
+					return yield* policies.listRecentEscalations(tenant.orgId, query.limit)
 				}).pipe(Effect.withSpan("HttpErrors.listRecentEscalations")),
 			)
 	}),

--- a/apps/api/src/runtime/graph-boundaries.test.ts
+++ b/apps/api/src/runtime/graph-boundaries.test.ts
@@ -74,6 +74,7 @@ describe("API runtime graph boundaries", () => {
 			"DashboardPersistenceService.layer",
 			"ErrorActorsServiceLive",
 			"ErrorIssueWorkflowServiceLive",
+			"ErrorPolicyServiceLive",
 			"ErrorsServiceLive",
 			"QueryEngineServiceLive",
 			"RecommendationIssueServiceLive",

--- a/apps/api/src/runtime/mcp-service-graph.ts
+++ b/apps/api/src/runtime/mcp-service-graph.ts
@@ -14,6 +14,7 @@ import { HazelOAuthService } from "@/services/auth/HazelOAuthService"
 import { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
 import { ErrorActorsService } from "@/services/errors/ErrorActorsService"
 import { ErrorIssueWorkflowService } from "@/services/errors/ErrorIssueWorkflowService"
+import { ErrorPolicyService } from "@/services/errors/ErrorPolicyService"
 import { ErrorsService } from "@/services/errors/ErrorsService"
 import { InvestigationService } from "@/services/errors/InvestigationService"
 import { RecommendationIssueService } from "@/services/errors/RecommendationIssueService"
@@ -100,6 +101,7 @@ const ErrorActorsServiceLive = ErrorActorsService.layer
 const ErrorIssueWorkflowServiceLive = ErrorIssueWorkflowService.layer.pipe(
 	Layer.provide(ErrorActorsServiceLive),
 )
+const ErrorPolicyServiceLive = ErrorPolicyService.layer
 
 const ErrorsServiceLive = ErrorsService.layer.pipe(
 	Layer.provide(
@@ -110,6 +112,7 @@ const ErrorsServiceLive = ErrorsService.layer.pipe(
 			NotificationDispatcherLive,
 			ErrorActorsServiceLive,
 			ErrorIssueWorkflowServiceLive,
+			ErrorPolicyServiceLive,
 		),
 	),
 )
@@ -137,6 +140,7 @@ const McpRuntimeServicesLive = Layer.mergeAll(
 	DashboardPersistenceService.layer,
 	ErrorActorsServiceLive,
 	ErrorIssueWorkflowServiceLive,
+	ErrorPolicyServiceLive,
 	ErrorsServiceLive,
 	QueryEngineServiceLive,
 	RecommendationIssueServiceLive,

--- a/apps/api/src/runtime/service-graph.ts
+++ b/apps/api/src/runtime/service-graph.ts
@@ -24,6 +24,7 @@ import { DigestService } from "@/services/digest/DigestService"
 import { AiTriageService } from "@/services/errors/AiTriageService"
 import { ErrorActorsService } from "@/services/errors/ErrorActorsService"
 import { ErrorIssueWorkflowService } from "@/services/errors/ErrorIssueWorkflowService"
+import { ErrorPolicyService } from "@/services/errors/ErrorPolicyService"
 import { ErrorsService } from "@/services/errors/ErrorsService"
 import { InvestigationService } from "@/services/errors/InvestigationService"
 import { RecommendationIssueService } from "@/services/errors/RecommendationIssueService"
@@ -160,6 +161,7 @@ const ErrorActorsServiceLive = ErrorActorsService.layer
 const ErrorIssueWorkflowServiceLive = ErrorIssueWorkflowService.layer.pipe(
 	Layer.provideMerge(ErrorActorsServiceLive),
 )
+const ErrorPolicyServiceLive = ErrorPolicyService.layer
 
 // Slack integration: OAuth install/callback, status, channels, uninstall, and
 // the internal bot-resolve endpoint. Needs ApiKeysService (mint the bot key) +
@@ -177,6 +179,7 @@ const ErrorsServiceLive = ErrorsService.layer.pipe(
 			NotificationDispatcherLive,
 			ErrorActorsServiceLive,
 			ErrorIssueWorkflowServiceLive,
+			ErrorPolicyServiceLive,
 		),
 	),
 )
@@ -242,6 +245,7 @@ const MainServicesLive = Layer.mergeAll(
 	AiTriageServiceLive,
 	InvestigationServiceLive,
 	ErrorIssueWorkflowServiceLive,
+	ErrorPolicyServiceLive,
 	ErrorsServiceLive,
 	RecommendationIssueServiceLive,
 	SetupAuditServiceLive,

--- a/apps/api/src/services/errors/ErrorPolicyService.test.ts
+++ b/apps/api/src/services/errors/ErrorPolicyService.test.ts
@@ -1,0 +1,226 @@
+import { randomUUID } from "node:crypto"
+import { afterEach, assert, describe, expect, it } from "@effect/vitest"
+import {
+	ErrorNotificationPolicyUpsertRequest,
+	EscalationPolicyEvaluationRequest,
+	IssueEscalationPolicyRule,
+	IssueEscalationPolicyUpsertRequest,
+	OrgId,
+	UserId,
+} from "@maple/domain/http"
+import { AlertDestinationId, ErrorIssueId, IssueEscalationId } from "@maple/domain/primitives"
+import { alertDestinations, issueEscalations } from "@maple/db"
+import { Clock, Effect, Layer, Schema } from "effect"
+import { Database } from "@/platform/DatabaseLive"
+import { msToDate } from "@/platform/time"
+import { cleanupTestDbs, createTestDb, type TestDb } from "@/platform/test-pglite"
+import { ErrorPolicyService } from "./ErrorPolicyService"
+
+// Compile-time guard: broadening policy persistence to Env, notifications,
+// warehouse, cache, WorkerEnvironment, actors, or workflow makes this fail.
+const databaseOnlyLayer: Layer.Layer<ErrorPolicyService, never, Database> = ErrorPolicyService.layer
+
+const asOrgId = Schema.decodeUnknownSync(OrgId)
+const asUserId = Schema.decodeUnknownSync(UserId)
+const asDestinationId = Schema.decodeUnknownSync(AlertDestinationId)
+const asIssueId = Schema.decodeUnknownSync(ErrorIssueId)
+const asEscalationId = Schema.decodeUnknownSync(IssueEscalationId)
+
+const ORG = asOrgId("org_error_policy_service_test")
+const OTHER_ORG = asOrgId("org_error_policy_service_other")
+const USER = asUserId("user_error_policy_service_test")
+const createdDbs: TestDb[] = []
+
+afterEach(() => cleanupTestDbs(createdDbs))
+
+const makeLayer = () => {
+	const database = createTestDb(createdDbs).layer
+	return databaseOnlyLayer.pipe(Layer.provide(database), Layer.provideMerge(database))
+}
+
+const insertDestination = (
+	id: ReturnType<typeof asDestinationId>,
+	orgId: ReturnType<typeof asOrgId>,
+	enabled = true,
+) =>
+	Effect.gen(function* () {
+		const database = yield* Database
+		const timestamp = yield* Clock.currentTimeMillis
+		yield* database.execute((db) =>
+			db.insert(alertDestinations).values({
+				id,
+				orgId,
+				name: `Destination ${id}`,
+				type: "webhook",
+				enabled,
+				configJson: {},
+				secretCiphertext: "ciphertext",
+				secretIv: "iv",
+				secretTag: "tag",
+				createdAt: msToDate(timestamp),
+				updatedAt: msToDate(timestamp),
+				createdBy: USER,
+				updatedBy: USER,
+			}),
+		)
+	})
+
+describe("ErrorPolicyService", () => {
+	it.effect("provides row-less notification defaults and persists partial updates", () =>
+		Effect.gen(function* () {
+			const policies = yield* ErrorPolicyService
+
+			const initial = yield* policies.getNotificationPolicy(ORG)
+			assert.isTrue(initial.enabled)
+			assert.deepStrictEqual(initial.destinationIds, [])
+			assert.isTrue(initial.notifyOnFirstSeen)
+			assert.strictEqual(initial.updatedBy, "system")
+
+			const destinationId = asDestinationId(randomUUID())
+			const updated = yield* policies.upsertNotificationPolicy(
+				ORG,
+				USER,
+				new ErrorNotificationPolicyUpsertRequest({
+					destinationIds: [destinationId],
+					notifyOnResolve: true,
+					minOccurrenceCount: 7,
+				}),
+			)
+
+			assert.deepStrictEqual(updated.destinationIds, [destinationId])
+			assert.isTrue(updated.notifyOnFirstSeen)
+			assert.isTrue(updated.notifyOnResolve)
+			assert.strictEqual(updated.minOccurrenceCount, 7)
+			assert.strictEqual(updated.updatedBy, USER)
+
+			const row = yield* policies.loadNotificationPolicyRow(ORG)
+			assert.isNotNull(row)
+			assert.deepStrictEqual(policies.parseNotificationDestinationIds(row?.destinationIdsJson), [
+				destinationId,
+			])
+		}).pipe(Effect.provide(makeLayer())),
+	)
+
+	it.effect("validates duplicate severities and destination ownership before policy writes", () =>
+		Effect.gen(function* () {
+			const policies = yield* ErrorPolicyService
+			const ownedId = asDestinationId(randomUUID())
+			const foreignId = asDestinationId(randomUUID())
+			yield* insertDestination(ownedId, ORG)
+			yield* insertDestination(foreignId, OTHER_ORG)
+
+			const duplicate = yield* Effect.flip(
+				policies.upsertEscalationPolicy(
+					ORG,
+					USER,
+					new IssueEscalationPolicyUpsertRequest({
+						rules: [
+							new IssueEscalationPolicyRule({
+								severity: "critical",
+								destinationIds: [ownedId],
+							}),
+							new IssueEscalationPolicyRule({
+								severity: "critical",
+								destinationIds: [ownedId],
+							}),
+						],
+					}),
+				),
+			)
+			assert.strictEqual(duplicate._tag, "@maple/http/errors/ErrorValidationError")
+			assert.include(duplicate.message, "duplicate severity")
+
+			const foreign = yield* Effect.flip(
+				policies.upsertEscalationPolicy(
+					ORG,
+					USER,
+					new IssueEscalationPolicyUpsertRequest({
+						rules: [
+							new IssueEscalationPolicyRule({
+								severity: "critical",
+								destinationIds: [ownedId, foreignId],
+							}),
+						],
+					}),
+				),
+			)
+			if (foreign._tag !== "@maple/http/errors/ErrorValidationError") {
+				return assert.fail(`Expected validation error, received ${foreign._tag}`)
+			}
+			assert.include(foreign.details, foreignId)
+			assert.notInclude(foreign.details, ownedId)
+
+			const accepted = yield* policies.upsertEscalationPolicy(
+				ORG,
+				USER,
+				new IssueEscalationPolicyUpsertRequest({
+					enabled: true,
+					rules: [
+						new IssueEscalationPolicyRule({
+							severity: "critical",
+							destinationIds: [ownedId],
+						}),
+					],
+				}),
+			)
+			assert.deepStrictEqual(accepted.rules[0]?.destinationIds, [ownedId])
+
+			const evaluation = yield* policies.evaluateEscalationPolicy(
+				ORG,
+				new EscalationPolicyEvaluationRequest({ severity: "critical", source: "manual" }),
+			)
+			assert.strictEqual(evaluation.outcome, "route")
+			assert.deepStrictEqual(evaluation.destinationIds, [ownedId])
+		}).pipe(Effect.provide(makeLayer())),
+	)
+
+	it.effect("lists issue and recent escalation attempts with org scoping and limits", () =>
+		Effect.gen(function* () {
+			const policies = yield* ErrorPolicyService
+			const database = yield* Database
+			const issueId = asIssueId(randomUUID())
+			const otherIssueId = asIssueId(randomUUID())
+			const timestamp = yield* Clock.currentTimeMillis
+			const rows = [
+				{ id: asEscalationId(randomUUID()), orgId: ORG, issueId, createdAt: timestamp },
+				{ id: asEscalationId(randomUUID()), orgId: ORG, issueId, createdAt: timestamp + 1 },
+				{
+					id: asEscalationId(randomUUID()),
+					orgId: ORG,
+					issueId: otherIssueId,
+					createdAt: timestamp + 2,
+				},
+				{
+					id: asEscalationId(randomUUID()),
+					orgId: OTHER_ORG,
+					issueId,
+					createdAt: timestamp + 3,
+				},
+			]
+			yield* database.execute((db) =>
+				db.insert(issueEscalations).values(
+					rows.map((row) => ({
+						id: row.id,
+						orgId: row.orgId,
+						issueId: row.issueId,
+						severity: "high" as const,
+						source: "manual" as const,
+						reason: "severity_set" as const,
+						payloadJson: {},
+						deliveryResultsJson: [],
+						status: "queued" as const,
+						attempts: 0,
+						dedupeKey: `test:${row.id}`,
+						createdAt: msToDate(row.createdAt),
+					})),
+				),
+			)
+
+			const issueAttempts = yield* policies.listIssueEscalations(ORG, issueId)
+			expect(issueAttempts.attempts.map((attempt) => attempt.id)).toEqual([rows[1]?.id, rows[0]?.id])
+
+			const recent = yield* policies.listRecentEscalations(ORG, 2)
+			expect(recent.attempts.map((attempt) => attempt.id)).toEqual([rows[2]?.id, rows[1]?.id])
+		}).pipe(Effect.provide(makeLayer())),
+	)
+})

--- a/apps/api/src/services/errors/ErrorPolicyService.ts
+++ b/apps/api/src/services/errors/ErrorPolicyService.ts
@@ -1,0 +1,443 @@
+import {
+	type AlertDestinationId,
+	ErrorNotificationPolicyDocument,
+	type ErrorNotificationPolicyUpsertRequest,
+	ErrorPersistenceError,
+	ErrorValidationError,
+	EscalationDestinationOutcome,
+	EscalationPolicyEvaluationDocument,
+	type EscalationPolicyEvaluationRequest,
+	EscalationSkipReason,
+	IssueEscalationAttemptDocument,
+	IssueEscalationAttemptsResponse,
+	IssueEscalationPolicyDocument,
+	IssueEscalationPolicyRule,
+	type IssueEscalationPolicyUpsertRequest,
+	type ErrorIssueId,
+	type OrgId,
+	type UserId,
+	UserId as UserIdSchema,
+} from "@maple/domain/http"
+import {
+	alertDestinations,
+	errorNotificationPolicies,
+	type ErrorNotificationPolicyRow,
+	issueEscalationPolicies,
+	type IssueEscalationPolicyRow,
+	issueEscalations,
+	type IssueEscalationRow,
+} from "@maple/db"
+import { and, desc, eq, inArray } from "drizzle-orm"
+import { Array as Arr, Clock, Context, Effect, HashSet, Layer, Option, Schema } from "effect"
+import { Database } from "@/platform/DatabaseLive"
+import { msToDate } from "@/platform/time"
+import { evaluateEscalationPolicy as evaluateRoutingPolicy } from "@/services/alerts/escalation-policy"
+import { makeErrorDatabaseExecute } from "./error-persistence"
+
+const decodeAlertDestinationIds = Schema.decodeUnknownOption(
+	ErrorNotificationPolicyDocument.fields.destinationIds,
+)
+const decodeStoredJsonArray = Schema.decodeUnknownOption(Schema.Array(Schema.Unknown))
+const decodeEscalationRules = Schema.decodeUnknownOption(Schema.Array(IssueEscalationPolicyRule))
+const decodeEscalationDeliveries = Schema.decodeUnknownOption(Schema.Array(EscalationDestinationOutcome))
+const decodeEscalationSkipReason = Schema.decodeUnknownOption(EscalationSkipReason)
+const decodeNotificationUpdatedAt = Schema.decodeUnknownSync(ErrorNotificationPolicyDocument.fields.updatedAt)
+const decodeEscalationUpdatedAt = Schema.decodeUnknownSync(IssueEscalationPolicyDocument.fields.updatedAt)
+const decodeEscalationAttemptCreatedAt = Schema.decodeUnknownSync(
+	IssueEscalationAttemptDocument.fields.createdAt,
+)
+const decodeEscalationAttemptProcessedAt = Schema.decodeUnknownSync(
+	IssueEscalationAttemptDocument.fields.processedAt,
+)
+
+export interface ErrorPolicyPublicShape {
+	readonly getNotificationPolicy: (
+		orgId: OrgId,
+	) => Effect.Effect<ErrorNotificationPolicyDocument, ErrorPersistenceError>
+	readonly upsertNotificationPolicy: (
+		orgId: OrgId,
+		userId: UserId,
+		request: ErrorNotificationPolicyUpsertRequest,
+	) => Effect.Effect<ErrorNotificationPolicyDocument, ErrorPersistenceError | ErrorValidationError>
+	readonly getEscalationPolicy: (
+		orgId: OrgId,
+	) => Effect.Effect<IssueEscalationPolicyDocument, ErrorPersistenceError>
+	readonly upsertEscalationPolicy: (
+		orgId: OrgId,
+		userId: UserId,
+		request: IssueEscalationPolicyUpsertRequest,
+	) => Effect.Effect<IssueEscalationPolicyDocument, ErrorPersistenceError | ErrorValidationError>
+	readonly evaluateEscalationPolicy: (
+		orgId: OrgId,
+		request: EscalationPolicyEvaluationRequest,
+	) => Effect.Effect<EscalationPolicyEvaluationDocument, ErrorPersistenceError>
+	readonly listIssueEscalations: (
+		orgId: OrgId,
+		issueId: ErrorIssueId,
+	) => Effect.Effect<IssueEscalationAttemptsResponse, ErrorPersistenceError>
+	readonly listRecentEscalations: (
+		orgId: OrgId,
+		limit?: number,
+	) => Effect.Effect<IssueEscalationAttemptsResponse, ErrorPersistenceError>
+}
+
+/** Policy persistence shared with the compatibility facade's notification and tick paths. */
+export interface ErrorPolicyServiceShape extends ErrorPolicyPublicShape {
+	readonly defaultNotificationPolicy: (orgId: OrgId, timestamp: number) => ErrorNotificationPolicyRow
+	readonly parseNotificationDestinationIds: (raw: unknown) => ReadonlyArray<AlertDestinationId>
+	readonly loadNotificationPolicyRow: (
+		orgId: OrgId,
+	) => Effect.Effect<ErrorNotificationPolicyRow | null, ErrorPersistenceError>
+}
+
+const make: Effect.Effect<ErrorPolicyServiceShape, never, Database> = Effect.gen(function* () {
+	const database = yield* Database
+	const dbExecute = makeErrorDatabaseExecute(database)
+	const decodeUserIdSync = Schema.decodeUnknownSync(UserIdSchema)
+
+	// Mirrors the column defaults on `error_notification_policies` — an org with no
+	// row must behave exactly like an org that just got one. Notifications are
+	// enabled but route nowhere until a destination is picked, so the empty
+	// `destinationIdsJson` (not `enabled`) is what holds delivery back. Setting
+	// `enabled: false` here instead made CFG-NOTIF-01 report "turned off" for
+	// row-less orgs and hid the real reason.
+	const defaultNotificationPolicy: ErrorPolicyServiceShape["defaultNotificationPolicy"] = (
+		orgId,
+		timestamp,
+	) => ({
+		orgId,
+		enabled: true,
+		destinationIdsJson: [],
+		notifyOnFirstSeen: true,
+		notifyOnRegression: true,
+		notifyOnResolve: false,
+		notifyOnTransitionInReview: false,
+		notifyOnTransitionDone: false,
+		notifyOnClaim: false,
+		minOccurrenceCount: 1,
+		severity: "warning",
+		updatedAt: msToDate(timestamp),
+		updatedBy: "system",
+	})
+
+	const parseNotificationDestinationIds: ErrorPolicyServiceShape["parseNotificationDestinationIds"] = (
+		raw,
+	) =>
+		Option.getOrElse(
+			Option.flatMap(decodeStoredJsonArray(raw), (parsed) =>
+				decodeAlertDestinationIds(parsed.filter((value) => typeof value === "string")),
+			),
+			() => [],
+		)
+
+	const notificationRowToDocument = (row: ErrorNotificationPolicyRow) =>
+		new ErrorNotificationPolicyDocument({
+			enabled: row.enabled,
+			destinationIds: parseNotificationDestinationIds(row.destinationIdsJson),
+			notifyOnFirstSeen: row.notifyOnFirstSeen,
+			notifyOnRegression: row.notifyOnRegression,
+			notifyOnResolve: row.notifyOnResolve,
+			notifyOnTransitionInReview: row.notifyOnTransitionInReview,
+			notifyOnTransitionDone: row.notifyOnTransitionDone,
+			notifyOnClaim: row.notifyOnClaim,
+			minOccurrenceCount: row.minOccurrenceCount,
+			severity: row.severity,
+			updatedAt: decodeNotificationUpdatedAt(row.updatedAt.toISOString()),
+			updatedBy: decodeUserIdSync(row.updatedBy),
+		})
+
+	const loadNotificationPolicyRow: ErrorPolicyServiceShape["loadNotificationPolicyRow"] = Effect.fn(
+		"ErrorsService.loadPolicyRow",
+	)(function* (orgId) {
+		const rows = yield* dbExecute((db) =>
+			db
+				.select()
+				.from(errorNotificationPolicies)
+				.where(eq(errorNotificationPolicies.orgId, orgId))
+				.limit(1),
+		)
+		return rows[0] ?? null
+	})
+
+	const getNotificationPolicy: ErrorPolicyServiceShape["getNotificationPolicy"] = Effect.fn(
+		"ErrorsService.getNotificationPolicy",
+	)(function* (orgId) {
+		yield* Effect.annotateCurrentSpan({ orgId })
+		const row = yield* loadNotificationPolicyRow(orgId)
+		const nowMs = yield* Clock.currentTimeMillis
+		return notificationRowToDocument(row ?? defaultNotificationPolicy(orgId, nowMs))
+	})
+
+	const upsertNotificationPolicy: ErrorPolicyServiceShape["upsertNotificationPolicy"] = Effect.fn(
+		"ErrorsService.upsertNotificationPolicy",
+	)(function* (orgId, userId, request) {
+		yield* Effect.annotateCurrentSpan({ orgId })
+		const existing = yield* loadNotificationPolicyRow(orgId)
+		const timestamp = yield* Clock.currentTimeMillis
+		const base = existing ?? defaultNotificationPolicy(orgId, timestamp)
+
+		const nextDestinations =
+			request.destinationIds !== undefined ? request.destinationIds : base.destinationIdsJson
+		const toFlag = (value: boolean | undefined, fallback: boolean): boolean =>
+			value === undefined ? fallback : value
+
+		const merged: ErrorNotificationPolicyRow = {
+			orgId,
+			enabled: toFlag(request.enabled, base.enabled),
+			destinationIdsJson: nextDestinations,
+			notifyOnFirstSeen: toFlag(request.notifyOnFirstSeen, base.notifyOnFirstSeen),
+			notifyOnRegression: toFlag(request.notifyOnRegression, base.notifyOnRegression),
+			notifyOnResolve: toFlag(request.notifyOnResolve, base.notifyOnResolve),
+			notifyOnTransitionInReview: toFlag(
+				request.notifyOnTransitionInReview,
+				base.notifyOnTransitionInReview,
+			),
+			notifyOnTransitionDone: toFlag(request.notifyOnTransitionDone, base.notifyOnTransitionDone),
+			notifyOnClaim: toFlag(request.notifyOnClaim, base.notifyOnClaim),
+			minOccurrenceCount:
+				request.minOccurrenceCount !== undefined
+					? request.minOccurrenceCount
+					: base.minOccurrenceCount,
+			severity: request.severity !== undefined ? request.severity : base.severity,
+			updatedAt: msToDate(timestamp),
+			updatedBy: userId,
+		}
+
+		yield* dbExecute((db) =>
+			db
+				.insert(errorNotificationPolicies)
+				.values(merged)
+				.onConflictDoUpdate({
+					target: errorNotificationPolicies.orgId,
+					set: {
+						enabled: merged.enabled,
+						destinationIdsJson: merged.destinationIdsJson,
+						notifyOnFirstSeen: merged.notifyOnFirstSeen,
+						notifyOnRegression: merged.notifyOnRegression,
+						notifyOnResolve: merged.notifyOnResolve,
+						notifyOnTransitionInReview: merged.notifyOnTransitionInReview,
+						notifyOnTransitionDone: merged.notifyOnTransitionDone,
+						notifyOnClaim: merged.notifyOnClaim,
+						minOccurrenceCount: merged.minOccurrenceCount,
+						severity: merged.severity,
+						updatedAt: merged.updatedAt,
+						updatedBy: merged.updatedBy,
+					},
+				}),
+		)
+
+		return notificationRowToDocument(merged)
+	})
+
+	const escalationRowToDocument = (row: IssueEscalationPolicyRow | null) =>
+		new IssueEscalationPolicyDocument({
+			enabled: row?.enabled ?? false,
+			rules: row == null ? [] : Option.getOrElse(decodeEscalationRules(row.rulesJson), () => []),
+			updatedAt: row == null ? null : decodeEscalationUpdatedAt(row.updatedAt.toISOString()),
+			updatedBy: row == null || row.updatedBy === "system" ? null : decodeUserIdSync(row.updatedBy),
+		})
+
+	const loadEscalationPolicyRow = Effect.fn("ErrorsService.loadEscalationPolicyRow")(function* (
+		orgId: OrgId,
+	) {
+		const rows = yield* dbExecute((db) =>
+			db
+				.select()
+				.from(issueEscalationPolicies)
+				.where(eq(issueEscalationPolicies.orgId, orgId))
+				.limit(1),
+		)
+		return rows[0] ?? null
+	})
+
+	const getEscalationPolicy: ErrorPolicyServiceShape["getEscalationPolicy"] = Effect.fn(
+		"ErrorsService.getEscalationPolicy",
+	)(function* (orgId) {
+		yield* Effect.annotateCurrentSpan({ orgId })
+		return escalationRowToDocument(yield* loadEscalationPolicyRow(orgId))
+	})
+
+	const upsertEscalationPolicy: ErrorPolicyServiceShape["upsertEscalationPolicy"] = Effect.fn(
+		"ErrorsService.upsertEscalationPolicy",
+	)(function* (orgId, userId, request) {
+		yield* Effect.annotateCurrentSpan({ orgId })
+		const existing = yield* loadEscalationPolicyRow(orgId)
+		const timestamp = yield* Clock.currentTimeMillis
+
+		if (request.rules !== undefined) {
+			const seen = new Set<string>()
+			for (const rule of request.rules) {
+				if (seen.has(rule.severity)) {
+					return yield* Effect.fail(
+						new ErrorValidationError({
+							message: "Escalation policy has duplicate severity rules",
+							details: [rule.severity],
+						}),
+					)
+				}
+				seen.add(rule.severity)
+			}
+
+			// Reject destination IDs that don't belong to this org at write time.
+			// Dispatch re-filters by org anyway (no cross-org leak), but a typo'd
+			// or foreign ID would otherwise only surface much later as a silently
+			// "skipped" escalation with reason no_enabled_destinations.
+			const referencedIds = Arr.dedupe(Arr.flatMap(request.rules, (rule) => rule.destinationIds))
+			if (referencedIds.length > 0) {
+				const ownedRows = yield* dbExecute((db) =>
+					db
+						.select({ id: alertDestinations.id })
+						.from(alertDestinations)
+						.where(
+							and(
+								eq(alertDestinations.orgId, orgId),
+								inArray(alertDestinations.id, referencedIds),
+							),
+						),
+				)
+				const owned = HashSet.fromIterable(Arr.map(ownedRows, (row) => row.id))
+				const unknown = Arr.filter(referencedIds, (id) => !HashSet.has(owned, id))
+				if (unknown.length > 0) {
+					return yield* Effect.fail(
+						new ErrorValidationError({
+							message: "Escalation policy references unknown destinations",
+							details: unknown,
+						}),
+					)
+				}
+			}
+		}
+
+		const merged: IssueEscalationPolicyRow = {
+			orgId,
+			enabled: request.enabled !== undefined ? request.enabled : (existing?.enabled ?? false),
+			rulesJson: request.rules !== undefined ? request.rules : (existing?.rulesJson ?? []),
+			updatedAt: msToDate(timestamp),
+			updatedBy: userId,
+		}
+
+		yield* dbExecute((db) =>
+			db
+				.insert(issueEscalationPolicies)
+				.values(merged)
+				.onConflictDoUpdate({
+					target: issueEscalationPolicies.orgId,
+					set: {
+						enabled: merged.enabled,
+						rulesJson: merged.rulesJson,
+						updatedAt: merged.updatedAt,
+						updatedBy: merged.updatedBy,
+					},
+				}),
+		)
+
+		return escalationRowToDocument(merged)
+	})
+
+	const escalationAttemptDocument = (row: IssueEscalationRow) =>
+		new IssueEscalationAttemptDocument({
+			id: row.id,
+			issueId: row.issueId,
+			investigationId: row.investigationId,
+			severity: row.severity,
+			source: row.source,
+			reason: row.reason,
+			status: row.status,
+			attempts: row.attempts,
+			skipReason:
+				row.status === "skipped" ? Option.getOrNull(decodeEscalationSkipReason(row.error)) : null,
+			deliveries: Option.getOrElse(decodeEscalationDeliveries(row.deliveryResultsJson), () => []),
+			createdAt: decodeEscalationAttemptCreatedAt(row.createdAt.toISOString()),
+			processedAt:
+				row.processedAt == null
+					? null
+					: decodeEscalationAttemptProcessedAt(row.processedAt.toISOString()),
+		})
+
+	const evaluatePolicy: ErrorPolicyServiceShape["evaluateEscalationPolicy"] = Effect.fn(
+		"ErrorsService.evaluateEscalationPolicy",
+	)(function* (orgId, request) {
+		yield* Effect.annotateCurrentSpan({ orgId })
+		const policy = yield* loadEscalationPolicyRow(orgId)
+		const rules =
+			policy == null ? [] : Option.getOrElse(decodeEscalationRules(policy.rulesJson), () => [])
+		const referencedIds = Arr.dedupe(Arr.flatMap(rules, (rule) => rule.destinationIds))
+		const enabledRows =
+			referencedIds.length === 0
+				? []
+				: yield* dbExecute((db) =>
+						db
+							.select({ id: alertDestinations.id })
+							.from(alertDestinations)
+							.where(
+								and(
+									eq(alertDestinations.orgId, orgId),
+									eq(alertDestinations.enabled, true),
+									inArray(alertDestinations.id, referencedIds),
+								),
+							),
+					)
+		const decision = evaluateRoutingPolicy({
+			enabled: policy?.enabled ?? false,
+			rules,
+			severity: request.severity,
+			source: request.source,
+			...(request.confidence === undefined ? {} : { confidence: request.confidence }),
+			enabledDestinationIds: new Set(enabledRows.map((row) => row.id)),
+		})
+		return new EscalationPolicyEvaluationDocument({
+			outcome: decision.outcome,
+			destinationIds: [...decision.destinationIds],
+			skipReason: decision.skipReason,
+		})
+	})
+
+	const listIssueEscalations: ErrorPolicyServiceShape["listIssueEscalations"] = Effect.fn(
+		"ErrorsService.listIssueEscalations",
+	)(function* (orgId, issueId) {
+		yield* Effect.annotateCurrentSpan({ orgId, issueId })
+		const rows = yield* dbExecute((db) =>
+			db
+				.select()
+				.from(issueEscalations)
+				.where(and(eq(issueEscalations.orgId, orgId), eq(issueEscalations.issueId, issueId)))
+				.orderBy(desc(issueEscalations.createdAt)),
+		)
+		return new IssueEscalationAttemptsResponse({ attempts: rows.map(escalationAttemptDocument) })
+	})
+
+	const listRecentEscalations: ErrorPolicyServiceShape["listRecentEscalations"] = Effect.fn(
+		"ErrorsService.listRecentEscalations",
+	)(function* (orgId, limit) {
+		yield* Effect.annotateCurrentSpan({ orgId })
+		const rows = yield* dbExecute((db) =>
+			db
+				.select()
+				.from(issueEscalations)
+				.where(eq(issueEscalations.orgId, orgId))
+				.orderBy(desc(issueEscalations.createdAt))
+				.limit(limit ?? 25),
+		)
+		return new IssueEscalationAttemptsResponse({ attempts: rows.map(escalationAttemptDocument) })
+	})
+
+	return {
+		getNotificationPolicy,
+		upsertNotificationPolicy,
+		getEscalationPolicy,
+		upsertEscalationPolicy,
+		evaluateEscalationPolicy: evaluatePolicy,
+		listIssueEscalations,
+		listRecentEscalations,
+		defaultNotificationPolicy,
+		parseNotificationDestinationIds,
+		loadNotificationPolicyRow,
+	} satisfies ErrorPolicyServiceShape
+})
+
+export class ErrorPolicyService extends Context.Service<ErrorPolicyService, ErrorPolicyServiceShape>()(
+	"@maple/api/services/errors/ErrorPolicyService",
+	{ make },
+) {
+	static readonly layer = Layer.effect(this, this.make)
+}

--- a/apps/api/src/services/errors/ErrorsService.test.ts
+++ b/apps/api/src/services/errors/ErrorsService.test.ts
@@ -41,6 +41,7 @@ import type { SqlQueryOptions, WarehouseQueryServiceShape } from "@/services/war
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
 import { ErrorActorsService } from "./ErrorActorsService"
 import { ErrorIssueWorkflowService } from "./ErrorIssueWorkflowService"
+import { ErrorPolicyService } from "./ErrorPolicyService"
 import { describeCause, ErrorsService, makePersistenceError } from "./ErrorsService"
 import { isErrorTickClaimLost, persistErrorTickWindow } from "./error-tick-persistence"
 import { NotificationDispatcher } from "@/services/alerts/NotificationDispatcher"
@@ -199,6 +200,7 @@ const makeErrorsLayer = (
 	const errorIssueWorkflowLive = ErrorIssueWorkflowService.layer.pipe(
 		Layer.provide(Layer.mergeAll(databaseLive, errorActorsLive)),
 	)
+	const errorPolicyLive = ErrorPolicyService.layer.pipe(Layer.provide(databaseLive))
 	// Held only so the service can hand an autonomous investigation turn its `submit_diagnosis`
 	// tool; no test here starts one. The real layer is cheap — it depends on nothing beyond Env
 	// and the database already wired above.
@@ -221,11 +223,12 @@ const makeErrorsLayer = (
 				dispatcherStub,
 				errorActorsLive,
 				errorIssueWorkflowLive,
+				errorPolicyLive,
 				investigationsLive,
 			),
 		),
 	)
-	return Layer.mergeAll(errorsLive, errorActorsLive, errorIssueWorkflowLive).pipe(
+	return Layer.mergeAll(errorsLive, errorActorsLive, errorIssueWorkflowLive, errorPolicyLive).pipe(
 		Layer.provideMerge(databaseLive),
 	)
 }
@@ -273,6 +276,7 @@ const makeGatingLayer = (opts: {
 	const errorIssueWorkflowLive = ErrorIssueWorkflowService.layer.pipe(
 		Layer.provide(Layer.mergeAll(databaseLive, errorActorsLive)),
 	)
+	const errorPolicyLive = ErrorPolicyService.layer.pipe(Layer.provide(databaseLive))
 	// Held only so the service can hand an autonomous investigation turn its `submit_diagnosis`
 	// tool; no test here starts one. The real layer is cheap — it depends on nothing beyond Env
 	// and the database already wired above.
@@ -329,6 +333,7 @@ const makeGatingLayer = (opts: {
 				dispatcherStub,
 				errorActorsLive,
 				errorIssueWorkflowLive,
+				errorPolicyLive,
 				investigationsLive,
 			),
 		),
@@ -394,12 +399,13 @@ const seedIngestKey = (orgId: string) =>
 		)
 	})
 
-describe("ErrorsService actor compatibility facade", () => {
-	it.effect("delegates extracted actor and workflow operations by exact reference", () =>
+describe("ErrorsService compatibility facade", () => {
+	it.effect("delegates extracted actor, workflow, and policy operations by exact reference", () =>
 		Effect.gen(function* () {
 			const errors = yield* ErrorsService
 			const actors = yield* ErrorActorsService
 			const workflow = yield* ErrorIssueWorkflowService
+			const policies = yield* ErrorPolicyService
 
 			expect(errors.registerAgent).toBe(actors.registerAgent)
 			expect(errors.listAgents).toBe(actors.listAgents)
@@ -411,6 +417,13 @@ describe("ErrorsService actor compatibility facade", () => {
 			expect(errors.setSeverity).toBe(workflow.setSeverity)
 			expect(errors.commentOnIssue).toBe(workflow.commentOnIssue)
 			expect(errors.listIssueEvents).toBe(workflow.listIssueEvents)
+			expect(errors.getNotificationPolicy).toBe(policies.getNotificationPolicy)
+			expect(errors.upsertNotificationPolicy).toBe(policies.upsertNotificationPolicy)
+			expect(errors.getEscalationPolicy).toBe(policies.getEscalationPolicy)
+			expect(errors.upsertEscalationPolicy).toBe(policies.upsertEscalationPolicy)
+			expect(errors.evaluateEscalationPolicy).toBe(policies.evaluateEscalationPolicy)
+			expect(errors.listIssueEscalations).toBe(policies.listIssueEscalations)
+			expect(errors.listRecentEscalations).toBe(policies.listRecentEscalations)
 		}).pipe(Effect.provide(makeErrorsLayer())),
 	)
 })

--- a/apps/api/src/services/errors/ErrorsService.ts
+++ b/apps/api/src/services/errors/ErrorsService.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto"
 import {
 	ActorDocument,
 	type ActorId,
-	type AlertDestinationId,
 	ErrorIncidentDocument,
 	ErrorIncidentsListResponse,
 	ErrorIssueDetailResponse,
@@ -15,19 +14,8 @@ import {
 	ErrorIssueTransitionError,
 	ErrorIssuesListResponse,
 	ErrorIssueTimeseriesPoint,
-	ErrorNotificationPolicyDocument,
-	type ErrorNotificationPolicyUpsertRequest,
 	ErrorPersistenceError,
 	ErrorValidationError,
-	EscalationDestinationOutcome,
-	EscalationPolicyEvaluationDocument,
-	type EscalationPolicyEvaluationRequest,
-	EscalationSkipReason,
-	IssueEscalationAttemptDocument,
-	IssueEscalationAttemptsResponse,
-	IssueEscalationPolicyDocument,
-	IssueEscalationPolicyRule,
-	type IssueEscalationPolicyUpsertRequest,
 	IssueListCursor,
 	type IssueListCursorFields,
 	IssueSeverityListCursor,
@@ -38,7 +26,6 @@ import {
 	RoleName,
 	SpanId as SpanIdSchema,
 	TraceId as TraceIdSchema,
-	type UserId,
 	UserId as UserIdSchema,
 	type WorkflowState,
 	TERMINAL_WORKFLOW_STATES,
@@ -52,15 +39,9 @@ import {
 	errorIssues,
 	errorIssueEvents,
 	type ErrorIssueRow,
-	alertDestinations,
 	errorIssueStates,
 	errorNotificationPolicies,
-	type ErrorNotificationPolicyRow,
 	errorTickStates,
-	issueEscalationPolicies,
-	type IssueEscalationPolicyRow,
-	type IssueEscalationRow,
-	issueEscalations,
 	orgClickHouseSettings,
 	orgIngestKeys,
 } from "@maple/db"
@@ -71,24 +52,11 @@ import {
 	warehouseDateTimeToIso,
 	formatWarehouseDateTime,
 } from "@maple/query-engine"
-import {
-	Array as Arr,
-	Cause,
-	Clock,
-	Context,
-	Effect,
-	HashSet,
-	Layer,
-	Match,
-	Option,
-	Ref,
-	Schema,
-} from "effect"
+import { Cause, Clock, Context, Effect, Layer, Match, Option, Ref, Schema } from "effect"
 import type { TenantContext } from "@/services/auth/AuthService"
 import { INVESTIGATION_FANOUT_BINDING, maybeEnqueueTriage } from "@/services/errors/ai-triage-enqueue"
 import { isErrorTickClaimLost, persistErrorTickWindow } from "@/services/errors/error-tick-persistence"
 import { SYSTEM_ERRORS_AGENT_NAME } from "@/services/auth/system-actors"
-import { evaluateEscalationPolicy } from "@/services/alerts/escalation-policy"
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
 import { Database } from "@/platform/DatabaseLive"
 import { selectDistinctOrgIds } from "@/platform/distinct-org-ids"
@@ -102,6 +70,7 @@ import {
 } from "@/services/warehouse/warehouse-org-quarantine"
 import { actorRowToDocument, ErrorActorsService, type ErrorActorsPublicShape } from "./ErrorActorsService"
 import { ErrorIssueWorkflowService, type ErrorIssueWorkflowPublicShape } from "./ErrorIssueWorkflowService"
+import { ErrorPolicyService, type ErrorPolicyPublicShape } from "./ErrorPolicyService"
 import { makeErrorDatabaseExecute, makePersistenceError } from "./error-persistence"
 
 export { describeCause, makePersistenceError } from "./error-persistence"
@@ -121,7 +90,6 @@ const decodeSpanIdSync = Schema.decodeUnknownSync(SpanIdSchema)
 
 // Lenient decoders for JSON stored in jsonb columns. Decode failures fall back
 // to an empty/null value at each call site — stored blobs are best-effort.
-const decodeStoredJsonArray = Schema.decodeUnknownOption(Schema.Array(Schema.Unknown))
 const ErrorNotificationOutboxPayload = Schema.Struct({
 	kind: Schema.Literals(["open", "resolve"]),
 	issueId: Schema.String,
@@ -213,7 +181,8 @@ const severitySortRank = (severity: IssueSeverity | null): number =>
 		Match.exhaustive,
 	)
 
-export interface ErrorsServiceShape extends ErrorActorsPublicShape, ErrorIssueWorkflowPublicShape {
+export interface ErrorsServiceShape
+	extends ErrorActorsPublicShape, ErrorIssueWorkflowPublicShape, ErrorPolicyPublicShape {
 	readonly listIssues: (
 		orgId: OrgId,
 		opts: {
@@ -311,34 +280,6 @@ export interface ErrorsServiceShape extends ErrorActorsPublicShape, ErrorIssueWo
 	readonly listOpenIncidents: (
 		orgId: OrgId,
 	) => Effect.Effect<ErrorIncidentsListResponse, ErrorPersistenceError>
-	readonly getNotificationPolicy: (
-		orgId: OrgId,
-	) => Effect.Effect<ErrorNotificationPolicyDocument, ErrorPersistenceError>
-	readonly upsertNotificationPolicy: (
-		orgId: OrgId,
-		userId: UserId,
-		request: ErrorNotificationPolicyUpsertRequest,
-	) => Effect.Effect<ErrorNotificationPolicyDocument, ErrorPersistenceError | ErrorValidationError>
-	readonly getEscalationPolicy: (
-		orgId: OrgId,
-	) => Effect.Effect<IssueEscalationPolicyDocument, ErrorPersistenceError>
-	readonly upsertEscalationPolicy: (
-		orgId: OrgId,
-		userId: UserId,
-		request: IssueEscalationPolicyUpsertRequest,
-	) => Effect.Effect<IssueEscalationPolicyDocument, ErrorPersistenceError | ErrorValidationError>
-	readonly evaluateEscalationPolicy: (
-		orgId: OrgId,
-		request: EscalationPolicyEvaluationRequest,
-	) => Effect.Effect<EscalationPolicyEvaluationDocument, ErrorPersistenceError>
-	readonly listIssueEscalations: (
-		orgId: OrgId,
-		issueId: ErrorIssueId,
-	) => Effect.Effect<IssueEscalationAttemptsResponse, ErrorPersistenceError>
-	readonly listRecentEscalations: (
-		orgId: OrgId,
-		limit?: number,
-	) => Effect.Effect<IssueEscalationAttemptsResponse, ErrorPersistenceError>
 	readonly runTick: () => Effect.Effect<
 		{
 			readonly orgsProcessed: number
@@ -365,10 +306,15 @@ const make: Effect.Effect<
 	| NotificationDispatcher
 	| ErrorActorsService
 	| ErrorIssueWorkflowService
+	| ErrorPolicyService
 > = Effect.gen(function* () {
 	const database = yield* Database
 	const actorService = yield* ErrorActorsService
 	const workflow = yield* ErrorIssueWorkflowService
+	const policies = yield* ErrorPolicyService
+	const loadPolicyRow = policies.loadNotificationPolicyRow
+	const defaultPolicy = policies.defaultNotificationPolicy
+	const parsePolicyDestinations = policies.parseNotificationDestinationIds
 	const warehouse = yield* WarehouseQueryService
 	const edgeCache = yield* EdgeCacheService
 	const env = yield* Env
@@ -1008,336 +954,6 @@ const make: Effect.Effect<
 		return new ErrorIncidentsListResponse({
 			incidents: rows.map(rowToIncident),
 		})
-	})
-
-	// Notification policy (per-org) controlling incident delivery.
-
-	const decodeAlertDestinationIds = Schema.decodeUnknownOption(
-		ErrorNotificationPolicyDocument.fields.destinationIds,
-	)
-
-	// Mirrors the column defaults on `error_notification_policies` — an org with no
-	// row must behave exactly like an org that just got one. Notifications are
-	// enabled but route nowhere until a destination is picked, so the empty
-	// `destinationIdsJson` (not `enabled`) is what holds delivery back. Setting
-	// `enabled: false` here instead made CFG-NOTIF-01 report "turned off" for
-	// row-less orgs and hid the real reason.
-	const defaultPolicy = (orgId: OrgId, timestamp: number): ErrorNotificationPolicyRow => ({
-		orgId,
-		enabled: true,
-		destinationIdsJson: [],
-		notifyOnFirstSeen: true,
-		notifyOnRegression: true,
-		notifyOnResolve: false,
-		notifyOnTransitionInReview: false,
-		notifyOnTransitionDone: false,
-		notifyOnClaim: false,
-		minOccurrenceCount: 1,
-		severity: "warning",
-		updatedAt: new Date(timestamp),
-		updatedBy: "system",
-	})
-
-	const parsePolicyDestinations = (raw: unknown): ReadonlyArray<AlertDestinationId> =>
-		Option.getOrElse(
-			Option.flatMap(decodeStoredJsonArray(raw), (parsed) =>
-				decodeAlertDestinationIds(parsed.filter((v) => typeof v === "string")),
-			),
-			() => [],
-		)
-
-	const rowToPolicy = (row: ErrorNotificationPolicyRow) =>
-		new ErrorNotificationPolicyDocument({
-			enabled: row.enabled,
-			destinationIds: parsePolicyDestinations(row.destinationIdsJson),
-			notifyOnFirstSeen: row.notifyOnFirstSeen,
-			notifyOnRegression: row.notifyOnRegression,
-			notifyOnResolve: row.notifyOnResolve,
-			notifyOnTransitionInReview: row.notifyOnTransitionInReview,
-			notifyOnTransitionDone: row.notifyOnTransitionDone,
-			notifyOnClaim: row.notifyOnClaim,
-			minOccurrenceCount: row.minOccurrenceCount,
-			severity: row.severity,
-			updatedAt: isoFromDate(row.updatedAt),
-			updatedBy: decodeUserIdSync(row.updatedBy),
-		})
-
-	const loadPolicyRow = Effect.fn("ErrorsService.loadPolicyRow")(function* (orgId: OrgId) {
-		const rows = yield* dbExecute((db) =>
-			db
-				.select()
-				.from(errorNotificationPolicies)
-				.where(eq(errorNotificationPolicies.orgId, orgId))
-				.limit(1),
-		)
-		return rows[0] ?? null
-	})
-
-	const getNotificationPolicy: ErrorsServiceShape["getNotificationPolicy"] = Effect.fn(
-		"ErrorsService.getNotificationPolicy",
-	)(function* (orgId) {
-		yield* Effect.annotateCurrentSpan({ orgId })
-		const row = yield* loadPolicyRow(orgId)
-		const nowMs = yield* Clock.currentTimeMillis
-		return rowToPolicy(row ?? defaultPolicy(orgId, nowMs))
-	})
-
-	const upsertNotificationPolicy: ErrorsServiceShape["upsertNotificationPolicy"] = Effect.fn(
-		"ErrorsService.upsertNotificationPolicy",
-	)(function* (orgId, userId, request) {
-		yield* Effect.annotateCurrentSpan({ orgId })
-		const existing = yield* loadPolicyRow(orgId)
-		const timestamp = yield* Clock.currentTimeMillis
-		const base = existing ?? defaultPolicy(orgId, timestamp)
-
-		const nextDestinations =
-			request.destinationIds !== undefined ? request.destinationIds : base.destinationIdsJson
-
-		const toFlag = (value: boolean | undefined, fallback: boolean): boolean =>
-			value === undefined ? fallback : value
-
-		const merged: ErrorNotificationPolicyRow = {
-			orgId,
-			enabled: toFlag(request.enabled, base.enabled),
-			destinationIdsJson: nextDestinations,
-			notifyOnFirstSeen: toFlag(request.notifyOnFirstSeen, base.notifyOnFirstSeen),
-			notifyOnRegression: toFlag(request.notifyOnRegression, base.notifyOnRegression),
-			notifyOnResolve: toFlag(request.notifyOnResolve, base.notifyOnResolve),
-			notifyOnTransitionInReview: toFlag(
-				request.notifyOnTransitionInReview,
-				base.notifyOnTransitionInReview,
-			),
-			notifyOnTransitionDone: toFlag(request.notifyOnTransitionDone, base.notifyOnTransitionDone),
-			notifyOnClaim: toFlag(request.notifyOnClaim, base.notifyOnClaim),
-			minOccurrenceCount:
-				request.minOccurrenceCount !== undefined
-					? request.minOccurrenceCount
-					: base.minOccurrenceCount,
-			severity: request.severity !== undefined ? request.severity : base.severity,
-			updatedAt: new Date(timestamp),
-			updatedBy: userId,
-		}
-
-		yield* dbExecute((db) =>
-			db
-				.insert(errorNotificationPolicies)
-				.values(merged)
-				.onConflictDoUpdate({
-					target: errorNotificationPolicies.orgId,
-					set: {
-						enabled: merged.enabled,
-						destinationIdsJson: merged.destinationIdsJson,
-						notifyOnFirstSeen: merged.notifyOnFirstSeen,
-						notifyOnRegression: merged.notifyOnRegression,
-						notifyOnResolve: merged.notifyOnResolve,
-						notifyOnTransitionInReview: merged.notifyOnTransitionInReview,
-						notifyOnTransitionDone: merged.notifyOnTransitionDone,
-						notifyOnClaim: merged.notifyOnClaim,
-						minOccurrenceCount: merged.minOccurrenceCount,
-						severity: merged.severity,
-						updatedAt: merged.updatedAt,
-						updatedBy: merged.updatedBy,
-					},
-				}),
-		)
-
-		return rowToPolicy(merged)
-	})
-
-	// Escalation policy (per-org severity → destination routing).
-
-	const decodeEscalationRules = Schema.decodeUnknownOption(Schema.Array(IssueEscalationPolicyRule))
-
-	const escalationRowToDocument = (row: IssueEscalationPolicyRow | null) =>
-		new IssueEscalationPolicyDocument({
-			enabled: row?.enabled ?? false,
-			rules: row == null ? [] : Option.getOrElse(decodeEscalationRules(row.rulesJson), () => []),
-			updatedAt: row == null ? null : isoFromDate(row.updatedAt),
-			updatedBy: row == null || row.updatedBy === "system" ? null : decodeUserIdSync(row.updatedBy),
-		})
-
-	const loadEscalationPolicyRow = Effect.fn("ErrorsService.loadEscalationPolicyRow")(function* (
-		orgId: OrgId,
-	) {
-		const rows = yield* dbExecute((db) =>
-			db
-				.select()
-				.from(issueEscalationPolicies)
-				.where(eq(issueEscalationPolicies.orgId, orgId))
-				.limit(1),
-		)
-		return rows[0] ?? null
-	})
-
-	const getEscalationPolicy: ErrorsServiceShape["getEscalationPolicy"] = Effect.fn(
-		"ErrorsService.getEscalationPolicy",
-	)(function* (orgId) {
-		yield* Effect.annotateCurrentSpan({ orgId })
-		return escalationRowToDocument(yield* loadEscalationPolicyRow(orgId))
-	})
-
-	const upsertEscalationPolicy: ErrorsServiceShape["upsertEscalationPolicy"] = Effect.fn(
-		"ErrorsService.upsertEscalationPolicy",
-	)(function* (orgId, userId, request) {
-		yield* Effect.annotateCurrentSpan({ orgId })
-		const existing = yield* loadEscalationPolicyRow(orgId)
-		const timestamp = yield* Clock.currentTimeMillis
-
-		if (request.rules !== undefined) {
-			const seen = new Set<string>()
-			for (const rule of request.rules) {
-				if (seen.has(rule.severity)) {
-					return yield* Effect.fail(
-						new ErrorValidationError({
-							message: "Escalation policy has duplicate severity rules",
-							details: [rule.severity],
-						}),
-					)
-				}
-				seen.add(rule.severity)
-			}
-
-			// Reject destination IDs that don't belong to this org at write time.
-			// Dispatch re-filters by org anyway (no cross-org leak), but a typo'd
-			// or foreign ID would otherwise only surface much later as a silently
-			// "skipped" escalation with reason no_enabled_destinations.
-			const referencedIds = Arr.dedupe(Arr.flatMap(request.rules, (rule) => rule.destinationIds))
-			if (referencedIds.length > 0) {
-				const ownedRows = yield* dbExecute((db) =>
-					db
-						.select({ id: alertDestinations.id })
-						.from(alertDestinations)
-						.where(
-							and(
-								eq(alertDestinations.orgId, orgId),
-								inArray(alertDestinations.id, referencedIds),
-							),
-						),
-				)
-				const owned = HashSet.fromIterable(Arr.map(ownedRows, (row) => row.id))
-				const unknown = Arr.filter(referencedIds, (id) => !HashSet.has(owned, id))
-				if (unknown.length > 0) {
-					return yield* Effect.fail(
-						new ErrorValidationError({
-							message: "Escalation policy references unknown destinations",
-							details: unknown,
-						}),
-					)
-				}
-			}
-		}
-
-		const merged: IssueEscalationPolicyRow = {
-			orgId,
-			enabled: request.enabled !== undefined ? request.enabled : (existing?.enabled ?? false),
-			rulesJson: request.rules !== undefined ? request.rules : (existing?.rulesJson ?? []),
-			updatedAt: new Date(timestamp),
-			updatedBy: userId,
-		}
-
-		yield* dbExecute((db) =>
-			db
-				.insert(issueEscalationPolicies)
-				.values(merged)
-				.onConflictDoUpdate({
-					target: issueEscalationPolicies.orgId,
-					set: {
-						enabled: merged.enabled,
-						rulesJson: merged.rulesJson,
-						updatedAt: merged.updatedAt,
-						updatedBy: merged.updatedBy,
-					},
-				}),
-		)
-
-		return escalationRowToDocument(merged)
-	})
-
-	const decodeEscalationDeliveries = Schema.decodeUnknownOption(Schema.Array(EscalationDestinationOutcome))
-	const decodeEscalationSkipReason = Schema.decodeUnknownOption(EscalationSkipReason)
-
-	const escalationAttemptDocument = (row: IssueEscalationRow) =>
-		new IssueEscalationAttemptDocument({
-			id: row.id,
-			issueId: row.issueId,
-			investigationId: row.investigationId,
-			severity: row.severity,
-			source: row.source,
-			reason: row.reason,
-			status: row.status,
-			attempts: row.attempts,
-			skipReason:
-				row.status === "skipped" ? Option.getOrNull(decodeEscalationSkipReason(row.error)) : null,
-			deliveries: Option.getOrElse(decodeEscalationDeliveries(row.deliveryResultsJson), () => []),
-			createdAt: isoFromDate(row.createdAt),
-			processedAt: row.processedAt ? isoFromDate(row.processedAt) : null,
-		})
-
-	const evaluatePolicy: ErrorsServiceShape["evaluateEscalationPolicy"] = Effect.fn(
-		"ErrorsService.evaluateEscalationPolicy",
-	)(function* (orgId, request) {
-		yield* Effect.annotateCurrentSpan({ orgId })
-		const policy = yield* loadEscalationPolicyRow(orgId)
-		const rules =
-			policy == null ? [] : Option.getOrElse(decodeEscalationRules(policy.rulesJson), () => [])
-		const referencedIds = Arr.dedupe(Arr.flatMap(rules, (rule) => rule.destinationIds))
-		const enabledRows =
-			referencedIds.length === 0
-				? []
-				: yield* dbExecute((db) =>
-						db
-							.select({ id: alertDestinations.id })
-							.from(alertDestinations)
-							.where(
-								and(
-									eq(alertDestinations.orgId, orgId),
-									eq(alertDestinations.enabled, true),
-									inArray(alertDestinations.id, referencedIds),
-								),
-							),
-					)
-		const decision = evaluateEscalationPolicy({
-			enabled: policy?.enabled ?? false,
-			rules,
-			severity: request.severity,
-			source: request.source,
-			...(request.confidence === undefined ? {} : { confidence: request.confidence }),
-			enabledDestinationIds: new Set(enabledRows.map((row) => row.id)),
-		})
-		return new EscalationPolicyEvaluationDocument({
-			outcome: decision.outcome,
-			destinationIds: [...decision.destinationIds],
-			skipReason: decision.skipReason,
-		})
-	})
-
-	const listIssueEscalations: ErrorsServiceShape["listIssueEscalations"] = Effect.fn(
-		"ErrorsService.listIssueEscalations",
-	)(function* (orgId, issueId) {
-		yield* Effect.annotateCurrentSpan({ orgId, issueId })
-		const rows = yield* dbExecute((db) =>
-			db
-				.select()
-				.from(issueEscalations)
-				.where(and(eq(issueEscalations.orgId, orgId), eq(issueEscalations.issueId, issueId)))
-				.orderBy(desc(issueEscalations.createdAt)),
-		)
-		return new IssueEscalationAttemptsResponse({ attempts: rows.map(escalationAttemptDocument) })
-	})
-
-	const listRecentEscalations: ErrorsServiceShape["listRecentEscalations"] = Effect.fn(
-		"ErrorsService.listRecentEscalations",
-	)(function* (orgId, limit) {
-		yield* Effect.annotateCurrentSpan({ orgId })
-		const rows = yield* dbExecute((db) =>
-			db
-				.select()
-				.from(issueEscalations)
-				.where(eq(issueEscalations.orgId, orgId))
-				.orderBy(desc(issueEscalations.createdAt))
-				.limit(limit ?? 25),
-		)
-		return new IssueEscalationAttemptsResponse({ attempts: rows.map(escalationAttemptDocument) })
 	})
 
 	const issueLinkUrl = (issueId: string) =>
@@ -2181,13 +1797,13 @@ const make: Effect.Effect<
 		ensureUserActor,
 		listIssueIncidents,
 		listOpenIncidents,
-		getNotificationPolicy,
-		upsertNotificationPolicy,
-		getEscalationPolicy,
-		upsertEscalationPolicy,
-		evaluateEscalationPolicy: evaluatePolicy,
-		listIssueEscalations,
-		listRecentEscalations,
+		getNotificationPolicy: policies.getNotificationPolicy,
+		upsertNotificationPolicy: policies.upsertNotificationPolicy,
+		getEscalationPolicy: policies.getEscalationPolicy,
+		upsertEscalationPolicy: policies.upsertEscalationPolicy,
+		evaluateEscalationPolicy: policies.evaluateEscalationPolicy,
+		listIssueEscalations: policies.listIssueEscalations,
+		listRecentEscalations: policies.listRecentEscalations,
 		runTick,
 	})
 })


### PR DESCRIPTION
## Summary

- extract notification and escalation policy operations into `ErrorPolicyService`
- require exactly `Database`; environment, dispatcher, warehouse, cache, actor, workflow, and scheduler dependencies are absent
- expose seven public policy operations and reuse the same default/parser/row-loader helpers from `ErrorsService` notification paths
- migrate the matching HTTP and MCP consumers while preserving exact-reference facade delegates
- retain the scheduler's direct batched policy select because it intentionally combines four reads into one database operation

## Verification

- API and alerting production typechecks
- dedicated PGlite policy coverage plus facade and runtime-boundary tests
- full rebased API stack: 143 files passed, 4 skipped; 1,654 tests passed, 184 skipped
- alerting suite: 8 tests passed
- type-aware Effect lint, Knip, formatting, and diff checks
- authoritative Worker startup: 128.1ms active CPU / 400ms budget

## Stack

Depends on #404. Part of stack #395.
