### PR TITLE
chore: compact code comments

### DIFF
--- a/.github/workflows/token-cost.yml
+++ b/.github/workflows/token-cost.yml
@@ -36,7 +36,7 @@ jobs:
             # workspaces accounted for roughly half of this job's wall time.
             - uses: ./.github/actions/bun-install
               with:
-                  filters: "@maple/api"
+                  filters: "@maple/api @maple-dev/effect-sdk @maple-dev/browser @maple-dev/clickhouse-builder"
 
             - name: Restore turbo cache
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/apps/alerting/src/worker.ts
+++ b/apps/alerting/src/worker.ts
@@ -44,8 +44,6 @@ interface AlertingWorkerEnv {
 }
 
 const buildLayer = (env: AlertingWorkerEnv) => {
-	// Keep config and binding services on the same invocation-scoped env record;
-	// scheduled handlers already receive the authoritative Cloudflare bindings.
 	const ConfigLive = layerFromEnv(env)
 	const WorkerEnvironmentLive = layerFromEnvRecord(env)
 	const EnvLive = Env.layer.pipe(Layer.provide(ConfigLive))
@@ -374,8 +372,7 @@ export default {
 			Match.when("*/15 * * * *", () => digestTick),
 			Match.when("0 * * * *", () => serviceMapRollupTick),
 			Match.when("* * * * *", () => everyMinuteTick),
-			// Fail closed: a newly configured cron must not silently inherit the
-			// every-minute alert/error/escalation fan-out.
+			// Unknown schedules must not inherit the every-minute fan-out.
 			Match.orElse((cron) =>
 				Effect.logWarning("Skipping unknown alerting cron schedule").pipe(
 					Effect.annotateLogs({ cron }),

--- a/apps/api/src/platform/DatabasePgLive.ts
+++ b/apps/api/src/platform/DatabasePgLive.ts
@@ -4,26 +4,14 @@ import { Database, type DatabaseClient, DatabaseError, type DatabaseShape } from
 import { executeOnFreshPgClient } from "./pg-execute"
 import { resolveDbConnectionSource } from "./pg-connection-source"
 
-// Workers constraint: this layer lives for the isolate, but TCP sockets are
-// tied to the request that opened them. So the layer holds only the connection
-// string and defers the dial to `executeOnFreshPgClient` — see pg-execute.ts
-// for why that is per-call.
-//
-// The env record is read directly rather than through `Env`/`Config` so this
-// layer's only requirement stays `WorkerEnvironment`: apps/alerting wires
-// `WorkerConfigProviderLayer` into `EnvLive` alone, not globally
-// (apps/alerting/src/worker.ts), so a `Config` read here would fall through to
-// the default provider (`process.env`, empty in a Worker) and silently resolve
-// to nothing.
+// Worker TCP sockets are request-bound, so connection happens per execute. Read
+// env directly to keep this layer on WorkerEnvironment rather than process.env.
 const makePgDatabase = Effect.gen(function* () {
 	const env = yield* WorkerEnvironment
 	const source = resolveDbConnectionSource(env)
 
 	if (source._tag === "Unavailable") {
-		// Dying here would abort construction of the ENTIRE isolate layer graph
-		// (layerPg is provideMerge'd into the handler in worker.ts), 504-ing every
-		// route including /health. Failing per `execute` keeps DB-free routes
-		// serving and turns DB-backed ones into ordinary 500s.
+		// Fail per execute so an absent DB does not abort the isolate layer graph.
 		return Database.of({
 			execute: () => Effect.fail(new DatabaseError({ message: source.reason, cause: undefined })),
 		} satisfies DatabaseShape)

--- a/apps/api/src/platform/pg-connection-source.test.ts
+++ b/apps/api/src/platform/pg-connection-source.test.ts
@@ -26,8 +26,6 @@ describe("resolveDbConnectionSource", () => {
 	it("never leaks credentials into span attributes", () => {
 		const source = resolveDbConnectionSource({ [HYPERDRIVE_BINDING]: hyperdriveBinding })
 
-		// The connection string necessarily carries the password (the driver
-		// needs it); the ATTRIBUTES are what reach a span, and must not.
 		expect(source._tag).toBe("Available")
 		const serialized = JSON.stringify(source._tag === "Available" ? source.attributes : {})
 		expect(serialized).not.toContain("pw")

--- a/apps/api/src/platform/pg-connection-source.ts
+++ b/apps/api/src/platform/pg-connection-source.ts
@@ -1,42 +1,20 @@
 /**
- * Resolve the `MAPLE_DB` Hyperdrive binding to a connection string plus the
- * span attributes that identify the origin.
- *
- * Shared by the request path (`DatabasePgLive`) and both Workflow entrypoints,
- * which each used to hand-roll their own structural narrow of the binding —
- * three slightly different versions, none of them tested, two of which threw
- * where the third degraded.
- *
- * Kept deliberately pure — no Effect, no I/O — so the "is there a database on
- * this stage" decision is unit-testable without a Worker isolate.
- *
- * A direct-to-PSBouncer transport briefly lived here as an alternative to
- * Hyperdrive (2026-08-11) and was removed the same day: dialing the pooler
- * straight from a Worker costs a full handshake per `execute`, because Workers
- * tie sockets to the request that opened them. Measured against prod, that was
- * 679ms connect + 158ms query versus Hyperdrive's 11ms + 14ms — same region,
- * same endpoint `apps/ingest` uses happily from a long-lived pool. Holding the
- * connection pool is the thing Hyperdrive is actually for here, so if the
- * question comes up again the answer is not "bypass Hyperdrive" but "stop
- * dialing per execute", which Workers do not currently allow.
+ * Pure resolver shared by request and Workflow paths. Keep Workers on
+ * Hyperdrive: request-scoped sockets make direct PSBouncer connections pay a
+ * handshake per execute (measured 679ms + 158ms versus Hyperdrive's 11ms + 14ms).
  */
 
-/** Env binding holding the Hyperdrive connection. */
 export const HYPERDRIVE_BINDING = "MAPLE_DB"
 
 export type DbConnectionSource =
 	| {
 			readonly _tag: "Available"
 			readonly connectionString: string
-			/** Span attributes for `executeWithSpan`'s `extraAttributes`. Never contains credentials. */
+			/** Never contains credentials. */
 			readonly attributes: Record<string, unknown>
 	  }
 	| { readonly _tag: "Unavailable"; readonly reason: string }
 
-/**
- * The subset of the Hyperdrive binding this module reads. Structural, because
- * the runtime binding is an opaque host object.
- */
 interface HyperdriveBindingShape {
 	readonly connectionString: string
 	readonly host: string
@@ -56,17 +34,10 @@ const isHyperdriveBinding = (value: unknown): value is HyperdriveBindingShape =>
 	)
 }
 
-/**
- * Resolve the application database for this worker.
- *
- * `Unavailable` is never a throw: callers turn it into a per-`execute`
- * `DatabaseError` so DB-free routes keep serving (see `DatabasePgLive`).
- */
 export const resolveDbConnectionSource = (env: Record<string, unknown>): DbConnectionSource => {
 	const binding = env[HYPERDRIVE_BINDING]
 	if (!isHyperdriveBinding(binding)) {
-		// Stages deployed without an application database (PR previews since
-		// 2026-08 — see resolveDatabaseMode in @maple/infra), and typo'd bindings.
+		// PR previews intentionally omit this binding.
 		return {
 			_tag: "Unavailable",
 			reason: `No application database on this stage (${HYPERDRIVE_BINDING} binding absent)`,
@@ -77,13 +48,7 @@ export const resolveDbConnectionSource = (env: Record<string, unknown>): DbConne
 		_tag: "Available",
 		connectionString: binding.connectionString,
 		attributes: {
-			// Hyperdrive presents itself to the driver as
-			// `<config-id>.hyperdrive.local` with the 32-char config id as the
-			// database name. Maple's read path deliberately collapses both spellings
-			// to the `hyperdrive` sentinel node (see OPAQUE_DB_NAMESPACE_RE in
-			// @maple/domain/tinybird/db-query-shape-sql), so emitting them as-is is
-			// correct — the node is branded "Hyperdrive" and the frontend resolves
-			// the real database behind it from the org's Hyperdrive config inventory.
+			// The read path normalizes Hyperdrive's opaque host/database to its sentinel node.
 			"db.namespace": binding.database,
 			"server.address": binding.host,
 			"server.port": binding.port,

--- a/apps/api/src/routes/query-runner.ts
+++ b/apps/api/src/routes/query-runner.ts
@@ -15,23 +15,8 @@ import type { QueryEngineServiceShape } from "@/services/warehouse/QueryEngineSe
 import type { WarehouseQueryServiceShape } from "@/services/warehouse/WarehouseQueryService"
 
 /**
- * Execute registry-declared warehouse queries.
- *
- * This is the API adapter for a `QueryDefinition`: it applies the definition's
- * span context, error label and cache policy — the five things that used to be
- * hand-repeated in each of 61 handlers, where the cache in particular was
- * silently omitted 50 times.
- *
- * Handlers keep their own row-to-response mapping. What they lose is the
- * plumbing, not the presentation.
- *
- * The services are taken as VALUES, not read from context, and the runners are
- * built once per handler group. That is load-bearing rather than stylistic:
- * `QueryEngineService.cachedDirect` accepts an `Effect` with no requirements, so
- * a context-reading runner could never be composed inside a cache wrapper —
- * which `spanHierarchy` needs, since its probe must only fire on a cache miss.
- * Currying here keeps every call site written as `runQuery(def, tenant, payload)`
- * while the effects it returns carry `R = never`.
+ * Applies registry cache and error policy. Services are values so the returned
+ * effects have no requirements and can run inside `cachedDirect`.
  */
 export interface QueryRunnerDeps {
 	readonly warehouse: WarehouseQueryServiceShape
@@ -39,13 +24,6 @@ export interface QueryRunnerDeps {
 }
 
 export const makeQueryRunners = ({ warehouse, queryEngine }: QueryRunnerDeps) => {
-	/**
-	 * Annotate failures with the query id, then apply the declared cache policy
-	 * (or don't). `cachedDirect` wraps the whole execution so a hit skips the
-	 * warehouse entirely, and it takes the raw payload as key input — it snaps
-	 * timestamps and sorts set-valued keys itself, which is why the payload goes
-	 * in unnormalized.
-	 */
 	const withPolicy = <Payload, Row, A, E extends QueryEngineDirectError>(
 		def: QueryDefinition<Payload, Row>,
 		tenant: TenantContext,
@@ -53,14 +31,10 @@ export const makeQueryRunners = ({ warehouse, queryEngine }: QueryRunnerDeps) =>
 		execute: Effect.Effect<A, E>,
 	) =>
 		Effect.gen(function* () {
-			// Only read the clock when a def actually needs it — a static policy
-			// must not pay for, or depend on, a Clock read.
+			// Static policies do not require a Clock service.
 			const nowMs = typeof def.cache === "function" ? yield* Clock.currentTimeMillis : 0
 			const cache = resolveQueryDefinitionCache(def, payload, nowMs)
 			const labelled = execute.pipe(
-				// Same annotation the old inline `mapExecError` produced, with the
-				// label derived from `def.id` rather than a hand-written string that
-				// could disagree with the span context beside it.
 				Effect.tapError(() =>
 					Effect.annotateCurrentSpan({
 						"maple.query_engine.failed_step": `${def.id} query failed`,
@@ -79,26 +53,12 @@ export const makeQueryRunners = ({ warehouse, queryEngine }: QueryRunnerDeps) =>
 			)
 		})
 
-	/**
-	 * Run a `QueryDefinition` that returns many rows.
-	 *
-	 * Rows-vs-first-row is a call-site concern rather than a field on the def:
-	 * the same compiled query legitimately supports both, and
-	 * `compiledQueryFirst` takes the identical `CompiledQuery`. Putting it in the
-	 * def would only let a caller disagree with it.
-	 */
 	const runQuery = <Payload, Row>(
 		def: QueryDefinition<Payload, Row>,
 		tenant: TenantContext,
 		payload: Payload,
 	) => withPolicy(def, tenant, payload, runQueryDefinition(warehouse, def, tenant, payload))
 
-	/**
-	 * Run a `QueryDefinition` that returns at most one row, as `Row | null`.
-	 *
-	 * Null rather than `Option` because every current caller immediately does
-	 * `Option.getOrNull` to build a nullable response field.
-	 */
 	const runQueryFirst = <Payload, Row>(
 		def: QueryDefinition<Payload, Row>,
 		tenant: TenantContext,

--- a/apps/api/src/routes/v1/query-engine.http.ts
+++ b/apps/api/src/routes/v1/query-engine.http.ts
@@ -224,12 +224,6 @@ const coerceStatusCode = (value: string): StatusCode =>
 // probe.
 const PROBE_RECENT_WINDOW_MS = 48 * 3_600_000
 
-/**
- * Row shapes for `servicePlatforms` / `serviceWorkloads`, shared by the standalone
- * handlers and `serviceMapBundle`. Extracted when the bundle landed: the platform
- * classification below is the kind of ordered rule set that silently diverges if
- * it exists in two places.
- */
 const toServicePlatformRow = (row: CH.ServicePlatformsOutput) => {
 	const k8sCluster = String(row.k8sCluster ?? "")
 	const k8sPodName = String(row.k8sPodName ?? "")
@@ -239,11 +233,9 @@ const toServicePlatformRow = (row: CH.ServicePlatformsOutput) => {
 	const faasName = String(row.faasName ?? "")
 	const mapleSdkType = String(row.mapleSdkType ?? "")
 	const processRuntimeName = String(row.processRuntimeName ?? "")
-	// Require pod/deployment, not just cluster.name — see SQL comment.
+	// cluster.name alone does not prove the service runs in Kubernetes.
 	const isKubernetes = k8sPodName !== "" || k8sDeploymentName !== ""
-	// Infrastructure signals win over SDK self-report so a server SDK on
-	// cloudflare/lambda still classifies by host. Pure browser apps never
-	// set k8s/cloud/faas, so they fall through to web.
+	// Host infrastructure takes precedence over SDK self-report.
 	const platform: "kubernetes" | "cloudflare" | "lambda" | "web" | "unknown" =
 		cloudPlatform === "cloudflare.workers" || cloudProvider === "cloudflare"
 			? "cloudflare"
@@ -981,9 +973,7 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 			.handle("serviceMapBundle", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					// The whole service-map page in one Worker invocation: four env-scoped
-					// queries concurrently behind a single config resolution, then the
-					// workload read the browser could only issue after the edges landed.
+					// Resolve warehouse routing once before the fan-out.
 					yield* warehouse.warmRoute(tenant)
 					const [dependencyRows, overviewRows, dbEdgeRows, platformRows] = yield* Effect.all(
 						[
@@ -995,10 +985,6 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 						{ concurrency: 4 },
 					)
 
-					// Workloads are keyed by the service set the map actually draws —
-					// every service touching an edge, plus every service with overview
-					// rows. Derived here rather than in the browser, which is what turns
-					// this from a second round-trip into a second server-side query.
 					const services = new Set<string>()
 					for (const row of dependencyRows) {
 						services.add(String(row.sourceService ?? ""))
@@ -1007,8 +993,6 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleApi, "queryEngine",
 					for (const row of overviewRows) services.add(String(row.serviceName ?? ""))
 					services.delete("")
 
-					// Matches the standalone handler: an empty service set short-circuits
-					// rather than issuing a guaranteed-empty query.
 					const workloadRows =
 						services.size === 0
 							? []

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -4901,8 +4901,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				// Incremented from fibers running under the concurrent per-rule forEach
 				// below, so it must be a Ref rather than a mutable closure variable.
 				const evaluationFailureCount = yield* Ref.make(0)
-				// Chunk keeps concurrent Ref appends immutable without copying the whole
-				// tick buffer on every write; flatten only at the existing flush boundary.
+				// Chunk makes concurrent appends immutable without copying the full buffer.
 				const pendingChecks = yield* Ref.make(Chunk.empty<AlertChecksRow>())
 				const issueBudget = yield* Ref.make(ISSUE_UPSERTS_PER_TICK)
 

--- a/apps/api/src/workflows/ClickHouseSchemaApplyWorkflow.run.ts
+++ b/apps/api/src/workflows/ClickHouseSchemaApplyWorkflow.run.ts
@@ -350,9 +350,6 @@ export async function runClickHouseSchemaApply(
 	event: WorkflowEventLike<SchemaApplyWorkflowPayload>,
 	step: WorkflowStepLike,
 ): Promise<SchemaApplyWorkflowResult> {
-	// Same resolver the request path uses, rather than a second hand-rolled
-	// narrow of the binding. Passing the attributes also fixes a pre-existing
-	// gap: these spans carried no `db.namespace`/`server.address`.
 	const source = resolveDbConnectionSource(env)
 	if (source._tag === "Unavailable") {
 		throw new Error(source.reason)

--- a/apps/api/src/workflows/InvestigationFanoutWorkflow.run.ts
+++ b/apps/api/src/workflows/InvestigationFanoutWorkflow.run.ts
@@ -585,11 +585,6 @@ export async function runInvestigationFanout(
 	}
 }
 
-/**
- * Dial Postgres through the same resolver the request path uses, rather than a
- * second hand-rolled narrow of the binding. Passing the attributes also fixes a
- * pre-existing gap: these spans carried no `db.namespace`/`server.address`.
- */
 const dialWorkflowDb = (env: InvestigationFanoutWorkflowEnv): TracedPgConnection => {
 	const source = resolveDbConnectionSource(env)
 	if (source._tag === "Unavailable") {

--- a/apps/web/src/api/warehouse/service-map.ts
+++ b/apps/web/src/api/warehouse/service-map.ts
@@ -419,18 +419,6 @@ export const getServiceDbQuerySummary = Effect.fn("QueryEngine.getServiceDbQuery
 	} satisfies ServiceDbQuerySummaryResponse
 })
 
-/**
- * The service-map page in ONE request (see the `serviceMapBundle` handler).
- *
- * Replaces four concurrent browser→Worker round-trips (edges, overview, db
- * edges, platforms) plus a fifth that could only start once the edges landed
- * (workloads keys off the service set derived from them). Each of those five
- * could hit a cold isolate and block on the Postgres config read; now at most
- * one does.
- *
- * The per-row transforms below are the same ones the standalone functions
- * apply, imported rather than re-derived so the two paths can't drift.
- */
 export const getServiceMapBundle = Effect.fn("QueryEngine.getServiceMapBundle")(function* ({
 	data,
 }: {
@@ -449,7 +437,6 @@ export const getServiceMapBundle = Effect.fn("QueryEngine.getServiceMapBundle")(
 					startTime,
 					endTime,
 					deploymentEnv: input.deploymentEnv,
-					// `serviceOverview` scopes by an array; the map only ever selects one.
 					environments: input.deploymentEnv ? [input.deploymentEnv] : undefined,
 				}),
 			})

--- a/apps/web/src/api/warehouse/services.ts
+++ b/apps/web/src/api/warehouse/services.ts
@@ -82,8 +82,7 @@ interface CoercedRow {
 	firstSeen: string
 }
 
-// Exported so `getServiceMapBundle` runs the identical overview transform on
-// the bundle's rows instead of forking a second copy of it.
+// Shared with the bundled service-map response path.
 export function coerceRow(raw: Record<string, unknown>): CoercedRow {
 	return {
 		serviceName: String(raw.serviceName ?? ""),

--- a/apps/web/src/components/app-error-boundary.tsx
+++ b/apps/web/src/components/app-error-boundary.tsx
@@ -1,19 +1,6 @@
 /**
- * Last-resort crash screen for errors that escape the router.
- *
- * The router's `RouteError` catches errors inside route boundaries; anything
- * thrown outside them (Clerk bridge, auth settling, providers) used to unmount
- * the whole tree and leave a blank white page. This boundary wraps the entire
- * app in `main.tsx` and renders a branded crash state instead.
- *
- * Visually it is the BootSplash's trace waterfall frozen at the moment of
- * failure: the first spans landed, the fourth errored (red, where the playhead
- * stopped), and the fifth never arrived — Maple's own material standing in for
- * a generic error illustration. Keep the row geometry in sync with the
- * `.boot-*` / `.crash-*` rules in `styles.css`.
- *
- * No router context exists here, so navigation uses plain anchors and
- * `window.location`. Stale-chunk errors auto-reload, same as `RouteError`.
+ * Last-resort boundary for errors outside router boundaries. It has no router
+ * context; crash artwork geometry is coupled to `.boot-*`/`.crash-*` in styles.css.
  */
 import { Component, type ReactNode } from "react"
 
@@ -46,8 +33,7 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
 		if (this.state.error !== undefined) {
 			return <CrashScreen error={this.state.error} />
 		}
-		// Dev-only preview: append ?__crash to any URL to render the crash screen
-		// without breaking the app (the boundary only fires on real render errors).
+		// Append ?__crash in development to preview the crash screen.
 		if (import.meta.env.DEV && new URLSearchParams(window.location.search).has("__crash")) {
 			return (
 				<CrashScreen error={new TypeError("Cannot read properties of undefined (reading 'spans')")} />

--- a/apps/web/src/components/integrations/integration-connect.tsx
+++ b/apps/web/src/components/integrations/integration-connect.tsx
@@ -16,34 +16,18 @@ import { showErrorToast } from "@/lib/error-toast"
 import { useMountEffect } from "@/hooks/use-mount-effect"
 import type { IntegrationId } from "./integration-catalog"
 
-/**
- * The lifted connect flow for an integration drill-in. Provided once per
- * drill-in by `IntegrationConnectProvider` so the header's Connect button and
- * the card's in-card action share one handler and one busy flag.
- */
 export interface IntegrationConnect {
 	readonly connect: () => void
-	/** True while the start call is in flight — disables every Connect affordance at once. */
 	readonly busy: boolean
-	/**
-	 * True while the OAuth popup is open (GitHub: plus a grace window after it
-	 * closes) — the flow may still complete server-side, so pollers key off this.
-	 */
 	readonly popupActive: boolean
 }
 
 const IntegrationConnectContext = createContext<IntegrationConnect | null>(null)
 
-/** Null for integrations without an OAuth connect flow (prometheus/warpstream). */
 export function useIntegrationConnect(): IntegrationConnect | null {
 	return use(IntegrationConnectContext)
 }
 
-/**
- * Mounts the matching OAuth connect flow for the drill-in. Scrape-based
- * integrations render children bare — `useIntegrationConnect()` stays null,
- * which is also the header's "no Connect button" signal.
- */
 export function IntegrationConnectProvider({
 	integration,
 	children,
@@ -65,14 +49,7 @@ export function IntegrationConnectProvider({
 	}
 }
 
-/**
- * Shared popup choreography for the OAuth flows: open the popup synchronously
- * (inside the click) so the browser doesn't block it, point it at the authorize
- * URL once the start call returns, and poll the handle for closure —
- * cross-origin popups fire no "closed" event, and the refresh-on-close covers
- * the case where the success message never arrives (popup closed manually or
- * blocked) so the drill-in can't get stuck on a stale view.
- */
+// Open synchronously to avoid popup blocking; cross-origin closure must be polled.
 function useOAuthPopupFlow({
 	windowName,
 	windowFeatures,
@@ -86,7 +63,6 @@ function useOAuthPopupFlow({
 	start: () => Promise<Exit.Exit<{ readonly redirectUrl: string }, unknown>>
 	startErrorTitle: string
 	onClosed: () => void
-	/** Keeps `popupActive` true for this long after close (GitHub's backfill-enqueue gap). */
 	closeGraceMs?: number
 }): IntegrationConnect {
 	const [busy, setBusy] = useState(false)
@@ -109,10 +85,8 @@ function useOAuthPopupFlow({
 		onClosed()
 	})
 
-	// A mount-scoped interval is intentional: it watches a cross-origin popup,
-	// including while the opener is hidden. Effect Event keeps current state/copy.
 	useMountEffect(() => {
-		// React Doctor cannot infer that useMountEffect is an Effect.
+		// React Doctor cannot infer useMountEffect.
 		// oxlint-disable-next-line react-doctor/rules-of-hooks
 		const poll = () => checkPopup()
 		const id = setInterval(poll, 500)
@@ -151,22 +125,19 @@ function useOAuthPopupFlow({
 	return { connect: () => void connect(), busy, popupActive: popupOpen || inCloseGrace }
 }
 
-/** The OAuth popup returns to this same SPA and posts a message before closing. */
 function useIntegrationMessage(
 	type: string,
 	onMessage: (data: { status?: string; message?: string }) => void,
 ) {
 	const handleMessage = useEffectEvent((event: MessageEvent) => {
 		if (event.data?.type !== type) return
-		// Every provider's popup posts back through here, so the activation event
-		// is recorded once rather than in each card's success branch.
 		if (event.data?.status === "success") {
 			trackProduct("integration_connected", { provider: type.split(":").pop() ?? type })
 		}
 		onMessage(event.data)
 	})
 	useMountEffect(() => {
-		// React Doctor cannot infer that useMountEffect is an Effect.
+		// React Doctor cannot infer useMountEffect.
 		// oxlint-disable-next-line react-doctor/rules-of-hooks
 		const listener = (event: MessageEvent) => handleMessage(event)
 		window.addEventListener("message", listener)
@@ -280,8 +251,7 @@ function GithubConnectBoundary({ children }: { children: React.ReactNode }) {
 			}),
 		startErrorTitle: "Failed to start GitHub connect flow",
 		onClosed: refreshStatus,
-		// Repos backfill server-side after install with no push channel — keep the
-		// card's status polling alive through the enqueue gap after the popup closes.
+		// Keep polling through the server-side repository backfill enqueue gap.
 		closeGraceMs: 10_000,
 	})
 
@@ -309,8 +279,6 @@ function PlanetscaleConnectBoundary({ children }: { children: React.ReactNode })
 	const value = useOAuthPopupFlow({
 		windowName: "maple-planetscale-connect",
 		windowFeatures: "popup,width=520,height=680",
-		// PlanetScale is the one provider on v2, whose wire format is snake_case —
-		// adapt at the boundary rather than teaching the shared hook two shapes.
 		start: () =>
 			startConnect({
 				payload: { return_to: window.location.href },

--- a/apps/web/src/components/route-error.tsx
+++ b/apps/web/src/components/route-error.tsx
@@ -20,7 +20,6 @@ function RouteError({ error, reset }: ErrorComponentProps) {
 		reset()
 		router.invalidate()
 	}
-	// Route-loader transport failures self-heal without a manual reload.
 	const autoRetrying = useNetworkAutoRetry(
 		formatted.recovery.kind === "retry" && formatted.recovery.automatic && !isStaleChunk,
 		retry,

--- a/apps/web/src/components/service-map/service-map-view.tsx
+++ b/apps/web/src/components/service-map/service-map-view.tsx
@@ -2481,9 +2481,6 @@ export function ServiceMapView({
 		[startTime, endTime],
 	)
 
-	// The whole env-scoped map in ONE fetch: edges, overview, db edges, platforms
-	// and workloads. Was five atoms — four concurrent, plus workloads, which could
-	// only fire after the edges came back to name the services it needed.
 	const bundleResult = useRefreshableAtomValue(getServiceMapBundleResultAtom(mapInput))
 	const cloudflareResult = useRefreshableAtomValue(getServiceMapCloudflareResultAtom(cloudflareInput))
 	// PlanetScale scraped metrics carry no deployment.environment either — share
@@ -2582,15 +2579,8 @@ export function ServiceMapView({
 		return map
 	}, [bundleResult])
 
-	// Workloads arrive with the bundle. The service set they key off (every service
-	// on an edge, plus every service with overview rows) is derived server-side
-	// now — that derivation is why this used to be a second round-trip.
 	const workloads = Result.isSuccess(bundleResult) ? bundleResult.value.workloads : []
 
-	// The `topologyPending` gate this replaced existed because edges, db edges and
-	// overviews arrived on separate queries, so the layout would re-flow as each
-	// landed. One bundle settles them together, so reaching `onSuccess` already
-	// means the graph is complete.
 	return Result.builder(bundleResult)
 		.onInitial(() => <ServiceMapLoading />)
 		.onError((error) => {

--- a/apps/web/src/hooks/use-network-auto-retry.ts
+++ b/apps/web/src/hooks/use-network-auto-retry.ts
@@ -2,24 +2,12 @@ import * as React from "react"
 
 import { useMountEffect } from "@/hooks/use-mount-effect"
 
-/** Poll backoff: 5s → 10s → 20s, then every 30s (±10% jitter). */
 const POLL_DELAYS_MS = [5_000, 10_000, 20_000, 30_000]
 const MAX_POLL_ATTEMPTS = 6
 
 /**
- * While `enabled`, invokes `onRetry` automatically:
- *
- * - immediately when the browser fires the window `online` event (or the tab
- *   becomes visible again),
- * - on a bounded backoff poll per {@link POLL_DELAYS_MS}, with jitter so several error
- *   panels on one screen don't probe in lockstep.
- *
- * Poll ticks are skipped while the tab is hidden or the browser reports
- * offline (the `online`/`visibilitychange` listeners fire the probe instead).
- * The timer chain is mount-scoped; `enabled` and `onRetry` are read fresh at
- * fire time. If a probe unmounts the host (error → loading → error remount),
- * the backoff resets to 5s — effectively a steady poll during a long outage,
- * which the 5s floor keeps cheap.
+ * Retries on reconnect, visibility, and bounded jittered backoff. Hidden or
+ * offline poll ticks wait for their corresponding browser event.
  */
 export function useNetworkAutoRetry(enabled: boolean, onRetry: (() => void) | undefined): boolean {
 	const [exhausted, setExhausted] = React.useState(false)
@@ -30,8 +18,7 @@ export function useNetworkAutoRetry(enabled: boolean, onRetry: (() => void) | un
 	})
 
 	useMountEffect(() => {
-		// React Doctor cannot infer that useMountEffect is an Effect; this is the
-		// canonical Effect Event pattern for a mount-scoped external subscription.
+		// React Doctor cannot infer useMountEffect.
 		// oxlint-disable-next-line react-doctor/rules-of-hooks
 		const probe = () => fire()
 

--- a/apps/web/src/lib/error-messages.ts
+++ b/apps/web/src/lib/error-messages.ts
@@ -32,13 +32,12 @@ export type ErrorRecovery =
 	| { readonly kind: "reload" }
 
 export interface ErrorDiagnostics {
-	/** Original value for telemetry and development tooling. Never render this directly. */
+	/** Raw telemetry-only value; never render. */
 	readonly value: unknown
 	readonly tag?: string
 	readonly technicalMessage?: string
 }
 
-/** Canonical application error. UI code should branch on this shape, never on raw failures. */
 export interface NormalizedAppError {
 	readonly category: ErrorCategory
 	readonly code?: string
@@ -52,7 +51,6 @@ export interface NormalizedAppError {
 	readonly diagnostics: ErrorDiagnostics
 }
 
-/** Stable presentation contract retained by existing error-state callers. */
 export interface FormattedError {
 	readonly title: string
 	readonly description: string
@@ -63,7 +61,7 @@ export interface FormattedError {
 	readonly docUrl?: string
 	readonly recovery: ErrorRecovery
 	readonly recognized: boolean
-	/** Compatibility signal for callers that have not moved to `recovery` yet. */
+	/** Compatibility signal for callers not yet using `recovery`. */
 	readonly kind?: "network"
 }
 
@@ -112,7 +110,6 @@ export interface V2ErrorInfo {
 	readonly docUrl?: string
 }
 
-/** Extract a v2 API error envelope, including its actionable optional fields. */
 export const v2ErrorInfo = (input: unknown): V2ErrorInfo | null => {
 	const error = unwrap(input)
 	if (typeof error !== "object" || error === null || !("error" in error)) return null
@@ -557,6 +554,5 @@ export const presentAppError = (error: NormalizedAppError): FormattedError => ({
 	...(error.recovery.kind === "retry" && error.recovery.automatic ? { kind: "network" as const } : {}),
 })
 
-/** Normalize once, then return safe copy and recovery metadata for any UI surface. */
 export const formatBackendError = (input: unknown): FormattedError =>
 	presentAppError(normalizeAppError(input))

--- a/apps/web/src/lib/error-toast.ts
+++ b/apps/web/src/lib/error-toast.ts
@@ -2,17 +2,12 @@ import { toastManager } from "@maple/ui/components/ui/toast"
 import { formatBackendError } from "./error-messages"
 
 interface ShowErrorToastOptions {
-	/** Operation-specific headline, such as "State change failed". */
 	readonly title?: string
-	/** Used only when the failure is not one of Maple's recognized error shapes. */
 	readonly fallbackTitle?: string
 	readonly type?: "error" | "warning"
 }
 
-/**
- * Put every mutation failure through the same safe formatter before it reaches
- * a toast. Raw Cause/Exit/error messages belong in telemetry, not UI copy.
- */
+/** Keeps raw Cause/Exit/error messages in telemetry rather than UI copy. */
 export const showErrorToast = (error: unknown, options: ShowErrorToastOptions = {}): void => {
 	const presentation = formatBackendError(error)
 	toastManager.add({
@@ -24,7 +19,6 @@ export const showErrorToast = (error: unknown, options: ShowErrorToastOptions = 
 	})
 }
 
-/** Safe one-line compatibility helper for surfaces that can only render a title. */
 export const errorMessage = (error: unknown, fallback: string): string => {
 	const presentation = formatBackendError(error)
 	return presentation.recognized ? presentation.description : fallback

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
@@ -500,9 +500,6 @@ export const getQueryBuilderBreakdownResultAtom = makeQueryAtomFamily(getQueryBu
 	staleTime: 30_000,
 })
 
-// Service-map page bundle: edges + overview + DB edges + platforms + workloads
-// in one fetch (replaces four concurrent atoms plus the edge-dependent
-// workloads atom that could only fire after them).
 export const getServiceMapBundleResultAtom = makeQueryAtomFamily(getServiceMapBundle, {
 	staleTime: 15_000,
 })

--- a/apps/web/src/lib/services/common/api-client-transform.ts
+++ b/apps/web/src/lib/services/common/api-client-transform.ts
@@ -4,7 +4,6 @@ import { apiBaseUrl } from "./api-base-url"
 import { hasCachedMapleAuthToken, invalidateMapleAuthToken } from "./auth-headers"
 import { withMapleRetryPolicy } from "./retry-policy"
 
-/** Requests already given their one stale-token retry, keyed by request identity. */
 const retriedUnauthorized = new WeakSet<object>()
 
 const refreshStaleAuthorization = (request: HttpClientRequest.HttpClientRequest): boolean => {
@@ -18,7 +17,6 @@ const refreshStaleAuthorization = (request: HttpClientRequest.HttpClientRequest)
 	return request.url.includes("/api/billing/")
 }
 
-/** Shared v1/v2 client transform: service-map attribution plus one retry policy. */
 export const transformMapleApiClient = <E, R>(
 	client: HttpClient.HttpClient.With<E, R>,
 ): HttpClient.HttpClient.With<E, R> =>

--- a/apps/web/src/lib/services/common/retry-policy.ts
+++ b/apps/web/src/lib/services/common/retry-policy.ts
@@ -11,13 +11,7 @@ const IDEMPOTENT_METHODS = new Set(["GET", "HEAD", "OPTIONS"])
 export const isIdempotentRequest = (request: HttpClientRequest.HttpClientRequest): boolean =>
 	IDEMPOTENT_METHODS.has(request.method.toUpperCase())
 
-/**
- * Transient network failure worth replaying: a `TransportError` (fetch failed,
- * DNS, connection reset) on an idempotent request. Transport failures can occur
- * after the request reached the server, so mutations are never replayed. The
- * 45s client timeout (`AbortSignal.timeout` in http-client.ts) also surfaces as
- * a TransportError — excluded so one hang doesn't multiply into several.
- */
+/** Retry transport failures only for idempotent requests, excluding client timeouts. */
 export const isRetryableTransportError = (error: unknown): boolean => {
 	if (!HttpClientError.isHttpClientError(error)) return false
 	if (error.reason._tag !== "TransportError") return false
@@ -28,31 +22,18 @@ export const isRetryableTransportError = (error: unknown): boolean => {
 	return isIdempotentRequest(error.request)
 }
 
-/**
- * Retry only the short server-failure set that commonly self-heals. A 504 is
- * usually a query-budget timeout and an identical replay just multiplies work;
- * 408/429 need user-visible pacing rather than a hidden retry burst.
- */
+// 504 repeats expensive timed-out queries; 408/429 require visible pacing.
 export const isRetryableResponse = (response: HttpClientResponse.HttpClientResponse): boolean =>
 	isIdempotentRequest(response.request) &&
 	(response.status === 500 || response.status === 502 || response.status === 503)
 
-/** Backoff between HTTP-layer retry attempts: 300ms → 600ms → 1.2s. */
 export const mapleRetrySchedule = Schedule.exponential("300 millis")
 
 interface MapleRetryPolicyOptions {
-	/** Return true after performing any stale-credential invalidation required for this request. */
 	readonly retryUnauthorized?: (request: HttpClientRequest.HttpClientRequest) => boolean
 }
 
-/**
- * Response-aware retry for raw Effect HTTP clients.
- *
- * `HttpClient.retry` only observes failed Effects, while HttpApi decoding turns
- * non-2xx responses into typed errors *after* the raw client transform. Handle
- * transient response statuses here, before decoding, and retain error retries
- * for genuine fetch/DNS failures. Mutations are never replayed.
- */
+// Non-2xx responses are still successes here; retry them before HttpApi decoding.
 export const withMapleRetryPolicy = <E, R>(
 	client: HttpClient.HttpClient.With<E, R>,
 	options: MapleRetryPolicyOptions = {},

--- a/packages/browser-session/src/browser-globals.ts
+++ b/packages/browser-session/src/browser-globals.ts
@@ -1,9 +1,6 @@
 /**
- * Narrow accessors for the browser globals this package reads.
- *
- * Session code also runs in tests and non-DOM embedders, so these are declared by
- * hand and every accessor may return `undefined`. Each names exactly the fields we
- * touch — an untyped `globalThis` bag would let a typo through as `any`.
+ * Narrow optional globals for tests and non-DOM embedders, without pulling in
+ * the full DOM types.
  */
 
 interface BrowserNavigator {

--- a/packages/domain/src/http/query-engine.ts
+++ b/packages/domain/src/http/query-engine.ts
@@ -745,7 +745,6 @@ export class ServicePlatformsRequest extends Schema.Class<ServicePlatformsReques
 	},
 ) {}
 
-/** One `servicePlatforms` row. Named so `serviceMapBundle` can reuse it verbatim. */
 const ServicePlatformRow = Schema.Struct({
 	serviceName: ServiceName,
 	platform: ServicePlatformLiteral,
@@ -773,7 +772,6 @@ export class ServiceWorkloadsRequest extends Schema.Class<ServiceWorkloadsReques
 	},
 ) {}
 
-/** One `serviceWorkloads` row. Named so `serviceMapBundle` can reuse it verbatim. */
 const ServiceWorkloadRow = Schema.Struct({
 	serviceName: ServiceName,
 	workloadKind: ServiceWorkloadKindLiteral,
@@ -791,35 +789,11 @@ export class ServiceWorkloadsResponse extends Schema.Class<ServiceWorkloadsRespo
 	data: Schema.Array(ServiceWorkloadRow),
 }) {}
 
-/**
- * The service-map page in ONE request.
- *
- * Same motivation as `serviceDependenciesBundle`: the four env-scoped map
- * queries run concurrently under a single tenant/config resolution instead of
- * four independent browser→Worker round-trips, each of which can land on a cold
- * isolate and block on the Postgres config read.
- *
- * It also folds in `serviceWorkloads`, which the browser could only issue AFTER
- * the edges came back (it keys off the service set derived from them) — a
- * genuine second round-trip that disappears when the derivation happens
- * server-side.
- *
- * Deliberately EXCLUDES:
- * - `serviceCloudflareStats` / `servicePlanetScaleStats` — those take an
- *   env-less input on purpose so switching environments doesn't refetch them.
- *   Folding them in here would put them behind an env-keyed cache entry and
- *   undo that.
- * - `servicesFacets` — the environment dropdown queries a stable 24h window,
- *   independent of the map's time range, so it stays its own cached request.
- */
 export class ServiceMapBundleRequest extends Schema.Class<ServiceMapBundleRequest>("ServiceMapBundleRequest")(
 	{
 		startTime: TinybirdDateTime,
 		endTime: TinybirdDateTime,
 		deploymentEnv: Schema.optional(DeploymentEnvironment),
-		// `serviceOverview` scopes by an array, and the map passes at most the one
-		// environment above. Kept separate rather than derived so the handler stays a
-		// straight pass-through to each query's own payload.
 		environments: OptionalDeploymentEnvs,
 	},
 ) {}

--- a/packages/domain/src/http/v2/api.ts
+++ b/packages/domain/src/http/v2/api.ts
@@ -28,7 +28,6 @@ import { V2UnexpectedErrors } from "./auth"
 
 const HTTP_OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head"] as const
 
-/** The slice of the generated OpenAPI document this post-pass mutates. */
 interface OpenApiResponse {
 	headers?: Record<string, unknown>
 }

--- a/packages/effect-sdk/src/client/browser-globals.ts
+++ b/packages/effect-sdk/src/client/browser-globals.ts
@@ -1,9 +1,6 @@
 /**
- * Narrow accessors for the browser globals this package reads.
- *
- * The client SDK ships without the DOM lib (it also runs in Workers and Node), so
- * these are declared by hand rather than pulled from `lib.dom`. Each accessor names
- * exactly the fields we touch — an untyped `globalThis` bag would let a typo through.
+ * Narrow optional globals for the DOM-free SDK build, which also runs in
+ * Workers and Node.
  */
 
 interface BrowserNavigator {

--- a/packages/effect-sdk/src/client/consent-http-client.ts
+++ b/packages/effect-sdk/src/client/consent-http-client.ts
@@ -9,9 +9,7 @@ import {
 } from "effect/unstable/http"
 
 /**
- * The slice of the OTLP/JSON envelope this filter walks. Unlisted fields (resource
- * attributes, scope metadata, span bodies) ride along through the spreads untouched,
- * so they deliberately go unmodelled — only the timestamps we compare are named.
+ * Only timestamps are modeled; all other OTLP fields pass through via spreads.
  */
 interface OtlpSpan {
 	readonly startTimeUnixNano?: unknown
@@ -78,10 +76,8 @@ const pruneLogs = (body: OtlpBody, threshold: bigint): OtlpBody | undefined => {
 }
 
 /**
- * Keep only signals captured under the current consent grant. Effect metrics
- * are cumulative and cannot be separated at this HTTP boundary, so the
- * built-in OTLP preset suppresses them when explicit consent gating is used;
- * MapleFlush uses its gated registry and can export post-grant metrics safely.
+ * Keeps signals captured under the current grant. Cumulative Effect metrics
+ * cannot be separated here, so explicit-consent installs suppress them.
  */
 export const filterOtlpRequestForConsent = (
 	request: HttpClientRequest.HttpClientRequest,
@@ -111,7 +107,6 @@ export const filterOtlpRequestForConsent = (
 	}
 }
 
-/** HTTP client used only by Effect's OTLP exporters. */
 export const consentHttpClientLayer = (requireConsent: boolean) =>
 	Layer.effect(
 		HttpClient.HttpClient,

--- a/packages/effect-sdk/src/client/standalone-session.test.ts
+++ b/packages/effect-sdk/src/client/standalone-session.test.ts
@@ -10,7 +10,6 @@ import { identify } from "./user.js"
 // `/v1/sessionReplays/meta` rows (active on setup, ended with observed trace
 // ids on tab-hide) when no `@maple-dev/browser` sink is on the page.
 
-/** The fields these assertions read off a `/v1/sessionReplays/meta` row. */
 interface MetaRowView {
 	readonly session_id: string
 	readonly status: string

--- a/packages/effect-sdk/src/shared/flushable-metrics.ts
+++ b/packages/effect-sdk/src/shared/flushable-metrics.ts
@@ -8,41 +8,21 @@ export interface MetricBuffer {
 }
 
 /**
- * Isolated Effect metric registry shared by a telemetry runtime and its
- * flush hook. Metric values are cumulative, so a flush snapshots rather than
- * clearing the registry. A snapshot is pending only after a metric changes;
- * failed exports mark it pending again through `restore`.
+ * Isolated cumulative registry. Drains only after changes, and `restore`
+ * re-marks failed exports as pending.
  */
 export const makeMetricBuffer = (): MetricBuffer => {
 	let disabled = false
-	/** Whether anything has actually been recorded under a live grant. */
 	let captured = false
-	/** Whether the cumulative registry changed since the last drain. */
 	let dirty = false
 	/**
-	 * Set when consent is withdrawn *after* something was recorded, and never
-	 * cleared.
-	 *
-	 * Metric state is cumulative and cannot be un-accumulated: a counter that
-	 * reached 5 under a grant still reads 5 after a revoke, so the first snapshot
-	 * taken after a re-grant would export data the user asked us to forget —
-	 * which the consent contract (`consent.ts`) forbids. Clearing the registry
-	 * instead is not an option: `Metric` instances cache their metadata, so a
-	 * cleared metric would keep updating an object no snapshot ever reads again —
-	 * it would vanish permanently rather than restart at zero.
-	 *
-	 * So a revoke ends metrics for the life of the page. This is the same trade
-	 * the OTLP preset makes by suppressing `/v1/metrics` outright under
-	 * `requireConsent` (`consent-http-client.ts`); spans and logs, whose buffers
-	 * *can* be dropped, resume normally after a re-grant. Gating on `captured`
-	 * keeps the ordinary late-grant case (buffer starts disabled, nothing
-	 * recorded yet, consent arrives) working normally.
+	 * Revoking after capture disables metrics for the page lifetime. Cumulative
+	 * state cannot forget prior samples, and clearing the registry breaks cached
+	 * Metric hooks. A late first grant still works because `captured` is false.
 	 */
 	let revoked = false
 	const registry = new Map<string, Metric.Metric.Metadata<any, any>>()
-	// Metric instances cache their hooks, so gating only `drain()` would let
-	// pre-consent updates surface in the first post-grant cumulative snapshot.
-	// Wrap each hook as it is registered; denied updates never reach its state.
+	// Gate hooks so pre-consent updates never enter cumulative state.
 	const set = registry.set.bind(registry)
 	registry.set = (key, metadata) => {
 		const hooks = metadata.hooks

--- a/packages/query-engine/src/registry/index.ts
+++ b/packages/query-engine/src/registry/index.ts
@@ -1,9 +1,4 @@
-/**
- * Declarative warehouse query registry.
- *
- * Kept out of the root barrel deliberately: definitions include runtime policy
- * and execution metadata, while the root barrel stays driver-free for web/cli.
- */
+// Separate from the driver-free root barrel used by web and CLI consumers.
 export {
 	defineQuery,
 	isTimeBucketQueryCachePolicy,

--- a/packages/query-engine/src/registry/logs.ts
+++ b/packages/query-engine/src/registry/logs.ts
@@ -86,8 +86,6 @@ export const logsTimeseries = defineQuery({
 	revision: 1,
 	profile: "aggregation",
 	cache: makeTimeBucketQueryCachePolicy<LogsTimeseriesInput>({
-		// The cache service owns the time range and bucket width. Keeping them out
-		// of this identity lets overlapping dashboard windows reuse stored buckets.
 		identity: ({ filters, groupBy, seriesLimit }) => ({ filters, groupBy, seriesLimit }),
 		fallback: 15,
 	}),

--- a/packages/query-engine/src/registry/queries.ts
+++ b/packages/query-engine/src/registry/queries.ts
@@ -48,43 +48,14 @@ import { defineQuery } from "./query-definition"
 export { logsCount, logsTimeseries } from "./logs"
 
 /**
- * The declarative warehouse query registry.
- *
- * Each entry replaces the profile/context/error-label/cache wiring that used to
- * be repeated inline in every handler in `apps/api/src/routes/v1/query-engine.http.ts`.
- * Handlers keep their own row-to-response mapping; see `QueryDefinition` for why
- * decoding is deliberately out of scope here.
- *
- * Migration is incremental and the two surfaces coexist: a handler either takes
- * a `QueryDefinition` through `runQuery` or keeps its inline wiring. Nothing breaks
- * while entries are added.
- *
- * ## Cache policy
- *
- * Every entry states a TTL. Two values do almost all the work:
- *
- * - **15s** — the house default, already proven on `serviceOverview`,
- *   `serviceHealthSnapshot`, `serviceApdex` and `listLogs`. Short enough that a
- *   panel never looks frozen, long enough to absorb the repeat loads that come
- *   from navigating between tabs of the same service.
- * - **60s** — dimension lists (facets, metric catalogues). These move on the
- *   scale of deploys, not requests, so a minute of staleness is invisible while
- *   the queries themselves are UNION fan-outs over wide Map columns.
- *
- * `cache: undefined` now means exactly one thing: the query runs inside an
- * outer `cachedDirect` in its handler, so caching it here would double-cache.
- * For `spanHierarchy`'s probes that is not merely redundant but wrong — they
- * exist to fire only on an outer miss, and caching them would run a probe on
- * every request. The seven such entries are commented individually.
- *
- * Anything that needs a different number should say why in a comment next to
- * it, the way `serviceUsage` (60s) and `serviceOverview` (15s, version 2) do.
+ * Declarative compile, execution, and cache policy. Handlers retain response
+ * shaping. Most TTLs are 15s; slow-changing discovery dimensions use 60s.
+ * `cache: undefined` means an outer `cachedDirect` owns the operation.
  */
 
 export const errorsByType = defineQuery({
 	id: "errorsByType",
 	profile: "aggregation",
-	// Was uncached inline. Preserved as-is: changing it belongs in its own commit.
 	cache: 15,
 	compile: (payload: ErrorsByTypeRequest, orgId: string) =>
 		CH.compile(
@@ -113,14 +84,12 @@ export const errorsTimeseries = defineQuery({
 				orgId,
 				startTime: payload.startTime,
 				endTime: payload.endTime,
-				// Matches the handler's previous inline default. The builder needs a
-				// bucket width and the request treats it as optional.
+				// Optional buckets default to one hour.
 				bucketSeconds: payload.bucketSeconds ?? 3600,
 			},
 		),
 })
 
-/** Single-row: the handler reads this through `runQueryFirst`. */
 export const errorsSummary = defineQuery({
 	id: "errorsSummary",
 	profile: "aggregation",
@@ -141,8 +110,6 @@ export const errorRateByService = defineQuery({
 	id: "errorRateByService",
 	profile: "aggregation",
 	cache: 15,
-	// The builder takes no options — this query is scoped entirely by org and
-	// time range. The payload still carries the range.
 	compile: (payload: ErrorRateByServiceRequest, orgId: string) =>
 		CH.compile(CH.errorRateByServiceQuery(), {
 			orgId,
@@ -154,9 +121,7 @@ export const errorRateByService = defineQuery({
 export const serviceOverview = defineQuery({
 	id: "serviceOverview",
 	profile: "aggregation",
-	// v2: rows gained per-commit `firstSeen`; the version bump keeps pre-upgrade
-	// cached rows (missing the field) from being served. Carried over verbatim
-	// from the handler — do not renumber without the same reasoning.
+	// v2 prevents cached rows without firstSeen from being served.
 	cache: makeDirectRouteCachePolicy({ ttlSeconds: 15, version: 2 }),
 	compile: (payload: ServiceOverviewRequest, orgId: string) =>
 		CH.compile(
@@ -266,20 +231,11 @@ export const serviceDbEdgesForService = defineQuery({
 		),
 })
 
-/**
- * Log search.
- *
- * `capabilityAware` closes a real gap rather than adding a nicety. The pipe path
- * (`list_logs`, which the `maple` CLI uses) has always passed these two modes,
- * so CLI log search gets bloom/tokenbf index acceleration while the dashboard's
- * HTTP path — compiling without capabilities — silently did full scans of the
- * same data. Same builder, same table, different plans.
- */
+/** Capability-aware so dashboard search uses the same bloom/tokenbf plan as the CLI. */
 export const listLogs = defineQuery({
 	id: "listLogs",
 	profile: "list",
-	// Annotated rather than inferred: with a three-parameter `compile`, TS
-	// resolves this callback before it can pin `Payload` from `compile`.
+	// TS resolves this before inferring Payload from the three-argument compile.
 	settings: (payload: ListLogsRequest) => (payload.search ? LOGS_BODY_SEARCH_SETTINGS : undefined),
 	cache: 15,
 	capabilityAware: true,
@@ -463,20 +419,7 @@ export const workloadDetailSummary = defineQuery({
 		),
 })
 
-// --- Sub-queries of composite (bundle) handlers ---------------------------
-//
-// Bundle endpoints run several queries in one Worker invocation so per-org
-// config resolves once and the browser makes one round-trip instead of three.
-// Each sub-query keeps its own id, because that id is both its span context and
-// its cache-key prefix -- collapsing them under the bundle's name would merge
-// unrelated cache entries.
-//
-// Their payload types are the MINIMAL input each needs rather than the bundle's
-// full payload. That is load-bearing: `runQuery` keys the cache on whatever
-// payload it is handed, so typing these narrowly reproduces the exact key the
-// hand-written `cachedDirect` calls used.
-
-/** Release markers for the service detail overview chart. Uncached, mirroring the standalone path. */
+// Bundle subqueries keep distinct ids and minimal payloads to preserve standalone cache keys.
 export const serviceReleases = defineQuery({
 	id: "serviceReleases",
 	profile: "list",
@@ -498,7 +441,6 @@ export const serviceReleases = defineQuery({
 		}),
 })
 
-/** Environments a service reported in the window. Edge-cached on a service-scoped key. */
 export const serviceEnvironments = defineQuery({
 	id: "serviceEnvironments",
 	profile: "discovery",
@@ -514,12 +456,6 @@ export const serviceEnvironments = defineQuery({
 		}),
 })
 
-/**
- * External (non-service) edges for the dependencies tab.
- *
- * Built by `serviceExternalEdgesSQL`, which returns a CompiledQuery directly
- * rather than going through `CH.compile`.
- */
 export const serviceExternalEdges = defineQuery({
 	id: "serviceExternalEdges",
 	profile: "aggregation",
@@ -539,19 +475,10 @@ export const serviceExternalEdges = defineQuery({
 		),
 })
 
-/**
- * Service usage totals.
- *
- * Two builders behind one id: with both previous-window bounds the query
- * returns current-vs-previous in a single scan, otherwise just the current
- * window. The branch lives in `compile` so the id, profile and TTL stay one
- * decision.
- */
 export const serviceUsage = defineQuery({
 	id: "serviceUsage",
 	profile: "aggregation",
-	// Usage totals (GB / session counts) tolerate a minute of staleness; a 60s
-	// TTL cuts repeat-load recomputes ~4x vs 15s.
+	// Usage totals tolerate a minute of staleness.
 	cache: 60,
 	compile: (payload: ServiceUsageRequest, orgId: string) => {
 		const prevStart = payload.previousStartTime
@@ -571,10 +498,6 @@ export const serviceUsage = defineQuery({
 				})
 	},
 })
-
-// --- Service-map edge queries ---------------------------------------------
-// These use `*SQL(opts, params)` builders, which return a CompiledQuery
-// directly instead of going through `CH.compile`.
 
 export const serviceDependencies = defineQuery({
 	id: "serviceDependencies",
@@ -598,13 +521,6 @@ export const serviceDbEdges = defineQuery({
 		),
 })
 
-/**
- * Workloads backing a set of services.
- *
- * The caller must skip this entirely for an empty service list — that guard
- * stays in the handler because it avoids issuing a query at all, which a def
- * cannot express.
- */
 export const serviceWorkloads = defineQuery({
 	id: "serviceWorkloads",
 	profile: "aggregation",
@@ -627,10 +543,6 @@ export const servicePlatforms = defineQuery({
 		),
 })
 
-// --- serviceDbQuerySummary's three sub-queries ----------------------------
-// All three take the identical params object, so it is built once per def from
-// the payload rather than threaded in from the handler.
-
 const dbQueryParams = (payload: ServiceDbQuerySummaryRequest, orgId: string) => ({
 	orgId,
 	dbSystem: payload.dbSystem,
@@ -643,7 +555,6 @@ const dbQueryParams = (payload: ServiceDbQuerySummaryRequest, orgId: string) => 
 	topN: payload.topN,
 })
 
-/** Single-row: read through `runQueryFirst`. */
 export const serviceDbQuerySummary = defineQuery({
 	id: "serviceDbQuerySummary",
 	profile: "aggregation",
@@ -667,16 +578,6 @@ export const serviceDbTopQueries = defineQuery({
 	compile: (payload: ServiceDbQuerySummaryRequest, orgId: string) =>
 		CH.serviceDbTopQueriesSQL(dbQueryParams(payload, orgId)),
 })
-
-// --- Web analytics --------------------------------------------------------
-//
-// Five queries behind one page, so they share a filter surface. `webAnalytics*`
-// payloads carry the filters flat; `webAnalyticsFilters` picks them off so each
-// entry below stays a one-line pass-through and the five can't drift apart.
-//
-// All 15s: this is a live dashboard people watch during a launch, and the
-// breakdown fan-out is over a 30-day-TTL table small enough that 60s buys
-// nothing but a page that looks stuck after a filter click.
 
 const webAnalyticsFilters = (
 	payload: {
@@ -710,21 +611,7 @@ const webAnalyticsFilters = (
 	useWebEvents,
 })
 
-// Each of the five is defined twice, differing only in which table page views
-// resolve against. The `id` is shared within a pair — it names the route, and
-// therefore the cache key and the `query.context` span label, neither of which
-// should shift when the flag flips. That's the same arrangement as
-// `serviceOperationsSummary` / `serviceOperationsSummaryRaw` below.
-//
-// A shared cache key across the pair is safe *because* the two are required to
-// return identical numbers: if a 15s-old entry written by one variant were wrong
-// for the other, parity is already broken and that is the bug to fix.
-//
-// Summary/timeseries/breakdowns read `session_replays` either way — they touch
-// the page-view source only through the semi-join, i.e. only when a host or
-// pagePath filter is set, which is precisely the case the rollup exists for.
-// They still come in pairs so the flag means one thing across the whole page
-// rather than being silently payload-dependent.
+// Rollup/raw pairs share ids and cache keys because parity tests require identical results.
 
 const webAnalyticsSummaryDef = (useWebEvents: boolean) => ({
 	id: "webAnalyticsSummary" as const,
@@ -739,7 +626,6 @@ const webAnalyticsSummaryDef = (useWebEvents: boolean) => ({
 })
 
 export const webAnalyticsSummary = defineQuery(webAnalyticsSummaryDef(true))
-/** Rollback path, used when `web_events` is absent or the flag is off. */
 export const webAnalyticsSummaryRaw = defineQuery(webAnalyticsSummaryDef(false))
 
 const webAnalyticsTimeseriesDef = (useWebEvents: boolean) => ({
@@ -796,8 +682,7 @@ export const webAnalyticsPagesRaw = defineQuery(webAnalyticsPagesDef(false))
 const webAnalyticsBreakdownsDef = (useWebEvents: boolean) => ({
 	id: "webAnalyticsBreakdowns" as const,
 	profile: "aggregation" as const,
-	// Same read-thread cap as the other UNION fan-outs: 12 branches over one
-	// table, and unbounded threads buy latency at the cost of memory spikes.
+	// Bound memory across the UNION fan-out.
 	settings: { maxThreads: 4 },
 	cache: 15,
 	compile: (payload: WebAnalyticsBreakdownsRequest, orgId: string) =>
@@ -813,13 +698,10 @@ const webAnalyticsBreakdownsDef = (useWebEvents: boolean) => ({
 export const webAnalyticsBreakdowns = defineQuery(webAnalyticsBreakdownsDef(true))
 export const webAnalyticsBreakdownsRaw = defineQuery(webAnalyticsBreakdownsDef(false))
 
-// --- Facet queries (UNION of per-dimension branches) ----------------------
-
 export const podFacets = defineQuery({
 	id: "podFacets",
 	profile: "discovery",
-	// Cap read-thread concurrency to bound Map-column decompression memory
-	// across the fan-out of UNION branches.
+	// Bound Map-column decompression memory across the UNION fan-out.
 	settings: { maxThreads: 4 },
 	cache: 60,
 	compile: (payload: PodFacetsRequest, orgId: string) =>
@@ -844,8 +726,7 @@ export const podFacets = defineQuery({
 export const nodeFacets = defineQuery({
 	id: "nodeFacets",
 	profile: "discovery",
-	// Cap read-thread concurrency to bound Map-column decompression memory
-	// across the fan-out of UNION branches.
+	// Bound Map-column decompression memory across the UNION fan-out.
 	settings: { maxThreads: 4 },
 	cache: 60,
 	compile: (payload: NodeFacetsRequest, orgId: string) =>
@@ -863,8 +744,7 @@ export const nodeFacets = defineQuery({
 export const workloadFacets = defineQuery({
 	id: "workloadFacets",
 	profile: "discovery",
-	// Cap read-thread concurrency to bound Map-column decompression memory
-	// across the fan-out of UNION branches.
+	// Bound Map-column decompression memory across the UNION fan-out.
 	settings: { maxThreads: 4 },
 	cache: 60,
 	compile: (payload: WorkloadFacetsRequest, orgId: string) =>
@@ -882,11 +762,7 @@ export const workloadFacets = defineQuery({
 		),
 })
 
-// --- listPods: page + denominator -----------------------------------------
-// Both run the same WHERE clause, so the "N of M" the list prints can never
-// disagree with the rows above it. The shared filter projection keeps that
-// true by construction rather than by two hand-kept copies.
-
+// Keep page and denominator filters identical.
 const listPodsFilters = (payload: ListPodsRequest) => ({
 	search: payload.search,
 	podNames: payload.podNames,
@@ -921,7 +797,6 @@ export const listPods = defineQuery({
 		),
 })
 
-/** Single-row denominator for listPods. Read through `runQueryFirst`. */
 export const listPodsCount = defineQuery({
 	id: "listPodsCount",
 	profile: "aggregation",
@@ -934,19 +809,8 @@ export const listPodsCount = defineQuery({
 		),
 })
 
-// --- spanHierarchy: probe, then the pruned hierarchy read -----------------
-//
-// `trace_detail_spans` is partitioned by toDate(Timestamp); without a time
-// predicate the hierarchy query seeks every daily partition (~30) — p95 ~8.8s
-// vs ~2.3s when pruned to one. When the caller has no timestamp (direct URL,
-// shared link, AI link) a cheap LIMIT-1 probe resolves one.
-//
-// All three carry `cache: undefined` ON PURPOSE. The handler wraps the whole
-// probe-then-read sequence in a single `cachedDirect`, so the probe only fires
-// on an outer cache miss. Caching them individually would run the probe on
-// every request and cache a result nobody asked for.
-
-/** Probe restricted to the recent window — tries ~2 daily partitions first. */
+// Probes resolve a time bound so hierarchy reads avoid ~30 daily partitions.
+// An outer cache owns the full sequence, so these definitions remain uncached.
 export const spanHierarchyProbeRecent = defineQuery({
 	id: "spanHierarchyProbeRecent",
 	profile: "discovery",
@@ -958,7 +822,6 @@ export const spanHierarchyProbeRecent = defineQuery({
 		}),
 })
 
-/** Unbounded fallback probe: every partition, only when the recent one missed. */
 export const spanHierarchyProbe = defineQuery({
 	id: "spanHierarchyProbe",
 	profile: "discovery",
@@ -994,19 +857,7 @@ export const spanHierarchy = defineQuery({
 	},
 })
 
-// --- serviceOperations: rollup and raw variants ---------------------------
-//
-// Four defs, two logical queries. Each has a rollup form and a raw form, and
-// the CHOICE between them stays in the handler because it is policy, not query
-// construction: the handler always reads the rollup and falls back to raw on a
-// typed `isMissingServiceOperationsRollup` error — a per-org degrade for BYO
-// clusters that never applied migration 0008. There is no flag.
-//
-// Rollup/raw pairs share an id, matching the context their spans already
-// report — the fallback is recorded separately as `query.rollup.fallback`.
-//
-// All four are `cache: undefined`; the handler wraps the whole sequence in one
-// `cachedDirect`.
+// Rollup/raw pairs share ids and an outer cache; handlers fall back per org when migration 0008 is absent.
 
 const serviceOperationsSummaryOptions = (payload: ServiceOperationsRequest) => ({
 	serviceName: payload.serviceName,
@@ -1033,22 +884,11 @@ export const serviceOperationsSummary = defineQuery({
 })
 
 /**
- * Ceiling for the two all-raw rollback shapes.
- *
- * These full-scan `traces` and compute the display-name rewrite per row, so on a
- * cluster without the 0008 rollup they are unbounded in practice: measured on a
- * BYO org, `serviceOperations` ran a p50 of 12.8s and 8 of 19 requests were
- * killed outright by the `aggregation` profile's 30s cap — returning nothing
- * after holding the tab for the full budget.
- *
- * 10s converts that into a fast, visible failure. It is deliberately below the
- * profile default rather than above it: a raw scan that has not finished in 10s
- * is not going to produce a usable interactive result, and the actionable fix is
- * applying migration 0008 to that cluster, not waiting longer.
+ * Raw fallback measured p50 12.8s with frequent 30s failures. Fail at 10s so
+ * clusters missing migration 0008 receive a fast, actionable error.
  */
 const SERVICE_OPERATIONS_RAW_SETTINGS = { maxExecutionTime: 10 }
 
-/** Rollback path, used when the rollup table is absent or the flag is off. */
 export const serviceOperationsSummaryRaw = defineQuery({
 	id: "serviceOperations",
 	profile: "aggregation",
@@ -1062,12 +902,7 @@ export const serviceOperationsSummaryRaw = defineQuery({
 		),
 })
 
-/**
- * `spanNames` and `bucketSeconds` ride in the payload: both are derived from the
- * summary rows and the requested window, so `compile` cannot see them. The
- * rollup is minute-grain, which is why the caller rounds the bucket to a whole
- * minute before passing it here.
- */
+// Derived after the summary; callers align buckets to the minute-grain rollup.
 type ServiceOperationsTimeseriesInput = ServiceOperationsRequest & {
 	readonly spanNames: ReadonlyArray<string>
 	readonly bucketSeconds: number

--- a/packages/query-engine/src/registry/query-definition.ts
+++ b/packages/query-engine/src/registry/query-definition.ts
@@ -7,15 +7,11 @@ import {
 	type DirectRouteCachePolicyInput,
 } from "../runtime/cache-policy"
 
-/**
- * A timeseries cache stores independently reusable time buckets. Its identity
- * deliberately excludes the requested range; the bucket cache owns that part
- * of the key and can therefore reuse an overlapping window.
- */
+/** Range-independent identity lets overlapping windows reuse stored buckets. */
 export interface TimeBucketQueryCachePolicy<Payload> {
 	readonly kind: "time-buckets"
 	readonly identity: (payload: Payload) => unknown
-	/** Whole-result policy used when bucket caching cannot serve the request. */
+	/** Whole-result fallback when bucket caching cannot serve the request. */
 	readonly fallback: DirectRouteCachePolicy
 }
 
@@ -25,18 +21,14 @@ export type QueryCachePolicy<Payload> =
 	| undefined
 	| ((payload: Payload, nowMs: number) => DirectRouteCachePolicyInput | undefined)
 
-/**
- * One semantic warehouse query, independent of the HTTP/RPC adapter that
- * supplied its input. The definition is the shared unit of compilation,
- * execution policy, observability, and cache identity.
- */
+/** Compile and execution policy for one semantic warehouse query. */
 export interface QueryDefinition<Payload, Row> {
 	readonly id: string
 	/** Bump when compilation or decoded-row semantics change incompatibly. */
 	readonly revision: number
 	readonly profile: QueryProfileName
 	readonly settings?: WarehouseQuerySettings | ((payload: Payload) => WarehouseQuerySettings | undefined)
-	/** Required: `undefined` is an explicit decision to leave this query uncached. */
+	/** Required; `undefined` explicitly disables caching. */
 	readonly cache: QueryCachePolicy<Payload>
 	/** Resolve live skip-index capabilities only when the compiled plan can use them. */
 	readonly capabilityAware?: boolean
@@ -51,7 +43,6 @@ type QueryDefinitionInput<Payload, Row> = Omit<QueryDefinition<Payload, Row>, "r
 	readonly revision?: number
 }
 
-/** Definitions start at revision 1 without repeating that noise at every declaration. */
 export const defineQuery = <Payload, Row>(
 	definition: QueryDefinitionInput<Payload, Row>,
 ): QueryDefinition<Payload, Row> => ({ revision: 1, ...definition })
@@ -81,7 +72,6 @@ export const resolveQueryDefinitionCache = <Payload, Row>(
 	return resolveDirectRouteCachePolicy(policy)
 }
 
-/** Canonical cache identity shared by every transport adapter for a definition. */
 export const queryDefinitionCacheIdentity = <Payload, Row>(
 	definition: QueryDefinition<Payload, Row>,
 	payload: Payload,

--- a/packages/query-engine/src/runtime/cache-policy.ts
+++ b/packages/query-engine/src/runtime/cache-policy.ts
@@ -4,7 +4,6 @@ export interface DirectRouteCachePolicy {
 	/** Bump when response or key semantics change incompatibly. */
 	readonly version: number
 	readonly ttlSeconds: number
-	/** Time-key coalescing is independent from storage lifetime. */
 	readonly snapWindowSeconds: number
 }
 

--- a/packages/query-engine/src/runtime/query-definition-runner.ts
+++ b/packages/query-engine/src/runtime/query-definition-runner.ts
@@ -8,7 +8,6 @@ export interface QueryDefinitionTenant {
 	readonly orgId: string
 }
 
-/** The two warehouse operations needed by ordinary, tenant-scoped definitions. */
 export interface QueryDefinitionWarehouse<Tenant extends QueryDefinitionTenant, Error> {
 	readonly compiledQuery: <Row>(
 		tenant: Tenant,
@@ -43,11 +42,7 @@ const queryDefinitionOptions = <Payload, Row>(
 	}
 }
 
-/**
- * Execute a definition without applying a cache. Cache orchestration sits one
- * level above this function so whole-result and time-bucket stores can both
- * reuse the exact same compilation path.
- */
+/** Executes a definition without caching; cache orchestration is caller-owned. */
 export const runQueryDefinition = <Payload, Row, Tenant extends QueryDefinitionTenant, Error>(
 	warehouse: QueryDefinitionWarehouse<Tenant, Error>,
 	definition: QueryDefinition<Payload, Row>,


### PR DESCRIPTION
## Summary

- Shorten verbose comments across API, web, SDK, query-engine, and workflow code.
- Preserve comments for non-obvious behavior, constraints, and operational caveats.
- Remove redundant documentation around straightforward implementations and shared paths.

## Testing

- Not run (comment-only changes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789033441&installation_model_id=427786&pr_number=407&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F407&signature=f7c35b5ca7dde166004ebc11ec82ff28413aac36cffde97fbc19fa6e5ba6cec6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->