### PR TITLE
fix(effect): preserve runtime and probe error safety

### DIFF
--- a/apps/api/src/services/integrations/ScrapeTargetsService.test.ts
+++ b/apps/api/src/services/integrations/ScrapeTargetsService.test.ts
@@ -451,6 +451,34 @@ describe("ScrapeTargetsService", () => {
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
+	it.effect("manual probes persist safe upstream messages without stack traces", () => {
+		const testDb = createTestDb(trackedDbs)
+		return Effect.gen(function* () {
+			const service = yield* ScrapeTargetsService
+			const orgId = asOrgId("org_1")
+			const target = yield* service.create(
+				orgId,
+				new CreateScrapeTargetRequest({
+					name: "Node Exporter",
+					url: "https://metrics.example.com/metrics",
+					scrapeIntervalSeconds: asScrapeIntervalSeconds(15),
+				}),
+			)
+
+			globalThis.fetch = (async () => {
+				throw new Error("socket exploded")
+			}) as typeof fetch
+
+			const probed = yield* service.probe(orgId, target.id)
+			assert.isFalse(probed.success)
+			assert.strictEqual(probed.lastScrapeError, "socket exploded")
+			assert.notInclude(probed.lastScrapeError ?? "", "ScrapeTargetsService.ts")
+
+			const checks = yield* service.listChecks(orgId, target.id, {})
+			assert.lengthOf(checks, 0)
+		}).pipe(Effect.provide(makeLayer(testDb)))
+	})
+
 	it.effect("recording results no longer prunes — retention is the cron's job", () => {
 		const testDb = createTestDb(trackedDbs)
 		return Effect.gen(function* () {

--- a/apps/api/src/services/integrations/ScrapeTargetsService.ts
+++ b/apps/api/src/services/integrations/ScrapeTargetsService.ts
@@ -1119,22 +1119,39 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 				// signal plus a fixed 10s `Effect.timeout`; the timeout lands as a failure
 				// in the captured Exit (→ success: false), matching the old abort path.
 				const requestExit = yield* Effect.tryPromise({
-					try: async (signal) => {
-						const response = await safeFetch(row.url, {
+					try: (signal) =>
+						safeFetch(row.url, {
 							method: "GET",
 							headers,
 							signal,
-						})
-						if (!response.ok) {
-							throw new Error(`HTTP ${response.status} ${response.statusText}`)
-						}
-					},
-					catch: (error) => (error instanceof Error ? error : new Error("Connection failed")),
+						}),
+					catch: (cause) =>
+						new ScrapeTargetUpstreamError({
+							message: cause instanceof Error ? cause.message : "Connection failed",
+						}),
 				}).pipe(
+					Effect.flatMap((response) =>
+						response.ok
+							? Effect.void
+							: Effect.fail(
+									new ScrapeTargetUpstreamError({
+										message: `HTTP ${response.status} ${response.statusText}`,
+										status: response.status,
+									}),
+								),
+					),
 					Effect.timeout(10_000),
-					Effect.catchTag("TimeoutError", () => Effect.fail(new Error("Connection failed"))),
+					Effect.catchTag("TimeoutError", () =>
+						Effect.fail(new ScrapeTargetUpstreamError({ message: "Connection failed" })),
+					),
 					Effect.exit,
 				)
+				const requestError = Exit.isFailure(requestExit)
+					? Option.match(Cause.findErrorOption(requestExit.cause), {
+							onNone: () => "Connection failed",
+							onSome: (error) => error.message,
+						})
+					: null
 
 				// Manual probes update lastScrapeAt/lastScrapeError but must not
 				// fabricate scheduled-check history rows.
@@ -1143,7 +1160,7 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 						{
 							targetId,
 							scrapedAt: now,
-							error: Exit.isSuccess(requestExit) ? null : Cause.pretty(requestExit.cause),
+							error: requestError,
 						},
 					],
 					{ recordChecks: false },

--- a/apps/scraper/src/main.ts
+++ b/apps/scraper/src/main.ts
@@ -34,6 +34,7 @@ const MainLayer = ScrapeScheduler.layer.pipe(
 const healthServer = Effect.gen(function* () {
 	const env = yield* ScraperEnv
 	const scheduler = yield* ScrapeScheduler
+	const runPromise = Effect.runPromiseWith(yield* Effect.context())
 
 	const server = yield* Effect.acquireRelease(
 		Effect.sync(() =>
@@ -43,7 +44,7 @@ const healthServer = Effect.gen(function* () {
 				fetch: async (request) => {
 					const url = new URL(request.url)
 					if (url.pathname === "/health") {
-						const stats = await Effect.runPromise(scheduler.stats)
+						const stats = await runPromise(scheduler.stats)
 						return new Response(JSON.stringify({ status: "ok", ...stats }), {
 							headers: { "content-type": "application/json" },
 						})

--- a/apps/web/src/lib/collections/api-runner.ts
+++ b/apps/web/src/lib/collections/api-runner.ts
@@ -5,12 +5,6 @@ import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 export type MapleApiV2Client = Effect.Success<typeof MapleApiV2AtomClient>
 
 /** Runs a public v2 API call on the same shared runtime used by Electric writes. */
-export const runMapleApiV2 = <A, E, R>(
-	use: (client: MapleApiV2Client) => Effect.Effect<A, E, R>,
-): Promise<A> =>
-	mapleRuntime.runPromise(
-		Effect.gen(function* () {
-			const client = yield* MapleApiV2AtomClient
-			return yield* use(client)
-		}) as Effect.Effect<A, E, MapleApiV2AtomClient>,
-	)
+export const runMapleApiV2 = <A, E>(
+	use: (client: MapleApiV2Client) => Effect.Effect<A, E>,
+): Promise<A> => mapleRuntime.runPromise(Effect.flatMap(MapleApiV2AtomClient, use))


### PR DESCRIPTION
## What changed

- Prevent runMapleApiV2 callbacks from hiding unsatisfied Effect services.
- Run scraper health statistics on the captured application runtime context.
- Keep manual scrape probe failures typed as ScrapeTargetUpstreamError.
- Persist safe upstream messages instead of formatted Causes and stack traces.
- Add a regression test for probe error persistence.

## Why

The audit found runtime casts and nested execution that could conceal missing services, plus probe failures that could persist implementation details. This layer fixes those correctness and exposure risks without broad lint churn.

## Validation

- bun typecheck
- bun run lint:effect
- ScrapeTargetsService focused test suite

This is layer 1 of the Effect audit cleanup stack.