### PR TITLE
refactor(effect): preserve typed schema inputs

### DIFF
--- a/apps/api/src/dashboard-templates/helpers.ts
+++ b/apps/api/src/dashboard-templates/helpers.ts
@@ -9,10 +9,10 @@ import type { TemplateParameterValues, WidgetDef } from "./types"
 // Brand makers — used inside template definitions for compile-time correctness
 
 export const templateId = (value: string): DashboardTemplateId =>
-	Schema.decodeUnknownSync(DashboardTemplateId)(value)
+	Schema.decodeSync(DashboardTemplateId)(value)
 
 export const paramKey = (value: string): DashboardTemplateParameterKey =>
-	Schema.decodeUnknownSync(DashboardTemplateParameterKey)(value)
+	Schema.decodeSync(DashboardTemplateParameterKey)(value)
 
 const decodePortableDashboard = Schema.decodeUnknownSync(PortableDashboardDocument)
 

--- a/apps/api/src/internal-rpc.ts
+++ b/apps/api/src/internal-rpc.ts
@@ -10,7 +10,7 @@ import type { TenantContext } from "@/services/auth/tenant-context"
 import { McpToolExecutor, listMcpTools } from "./mcp/dispatcher"
 import { InvestigationService } from "./services/errors/InvestigationService"
 
-const internalServiceUserId = Schema.decodeUnknownSync(UserId)("internal-service")
+const internalServiceUserId = Schema.decodeSync(UserId)("internal-service")
 
 const invalidInput = (method: "callMcpTool" | "submitDiagnosis") => (error: { message: string }) =>
 	new InternalRpcInvalidInputError({ method, message: error.message })

--- a/apps/api/src/mcp/__evals__/eval-runtime.ts
+++ b/apps/api/src/mcp/__evals__/eval-runtime.ts
@@ -57,8 +57,8 @@ export const makeEvalRuntime = (): EvalRuntime => {
 	const runtime = ManagedRuntime.make(layer as any) as ManagedRuntime.ManagedRuntime<any, never>
 
 	const tenant: TenantContext = {
-		orgId: Schema.decodeUnknownSync(OrgId)(FIXTURES.orgId),
-		userId: Schema.decodeUnknownSync(UserId)("internal-service"),
+		orgId: Schema.decodeSync(OrgId)(FIXTURES.orgId),
+		userId: Schema.decodeSync(UserId)("internal-service"),
 		roles: [],
 		authMode: "self_hosted",
 	}

--- a/apps/api/src/mcp/lib/dashboard-mutations.ts
+++ b/apps/api/src/mcp/lib/dashboard-mutations.ts
@@ -38,27 +38,21 @@ const jsonDecodeError = (field: string, tool: string) => (error: unknown) =>
 	})
 
 export const decodeWidgetJson = (json: string, tool: string) =>
-	Schema.decodeUnknownEffect(WidgetFromJson)(json).pipe(
-		Effect.mapError(jsonDecodeError("widget_json", tool)),
-	)
+	Schema.decodeEffect(WidgetFromJson)(json).pipe(Effect.mapError(jsonDecodeError("widget_json", tool)))
 
 export const decodeDataSourceJson = (json: string, tool: string) =>
-	Schema.decodeUnknownEffect(DataSourceFromJson)(json).pipe(
+	Schema.decodeEffect(DataSourceFromJson)(json).pipe(
 		Effect.mapError(jsonDecodeError("data_source_json", tool)),
 	)
 
 export const decodeDisplayJson = (json: string, tool: string) =>
-	Schema.decodeUnknownEffect(DisplayFromJson)(json).pipe(
-		Effect.mapError(jsonDecodeError("display_json", tool)),
-	)
+	Schema.decodeEffect(DisplayFromJson)(json).pipe(Effect.mapError(jsonDecodeError("display_json", tool)))
 
 export const decodeLayoutJson = (json: string, tool: string) =>
-	Schema.decodeUnknownEffect(LayoutFromJson)(json).pipe(
-		Effect.mapError(jsonDecodeError("layout_json", tool)),
-	)
+	Schema.decodeEffect(LayoutFromJson)(json).pipe(Effect.mapError(jsonDecodeError("layout_json", tool)))
 
 export const decodeTimeRangeJson = (json: string, tool: string) =>
-	Schema.decodeUnknownEffect(TimeRangeFromJson)(json).pipe(
+	Schema.decodeEffect(TimeRangeFromJson)(json).pipe(
 		Effect.mapError(jsonDecodeError("time_range_json", tool)),
 	)
 

--- a/apps/api/src/mcp/tools/create-dashboard.ts
+++ b/apps/api/src/mcp/tools/create-dashboard.ts
@@ -361,9 +361,7 @@ export function registerCreateDashboardTool(server: McpToolRegistrar) {
 					}
 				}
 
-				portable = yield* Schema.decodeUnknownEffect(PortableDashboardFromJson)(
-					params.dashboard_json,
-				).pipe(
+				portable = yield* Schema.decodeEffect(PortableDashboardFromJson)(params.dashboard_json).pipe(
 					Effect.mapError(
 						(cause) =>
 							new McpQueryError({

--- a/apps/api/src/mcp/tools/registry.ts
+++ b/apps/api/src/mcp/tools/registry.ts
@@ -227,13 +227,14 @@ export const executeRegisteredMcpToolUnscoped = Effect.fn("McpToolRegistry.execu
 	}
 
 	yield* Effect.annotateCurrentSpan({ tool: definition.name })
-	const decoded = yield* Effect.try({
-		try: () => Schema.decodeUnknownSync(definition.schema)(input),
-		catch: (error) =>
-			new McpDecodeError({
-				errorMessage: toDecodeErrorMessage(definition, error),
-			}),
-	})
+	const decoded = yield* Schema.decodeUnknownEffect(definition.schema)(input).pipe(
+		Effect.mapError(
+			(error) =>
+				new McpDecodeError({
+					errorMessage: toDecodeErrorMessage(definition, error),
+				}),
+		),
+	)
 
 	return yield* definition.handler(decoded).pipe(Effect.tap(() => Effect.logInfo("Tool completed")))
 })

--- a/apps/api/src/mcp/tools/reorder-dashboard-widgets.ts
+++ b/apps/api/src/mcp/tools/reorder-dashboard-widgets.ts
@@ -72,7 +72,7 @@ export function registerReorderDashboardWidgetsTool(server: McpToolRegistrar) {
 			),
 		}),
 		Effect.fn("McpTool.reorderDashboardWidgets")(function* ({ dashboard_id, layouts_json }) {
-			const layouts = yield* Schema.decodeUnknownEffect(LayoutsFromJson)(layouts_json).pipe(
+			const layouts = yield* Schema.decodeEffect(LayoutsFromJson)(layouts_json).pipe(
 				Effect.mapError(
 					(error) =>
 						new McpQueryError({

--- a/apps/api/src/mcp/tools/update-dashboard.ts
+++ b/apps/api/src/mcp/tools/update-dashboard.ts
@@ -50,7 +50,7 @@ export function registerUpdateDashboardTool(server: McpToolRegistrar) {
 			const persistence = yield* DashboardPersistenceService
 
 			const portable = dashboard_json
-				? yield* Schema.decodeUnknownEffect(PortableDashboardFromJson)(dashboard_json).pipe(
+				? yield* Schema.decodeEffect(PortableDashboardFromJson)(dashboard_json).pipe(
 						Effect.mapError(
 							(cause) =>
 								new McpQueryError({

--- a/apps/api/src/mcp/tools/update-error-notification-policy.ts
+++ b/apps/api/src/mcp/tools/update-error-notification-policy.ts
@@ -91,9 +91,7 @@ export function registerUpdateErrorNotificationPolicyTool(server: McpToolRegistr
 			if (min_occurrence_count !== undefined) patch.minOccurrenceCount = min_occurrence_count
 			if (decodedSeverity !== undefined) patch.severity = decodedSeverity
 
-			const decodedPatch = yield* Schema.decodeUnknownEffect(ErrorNotificationPolicyUpsertRequest)(
-				patch,
-			).pipe(
+			const decodedPatch = yield* Schema.decodeEffect(ErrorNotificationPolicyUpsertRequest)(patch).pipe(
 				Effect.mapError(
 					(error) =>
 						new McpQueryError({

--- a/apps/api/src/routes/v1/chat.http.ts
+++ b/apps/api/src/routes/v1/chat.http.ts
@@ -110,14 +110,15 @@ export const HttpChatLive = HttpApiBuilder.group(MapleApi, "chat", (handlers) =>
 				return yield* new ChatToolNotFoundError({ tool, message: `Unknown tool "${tool}".` })
 			}
 
-			yield* Effect.try({
-				try: () => Schema.decodeUnknownSync(definition.schema)(payload.input),
-				catch: (error) =>
-					new ChatToolInvalidInputError({
-						tool,
-						message: `Invalid input for "${tool}": ${String(error)}`,
-					}),
-			})
+			yield* Schema.decodeUnknownEffect(definition.schema)(payload.input).pipe(
+				Effect.mapError(
+					(error) =>
+						new ChatToolInvalidInputError({
+							tool,
+							message: `Invalid input for "${tool}": ${String(error)}`,
+						}),
+				),
+			)
 
 			// Domain-level tool failures are encoded as `isError` by the shared dispatcher.
 			// A defect remains a transport failure, but it is declared and serialized instead

--- a/apps/api/src/routes/v1/scraper-internal.http.ts
+++ b/apps/api/src/routes/v1/scraper-internal.http.ts
@@ -22,7 +22,7 @@ const decodeOrgIdSync = Schema.decodeUnknownSync(OrgId)
 const decodeScrapeIntervalSecondsSync = Schema.decodeUnknownSync(ScrapeIntervalSeconds)
 
 /** Audit identity for lazily-created ingest keys (org_ingest_keys.created_by). */
-const SCRAPER_SYSTEM_USER = Schema.decodeUnknownSync(UserId)("system-prometheus-scraper")
+const SCRAPER_SYSTEM_USER = Schema.decodeSync(UserId)("system-prometheus-scraper")
 const decodeScrapeResultsEffect = Schema.decodeUnknownEffect(ScrapeResultReportList)
 const decodeLabelsEffect = Schema.decodeUnknownEffect(Schema.Record(Schema.String, Schema.String))
 

--- a/apps/api/src/routes/v2/error-issues.http.ts
+++ b/apps/api/src/routes/v2/error-issues.http.ts
@@ -127,7 +127,7 @@ const decodeCursor = (
 				invalidRequest("cursor_sort_mismatch", "Cursor does not match the selected sort.", "cursor"),
 			)
 		}
-		return Schema.decodeUnknownEffect(IssueSeverityListCursor)(cursor.slice(4)).pipe(
+		return Schema.decodeEffect(IssueSeverityListCursor)(cursor.slice(4)).pipe(
 			Effect.mapError(() => invalidRequest("cursor_invalid", "Invalid pagination cursor.", "cursor")),
 		)
 	}
@@ -136,7 +136,7 @@ const decodeCursor = (
 			invalidRequest("cursor_sort_mismatch", "Cursor does not match the selected sort.", "cursor"),
 		)
 	}
-	return Schema.decodeUnknownEffect(IssueListCursor)(cursor).pipe(
+	return Schema.decodeEffect(IssueListCursor)(cursor).pipe(
 		Effect.mapError(() => invalidRequest("cursor_invalid", "Invalid pagination cursor.", "cursor")),
 	)
 }

--- a/apps/api/src/routes/v2/investigations.http.ts
+++ b/apps/api/src/routes/v2/investigations.http.ts
@@ -82,7 +82,7 @@ const toWireSubject = Effect.fn("HttpV2Investigations.toWireSubject")(function* 
 		})
 	return yield* Match.value(subject.incidentKind).pipe(
 		Match.when("error", () =>
-			Schema.decodeUnknownEffect(ErrorIncidentId)(subject.incidentId).pipe(
+			Schema.decodeEffect(ErrorIncidentId)(subject.incidentId).pipe(
 				Effect.catchTag("SchemaError", () => Effect.fail(decodeFailure())),
 				Effect.map((incidentId) => ({
 					...shared,
@@ -92,7 +92,7 @@ const toWireSubject = Effect.fn("HttpV2Investigations.toWireSubject")(function* 
 			),
 		),
 		Match.when("anomaly", () =>
-			Schema.decodeUnknownEffect(AnomalyIncidentId)(subject.incidentId).pipe(
+			Schema.decodeEffect(AnomalyIncidentId)(subject.incidentId).pipe(
 				Effect.catchTag("SchemaError", () => Effect.fail(decodeFailure())),
 				Effect.map((incidentId) => ({
 					...shared,
@@ -102,7 +102,7 @@ const toWireSubject = Effect.fn("HttpV2Investigations.toWireSubject")(function* 
 			),
 		),
 		Match.when("alert", () =>
-			Schema.decodeUnknownEffect(AlertIncidentId)(subject.incidentId).pipe(
+			Schema.decodeEffect(AlertIncidentId)(subject.incidentId).pipe(
 				Effect.catchTag("SchemaError", () => Effect.fail(decodeFailure())),
 				Effect.map((incidentId) => ({
 					...shared,
@@ -131,14 +131,14 @@ const toInternalSubject = (subject: V2InvestigationCreateSubject): Investigation
 			})
 
 const toInternalSnapshot = (snapshot: V2InvestigationCreateParams["snapshot"] | undefined) =>
-	snapshot === undefined ? undefined : Schema.decodeUnknownSync(InvestigationSubjectSnapshot)(snapshot)
+	snapshot === undefined ? undefined : Schema.decodeSync(InvestigationSubjectSnapshot)(snapshot)
 
 const toV2Investigation = Effect.fn("HttpV2Investigations.toV2Investigation")(function* (
 	doc: InvestigationDocument,
 ): Effect.fn.Return<V2Investigation, InvestigationSubjectDecodeError> {
 	yield* Effect.annotateCurrentSpan("investigationId", doc.id)
 	const decodeReportTraceId = (traceId: string) =>
-		Schema.decodeUnknownEffect(TraceId)(traceId).pipe(
+		Schema.decodeEffect(TraceId)(traceId).pipe(
 			Effect.catchTag("SchemaError", () =>
 				Effect.fail(
 					new InvestigationSubjectDecodeError({

--- a/apps/api/src/services/alerts/AlertDestinationHydration.ts
+++ b/apps/api/src/services/alerts/AlertDestinationHydration.ts
@@ -86,7 +86,7 @@ const parseSecretConfig = <E>(
 	json: string,
 	onError: (cause: unknown) => E,
 ): Effect.Effect<DestinationSecretConfig, E> =>
-	Schema.decodeUnknownEffect(SecretConfigFromJson)(json).pipe(Effect.mapError(onError))
+	Schema.decodeEffect(SecretConfigFromJson)(json).pipe(Effect.mapError(onError))
 
 export const hydrateDestinationRow = <E>(
 	row: AlertDestinationRow,

--- a/apps/api/src/services/auth/auth.ts
+++ b/apps/api/src/services/auth/auth.ts
@@ -1,8 +1,8 @@
 import { Effect, Schema } from "effect"
 import { RoleName } from "@maple/domain/http"
 
-const ROOT_ROLE = Schema.decodeUnknownSync(RoleName)("root")
-const ORG_ADMIN_ROLE = Schema.decodeUnknownSync(RoleName)("org:admin")
+const ROOT_ROLE = Schema.decodeSync(RoleName)("root")
+const ORG_ADMIN_ROLE = Schema.decodeSync(RoleName)("org:admin")
 
 const ADMIN_ROLES: ReadonlyArray<RoleName> = [ROOT_ROLE, ORG_ADMIN_ROLE]
 

--- a/apps/api/src/services/auth/scrape-auth.ts
+++ b/apps/api/src/services/auth/scrape-auth.ts
@@ -69,7 +69,7 @@ export const catchOAuthTokenFailure = {
 } as const
 
 const decodeCredentials = <S extends Schema.Top>(schema: S, credentialsJson: string) =>
-	Schema.decodeUnknownEffect(Schema.fromJsonString(schema))(credentialsJson).pipe(
+	Schema.decodeEffect(Schema.fromJsonString(schema))(credentialsJson).pipe(
 		Effect.mapError(() => toEncryptionError("Failed to decode auth credentials")),
 	)
 

--- a/apps/api/src/services/errors/InvestigationService.ts
+++ b/apps/api/src/services/errors/InvestigationService.ts
@@ -223,7 +223,7 @@ export interface InvestigationServiceShape {
 }
 
 /** Identity an autonomous investigation turn runs as — the same one the internal MCP RPC uses. */
-const internalServiceUserId = Schema.decodeUnknownSync(UserIdSchema)("internal-service")
+const internalServiceUserId = Schema.decodeSync(UserIdSchema)("internal-service")
 
 export class InvestigationService extends Context.Service<InvestigationService, InvestigationServiceShape>()(
 	"@maple/api/services/InvestigationService",

--- a/apps/api/src/services/errors/ai-triage-enqueue.ts
+++ b/apps/api/src/services/errors/ai-triage-enqueue.ts
@@ -28,7 +28,7 @@ import {
 import { UserId } from "@maple/domain/primitives"
 
 /** Identity an autonomous investigation turn runs as — the same one the internal MCP RPC uses. */
-const internalServiceUserId = Schema.decodeUnknownSync(UserId)("internal-service")
+const internalServiceUserId = Schema.decodeSync(UserId)("internal-service")
 
 /** Cloudflare Workflow binding that runs a fan-out. Present only in a Worker isolate. */
 export const INVESTIGATION_FANOUT_BINDING = "INVESTIGATION_FANOUT_WORKFLOW"

--- a/apps/api/src/services/integrations/PlanetScaleDiscoveryService.ts
+++ b/apps/api/src/services/integrations/PlanetScaleDiscoveryService.ts
@@ -259,8 +259,9 @@ export class PlanetScaleDiscoveryService extends Context.Service<
 			if (row.authType !== "planetscale_oauth") {
 				return yield* buildScrapeAuthHeaders(row, encryptionKey)
 			}
+			const orgId = yield* Schema.decodeEffect(OrgId)(row.orgId).pipe(Effect.orDie)
 			const { accessToken } = yield* psOAuth
-				.getValidAccessToken(Schema.decodeUnknownSync(OrgId)(row.orgId))
+				.getValidAccessToken(orgId)
 				.pipe(Effect.catchTags(catchOAuthTokenFailure))
 			return { Authorization: planetScaleBearerHeader(accessToken) }
 		})
@@ -307,7 +308,7 @@ export class PlanetScaleDiscoveryService extends Context.Service<
 				)
 			}
 
-			const groups = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(HttpSdResponse))(
+			const groups = yield* Schema.decodeEffect(Schema.fromJsonString(HttpSdResponse))(
 				response.text,
 			).pipe(
 				Effect.mapError(() =>

--- a/apps/api/src/services/integrations/PlanetScaleService.ts
+++ b/apps/api/src/services/integrations/PlanetScaleService.ts
@@ -383,17 +383,17 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 				return items
 			})
 
-			const decodeOrgIdSync = Schema.decodeUnknownSync(OrgId)
-
 			/**
 			 * Bearer Authorization for the org's OAuth grant, refreshed as needed.
 			 * A revoked/missing grant surfaces as-is — the poller records it per-org
 			 * and moves on; queryInsights lets the endpoint error union carry it.
 			 */
 			const authorizationFor = (connection: PlanetScaleConnectionRow) =>
-				psOAuth
-					.getValidAccessToken(decodeOrgIdSync(connection.orgId))
-					.pipe(Effect.map(({ accessToken }) => planetScaleBearerHeader(accessToken)))
+				Schema.decodeEffect(OrgId)(connection.orgId).pipe(
+					Effect.orDie,
+					Effect.flatMap((orgId) => psOAuth.getValidAccessToken(orgId)),
+					Effect.map(({ accessToken }) => planetScaleBearerHeader(accessToken)),
+				)
 
 			/**
 			 * Claim the org's inventory anchor row for this tick. A non-"claimed"
@@ -749,6 +749,7 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 						yield* Effect.annotateCurrentSpan({ "maple.planetscale.skip_reason": claim })
 						return 0
 					}
+					const orgId = yield* Schema.decodeEffect(OrgId)(connection.orgId).pipe(Effect.orDie)
 
 					const state = yield* readPollState(
 						connection.orgId,
@@ -781,7 +782,7 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 						for (const row of deployRequestTimelineRows(request)) {
 							if (row.occurredAtMs < now - DEPLOY_REQUESTS_FLOOR_MS) continue
 							const result = yield* appendTimelineEvent({
-								orgId: decodeOrgIdSync(connection.orgId),
+								orgId,
 								databaseName: database_.name,
 								// A deploy request spans two branches; pinning the marker to
 								// one of them would be a guess the payload doesn't support.
@@ -1082,7 +1083,7 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 					})
 				}
 
-				const decoded = yield* Schema.decodeUnknownEffect(
+				const decoded = yield* Schema.decodeEffect(
 					Schema.fromJsonString(PageSchema(InsightRowSchema)),
 				)(response.text).pipe(
 					Effect.mapError(

--- a/apps/api/src/services/integrations/ScrapeTargetsService.ts
+++ b/apps/api/src/services/integrations/ScrapeTargetsService.ts
@@ -259,7 +259,7 @@ const validateAuthCredentials = (authType: string, authCredentials: string | nul
 			: authType === "token"
 				? TokenCredentialsSchema
 				: BasicCredentialsSchema
-	return Schema.decodeUnknownEffect(Schema.fromJsonString(schema))(authCredentials).pipe(
+	return Schema.decodeEffect(Schema.fromJsonString(schema))(authCredentials).pipe(
 		Effect.mapError(
 			() =>
 				new ScrapeTargetValidationError({
@@ -341,7 +341,7 @@ const validateInterval = (seconds: number | undefined) => {
  */
 const validateLabelsJson = (labelsJson: string | null | undefined) => {
 	if (labelsJson === undefined || labelsJson === null) return Effect.succeed(labelsJson)
-	return Schema.decodeUnknownEffect(Schema.fromJsonString(ScrapeLabelsSchema))(labelsJson).pipe(
+	return Schema.decodeEffect(Schema.fromJsonString(ScrapeLabelsSchema))(labelsJson).pipe(
 		Effect.mapError(
 			() =>
 				new ScrapeTargetValidationError({
@@ -486,8 +486,9 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 				if (row.authType !== "planetscale_oauth") {
 					return yield* buildScrapeAuthHeaders(row, encryptionKey)
 				}
+				const orgId = yield* Schema.decodeEffect(OrgId)(row.orgId).pipe(Effect.orDie)
 				const { accessToken } = yield* psOAuth
-					.getValidAccessToken(Schema.decodeUnknownSync(OrgId)(row.orgId))
+					.getValidAccessToken(orgId)
 					.pipe(Effect.catchTags(catchOAuthTokenFailure))
 				return { Authorization: planetScaleBearerHeader(accessToken) }
 			})

--- a/apps/api/src/services/org/OrgClickHouseSettingsService.ts
+++ b/apps/api/src/services/org/OrgClickHouseSettingsService.ts
@@ -193,8 +193,8 @@ const toCachedChSettings = (row: CachedSettingsRow): CachedChSettings => ({
 	chPasswordTag: row.chPasswordTag,
 })
 
-const ROOT_ROLE = Schema.decodeUnknownSync(RoleName)("root")
-const ORG_ADMIN_ROLE = Schema.decodeUnknownSync(RoleName)("org:admin")
+const ROOT_ROLE = Schema.decodeSync(RoleName)("root")
+const ORG_ADMIN_ROLE = Schema.decodeSync(RoleName)("org:admin")
 const decodeIsoDateTimeStringSync = Schema.decodeUnknownSync(IsoDateTimeString)
 
 export interface OrgClickHouseSettingsServiceShape {

--- a/apps/api/src/services/org/OrganizationService.ts
+++ b/apps/api/src/services/org/OrganizationService.ts
@@ -39,8 +39,8 @@ import { Context, Effect, Layer, Option, Redacted, Schema } from "effect"
 import { Database } from "@/platform/DatabaseLive"
 import { Env } from "@/platform/Env"
 
-const ROOT_ROLE = Schema.decodeUnknownSync(RoleName)("root")
-const ORG_ADMIN_ROLE = Schema.decodeUnknownSync(RoleName)("org:admin")
+const ROOT_ROLE = Schema.decodeSync(RoleName)("root")
+const ORG_ADMIN_ROLE = Schema.decodeSync(RoleName)("org:admin")
 
 const isOrgAdmin = (roles: ReadonlyArray<RoleName>) =>
 	roles.includes(ROOT_ROLE) || roles.includes(ORG_ADMIN_ROLE)

--- a/apps/api/src/workflows/InvestigationFanoutWorkflow.run.ts
+++ b/apps/api/src/workflows/InvestigationFanoutWorkflow.run.ts
@@ -94,7 +94,7 @@ const decodeReport = Schema.decodeUnknownSync(AiTriageResult)
 const decodeReportOption = Schema.decodeUnknownOption(AiTriageResult)
 
 /** Internal actor the lane tools run as — same identity the internal MCP RPC path uses. */
-const internalServiceUserId = Schema.decodeUnknownSync(UserId)("internal-service")
+const internalServiceUserId = Schema.decodeSync(UserId)("internal-service")
 
 /**
  * Wall-clock for the planning pass. Still short, because planning is scoping —

--- a/apps/cli/src/core/executor.ts
+++ b/apps/cli/src/core/executor.ts
@@ -8,8 +8,8 @@ import { debugLog } from "../lib/debug"
 // Local mode is single-tenant: the local binary writes every row under this
 // OrgId, and every compiled query filters on it. `OrgId` is a non-empty trimmed
 // branded string, so "local" decodes cleanly (no cast needed).
-const LOCAL_ORG_ID = Schema.decodeUnknownSync(OrgId)("local")
-const LOCAL_USER_ID = Schema.decodeUnknownSync(UserId)("local")
+const LOCAL_ORG_ID = Schema.decodeSync(OrgId)("local")
+const LOCAL_USER_ID = Schema.decodeSync(UserId)("local")
 
 const LOCAL_TENANT = { orgId: LOCAL_ORG_ID, userId: LOCAL_USER_ID, authMode: "local" }
 

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
@@ -151,7 +151,7 @@ function makeQueryAtomFamily<Input, Output>(query: QueryEffect<Input, Output>, o
 		// shipped). The inner query spans already export by re-providing this same
 		// (memoized) layer; this lifts the parent onto the same tracer.
 		let resultAtom = MapleApiAtomClient.runtime.atom(
-			Schema.decodeUnknownEffect(UnknownFromJson)(orgScopedKeyPayload(key)).pipe(
+			Schema.decodeEffect(UnknownFromJson)(orgScopedKeyPayload(key)).pipe(
 				Effect.mapError(
 					(cause) =>
 						new QueryAtomError({

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -66,13 +66,13 @@ const unauthorized = (message: string) =>
 // callers — that's an oracle for credential stuffing. Do not refactor these to
 // preserve `cause`.
 const decodeOrgId = (value: string, message: string): Effect.Effect<OrgId, UnauthorizedError> =>
-	Schema.decodeUnknownEffect(OrgId)(value).pipe(Effect.mapError(() => unauthorized(message)))
+	Schema.decodeEffect(OrgId)(value).pipe(Effect.mapError(() => unauthorized(message)))
 
 const decodeUserId = (value: string, message: string): Effect.Effect<UserId, UnauthorizedError> =>
-	Schema.decodeUnknownEffect(UserId)(value).pipe(Effect.mapError(() => unauthorized(message)))
+	Schema.decodeEffect(UserId)(value).pipe(Effect.mapError(() => unauthorized(message)))
 
 const decodeRoleName = (value: string, message: string): Effect.Effect<RoleName, UnauthorizedError> =>
-	Schema.decodeUnknownEffect(RoleName)(value).pipe(Effect.mapError(() => unauthorized(message)))
+	Schema.decodeEffect(RoleName)(value).pipe(Effect.mapError(() => unauthorized(message)))
 
 const getHeader = (headers: HeaderRecord, key: string): string | undefined => {
 	const exact = headers[key]
@@ -128,7 +128,7 @@ const verifyHs256Jwt = Effect.fn("AuthService.verifyHs256Jwt")(function* (
 	}
 
 	const [encodedHeader, encodedPayload, encodedSignature] = parts
-	const header = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(JwtHeaderSchema))(
+	const header = yield* Schema.decodeEffect(Schema.fromJsonString(JwtHeaderSchema))(
 		decodeBase64Url(encodedHeader),
 	).pipe(Effect.mapError(() => unauthorized("Invalid JWT header")))
 	if (header.alg !== "HS256") {
@@ -144,7 +144,7 @@ const verifyHs256Jwt = Effect.fn("AuthService.verifyHs256Jwt")(function* (
 		return yield* unauthorized("Invalid JWT signature")
 	}
 
-	const payload = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(JwtPayloadSchema))(
+	const payload = yield* Schema.decodeEffect(Schema.fromJsonString(JwtPayloadSchema))(
 		decodeBase64Url(encodedPayload),
 	).pipe(Effect.mapError(() => unauthorized("Invalid JWT payload")))
 	// JWT exp/nbf are in seconds since epoch (RFC 7519); divide Clock millis.

--- a/packages/domain/src/tinybird/project-sync.ts
+++ b/packages/domain/src/tinybird/project-sync.ts
@@ -354,9 +354,7 @@ export class TinybirdProjectSync extends Context.Service<TinybirdProjectSync, Ti
 						)
 					}
 
-					const body = yield* Schema.decodeUnknownEffect(DeploymentStatusBodyFromJson)(
-						rawBody,
-					).pipe(
+					const body = yield* Schema.decodeEffect(DeploymentStatusBodyFromJson)(rawBody).pipe(
 						Effect.mapError(() =>
 							toUnavailableError(
 								`Tinybird returned invalid JSON from deployment status.\nResponse: ${rawBody}`,
@@ -402,7 +400,7 @@ export class TinybirdProjectSync extends Context.Service<TinybirdProjectSync, Ti
 						)
 					}
 
-					const body = yield* Schema.decodeUnknownEffect(DeploymentsListBodyFromJson)(rawBody).pipe(
+					const body = yield* Schema.decodeEffect(DeploymentsListBodyFromJson)(rawBody).pipe(
 						Effect.mapError(() =>
 							toUnavailableError(
 								`Tinybird returned invalid JSON from deployments list.\nResponse: ${rawBody}`,
@@ -488,9 +486,7 @@ export class TinybirdProjectSync extends Context.Service<TinybirdProjectSync, Ti
 					)
 				}
 
-				const deployBody = yield* Schema.decodeUnknownEffect(DeployResponseFromJson)(
-					deployRawBody,
-				).pipe(
+				const deployBody = yield* Schema.decodeEffect(DeployResponseFromJson)(deployRawBody).pipe(
 					Effect.mapError(() =>
 						toUnavailableError(
 							`Tinybird returned invalid JSON from /v1/deploy.\nResponse: ${deployRawBody}`,


### PR DESCRIPTION
## What changed

- Use typed Schema decoders when inputs already match each schema encoded type.
- Replace synchronous Schema decoding inside Effect generators with Effect decoders.
- Preserve domain error mapping for request input failures.
- Treat invalid IDs loaded from Maple storage as invariant defects without widening service error unions.

## Why

Unknown decoders discarded useful compile-time input information, while synchronous decoding inside Effect code could throw outside the typed error channel. This layer strengthens those boundaries across production code while leaving query-engine untouched.

## Validation

- bun typecheck
- bun run lint:effect
- 100 focused tests across API, auth, and domain

This is layer 2 of the Effect audit cleanup stack and depends on PR #409.