### PR TITLE
refactor(effect): use managed HTTP clients

### DIFF
--- a/apps/api/src/routes/v1/billing.http.test.ts
+++ b/apps/api/src/routes/v1/billing.http.test.ts
@@ -88,12 +88,12 @@ describe("updateCustomerBillingControls", () => {
 			assert.strictEqual(result.statusCode, 200)
 			assert.strictEqual(request?.url, "https://api.useautumn.com/v1/customers.update")
 			assert.strictEqual(request?.init?.method, "POST")
-			assert.deepStrictEqual(request?.init?.headers, {
-				Authorization: "Bearer am_sk_test",
-				"Content-Type": "application/json",
-				"x-api-version": "2.3.0",
-			})
-			assert.deepStrictEqual(JSON.parse(String(request?.init?.body)), {
+			const headers = new Headers(request?.init?.headers)
+			assert.strictEqual(headers.get("authorization"), "Bearer am_sk_test")
+			assert.strictEqual(headers.get("content-type"), "application/json")
+			assert.strictEqual(headers.get("x-api-version"), "2.3.0")
+			const requestBody = await new Response(request?.init?.body).text()
+			assert.deepStrictEqual(JSON.parse(requestBody), {
 				customer_id: ORG,
 				billing_controls: {
 					spend_limits: [

--- a/apps/api/src/services/billing/autumn-client.ts
+++ b/apps/api/src/services/billing/autumn-client.ts
@@ -1,4 +1,5 @@
 import { Effect, Schema } from "effect"
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { autumnHandler, type CustomerData } from "autumn-js/backend"
 import type { EdgeCacheServiceShape } from "@maple/cache"
 import { isActivePlanSubscription } from "@maple/domain/billing"
@@ -115,6 +116,11 @@ export const makeCallAutumn =
 						}),
 				})
 
+const toBillingUpstreamError = (error: unknown) =>
+	new BillingUpstreamError({
+		message: error instanceof Error ? error.message : String(error),
+	})
+
 /**
  * `autumnHandler` intentionally exposes only its RPC route list; customer
  * billing controls live on the canonical REST surface instead.
@@ -127,45 +133,44 @@ export const updateCustomerBillingControls = (
 ): Effect.Effect<AutumnResult, BillingUpstreamError> =>
 	secretKey === undefined
 		? Effect.fail(new BillingUpstreamError({ message: "Billing is not configured" }))
-		: Effect.tryPromise({
-				try: async () => {
-					const response = await fetch(`${apiUrl.replace(/\/+$/, "")}/v1/customers.update`, {
-						method: "POST",
+		: Effect.gen(function* () {
+				const client = yield* HttpClient.HttpClient
+				const request = yield* HttpClientRequest.bodyJson(
+					HttpClientRequest.post(`${apiUrl.replace(/\/+$/, "")}/v1/customers.update`, {
 						headers: {
 							Authorization: `Bearer ${secretKey}`,
-							"Content-Type": "application/json",
 							"x-api-version": AUTUMN_API_VERSION,
 						},
-						body: JSON.stringify({
-							customer_id: orgId,
-							billing_controls: {
-								spend_limits: controls.spendLimits.map((limit) => ({
-									feature_id: limit.featureId,
-									enabled: limit.enabled,
-									limit_type: limit.limitType,
-									overage_limit: limit.overageLimit,
-								})),
-								usage_alerts: controls.usageAlerts.map((alert) => ({
-									feature_id: alert.featureId,
-									enabled: alert.enabled,
-									threshold: alert.threshold,
-									threshold_type: alert.thresholdType,
-									...(alert.name ? { name: alert.name } : {}),
-								})),
-							},
-						}),
-					})
-					const text = await response.text()
-					return {
-						statusCode: response.status,
-						response: text.length === 0 ? {} : JSON.parse(text),
-					} as AutumnResult
-				},
-				catch: (error) =>
-					new BillingUpstreamError({
-						message: error instanceof Error ? error.message : String(error),
 					}),
-			})
+					{
+						customer_id: orgId,
+						billing_controls: {
+							spend_limits: controls.spendLimits.map((limit) => ({
+								feature_id: limit.featureId,
+								enabled: limit.enabled,
+								limit_type: limit.limitType,
+								overage_limit: limit.overageLimit,
+							})),
+							usage_alerts: controls.usageAlerts.map((alert) => ({
+								feature_id: alert.featureId,
+								enabled: alert.enabled,
+								threshold: alert.threshold,
+								threshold_type: alert.thresholdType,
+								...(alert.name ? { name: alert.name } : {}),
+							})),
+						},
+					},
+				).pipe(Effect.mapError(toBillingUpstreamError))
+				const response = yield* client.execute(request).pipe(Effect.mapError(toBillingUpstreamError))
+				const text = yield* response.text.pipe(Effect.mapError(toBillingUpstreamError))
+				const responseBody =
+					text.length === 0
+						? {}
+						: yield* Schema.decodeEffect(Schema.fromJsonString(Schema.Unknown))(text).pipe(
+								Effect.mapError(toBillingUpstreamError),
+							)
+				return { statusCode: response.status, response: responseBody } as AutumnResult
+			}).pipe(Effect.provide(FetchHttpClient.layer))
 
 // Surface a readable message for a non-2xx Autumn response (it carries a
 // `{ message }` / `{ error }` body) so the client error isn't an opaque 502.

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -2,6 +2,7 @@ import * as os from "node:os"
 import * as Command from "effect/unstable/cli/Command"
 import * as Flag from "effect/unstable/cli/Flag"
 import { Console, Duration, Effect, Option, Redacted, Schema } from "effect"
+import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { MapleConfig } from "../core/config"
 import { deleteNativeCredential } from "../core/credential-store"
 import { Mode } from "../core/mode"
@@ -64,28 +65,55 @@ const normalizeApiUrl = (value: string) =>
 		catch: () => new CliAuthError({ message: `Invalid Maple API URL: ${value}` }),
 	})
 
-const requestJson = <A>(url: string, init?: RequestInit): Effect.Effect<A, CliAuthError> =>
-	Effect.tryPromise({
-		try: async () => {
-			const response = await fetch(url, init)
-			const body = (await response.json().catch(() => null)) as ({ message?: unknown } & A) | null
-			if (!response.ok) {
-				throw new Error(
+interface JsonRequestInit {
+	readonly method?: "GET" | "POST" | "DELETE"
+	readonly headers?: Readonly<Record<string, string>>
+	readonly body?: string
+}
+
+const requestJson = <A>(
+	url: string,
+	init?: JsonRequestInit,
+): Effect.Effect<A, CliAuthError, HttpClient.HttpClient> =>
+	Effect.gen(function* () {
+		const client = yield* HttpClient.HttpClient
+		let request = HttpClientRequest.make(init?.method ?? "GET")(url)
+		if (init?.headers !== undefined) {
+			request = HttpClientRequest.setHeaders(request, init.headers)
+		}
+		if (init?.body !== undefined) {
+			request = HttpClientRequest.bodyText(request, init.body, "application/json")
+		}
+
+		const response = yield* client.execute(request).pipe(
+			Effect.mapError(
+				(error) =>
+					new CliAuthError({
+						message: error instanceof Error ? error.message : "Maple API request failed",
+					}),
+			),
+		)
+		const body = (yield* response.json.pipe(Effect.orElseSucceed(() => null))) as
+			| ({ message?: unknown } & A)
+			| null
+		if (response.status < 200 || response.status >= 300) {
+			return yield* new CliAuthError({
+				message:
 					typeof body?.message === "string"
 						? body.message
 						: `Maple API returned HTTP ${response.status}`,
-				)
-			}
-			if (body === null) throw new Error("Maple API returned an empty response")
-			return body
-		},
-		catch: (error) =>
-			new CliAuthError({
-				message: error instanceof Error ? error.message : "Maple API request failed",
-			}),
+			})
+		}
+		if (body === null) {
+			return yield* new CliAuthError({ message: "Maple API returned an empty response" })
+		}
+		return body
 	})
 
-const validateToken = (apiUrl: string, token: string): Effect.Effect<Session, CliAuthError> =>
+const validateToken = (
+	apiUrl: string,
+	token: string,
+): Effect.Effect<Session, CliAuthError, HttpClient.HttpClient> =>
 	requestJson<Session>(`${apiUrl}/api/auth/session`, {
 		headers: { authorization: `Bearer ${token}` },
 	}).pipe(


### PR DESCRIPTION
## What changed

- Move CLI authentication requests from global fetch to the managed Effect HTTP client.
- Move Autumn billing-control updates to the managed Effect HTTP client.
- Encode and decode Autumn JSON through Effect Schema.
- Keep existing HTTP status and BillingUpstreamError behavior.
- Verify the Autumn request URL, bearer header, API version, and wire body.

## Why

Raw fetch calls inside Effect programs bypass interruption, tracing, and service-based testability. This layer moves the two meaningful backend and CLI findings onto the existing managed HTTP boundary.

## Validation

- bun typecheck
- bun run lint:effect
- billing route focused test suite

This is layer 3 of the Effect audit cleanup stack and depends on PR #410.