### PR TITLE
fix(chat): release timed-out SSE waiters

### DIFF
--- a/apps/api/src/chat/ChatSession.test.ts
+++ b/apps/api/src/chat/ChatSession.test.ts
@@ -420,6 +420,19 @@ describe("ChatSession.subscribe", () => {
 
 		assert.equal(outcome, "still-open")
 	})
+
+	it("removes a timed-out waiter before the next idle reconnect", async () => {
+		const { session } = makeSession()
+		const waitForAppend: unknown = Reflect.get(session, "waitForAppend")
+		if (typeof waitForAppend !== "function") assert.fail("waitForAppend must be a function")
+
+		for (let reconnect = 0; reconnect < 3; reconnect++) {
+			assert.isFalse(await Reflect.apply(waitForAppend, session, [0]))
+			const waiters: unknown = Reflect.get(session, "waiters")
+			assert.instanceOf(waiters, Set)
+			assert.equal(waiters.size, 0)
+		}
+	})
 })
 
 describe("ChatSession.history — sub-agent transcripts", () => {

--- a/apps/api/src/chat/ChatSession.ts
+++ b/apps/api/src/chat/ChatSession.ts
@@ -117,7 +117,7 @@ export class ChatSession extends DurableObject<Record<string, unknown>> {
 	 * into. Reader and writer are different requests but the *same object*, so the writer can simply
 	 * tap the reader on the shoulder.
 	 */
-	private waiters: Array<() => void> = []
+	private waiters = new Set<() => void>()
 
 	constructor(ctx: DurableObjectState, env: Record<string, unknown>) {
 		super(ctx, env)
@@ -233,9 +233,9 @@ export class ChatSession extends DurableObject<Record<string, unknown>> {
 
 	/** Wake every parked subscriber. Cheap and unconditional — the list is empty when nobody reads. */
 	private notify(): void {
-		if (this.waiters.length === 0) return
+		if (this.waiters.size === 0) return
 		const parked = this.waiters
-		this.waiters = []
+		this.waiters = new Set()
 		for (const wake of parked) wake()
 	}
 
@@ -243,15 +243,17 @@ export class ChatSession extends DurableObject<Record<string, unknown>> {
 	private waitForAppend(timeoutMs: number): Promise<boolean> {
 		return new Promise<boolean>((resolve) => {
 			let settled = false
+			const wake = () => settle(true)
 			const settle = (appended: boolean) => {
 				if (settled) return
 				settled = true
 				resolve(appended)
 			}
-			this.waiters.push(() => settle(true))
-			// A timed-out waiter is left in the list; its closure is a no-op once settled, and
-			// `notify` clears the array wholesale on the next append.
-			void scheduler.wait(timeoutMs).then(() => settle(false))
+			this.waiters.add(wake)
+			void scheduler.wait(timeoutMs).then(() => {
+				this.waiters.delete(wake)
+				settle(false)
+			})
 		})
 	}
 


### PR DESCRIPTION
## Summary

- remove timed-out SSE waiter callbacks from idle `ChatSession` Durable Objects
- use a `Set` so individual waiters can be released without affecting active subscribers
- cover repeated idle reconnects with a regression test

## Root cause

Every 25-second idle timeout settled its promise but left the callback in `waiters`. On a conversation with no later append, browser reconnects retained one additional closure per cycle for the lifetime of the Durable Object.

## Validation

- `bun run --cwd apps/api test --run src/chat/ChatSession.test.ts` — 29 passed
- `bun run --cwd apps/api typecheck`
- targeted standard and Effect lint for both changed files
- `oxfmt --check` for both changed files

The repository-wide Effect lint and test typecheck still report unrelated pre-existing query-engine/type-resolution failures; this PR does not touch those files.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
