### PR TITLE
fix(errors): stop the error tick binding a JS Date into raw SQL

### DIFF
--- a/apps/api/src/platform/test-pglite.ts
+++ b/apps/api/src/platform/test-pglite.ts
@@ -25,6 +25,54 @@ export interface TestDb {
 	readonly close: () => Promise<void>
 }
 
+/**
+ * Reject a bound `Date`, which PGlite accepts and the deployed driver does not.
+ *
+ * Production runs `drizzle-orm/postgres-js` → `client.unsafe(sql, params)`, which
+ * refuses a `Date` param outright ("Received an instance of Date"). PGlite
+ * serializes one happily, so without this the difference is invisible to the
+ * suite — which is how a raw `sql` template binding a `Date` reached production
+ * and stalled the error tick for 25 hours.
+ *
+ * There is no legitimate `Date` param: every timestamptz column is
+ * `mode: "date"`, whose `mapToDriverValue` already returns an ISO string. A
+ * `Date` surviving into the param array therefore always means a raw `sql`
+ * fragment with no column type behind it — use `msToSqlTimestamp` there.
+ */
+const assertNoDateParams = (sql: string, params: unknown[] | undefined): void => {
+	const index = params?.findIndex((param) => param instanceof Date) ?? -1
+	if (index === -1) return
+	throw new Error(
+		`Bound a Date as param $${index + 1}, which the deployed postgres.js driver rejects. ` +
+			`Interpolate an ISO string (msToSqlTimestamp) into raw \`sql\` templates instead.\n${sql}`,
+	)
+}
+
+/**
+ * PGlite with the guard applied to `query` and, crucially, to the client
+ * drizzle hands to a `transaction` callback — that is a different object, and
+ * without re-wrapping it the guard would miss every statement inside a
+ * transaction, which is exactly where the raw templates live.
+ */
+const withDateParamGuard = <T extends object>(client: T): T =>
+	new Proxy(client, {
+		get(target, property) {
+			const value = Reflect.get(target, property)
+			if (typeof value !== "function") return value
+			if (property === "query") {
+				return (sql: string, params?: unknown[], ...rest: unknown[]) => {
+					assertNoDateParams(sql, params)
+					return value.call(target, sql, params, ...rest)
+				}
+			}
+			if (property === "transaction") {
+				return (callback: (tx: object) => unknown, ...rest: unknown[]) =>
+					value.call(target, (tx: object) => callback(withDateParamGuard(tx)), ...rest)
+			}
+			return value.bind(target)
+		},
+	})
+
 export const createTestDb = (track?: TestDb[]): TestDb => {
 	const pglite = new PGlite({ loadDataDir: SNAPSHOT })
 	// Building the layer twice over the same DB is legitimate (tests that provide
@@ -36,7 +84,9 @@ export const createTestDb = (track?: TestDb[]): TestDb => {
 		Database,
 		Effect.gen(function* () {
 			yield* Effect.promise(() => pglite.waitReady)
-			return databaseFromInstance(pglite)
+			// The raw instance stays on `TestDb.pglite` for executeSql/queryFirstRow —
+			// those are test fixtures writing their own SQL, not the app's write path.
+			return databaseFromInstance(withDateParamGuard(pglite))
 		}),
 	)
 	const db: TestDb = {

--- a/apps/api/src/platform/time.ts
+++ b/apps/api/src/platform/time.ts
@@ -12,6 +12,20 @@ export function msToDate(ms: number | null | undefined): Date | null {
 	return ms === null || ms === undefined ? null : new Date(ms)
 }
 
+/**
+ * Epoch-ms → ISO 8601 string, for interpolation into a raw `sql` template.
+ *
+ * Raw templates only. A drizzle *column* context (`.values()`, `.set()`,
+ * `eq(col, …)`) carries the column's `mapToDriverValue` and converts a `Date`
+ * itself — use `msToDate` there. A raw fragment has no column type behind it, so
+ * whatever is interpolated reaches the driver verbatim, and the deployed
+ * postgres.js path rejects a `Date` outright. Bind a string and pair it with the
+ * explicit `::timestamptz` the statement already carries.
+ */
+export function msToSqlTimestamp(ms: number): string {
+	return new Date(ms).toISOString()
+}
+
 export function dateToMs(date: Date): number
 export function dateToMs(date: Date | null): number | null
 export function dateToMs(date: Date | null | undefined): number | null

--- a/apps/api/src/services/errors/error-tick-persistence.ts
+++ b/apps/api/src/services/errors/error-tick-persistence.ts
@@ -11,7 +11,7 @@ import {
 	type ErrorNotificationPolicyRow,
 } from "@maple/db"
 import type { DatabaseClient } from "@/platform/DatabaseLive"
-import { msToDate } from "@/platform/time"
+import { msToDate, msToSqlTimestamp } from "@/platform/time"
 import type {
 	ActorId,
 	AlertDestinationId,
@@ -200,6 +200,9 @@ export const persistErrorTickWindow = (
 ): Promise<PersistErrorTickWindowResult> =>
 	db.transaction(async (tx) => {
 		const windowEnd = msToDate(input.windowEndMs)
+		// The raw `sql` bulk updates below bind this with no column type behind it,
+		// so it has to reach the driver as a string — see `msToSqlTimestamp`.
+		const windowEndSql = msToSqlTimestamp(input.windowEndMs)
 
 		// Lock the cursor row for the life of the transaction. `claimTickWindow`
 		// skips locked rows, so an in-flight apply can no longer be stolen by the
@@ -403,7 +406,7 @@ export const persistErrorTickWindow = (
 			const incidentValues = sql.join(
 				refreshing.map(
 					(item) =>
-						sql`(${item.incidentId}::text, ${msToDate(item.row.lastSeenMs)}::timestamptz, ${item.row.count}::integer)`,
+						sql`(${item.incidentId}::text, ${msToSqlTimestamp(item.row.lastSeenMs)}::timestamptz, ${item.row.count}::integer)`,
 				),
 				sql`, `,
 			)
@@ -411,22 +414,23 @@ export const persistErrorTickWindow = (
 				update ${errorIncidents} as t
 				set last_triggered_at = greatest(t.last_triggered_at, v.last_seen),
 				    occurrence_count = t.occurrence_count + v.cnt,
-				    updated_at = ${windowEnd}::timestamptz
+				    updated_at = ${windowEndSql}::timestamptz
 				from (values ${incidentValues}) as v(incident_id, last_seen, cnt)
 				where t.id = v.incident_id
 			`)
 
 			const stateValues = sql.join(
 				refreshing.map(
-					(item) => sql`(${item.issueId}::text, ${msToDate(item.row.lastSeenMs)}::timestamptz)`,
+					(item) =>
+						sql`(${item.issueId}::text, ${msToSqlTimestamp(item.row.lastSeenMs)}::timestamptz)`,
 				),
 				sql`, `,
 			)
 			await tx.execute(sql`
 				update ${errorIssueStates} as t
 				set last_observed_occurrence_at = greatest(t.last_observed_occurrence_at, v.last_seen),
-				    last_evaluated_at = ${windowEnd}::timestamptz,
-				    updated_at = ${windowEnd}::timestamptz
+				    last_evaluated_at = ${windowEndSql}::timestamptz,
+				    updated_at = ${windowEndSql}::timestamptz
 				from (values ${stateValues}) as v(issue_id, last_seen)
 				where t.org_id = ${input.orgId} and t.issue_id = v.issue_id
 			`)


### PR DESCRIPTION
## The problem

The `alerting` worker has been emitting a flat **~600/hour of `ErrorsService dbExecute failed` plus ~600/hour of `Error tick failed for org`** since **2026-08-10 ~10:00 UTC** — 10 orgs × 1 tick/min, failing identically every minute.

This is **not log noise. Error tracking has been dead for those orgs for 25+ hours.** `persistErrorTickWindow` applies a window in one transaction, so the throw rolls back the cursor advance too. Production telemetry shows `windowEndMs` for the affected orgs frozen between `2026-08-10 10:50` and `17:45` — no new error issues, incidents or notifications for them since.

Root cause, read verbatim off the failing span's `StatusMessage`:

```
Failed query:
  update "error_incidents" as t
  set last_triggered_at = greatest(t.last_triggered_at, v.last_seen), ...
[caused by: The "string" argument must be of type string or an instance of Buffer
 or ArrayBuffer. Received an instance of Date]
```

`error-tick-persistence.ts` builds two raw `` sql`…` `` templates that interpolate JS `Date` objects as bound params. Everywhere else in that file Dates are fine because they pass through drizzle *column* builders, where the timestamptz column's `mapToDriverValue` already returns an ISO string. A raw fragment has no column type behind it, so the `Date` reaches postgres.js verbatim and the deployed driver refuses it.

Introduced in c45eaef48 / 99ba666c1 and first reached production when bf6b99805 unblocked deploys — **this path has never worked in production.**

## What changed

- **`apps/api/src/platform/time.ts`** — adds `msToSqlTimestamp(ms)` beside `msToDate`, documented so the raw-template vs column-context distinction is visible at the call site.
- **`apps/api/src/services/errors/error-tick-persistence.ts`** — five interpolations switched to it (lines 406, 414, 421, 428, 429). A repo-wide sweep of every `` sql`…` `` template under `apps packages lib scripts` confirms these were the **only** raw-template `Date` bindings; every other hit binds a drizzle `Column`/`Table` identifier or a primitive.
- **`apps/api/src/platform/test-pglite.ts`** — the harness now rejects a bound `Date`.

`toISOString()` against the existing `::timestamptz` casts is byte-for-byte what drizzle's own `PgTimestamp.mapToDriverValue` emits for these columns elsewhere in the file, so there is no semantic change.

## Why the suite missed it

PGlite (`drizzle-orm/pglite`) serializes a `Date` param happily; production (`drizzle-orm/postgres-js` → `client.unsafe`) does not. The difference was structurally invisible to every test.

`createTestDb` now throws on a bound `Date`, and **crucially also re-wraps the client drizzle swaps in for a `transaction` callback** — that is a different object, and without it the guard would miss every statement inside a transaction, which is exactly where these templates live.

Chosen over an oxlint rule on the numbers: an AST-only rule matches the two literal `msToDate(...)` call sites but cannot see that the bare identifier `${windowEnd}` holds a `Date` — it would catch 2 of 5 sites and leave the statement still throwing. Zero false positives here: every timestamptz column is `mode: "date"`, so a `Date` surviving into a param array always means a raw fragment.

## Verification

- **Guard applied first, before the fix**: it trips on the `update "error_incidents"` statement and fails the "ongoing fingerprint" test — direct proof it would have caught this incident, with no new test written.
- With the fix: `1684 passed | 184 skipped` across `apps/api` (the harness change touches all 59 suites that use `createTestDb`, hence the package-wide run rather than just the touched file).
- `bun typecheck` clean.

## For the reviewer

**Deploy does not fix the stuck orgs on its own.** Their cursors stay frozen at Aug 10 and need a one-off `error_tick_states` fast-forward against prd afterwards. The accompanying `error_incidents.last_triggered_at` bump is not cosmetic — without it the next tick mass-resolves every incident older than 30 min (`AUTO_RESOLVE_MINUTES`), fires a resolve notification each, then immediately re-opens them.

Ruled out by data: a `MAX_PARAMETERS_EXCEEDED` theory would need ~2,520 fingerprints in a window; peak observed `scanFingerprints` across all orgs is **82**, `windowSplits` 0 everywhere.

Latent, filed separately rather than fixed here: `TICK_MAX_WINDOW_ROWS = 20_000` against the 26-column `errorIssues` upsert allows ~520k bind params, 8× postgres.js's 65,534 wire cap. Nowhere near firing today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789042389&installation_model_id=427786&pr_number=415&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F415&signature=aaedd678eab17a598a78f7ae3bc1aa3977c372c4a959471a7955c46940aa904d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->