### PR TITLE
perf(api): drop the dial budget, retry and probe from the Postgres path

### DIFF
--- a/apps/api/src/platform/DatabaseLive.test.ts
+++ b/apps/api/src/platform/DatabaseLive.test.ts
@@ -187,58 +187,44 @@ describe("Database execute span instrumentation", () => {
  * a slow query — the ambiguity that made the production p95 investigation
  * guesswork. These cover the split that resolves it.
  */
-describe("Database execute connect/query split", () => {
-	it.effect("reports both phases when the body marks the handshake", () =>
-		Effect.gen(function* () {
-			const { spans, tracer } = makeRecordingTracer()
-			const database = yield* Database
-
-			yield* database
-				.execute((db) => db.execute(sql`select 1 as probe`))
-				.pipe(Effect.withTracer(tracer))
-
-			const [span] = dbSpans(spans)
-			assert.isDefined(span)
-			assert.strictEqual(span.attributes.get("db.connect.completed"), true)
-			assert.isNumber(span.attributes.get("db.connect_ms"))
-			assert.isNumber(span.attributes.get("db.query_ms"))
-		}).pipe(Effect.provide(createTestDb(trackedDbs).layer)),
-	)
-
-	it.effect("attributes time before the handshake to connect, not to the query", () =>
-		Effect.gen(function* () {
-			const { spans, tracer } = makeRecordingTracer()
-
-			yield* executeWithSpan(async (hooks) => {
-				await new Promise((resolve) => setTimeout(resolve, 30))
-				hooks.markConnected()
-				hooks.collect("select 1")
-				return "ok"
-			}).pipe(Effect.withTracer(tracer))
-
-			const [span] = dbSpans(spans)
-			assert.isDefined(span)
-			// Margin for timer imprecision; the point is that the pre-mark wait
-			// landed in connect instead of being folded into query time.
-			assert.isAtLeast(span.attributes.get("db.connect_ms") as number, 25)
-		}),
-	)
-
-	it.effect("flags a dial that never completed and omits query time", () =>
+describe("Database execute failure classification", () => {
+	// There is no connect/query split any more. postgres.js connects on the first
+	// statement, so the split could only ever be synthesized by a `select 1` probe
+	// that cost a round trip on every request. What it was used to infer — is this
+	// a connection problem or a query problem — `error.type` states outright.
+	it.effect("classifies a connection failure by class rather than by duration", () =>
 		Effect.gen(function* () {
 			const { spans, tracer } = makeRecordingTracer()
 
 			const exit = yield* executeWithSpan(() =>
-				Promise.reject(new Error("write CONNECT_TIMEOUT")),
+				Promise.reject(
+					Object.assign(new Error("write CONNECT_TIMEOUT"), { code: "CONNECT_TIMEOUT" }),
+				),
 			).pipe(Effect.withTracer(tracer), Effect.exit)
 
 			assert.isTrue(Exit.isFailure(exit))
 			const [span] = dbSpans(spans)
 			assert.isDefined(span)
-			assert.strictEqual(span.attributes.get("db.connect.completed"), false)
-			// Still reports the time burned before giving up.
-			assert.isNumber(span.attributes.get("db.connect_ms"))
-			assert.isUndefined(span.attributes.get("db.query_ms"))
+			assert.strictEqual(span.attributes.get("error.type"), "CONNECT_TIMEOUT")
+			assert.strictEqual(span.attributes.get("db.connect.failed"), true)
+			assert.isNumber(span.attributes.get("db.duration_ms"))
+		}),
+	)
+
+	it.effect("classifies a statement failure separately, with its SQLSTATE", () =>
+		Effect.gen(function* () {
+			const { spans, tracer } = makeRecordingTracer()
+
+			const exit = yield* executeWithSpan(() =>
+				Promise.reject(Object.assign(new Error("duplicate key"), { code: "23505" })),
+			).pipe(Effect.withTracer(tracer), Effect.exit)
+
+			assert.isTrue(Exit.isFailure(exit))
+			const [span] = dbSpans(spans)
+			assert.isDefined(span)
+			assert.strictEqual(span.attributes.get("error.type"), "23505")
+			assert.strictEqual(span.attributes.get("db.response.status_code"), "23505")
+			assert.strictEqual(span.attributes.get("db.connect.failed"), false)
 		}),
 	)
 
@@ -247,14 +233,13 @@ describe("Database execute connect/query split", () => {
 			const { spans, tracer } = makeRecordingTracer()
 
 			yield* executeWithSpan((hooks) => {
-				hooks.record({ "db.connect.in_flight": 3 })
-				hooks.markConnected()
+				hooks.record({ "db.connect.reused": true })
 				return Promise.resolve("ok")
 			}).pipe(Effect.withTracer(tracer))
 
 			const [span] = dbSpans(spans)
 			assert.isDefined(span)
-			assert.strictEqual(span.attributes.get("db.connect.in_flight"), 3)
+			assert.strictEqual(span.attributes.get("db.connect.reused"), true)
 		}),
 	)
 })

--- a/apps/api/src/platform/DatabaseLive.ts
+++ b/apps/api/src/platform/DatabaseLive.ts
@@ -17,8 +17,8 @@ export interface DatabaseShape {
 
 /**
  * Callbacks handed to an `executeWithSpan` body so it can report what only it
- * knows: which statements ran, when the connection actually became usable, and
- * any transport-level attributes discovered along the way.
+ * knows: which statements ran, and any transport-level attributes discovered
+ * along the way.
  */
 export interface ExecuteHooks {
 	/**
@@ -26,14 +26,6 @@ export interface ExecuteHooks {
 	 * `db.query.text`.
 	 */
 	readonly collect: (query: string) => void
-	/**
-	 * Call exactly once, the moment the connection is usable (TCP + startup/auth
-	 * complete). Splits `db.connect_ms` from `db.query_ms`; without it the span
-	 * reports only the combined `db.duration_ms` and a stalled dial is
-	 * indistinguishable from a slow query. Bodies that do not own a dial (PGlite,
-	 * a caller-owned client) simply never call it.
-	 */
-	readonly markConnected: () => void
 	/** Merge extra attributes into the span at annotate time. */
 	readonly record: (attributes: Record<string, unknown>) => void
 }
@@ -65,14 +57,12 @@ export const toDatabaseError = (cause: unknown): DatabaseError => {
  * for the same origin database, so the two paths don't produce divergent
  * service-map targets (MAP-01 in the maple-audit skill).
  *
- * Two clocks, deliberately. `db.duration_ms` stays on `Clock.currentTimeMillis`
- * because dashboards read it and `TestClock` drives it in unit tests. The
- * connect/query split needs real elapsed time, so it reads `Date.now()`. On
- * Workers that clock is frozen between I/O operations, but the dial and the
- * query are separate I/O, so it advances at each boundary and the split is
- * observable. What it cannot see is CPU time — if `db.connect_ms + db.query_ms`
- * falls materially short of the span's own wall duration, the residue is
- * scheduler/CPU delay rather than the socket.
+ * There is no connect/query split. postgres.js connects on the first statement,
+ * so there is no separate connect phase to time — the split previously came from
+ * a `select 1` probe that cost a round trip on every request purely to produce
+ * it. What that split was used to infer, `error.type` now states outright: a
+ * `CONNECT_TIMEOUT` and a constraint violation are different classes, not
+ * different durations.
  */
 export const executeWithSpan = Effect.fn("Database.execute", {
 	kind: "client",
@@ -87,8 +77,6 @@ export const executeWithSpan = Effect.fn("Database.execute", {
 	const statements: Array<string> = []
 	const recorded: Record<string, unknown> = {}
 	const startedMs = yield* Clock.currentTimeMillis
-	const wallStartedMs = yield* Effect.sync(() => Date.now())
-	let connectedAtMs: number | undefined
 	// Shared by the success and error paths — tapError runs inside the span,
 	// so a failing statement still carries its SQL and timing.
 	const annotate = Effect.gen(function* () {
@@ -97,7 +85,6 @@ export const executeWithSpan = Effect.fn("Database.execute", {
 		// exactly the input the warehouse would derive a shape label from, so the
 		// emitted summary can never disagree with the fallback derivation.
 		const { operation, collection, summary } = summarizeSql(sqlText)
-		const wallNowMs = yield* Effect.sync(() => Date.now())
 		yield* Effect.annotateCurrentSpan({
 			...recorded,
 			"db.query.text": truncateSql(sqlText, SQL_TRACE_MAX),
@@ -106,12 +93,6 @@ export const executeWithSpan = Effect.fn("Database.execute", {
 			"db.query.fingerprint": fingerprintSql(sqlText),
 			"db.statement_count": statements.length,
 			"db.duration_ms": (yield* Clock.currentTimeMillis) - startedMs,
-			// A dial that never completed reports the time it burned before giving
-			// up and omits `db.query_ms` — a tail made of `completed: false` spans
-			// is a different bug from one made of completed-but-slow dials.
-			"db.connect.completed": connectedAtMs !== undefined,
-			"db.connect_ms": (connectedAtMs ?? wallNowMs) - wallStartedMs,
-			...(connectedAtMs === undefined ? {} : { "db.query_ms": wallNowMs - connectedAtMs }),
 		})
 		if (summary !== "") {
 			yield* Effect.annotateCurrentSpan("db.query.summary", summary)
@@ -145,11 +126,6 @@ export const executeWithSpan = Effect.fn("Database.execute", {
 		try: () =>
 			run({
 				collect: (query) => statements.push(query),
-				// First call wins, so a body that marks defensively can't move the
-				// boundary once the query is already running.
-				markConnected: () => {
-					connectedAtMs ??= Date.now()
-				},
 				record: (attributes) => Object.assign(recorded, attributes),
 			}),
 		catch: toDatabaseError,

--- a/apps/api/src/platform/DatabasePgLive.test.ts
+++ b/apps/api/src/platform/DatabasePgLive.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { layerFromEnvRecord } from "@maple/effect-cloudflare"
+import { sql } from "drizzle-orm"
 import { Cause, Effect, Exit, Layer, Tracer } from "effect"
 import { Database, type DatabaseClient } from "./DatabaseLive"
 import { layerPg } from "./DatabasePgLive"
@@ -58,24 +59,25 @@ describe("layerPg", () => {
 		}),
 	)
 
-	it.effect("dials per execute when no connection scope is installed", () =>
+	it.effect("uses a per-call client when no connection scope is installed", () =>
 		Effect.gen(function* () {
 			const { spans, tracer } = makeRecordingTracer()
 			const database = yield* databaseFor(closedPortBinding)
 
+			// The callback must issue a statement: the client is lazy, so a callback
+			// that never queries would never reach the closed port and would succeed.
 			const exit = yield* Effect.exit(
-				database.execute(() => Promise.resolve("unreachable")).pipe(Effect.withTracer(tracer)),
+				database.execute((db) => db.execute(sql`select 1`)).pipe(Effect.withTracer(tracer)),
 			)
 
 			assert.isTrue(Exit.isFailure(exit))
 			const span = dbSpan(spans)
 			assert.isDefined(span)
-			// `db.retry.attempts` is only emitted by `executeOnFreshPgClient`, so its
-			// presence is what proves the fallback ran — Workflow entrypoints and
-			// tests depend on this branch still working.
-			assert.isDefined(span.attributes.get("db.retry.attempts"))
-			assert.isUndefined(span.attributes.get("db.connect.dials"))
-			assert.strictEqual(span.attributes.get("db.connect.completed"), false)
+			// `db.connect.reused` is only emitted by the scope, so its ABSENCE is what
+			// proves the fallback ran — Workflow entrypoints and tests depend on this
+			// branch still working.
+			assert.isUndefined(span.attributes.get("db.connect.reused"))
+			assert.strictEqual(span.attributes.get("db.connect.failed"), true)
 		}),
 	)
 

--- a/apps/api/src/platform/DatabasePgliteLive.ts
+++ b/apps/api/src/platform/DatabasePgliteLive.ts
@@ -30,16 +30,12 @@ export const databaseFromInstance = (pglite: PGlite): DatabaseShape =>
 	Database.of({
 		execute: <T>(fn: (db: DatabaseClient) => Promise<T>) =>
 			executeWithSpan(
-				(hooks) => {
-					// PGlite is in-process — there is no dial, so mark immediately or
-					// the whole call would be attributed to `db.connect_ms`.
-					hooks.markConnected()
-					return fn(
+				(hooks) =>
+					fn(
 						createMaplePgliteClient(pglite, {
 							onQuery: hooks.collect,
 						}) as unknown as DatabaseClient,
-					)
-				},
+					),
 				// Without a namespace these spans collapse into the per-system
 				// generic node. There is no server to address — PGlite is in-process —
 				// so name the engine rather than a host, which also keeps local and

--- a/apps/api/src/platform/fork-request-scoped.ts
+++ b/apps/api/src/platform/fork-request-scoped.ts
@@ -1,0 +1,23 @@
+import { Effect, Option, Scope } from "effect"
+
+/**
+ * Fork background work so it cannot outlive the invocation that owns the
+ * Postgres socket.
+ *
+ * `Effect.forkDetach` is the wrong tool for anything that touches the database.
+ * A detached fiber inherits the `PgConnectionScope` reference from the request
+ * context but not the request's lifetime, so it can still be running when
+ * `withPgConnectionScopeOf`'s `Effect.ensuring` closes the socket. The next
+ * `execute` then finds no socket and dials a new one *after the request has
+ * ended*, which a Worker cannot do — and because these call sites are
+ * `Effect.ignore`d, the failure is silent.
+ *
+ * HTTP routes always have a request `Scope` (HttpRouter provides one). Non-HTTP
+ * callers — crons, queue consumers, workflows — do not, and there the calling
+ * fiber IS the whole job, so it is a safe parent.
+ */
+export const forkRequestScoped = <A, E, R>(work: Effect.Effect<A, E, R>) =>
+	Effect.gen(function* () {
+		const scope = yield* Effect.serviceOption(Scope.Scope)
+		return Option.isSome(scope) ? yield* Effect.forkIn(work, scope.value) : yield* Effect.forkChild(work)
+	})

--- a/apps/api/src/platform/pg-connection-scope.test.ts
+++ b/apps/api/src/platform/pg-connection-scope.test.ts
@@ -10,58 +10,44 @@ import {
 	withPgConnectionScope,
 	withPgConnectionScopeOf,
 } from "./pg-connection-scope"
-import { CONNECT_ATTEMPT_TIMEOUT_SECONDS } from "./pg-execute"
 
 /**
- * A socket that never touches the network.
+ * A client that never touches the network.
  *
  * `sql` is a real postgres.js client because `wrapMaplePgClient` builds drizzle
- * over it — constructing one dials nothing (postgres.js connects lazily), and
- * these tests never issue a statement, so the port below is never reached.
+ * over it — constructing one connects to nothing (postgres.js connects lazily on
+ * the first statement), and these tests never issue one, so the port below is
+ * never reached.
  */
-const fakeSocket = (options: {
-	readonly onConnect: () => Promise<void>
-	readonly onEnd: () => void
-}): MaplePgSocketHandle => {
+const fakeSocket = (onEnd: () => void): MaplePgSocketHandle => {
 	const real = createMaplePgSocket("postgres://maple:maple@127.0.0.1:1/never", {
 		maxConnections: 1,
 	})
 	return {
 		sql: real.sql,
-		awaitConnected: options.onConnect,
 		end: async () => {
-			options.onEnd()
+			onEnd()
 			await real.end().catch(() => undefined)
 		},
 	}
 }
 
 interface Recorder {
-	readonly openSocket: (connectTimeoutSeconds: number) => MaplePgSocketHandle
-	/** Dial budget passed to each attempt, in call order. */
-	readonly budgets: Array<number>
+	readonly openSocket: () => MaplePgSocketHandle
+	readonly creations: () => number
 	readonly ends: () => number
 }
 
-/** `failures` dial attempts reject before any subsequent attempt succeeds. */
-const recorder = (failures = 0): Recorder => {
-	const budgets: Array<number> = []
-	let attempts = 0
+const recorder = (): Recorder => {
+	let creations = 0
 	let ends = 0
 	return {
-		budgets,
+		creations: () => creations,
 		ends: () => ends,
-		openSocket: (connectTimeoutSeconds) => {
-			budgets.push(connectTimeoutSeconds)
-			const shouldFail = attempts < failures
-			attempts += 1
-			return fakeSocket({
-				onConnect: shouldFail
-					? () => Promise.reject(new Error("write CONNECT_TIMEOUT"))
-					: () => Promise.resolve(),
-				onEnd: () => {
-					ends += 1
-				},
+		openSocket: () => {
+			creations += 1
+			return fakeSocket(() => {
+				ends += 1
 			})
 		},
 	}
@@ -85,71 +71,44 @@ const dbSpans = (spans: ReadonlyArray<Tracer.NativeSpan>) =>
 	spans.filter((span) => span.attributes.get("db.system.name") === "postgresql")
 
 describe("PgConnectionScope", () => {
-	it.effect("dials once and reuses the socket across every execute", () =>
+	it.effect("creates one client and reuses it across every execute", () =>
 		Effect.gen(function* () {
 			const rec = recorder()
-			const scope = makePgConnectionScope("postgres://unused", undefined, rec.openSocket)
-
-			yield* scope.run(noop)
-			yield* scope.run(noop)
-			yield* scope.run(noop)
-
-			// The whole point: five calls used to mean five handshakes.
-			assert.strictEqual(rec.budgets.length, 1)
-			yield* Effect.promise(() => scope.close())
-			assert.strictEqual(rec.ends(), 1)
-		}),
-	)
-
-	it.effect("single-flights the dial when concurrent calls both find it cold", () =>
-		Effect.gen(function* () {
-			const rec = recorder()
-			const scope = makePgConnectionScope("postgres://unused", undefined, rec.openSocket)
-
-			// Without the shared promise these race into two dials — two of the
-			// Worker's six outbound slots for one logical connection.
-			yield* Effect.all([scope.run(noop), scope.run(noop), scope.run(noop)], {
-				concurrency: 3,
+			const scope = makePgConnectionScope("postgres://unused", undefined, {
+				openSocket: rec.openSocket,
 			})
 
-			assert.strictEqual(rec.budgets.length, 1)
+			yield* scope.run(noop)
+			yield* scope.run(noop)
+			yield* scope.run(noop)
+
+			// The whole point: these used to be three connections.
+			assert.strictEqual(rec.creations(), 1)
 			yield* Effect.promise(() => scope.close())
-		}),
-	)
-
-	it.effect("retries a failed dial on the next budget and drops the dead socket", () =>
-		Effect.gen(function* () {
-			const rec = recorder(1)
-			const scope = makePgConnectionScope("postgres://unused", undefined, rec.openSocket)
-
-			const result = yield* scope.run(noop)
-
-			assert.strictEqual(result, "ok")
-			assert.deepStrictEqual(rec.budgets, [...CONNECT_ATTEMPT_TIMEOUT_SECONDS])
-			// The failed attempt's socket is closed rather than left holding a slot.
 			assert.strictEqual(rec.ends(), 1)
-			yield* Effect.promise(() => scope.close())
-			assert.strictEqual(rec.ends(), 2)
 		}),
 	)
 
-	it.effect("fails the execute once every dial budget is spent", () =>
+	it.effect("creates nothing for a scope that never touches the database", () =>
 		Effect.gen(function* () {
-			const rec = recorder(CONNECT_ATTEMPT_TIMEOUT_SECONDS.length)
-			const scope = makePgConnectionScope("postgres://unused", undefined, rec.openSocket)
+			const rec = recorder()
+			const scope = makePgConnectionScope("postgres://unused", undefined, {
+				openSocket: rec.openSocket,
+			})
 
-			const exit = yield* Effect.exit(scope.run(noop))
-
-			assert.isTrue(Exit.isFailure(exit))
-			assert.strictEqual(rec.budgets.length, CONNECT_ATTEMPT_TIMEOUT_SECONDS.length)
 			yield* Effect.promise(() => scope.close())
+
+			assert.strictEqual(rec.creations(), 0)
+			assert.strictEqual(rec.ends(), 0)
 		}),
 	)
 
 	it.effect("gives each execute its own drizzle client so statements cannot cross-attribute", () =>
 		Effect.gen(function* () {
 			const rec = recorder()
-			const scope = makePgConnectionScope("postgres://unused", undefined, rec.openSocket)
+			const scope = makePgConnectionScope("postgres://unused", undefined, {
+				openSocket: rec.openSocket,
+			})
 			const clients: Array<DatabaseClient> = []
 			const capture = (db: DatabaseClient) => {
 				clients.push(db)
@@ -158,20 +117,22 @@ describe("PgConnectionScope", () => {
 
 			yield* Effect.all([scope.run(capture), scope.run(capture)], { concurrency: 2 })
 
-			// One socket, two wrappers. A shared wrapper would share drizzle's logger
+			// One client, two wrappers. A shared wrapper would share drizzle's logger
 			// and put both calls' SQL on whichever span looked last.
-			assert.strictEqual(rec.budgets.length, 1)
+			assert.strictEqual(rec.creations(), 1)
 			assert.strictEqual(clients.length, 2)
 			assert.notStrictEqual(clients[0], clients[1])
 			yield* Effect.promise(() => scope.close())
 		}),
 	)
 
-	it.effect("reports reuse and dial count on the span", () =>
+	it.effect("reports reuse on the span", () =>
 		Effect.gen(function* () {
 			const rec = recorder()
 			const { spans, tracer } = makeRecordingTracer()
-			const scope = makePgConnectionScope("postgres://unused", undefined, rec.openSocket)
+			const scope = makePgConnectionScope("postgres://unused", undefined, {
+				openSocket: rec.openSocket,
+			})
 
 			yield* scope.run(noop).pipe(Effect.withTracer(tracer))
 			yield* scope.run(noop).pipe(Effect.withTracer(tracer))
@@ -181,68 +142,6 @@ describe("PgConnectionScope", () => {
 			assert.isDefined(second)
 			assert.strictEqual(first.attributes.get("db.connect.reused"), false)
 			assert.strictEqual(second.attributes.get("db.connect.reused"), true)
-			assert.strictEqual(second.attributes.get("db.connect.dials"), 1)
-			yield* Effect.promise(() => scope.close())
-		}),
-	)
-
-	it.effect("close is a no-op when nothing ever dialed", () =>
-		Effect.gen(function* () {
-			const rec = recorder()
-			const scope = makePgConnectionScope("postgres://unused", undefined, rec.openSocket)
-
-			yield* Effect.promise(() => scope.close())
-
-			assert.strictEqual(rec.budgets.length, 0)
-			assert.strictEqual(rec.ends(), 0)
-		}),
-	)
-
-	it.effect("close waits for an in-flight dial instead of orphaning the socket", () =>
-		Effect.gen(function* () {
-			let releaseDial: (() => void) | undefined
-			let ends = 0
-			const scope = makePgConnectionScope("postgres://unused", undefined, () =>
-				fakeSocket({
-					onConnect: () =>
-						new Promise<void>((resolve) => {
-							releaseDial = resolve
-						}),
-					onEnd: () => {
-						ends += 1
-					},
-				}),
-			)
-
-			// Start a call, let it reach the dial, then close while it is still open —
-			// the request-aborted-mid-dial case. Without the `await pending` branch the
-			// socket lands after close and holds its slot with nobody to release it.
-			const running = yield* Effect.forkChild(scope.run(noop))
-			yield* Effect.yieldNow
-			assert.isDefined(releaseDial)
-
-			const closing = yield* Effect.forkChild(Effect.promise(() => scope.close()))
-			releaseDial?.()
-			yield* Fiber.await(running)
-			yield* Fiber.await(closing)
-
-			assert.strictEqual(ends, 1)
-		}),
-	)
-
-	it.effect("clears the memo after a total dial failure so a later call retries", () =>
-		Effect.gen(function* () {
-			// Both budgets fail on the first call; the second call must get its own
-			// budget rather than inheriting the rejected promise.
-			const rec = recorder(CONNECT_ATTEMPT_TIMEOUT_SECONDS.length)
-			const scope = makePgConnectionScope("postgres://unused", undefined, rec.openSocket)
-
-			const first = yield* Effect.exit(scope.run(noop))
-			const second = yield* scope.run(noop)
-
-			assert.isTrue(Exit.isFailure(first))
-			assert.strictEqual(second, "ok")
-			assert.strictEqual(rec.budgets.length, CONNECT_ATTEMPT_TIMEOUT_SECONDS.length + 1)
 			yield* Effect.promise(() => scope.close())
 		}),
 	)
@@ -254,7 +153,7 @@ describe("PgConnectionScope", () => {
 			const scope = makePgConnectionScope(
 				"postgres://unused",
 				{ "db.namespace": "maple", "server.address": "cfg.hyperdrive.local" },
-				rec.openSocket,
+				{ openSocket: rec.openSocket },
 			)
 
 			yield* scope.run(noop).pipe(Effect.withTracer(tracer))
@@ -263,6 +162,32 @@ describe("PgConnectionScope", () => {
 			assert.isDefined(span)
 			assert.strictEqual(span.attributes.get("db.namespace"), "maple")
 			assert.strictEqual(span.attributes.get("server.address"), "cfg.hyperdrive.local")
+			yield* Effect.promise(() => scope.close())
+		}),
+	)
+
+	it.effect("surfaces a failing statement without swallowing it", () =>
+		Effect.gen(function* () {
+			const rec = recorder()
+			const scope = makePgConnectionScope("postgres://unused", undefined, {
+				openSocket: rec.openSocket,
+			})
+
+			// With no probe there is no separate connect phase: a connection problem
+			// arrives as the statement's own error, which is what `postgres-errors`
+			// classifies.
+			const exit = yield* Effect.exit(
+				scope.run(() =>
+					Promise.reject(
+						Object.assign(new Error("write CONNECT_TIMEOUT"), {
+							code: "CONNECT_TIMEOUT",
+						}),
+					),
+				),
+			)
+
+			assert.isTrue(Exit.isFailure(exit))
+			assert.strictEqual(rec.creations(), 1)
 			yield* Effect.promise(() => scope.close())
 		}),
 	)
@@ -281,7 +206,7 @@ const countingScope = () => {
 }
 
 describe("withPgConnectionScopeOf", () => {
-	it.effect("releases the socket when the program succeeds", () =>
+	it.effect("releases the connection when the program succeeds", () =>
 		Effect.gen(function* () {
 			const { scope, closes } = countingScope()
 
@@ -292,20 +217,20 @@ describe("withPgConnectionScopeOf", () => {
 		}),
 	)
 
-	it.effect("releases the socket when the program fails, and preserves the error", () =>
+	it.effect("releases the connection when the program fails, and preserves the error", () =>
 		Effect.gen(function* () {
 			const { scope, closes } = countingScope()
 
 			const exit = yield* Effect.exit(withPgConnectionScopeOf(scope, Effect.fail("boom")))
 
-			// A leak here is the worst case: the request is over, but its socket is
-			// still holding one of the Worker's six outbound slots.
+			// A leak here is the worst case: the request is over, but its connection
+			// is still holding one of the Worker's six outbound slots.
 			assert.strictEqual(closes(), 1)
 			assert.isTrue(Exit.isFailure(exit))
 		}),
 	)
 
-	it.effect("releases the socket when the program is interrupted", () =>
+	it.effect("releases the connection when the program is interrupted", () =>
 		Effect.gen(function* () {
 			const { scope, closes } = countingScope()
 			const fiber = yield* Effect.forkChild(withPgConnectionScopeOf(scope, Effect.never))
@@ -346,7 +271,7 @@ describe("withPgConnectionScope", () => {
 				Effect.provideService(WorkerEnvironment, hyperdriveEnv),
 			)
 
-			// Lazy: resolving the binding must not dial. Nothing here reaches the
+			// Lazy: resolving the binding must not connect. Nothing here reaches the
 			// network, and the host above does not resolve.
 			assert.isDefined(scope)
 		}),

--- a/apps/api/src/platform/pg-connection-scope.ts
+++ b/apps/api/src/platform/pg-connection-scope.ts
@@ -5,35 +5,28 @@ import type { HttpMiddleware } from "effect/unstable/http"
 import type { DatabaseClient, DatabaseError } from "./DatabaseLive"
 import { executeWithSpan } from "./DatabaseLive"
 import { resolveDbConnectionSource } from "./pg-connection-source"
-import { CONNECT_ATTEMPT_TIMEOUT_SECONDS } from "./pg-execute"
 
 /**
- * One socket per scope, never more.
+ * One connection per scope, never more.
  *
- * The constraint that actually bites is Cloudflare's cap of six simultaneous
- * outbound connections per Worker. `cache.match()` holds a slot until response
- * headers arrive and cannot be cancelled, and warehouse `fetch()` calls hold
- * theirs for 110ms to several seconds (measured — see lib/cache/src/edge-cache.ts).
- * Postgres dials queue behind them, which is why `db.connect_ms` is bimodal:
- * a dial either finds a free slot in ~12ms or never lands at all.
- *
- * Raising this trades directly against that budget, so it stays at 1 and
- * concurrent statements pipeline over the single connection instead.
+ * Deliberately not the `max: 5` Cloudflare's Hyperdrive example uses. A Worker
+ * gets six simultaneous outbound connections in total, and `cache.match()` holds
+ * one until response headers arrive and cannot be cancelled, while warehouse
+ * `fetch()` calls hold theirs for 110ms to several seconds — measured, with
+ * numbers, in lib/cache/src/edge-cache.ts. Postgres competes with those for the
+ * same six, so the pool size is capped independently of anything to do with
+ * dialing. Concurrent statements pipeline over the single connection instead.
  */
 const SCOPE_MAX_CONNECTIONS = 1
 
 /**
- * A per-request (or per-tick) Postgres connection, dialed at most once and
+ * A per-request (or per-tick) Postgres connection, created at most once and
  * shared by every `Database.execute` inside the scope.
  */
 export interface PgConnectionScopeShape {
-	/** Run one logical DB call on the scope's socket, inside the standard client span. */
+	/** Run one logical DB call on the scope's connection, inside the standard client span. */
 	readonly run: <T>(fn: (db: DatabaseClient) => Promise<T>) => Effect.Effect<T, DatabaseError>
-	/**
-	 * Release the socket. Safe to call when nothing was ever dialed, and safe to
-	 * call while a dial is still in flight — it waits for that dial rather than
-	 * leaving an orphaned socket to land after the request is gone.
-	 */
+	/** Release the connection. Safe when nothing was ever created. */
 	readonly close: () => Promise<void>
 }
 
@@ -41,7 +34,7 @@ export interface PgConnectionScopeShape {
  * The scope in force for the current fiber, or `undefined` outside one.
  *
  * A reference rather than a service so `DatabasePgLive` can read it at call
- * time and fall back to dial-per-execute where no scope was installed
+ * time and fall back to a per-call client where no scope was installed
  * (Workflow entrypoints, tests, any future entry point that forgets to wrap).
  */
 export class PgConnectionScope extends Context.Reference<PgConnectionScopeShape | undefined>(
@@ -50,98 +43,63 @@ export class PgConnectionScope extends Context.Reference<PgConnectionScopeShape 
 ) {}
 
 /**
+ * Test seam: how to create the scope's client. Real callers pass nothing.
+ * Same precedent as `tracedPgConnectionFrom`, which exists so the Workflow
+ * tests can drive a connection they own.
+ */
+export interface PgConnectionScopeSeams {
+	readonly openSocket?: () => MaplePgSocketHandle
+}
+
+/**
  * Build a scope over one connection string.
  *
- * Dialing is lazy — a request that never touches the database never opens a
- * socket — and single-flighted, so concurrent first calls share one dial
- * instead of racing two into the same six-slot budget.
+ * This is Cloudflare's documented Hyperdrive shape — one client per request,
+ * created lazily, closed at the boundary — reached through a `Context.Reference`
+ * because `Database.execute` is called from ~200 places that cannot each be
+ * handed the client.
+ *
+ * There is no dial step, no retry and no failure latch. postgres.js connects on
+ * the first query, so creating the client is synchronous and cannot fail; a
+ * connection problem surfaces as that query's error, classified by
+ * `postgres-errors.ts`. The machinery that used to live here — a 2s/8s dial
+ * budget, a retry for the budget, and a cooldown for the retry — was a chain of
+ * compensations for a cap we imposed ourselves.
  */
 export const makePgConnectionScope = (
 	connectionString: string,
 	extraAttributes?: Record<string, unknown>,
-	/**
-	 * Test seam: how to open one socket, given that attempt's dial budget in
-	 * seconds. Real callers take the default. Same precedent as
-	 * `tracedPgConnectionFrom`, which exists so the Workflow tests can drive a
-	 * connection they own.
-	 */
-	openSocket: (connectTimeoutSeconds: number) => MaplePgSocketHandle = (connectTimeoutSeconds) =>
-		createMaplePgSocket(connectionString, {
-			maxConnections: SCOPE_MAX_CONNECTIONS,
-			connectTimeoutSeconds,
-		}),
+	seams?: PgConnectionScopeSeams,
 ): PgConnectionScopeShape => {
+	const openSocket =
+		seams?.openSocket ??
+		(() => createMaplePgSocket(connectionString, { maxConnections: SCOPE_MAX_CONNECTIONS }))
+
 	let socket: MaplePgSocketHandle | undefined
-	let pending: Promise<MaplePgSocketHandle> | undefined
-	let dials = 0
-
-	const dial = async (): Promise<MaplePgSocketHandle> => {
-		let lastConnectError: unknown
-		for (let attempt = 0; attempt < CONNECT_ATTEMPT_TIMEOUT_SECONDS.length; attempt++) {
-			const handle = openSocket(CONNECT_ATTEMPT_TIMEOUT_SECONDS[attempt])
-			dials += 1
-			try {
-				await handle.awaitConnected()
-				return handle
-			} catch (error) {
-				// Dial-only retry, same invariant as `executeOnFreshPgClient`: nothing
-				// has been issued on this socket, so re-dialing cannot re-run a
-				// statement. Drop the dead socket before trying again so a failed
-				// attempt does not hold its slot.
-				lastConnectError = error
-				await handle.end().catch(() => undefined)
-			}
-		}
-		throw lastConnectError
-	}
-
-	const acquire = (): Promise<MaplePgSocketHandle> => {
-		if (socket !== undefined) return Promise.resolve(socket)
-		// A failed dial clears the memo so a later call in the same scope gets its
-		// own budget rather than inheriting a poisoned one — matching what
-		// dial-per-execute did before.
-		pending ??= dial().then(
-			(handle) => {
-				socket = handle
-				pending = undefined
-				return handle
-			},
-			(error) => {
-				pending = undefined
-				throw error
-			},
-		)
-		return pending
-	}
 
 	return {
 		run: <T>(fn: (db: DatabaseClient) => Promise<T>) =>
 			executeWithSpan(async (hooks) => {
-				const dialsBefore = dials
-				const handle = await acquire()
-				// `reused` is derived from whether this call actually dialed, not from
-				// whether a socket existed on entry — otherwise concurrent first calls
-				// would all claim to have dialed when only one of them did.
-				hooks.record({ "db.connect.reused": dials === dialsBefore, "db.connect.dials": dials })
-				hooks.markConnected()
+				// Lazy: a request that never touches the database never creates one.
+				const reused = socket !== undefined
+				socket ??= openSocket()
+				hooks.record({ "db.connect.reused": reused })
 				// Wrapped per call so each call's statements land in its own span.
 				// One shared wrapper would cross-attribute `db.query.text` between
 				// concurrent executes; the wrapper is cheap (relational config only).
-				return await fn(wrapMaplePgClient(handle.sql, { onQuery: hooks.collect }))
+				return await fn(wrapMaplePgClient(socket.sql, { onQuery: hooks.collect }))
 			}, extraAttributes),
 
 		close: async () => {
-			if (pending !== undefined) await pending.catch(() => undefined)
 			const open = socket
 			socket = undefined
-			pending = undefined
 			if (open !== undefined) await open.end().catch(() => undefined)
 		},
 	}
 }
 
 /**
- * Run `program` against `scope`, releasing the socket however the program
+ * Run `program` against `scope`, releasing the connection however the program
  * settles — success, failure, or interruption. Split from
  * `withPgConnectionScope` so the release contract can be tested without a
  * connection string or a live server.
@@ -177,7 +135,7 @@ export const withPgConnectionScope = <A, E, R>(
 	})
 
 /**
- * HTTP boundary for the scope: one socket per request.
+ * HTTP boundary for the scope: one connection per request.
  *
  * Also satisfies the api worker's standing requirement that SOME middleware be
  * present — `POST /mcp` hangs on Workers when `toWebHandler` is given none.

--- a/apps/api/src/platform/pg-execute.ts
+++ b/apps/api/src/platform/pg-execute.ts
@@ -3,78 +3,27 @@ import type { Effect } from "effect"
 import { type DatabaseClient, type DatabaseError, executeWithSpan } from "./DatabaseLive"
 
 /**
- * Per-attempt dial budgets, in seconds, for the request path.
- *
- * Production measurement behind these numbers: `db.connect_ms` is bimodal —
- * p50 12ms, but >5% never complete — while `db.query_ms` p95 is 83ms. So the
- * query is never the problem and a dial either lands immediately or stalls;
- * there is no middle.
- *
- * That shape is a slot budget, not a sick origin. Cloudflare caps a Worker at
- * six simultaneous outbound connections, and a `cache.match()` holds one until
- * response headers arrive and cannot be cancelled (lib/cache/src/edge-cache.ts
- * measured this directly). A dial either finds a free slot or queues behind an
- * uncancellable cache read and never lands.
- *
- * `db.connect.in_flight` was once read as evidence that "this is not our own
- * concurrency". It is not evidence of that: it counts only Postgres dials in
- * one isolate, so it cannot see the cache reads and warehouse fetches holding
- * the other slots. Reaching the origin a different way cannot help either —
- * dropping Hyperdrive for a direct PSBouncer socket moved dial failures
- * 4.68% -> 1.57% but cost 800ms per request, because that socket spends the
- * same slot. The lever that works is opening fewer sockets, which is what
- * `pg-connection-scope.ts` does.
- *
- * A short first attempt catches the common case without waiting on a stall.
- * The retry is what makes that safe — a dial can fail for no reason attributable
- * to this request, and postgres.js will not re-try it for us: `connectTimedOut`
- * destroys the socket and `errored()` rejects the queued query outright
- * (postgres 3.4.9, src/connection.js:261-264, :390-394).
- *
- * The second attempt gets a longer budget because a stall means Hyperdrive is
- * likely establishing a fresh origin connection to us-east-1 rather than
- * serving a warm one, and that legitimately takes seconds. Worst case is
- * bounded at ~10s instead of the driver's 30s default.
- *
- * Retrying is safe **only because it is dial-only** — see the loop below, which
- * never re-runs `fn` once a statement could have been issued.
- */
-export const CONNECT_ATTEMPT_TIMEOUT_SECONDS = [2, 8] as const
-
-/**
- * Workflow entrypoints run for minutes and dial once per run, so a
- * request-shaped bound would be wrong for them — but the driver's 30s default
- * is still longer than a dial should ever legitimately take.
- */
-const WORKFLOW_CONNECT_TIMEOUT_SECONDS = 10
-
-/**
- * Dials in progress in this isolate, sampled onto each span as
- * `db.connect.in_flight`.
- *
- * The open question this answers: whether a slow dial is slow on its own, or
- * slow because it is queued behind siblings competing for the isolate's
- * connection slots. Those two have different fixes, and the span cannot tell
- * them apart without this number.
- */
-let dialsInFlight = 0
-
-/**
- * Run one callback against a freshly dialed Postgres client, inside the
- * standard `Database.execute` client span.
+ * Run one callback against its own Postgres client, inside the standard
+ * `Database.execute` client span.
  *
  * This is the fallback path, used where no `PgConnectionScope` is installed:
  * the Workflow entrypoints (which can't take the Effect `Database` service,
  * since they run outside the worker's layer graph), tests, and any entry point
  * that has not been wrapped. Requests and cron ticks go through the scope
- * instead and dial once for the whole invocation.
+ * instead and share one client for the whole invocation.
  *
- * Dialing per call is safe but expensive. Workers tie TCP sockets to the
- * request that opened them, so a socket may be reused freely WITHIN an
- * invocation — it just must not outlive it. Every dial here spends one of the
- * Worker's six outbound connection slots for a full handshake plus a `select 1`
- * probe, so a route making five calls spends five. Transactions run inside one
- * callback, so atomicity is unaffected either way.
+ * A client per call is correct but wasteful. Workers tie TCP sockets to the
+ * request that opened them, so a connection may be reused freely WITHIN an
+ * invocation — it just must not outlive it — and each connection here spends one
+ * of the Worker's six outbound slots. Transactions run inside one callback, so
+ * atomicity is unaffected either way.
+ *
+ * There is no dial budget and no retry. postgres.js connects on the first
+ * statement, so there is no separate connect phase to bound or to re-attempt,
+ * and retrying a statement that may already have committed would make writes
+ * at-least-once. A connection failure surfaces as that statement's error and is
+ * classified by `postgres-errors.ts` (`error.type` = `CONNECT_TIMEOUT`,
+ * `ECONNREFUSED`, …).
  */
 export const executeOnFreshPgClient = <T>(
 	connectionString: string,
@@ -82,42 +31,16 @@ export const executeOnFreshPgClient = <T>(
 	extraAttributes?: Record<string, unknown>,
 ) =>
 	executeWithSpan(async (hooks) => {
-		let lastConnectError: unknown
-		for (let attempt = 0; attempt < CONNECT_ATTEMPT_TIMEOUT_SECONDS.length; attempt++) {
-			const { db, awaitConnected, end } = createMaplePgClient(connectionString, {
-				maxConnections: 1,
-				connectTimeoutSeconds: CONNECT_ATTEMPT_TIMEOUT_SECONDS[attempt],
-				onQuery: hooks.collect,
-			})
-			dialsInFlight += 1
-			try {
-				hooks.record({ "db.connect.in_flight": dialsInFlight, "db.retry.attempts": attempt })
-				// Establish the connection before running the query, so the span can
-				// attribute handshake time separately — without this the dial and the
-				// query are one opaque number and a stalled handshake is
-				// indistinguishable from slow SQL, which is the ambiguity that made
-				// the p95 investigation guesswork. Costs one extra round-trip per
-				// execute (see `awaitConnected`); revisit once the tail is understood.
-				try {
-					await awaitConnected()
-				} catch (error) {
-					// Dial-only retry. Nothing has been issued on this connection yet,
-					// so re-dialing cannot re-run a statement — which is the entire
-					// reason this is safe. A query-phase failure must never land here:
-					// a statement that timed out may already have committed, and
-					// retrying it would make writes at-least-once.
-					lastConnectError = error
-					continue
-				}
-				hooks.markConnected()
-				return await fn(db)
-			} finally {
-				dialsInFlight -= 1
-				// Never let a socket-teardown error shadow the real DB error from fn(db).
-				await end().catch(() => undefined)
-			}
+		const { db, end } = createMaplePgClient(connectionString, {
+			maxConnections: 1,
+			onQuery: hooks.collect,
+		})
+		try {
+			return await fn(db)
+		} finally {
+			// Never let a socket-teardown error shadow the real DB error from fn(db).
+			await end().catch(() => undefined)
 		}
-		throw lastConnectError
 	}, extraAttributes)
 
 /**
@@ -125,8 +48,8 @@ export const executeOnFreshPgClient = <T>(
  *
  * The Workflow entrypoints hold one client for the whole run and thread it
  * through helpers, so they can't use `executeOnFreshPgClient` (that would
- * re-dial per statement). `step()` wraps one logical unit of DB work in the
- * standard `Database.execute` client span instead.
+ * create a client per statement). `step()` wraps one logical unit of DB work in
+ * the standard `Database.execute` client span instead.
  */
 export interface TracedPgConnection {
 	readonly db: DatabaseClient
@@ -149,10 +72,8 @@ export const makeTracedPgConnection = (
 	extraAttributes?: Record<string, unknown>,
 ): TracedPgConnection => {
 	let collector: ((query: string) => void) | undefined
-	let connected = false
-	const { db, awaitConnected, end } = createMaplePgClient(connectionString, {
+	const { db, end } = createMaplePgClient(connectionString, {
 		maxConnections: 1,
-		connectTimeoutSeconds: WORKFLOW_CONNECT_TIMEOUT_SECONDS,
 		onQuery: (query) => collector?.(query),
 	})
 	return {
@@ -161,15 +82,6 @@ export const makeTracedPgConnection = (
 			executeWithSpan(async (hooks) => {
 				collector = hooks.collect
 				try {
-					// One dial serves the whole run, so only the first step pays for
-					// it; the rest report `db.connect_ms` ~0 and `reused: true`.
-					const reused = connected
-					if (!connected) {
-						await awaitConnected()
-						connected = true
-					}
-					hooks.record({ "db.connect.reused": reused })
-					hooks.markConnected()
 					return await fn(db)
 				} finally {
 					collector = undefined
@@ -184,19 +96,12 @@ export const makeTracedPgConnection = (
  * a PGlite-backed drizzle). No statement collector is available, so spans carry
  * kind, identity and timing but no `db.query.text`; `end` is a no-op because the
  * caller owns the connection.
- *
- * `markConnected` fires immediately: there is no dial to attribute here, so
- * without it the whole step would be miscounted as connect time.
  */
 export const tracedPgConnectionFrom = (
 	db: DatabaseClient,
 	extraAttributes?: Record<string, unknown>,
 ): TracedPgConnection => ({
 	db,
-	step: (fn) =>
-		executeWithSpan((hooks) => {
-			hooks.markConnected()
-			return fn(db)
-		}, extraAttributes),
+	step: (fn) => executeWithSpan(() => fn(db), extraAttributes),
 	end: () => Promise.resolve(),
 })

--- a/apps/api/src/services/integrations/ScrapeTargetsService.ts
+++ b/apps/api/src/services/integrations/ScrapeTargetsService.ts
@@ -23,6 +23,7 @@ import { scrapeTargetChecks, scrapeTargets, type ScrapeTargetCheckRow } from "@m
 import { and, desc, eq, gte, inArray, lte } from "drizzle-orm"
 import { Cause, Clock, Context, Effect, Exit, Layer, Option, Redacted, Schema } from "effect"
 import { encryptAes256Gcm, parseBase64Aes256GcmKey, type EncryptedValue } from "@/platform/Crypto"
+import { forkRequestScoped } from "@/platform/fork-request-scoped"
 import { Database } from "@/platform/DatabaseLive"
 import { Env } from "@/platform/Env"
 import {
@@ -665,13 +666,20 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 				// before it can record a result (e.g. a revoked/not-connected OAuth
 				// grant → ScrapeTargetAuthError) would otherwise leave the fresh target
 				// looking healthy with no log and no lastScrapeError row.
-				yield* probe(orgId, id).pipe(
-					Effect.catchCause((cause) =>
-						Effect.logWarning("Initial scrape probe failed").pipe(
-							Effect.annotateLogs({ orgId, scrapeTargetId: id, error: Cause.pretty(cause) }),
+				// Scoped, not detached: the probe records its result through the
+				// request's Postgres socket, which is released when the request ends.
+				yield* forkRequestScoped(
+					probe(orgId, id).pipe(
+						Effect.catchCause((cause) =>
+							Effect.logWarning("Initial scrape probe failed").pipe(
+								Effect.annotateLogs({
+									orgId,
+									scrapeTargetId: id,
+									error: Cause.pretty(cause),
+								}),
+							),
 						),
 					),
-					Effect.forkDetach,
 				)
 
 				return rowToResponse(row.value)

--- a/apps/api/src/services/org/ApiKeysService.ts
+++ b/apps/api/src/services/org/ApiKeysService.ts
@@ -18,6 +18,7 @@ import { and, desc, eq, isNull, lt, or } from "drizzle-orm"
 import { Clock, Effect, Layer, Option, Redacted, Schema, Context } from "effect"
 import { Database } from "@/platform/DatabaseLive"
 import { readTxid, txidColumn } from "@/platform/electric-txid"
+import { forkRequestScoped } from "@/platform/fork-request-scoped"
 import { Env } from "@/platform/Env"
 import { dateToMs, msToDate } from "@/platform/time"
 
@@ -431,7 +432,9 @@ export class ApiKeysService extends Context.Service<ApiKeysService>()("@maple/ap
 				),
 			)
 			if (Option.isSome(resolved)) {
-				yield* touchLastUsed(resolved.value.keyId).pipe(Effect.ignore, Effect.forkDetach)
+				// Scoped, not detached: this write shares the request's single Postgres
+				// socket, and a detached fiber can outlive the socket's release.
+				yield* forkRequestScoped(touchLastUsed(resolved.value.keyId).pipe(Effect.ignore))
 			}
 			return resolved
 		})

--- a/apps/api/src/services/org/OrgClickHouseSettingsService.ts
+++ b/apps/api/src/services/org/OrgClickHouseSettingsService.ts
@@ -42,7 +42,6 @@ import {
 	Ref,
 	Schedule,
 	Schema,
-	Scope,
 } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import {
@@ -53,6 +52,7 @@ import {
 } from "@/platform/Crypto"
 import { Database } from "@/platform/DatabaseLive"
 import { Env } from "@/platform/Env"
+import { forkRequestScoped } from "@/platform/fork-request-scoped"
 import { dateToMs } from "@/platform/time"
 import { validateExternalUrl } from "@/http/url-validator"
 
@@ -129,6 +129,29 @@ interface RuntimeConfigMemoEntry {
 }
 const runtimeConfigMemo = new Map<string, RuntimeConfigMemoEntry>()
 
+/**
+ * Recent failures of the blocking read, so one unreachable origin is not
+ * re-discovered by every caller.
+ *
+ * Only successes were ever memoized, which meant a failing Postgres cost every
+ * branch of an in-request fan-out its own full dial budget — the 22-per-trace
+ * shape described below, at ~10s each. Giving each request a single socket did
+ * not help: that reduced how many dials a HEALTHY request makes, not how many a
+ * failing one retries.
+ *
+ * Held for seconds, not the success TTL. The cost of being wrong is bounded and
+ * symmetric: an org whose database recovers within the window waits it out, and
+ * in exchange a degraded origin stops being hammered by callers that would each
+ * spend 10s failing. Failing fast also returns outbound connection slots, which
+ * is what lets the isolate recover at all.
+ */
+const ORG_CH_CONFIG_FAILURE_TTL_MS = 2_000
+interface RuntimeConfigFailureEntry {
+	readonly error: OrgClickHouseSettingsPersistenceError
+	readonly atMs: number
+}
+const runtimeConfigFailures = new Map<string, RuntimeConfigFailureEntry>()
+
 // Dedup marker for in-flight background refreshes, so N concurrent widget
 // requests that all find the same stale entry fork ONE Postgres read rather
 // than N.
@@ -163,6 +186,9 @@ const REFRESH_MARKER_STALE_MS = 10_000
 export const invalidateOrgRuntimeConfigMemo = (orgId: string): void => {
 	runtimeConfigMemo.delete(orgId)
 	refreshInFlight.delete(orgId)
+	// Third map, same rule: a stale failure must not outlive an explicit
+	// invalidation and turn a fresh write into a spurious read error.
+	runtimeConfigFailures.delete(orgId)
 }
 
 /**
@@ -1440,15 +1466,10 @@ export class OrgClickHouseSettingsService extends Context.Service<
 				Effect.ensuring(Effect.sync(() => refreshInFlight.delete(orgId))),
 			)
 
-			const scope = yield* Effect.serviceOption(Scope.Scope)
-			// HTTP routes always have a request scope (HttpRouter provides one).
-			// Non-HTTP callers — crons, queue consumers, workflows — do not, and there
-			// the calling fiber IS the whole job, so it is a safe parent.
-			if (Option.isSome(scope)) {
-				yield* Effect.forkIn(work, scope.value)
-			} else {
-				yield* Effect.forkChild(work)
-			}
+			// Scoped rather than detached — see `forkRequestScoped` for why anything
+			// that touches Postgres must not outlive the invocation that owns the
+			// socket. This call site is where that rule was first worked out.
+			yield* forkRequestScoped(work)
 			return true
 		})
 
@@ -1516,11 +1537,30 @@ export class OrgClickHouseSettingsService extends Context.Service<
 					return memoized.value
 				}
 
+				// Reuse a very recent failure rather than re-discovering it. Checked
+				// only on this branch: a usable memo above never reaches Postgres, so
+				// a blip can never take a served org offline — only callers that were
+				// going to make the blocking read anyway are short-circuited.
+				const failed = runtimeConfigFailures.get(orgId)
+				if (failed !== undefined && nowMs - failed.atMs < ORG_CH_CONFIG_FAILURE_TTL_MS) {
+					yield* Effect.annotateCurrentSpan({
+						"clickhouse.config.source": "postgres_failed",
+						"clickhouse.config.memoHit": false,
+						"clickhouse.config.failure_reused": true,
+					})
+					return yield* Effect.fail(failed.error)
+				}
+
 				yield* Effect.annotateCurrentSpan({
 					"clickhouse.config.source": "postgres",
 					"clickhouse.config.memoHit": false,
 				})
-				const cached = yield* readSettingsFromPostgres(orgId)
+				const cached = yield* readSettingsFromPostgres(orgId).pipe(
+					Effect.tapError((error) =>
+						Effect.sync(() => runtimeConfigFailures.set(orgId, { error, atMs: nowMs })),
+					),
+				)
+				runtimeConfigFailures.delete(orgId)
 				storeCachedSettings(orgId, cached, nowMs)
 				return cached
 			},

--- a/apps/api/test/integration/pg-connection-scope.integration.test.ts
+++ b/apps/api/test/integration/pg-connection-scope.integration.test.ts
@@ -76,21 +76,21 @@ describe.skipIf(PG_URL === undefined)("PgConnectionScope against a real Postgres
 		await waitForBackends(0)
 		const scope = makePgConnectionScope(url)
 
+		// Sampled AFTER each execute, not inside it: the client is lazy, so before
+		// the first statement runs there is legitimately no connection yet.
 		const observed: Array<number> = []
-		for (let i = 0; i < 5; i++) {
-			await Effect.runPromise(
-				scope.run(async (db: DatabaseClient) => {
-					observed.push(await backends())
-					return db.execute(sql`select 1 as one`)
-				}),
-			)
+		try {
+			for (let i = 0; i < 5; i++) {
+				await Effect.runPromise(scope.run((db: DatabaseClient) => db.execute(sql`select 1 as one`)))
+				observed.push(await backends())
+			}
+		} finally {
+			await scope.close()
 		}
 
-		// The claim the whole PR rests on: five executes, one connection. Before
-		// this change each of these was its own handshake and its own slot.
+		// The claim this rests on: five executes, one connection. Each of these
+		// used to be its own handshake and its own outbound slot.
 		assert.deepStrictEqual(observed, [1, 1, 1, 1, 1])
-
-		await scope.close()
 		assert.strictEqual(await waitForBackends(0), 0)
 	})
 
@@ -109,7 +109,7 @@ describe.skipIf(PG_URL === undefined)("PgConnectionScope against a real Postgres
 			).pipe(Effect.withTracer(tracer)),
 		)
 
-		assert.strictEqual(await backends(), 1)
+		const backendsDuring = await backends()
 
 		// The real test of the per-call `wrapMaplePgClient`. Drizzle fixes its
 		// logger at construction, so a single shared wrapper would put both
@@ -123,6 +123,7 @@ describe.skipIf(PG_URL === undefined)("PgConnectionScope against a real Postgres
 		assert.strictEqual(beta.length, 1)
 		assert.notInclude(alpha[0], "beta_marker")
 		assert.notInclude(beta[0], "alpha_marker")
+		assert.strictEqual(backendsDuring, 1)
 
 		await scope.close()
 	})
@@ -167,10 +168,10 @@ describe.skipIf(PG_URL === undefined)("PgConnectionScope against a real Postgres
 		await scope.close()
 	})
 
-	it("classifies a refused dial as a connection error on a real socket", async () => {
-		// Port 1 is refused immediately, so both attempt budgets are spent in
-		// milliseconds. This closes the loop on postgres-errors.ts, which the unit
-		// suite only exercises against hand-built error objects.
+	it("classifies a refused connection as a connection error on a real socket", async () => {
+		// Port 1 is refused immediately. This closes the loop on postgres-errors.ts,
+		// which the unit suite only exercises against hand-built error objects, and
+		// is the diagnostic that replaced the connect/query duration split.
 		const scope = makePgConnectionScope("postgres://maple:maple@127.0.0.1:1/never")
 		const { spans, tracer } = makeRecordingTracer()
 
@@ -186,8 +187,49 @@ describe.skipIf(PG_URL === undefined)("PgConnectionScope against a real Postgres
 		}
 		const [span] = dbSpans(spans)
 		assert.isDefined(span)
-		assert.strictEqual(span.attributes.get("db.connect.completed"), false)
+		assert.strictEqual(span.attributes.get("db.connect.failed"), true)
 		assert.isDefined(span.attributes.get("error.type"))
+
+		await scope.close()
+	})
+
+	it("opens one connection for a whole fan-out against an unreachable origin", async () => {
+		// The production shape this exists for: a request whose branches all miss
+		// the org-config memo, against an origin that cannot be reached. Each branch
+		// must reuse the scope's one client rather than creating its own — an
+		// unreachable origin should cost one connection attempt's worth of outbound
+		// slot, not N.
+		//
+		// Real clients, counted: `openSocket` wraps the production constructor
+		// rather than replacing it, so this measures the same code path the unit
+		// test fakes.
+		let creations = 0
+		const scope = makePgConnectionScope("postgres://maple:maple@127.0.0.1:1/never", undefined, {
+			openSocket: () => {
+				creations += 1
+				return createMaplePgSocket("postgres://maple:maple@127.0.0.1:1/never", {
+					maxConnections: 1,
+				})
+			},
+		})
+
+		// Sequential on purpose: a concurrent version would pass trivially. The case
+		// that matters is the branch arriving after the previous failure resolved,
+		// which must not decide to start over with a new client.
+		const results: Array<"ok" | "rejected"> = []
+		for (let i = 0; i < 10; i++) {
+			results.push(
+				await Effect.runPromise(scope.run((db: DatabaseClient) => db.execute(sql`select 1`)))
+					.then(() => "ok" as const)
+					.catch(() => "rejected" as const),
+			)
+		}
+
+		assert.deepStrictEqual(
+			results,
+			Array.from({ length: 10 }, () => "rejected" as const),
+		)
+		assert.strictEqual(creations, 1)
 
 		await scope.close()
 	})

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -8,35 +8,21 @@ import * as schema from "./schema"
 export type MaplePgSocket = ReturnType<typeof postgres>
 
 /**
- * One dialed socket, without any drizzle wrapper bound to it.
+ * One client, without any drizzle wrapper bound to it.
  *
- * Split out from `MaplePgConnection` so a caller can hold ONE socket across
- * many logical calls while still giving each call its own `onQuery` collector —
+ * Split out from `MaplePgConnection` so a caller can hold ONE client across many
+ * logical calls while still giving each call its own `onQuery` collector —
  * drizzle fixes its logger at construction, so collector isolation has to come
- * from a per-call `wrapMaplePgClient`, not from a per-call socket. That is what
- * lets the request path dial once instead of once per `execute`.
+ * from a per-call `wrapMaplePgClient`, not from a per-call client.
+ *
+ * There is deliberately no "wait until connected" member. postgres.js connects
+ * lazily on the first query, so a separate connect step can only be synthesized
+ * with a `select 1`, and that round trip bought nothing but a telemetry split.
+ * Its absence is what lets the request path create a client synchronously.
  */
 export interface MaplePgSocketHandle {
 	/** The raw postgres.js client. Wrap it per call with `wrapMaplePgClient`. */
 	readonly sql: MaplePgSocket
-	/**
-	 * Resolves once the connection is usable, so callers can time the dial
-	 * separately from the query.
-	 *
-	 * This costs one `select 1` round-trip, which is not free and is not the
-	 * first design we tried. postgres.js' `reserve()` looks like the zero-cost
-	 * answer but silently never resolves under `fetch_types: false`: it passes
-	 * the reservation as the connection's `initial` query, and the ReadyForQuery
-	 * handler only re-enters (and so only calls `onopen`, which is what resolves
-	 * the reservation) via the `needsTypes` branch. With type fetching off that
-	 * branch is skipped, `initial` is dropped, and the promise hangs forever.
-	 * Verified against postgres 3.4.9, src/connection.js:554-570.
-	 *
-	 * The probe goes through the raw postgres.js client rather than drizzle, so
-	 * it never reaches the `onQuery` collector and cannot pollute
-	 * `db.query.text`.
-	 */
-	readonly awaitConnected: () => Promise<void>
 	/** Closes the underlying postgres.js connection pool. */
 	readonly end: () => Promise<void>
 }
@@ -74,11 +60,15 @@ const toDrizzleLogger = (onQuery: ((query: string) => void) | undefined) =>
 	onQuery ? { logQuery: (query: string, _params: unknown[]) => onQuery(query) } : undefined
 
 /**
- * Dial one postgres.js socket, for real Postgres (PlanetScale via Hyperdrive in
- * Workers, docker-compose Postgres in `wrangler dev`, direct URLs in scripts).
+ * Create one postgres.js client, for real Postgres (PlanetScale via Hyperdrive
+ * in Workers, docker-compose Postgres in `wrangler dev`, direct URLs in
+ * scripts).
+ *
+ * Creating one costs nothing: postgres.js connects lazily on the first query,
+ * so this is synchronous and does not touch the network.
  *
  * Workers note: TCP sockets are tied to the request that opened them, so a
- * socket may be reused freely WITHIN a request but must never outlive it. The
+ * client may be reused freely WITHIN a request but must never outlive it. The
  * request path holds one of these per request (`maxConnections: 1`) and `end()`s
  * it at the boundary — see apps/api/src/platform/pg-connection-scope.ts.
  * `fetch_types: false` skips the pg_types round-trip (we only use built-in
@@ -104,13 +94,7 @@ export const createMaplePgSocket = (
 		// back to the driver default.
 		...(connectTimeoutSeconds === undefined ? {} : { connect_timeout: connectTimeoutSeconds }),
 	})
-	return {
-		sql,
-		awaitConnected: async () => {
-			await sql`select 1`
-		},
-		end: () => sql.end(),
-	}
+	return { sql, end: () => sql.end() }
 }
 
 /**


### PR DESCRIPTION
**350 insertions, 503 deletions.** This removes three mechanisms rather than adding a fourth.

## Why

Production kept emitting `CONNECT_TIMEOUT` after #408, tagged as a warehouse error on the `capabilities` pipe. It isn't a warehouse failure — `"capabilities"` is just the label `resolveRoute` passes (`executor.ts:284`); the real failure is a Postgres read in `OrgClickHouseSettingsService.selectCachedRow`, re-tagged at `WarehouseQueryService.ts:350-360`. The request *was* inside a connection scope and the scope worked. Its one connection failed.

#408 was never going to stop that: it reduced how many connections a healthy request opens, not what happens when one fails.

## The chain being removed

| Commit | Added | Because |
|---|---|---|
| `a61f4d2` | 2s dial cap | dials stalled to Hyperdrive's 15s; p99 was 15.4s |
| `aa67037` | retry at 8s | the cap alone took 5xx from 0.06% → **5.01%** |
| `d967e4e` | one connection per request | requests opened 4–6 |
| *(next would have been)* | failure cooldown | the retry re-arms per sibling, so failures fan out |

Each layer fixes the previous layer's side effect. Cloudflare's Hyperdrive example is one lazily-created client per request; #408 already converged on that, and everything stacked above it was ours.

## What dropping the probe unlocks

The `select 1` probe existed to synthesize a connect phase so `db.connect_ms`/`db.query_ms` could be split — at the cost of a round trip on every DB-touching request. Without it, **postgres.js connects on the first statement, so creating a client is synchronous and cannot fail.** That removes the async dial, the single-flight promise, and any need for a failure latch in one move:

```ts
const acquire = () => (socket ??= openSocket())
```

A connection problem now arrives as the statement's own error, classified by `postgres-errors.ts` — `error.type` states outright what the duration split was being used to infer.

`executeOnFreshPgClient` and `makeTracedPgConnection` shed the same machinery.

## Deliberately kept

Neither belongs to the compensation chain:

- **`max: 1`** — capped by Cloudflare's six-simultaneous-outbound-connection budget (measured with numbers in `lib/cache/src/edge-cache.ts:122-150`), not by anything to do with dialing. Not reverted to the example's `max: 5`.
- **Per-call `wrapMaplePgClient`** — drizzle fixes its logger at construction, so a shared wrapper cross-attributes SQL between concurrent executes.

## Also here, independent of the connection mechanism

- A short **negative cache** on the org-config read, so an unreachable origin isn't re-discovered by every branch of the documented 22-branch in-request fan-out.
- **`forkRequestScoped`** replacing `Effect.forkDetach` at `ApiKeysService.ts:434` and `ScrapeTargetsService.ts:674`. A detached fiber inherits the scope reference but not the request lifetime, so it could outlive the connection it writes through — a latent bug from #408.

## Accepted trade

With no cap and no retry, a bad connection can stall toward Hyperdrive's timeout instead of failing at 10s. `a61f4d2` measured that under dial-per-execute, so the exposure is now **one** connection per request rather than four to six. The explicit intent is to simplify, then measure — nothing has been measured since #408 deployed. `aa67037`'s 5.01% figure was *cap-without-retry*, a different configuration, and shouldn't be read as a prediction here.

## Verification

- `bun typecheck` 37/37; `lint:effect` clean.
- `@maple/api` 1677 passed, `@maple/db` 5 passed.
- Real-Postgres integration suite 5/5 (runs in the `Postgres connection scope E2E` CI job).
- **Mutation-checked**: sharing one drizzle wrapper fails the cross-attribution test with `beta_marker` appearing on alpha's span; raising `max` above 1 fails the `pg_stat_activity` backend count.
- One integration assertion genuinely changed meaning and was fixed rather than forced: sampling backends *inside* the first execute now legitimately reads 0, because the client is lazy. It samples after each execute instead.

Pre-existing failures unrelated to this change: `@maple/cli` (needs `/usr/bin/time` + IPv6), `@maple/domain` (`project-manifest.test.ts` 5s timeout), `@maple/alerting` (`vitest: command not found` in my container only).

## Follow-up worth settling

`61314afdf90bb5d91780b0244ff87901` — the Hyperdrive host in the production error — appears nowhere in the repo, yet `stage.ts:191-200` hardcodes `ad4c4878…` for prd api and `f4731672…` for prd alerting. Worth querying `Database.execute` spans by `server.address` / `service.name` / `deployment.environment.name` to confirm which worker and stage that host belongs to. If prd api is bound to an unlisted config, the api/alerting pool split from `0b27213` may not be in effect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbizSpW9vjfVRrBKZvwHPS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789042590&installation_model_id=427786&pr_number=416&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F416&signature=2d8f2ba4681b58aecab2d6216d3ef36742f917af59a3e4c2a40ab511dfd8762c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->