### PR TITLE
fix(ci): stop knip failing main on type-test files

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -8,7 +8,7 @@
 		"lib/llm",
 		"lib/thinking-orbs"
 	],
-	"ignore": ["**/routeTree.gen.ts", ".context/**", ".deepsec/**"],
+	"ignore": ["**/routeTree.gen.ts", ".context/**", ".deepsec/**", "**/*.type-test.ts"],
 	"ignoreExportsUsedInFile": true,
 	"workspaces": {
 		".": {


### PR DESCRIPTION
One line. `main` is currently red and this unblocks it.

## What's broken

`d9af3db "harden Effect Oxlint audit"` added `lib/effect-db/src/electric/handlers.type-test.ts`. knip's `files` rule is `error`, and a `.type-test.ts` is compile-time only — it asserts types and is never imported, so knip correctly sees an unreferenced file and correctly fails the build:

```
Unused files (1)
lib/effect-db/src/electric/handlers.type-test.ts
...
error: script "knip" exited with code 1
```

Both `main` runs since then have failed on it (`d9af3db` 11:26, `a8cbd35e` 12:01), in `TypeScript (test-packages)`.

## The fix

Adds `**/*.type-test.ts` to knip's `ignore`. Pattern rather than the single path, because every future type test has the same shape, and the alternative — listing each as a workspace entry point — would have to be repeated per workspace.

## One thing worth calling out

The same knip output lists five unused exports and one duplicate export, and they draw the eye because they're the last thing printed before the failure. **They are not the cause.** `knip.json` sets `"exports": "warn"` and `"duplicates": "warn"`, so they cannot fail CI. I checked each before concluding that:

- the three `apps/cli/src/server/local-store-migrations.ts` entries are redundant re-exports of modules already imported and used internally in the same file;
- `CurrentMcpTenant` / `resolveTenant` are both genuinely used — the class in `provideService`/`Layer.succeed`/type positions, the alias in ~50 MCP tool files — so that pair is intentional, not dead code.

Nothing there needs changing, and this PR doesn't touch them.

## Verification

`bun run knip` locally no longer reports the type-test file (0 occurrences, down from 1 unused-file error). The only remaining `Unused files` entry in my environment is `apps/alerting/src/worker.test.ts`, which is a local-only artifact of `vitest` not resolving in this container — CI's run listed the type-test file alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbizSpW9vjfVRrBKZvwHPS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789043284&installation_model_id=427786&pr_number=417&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F417&signature=a5e82ee6cad1c21d9da6c8ff9d74e384e374577be63f9db9633accee50ac77a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->