### PR TITLE
Finish Effect audit hardening

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -89,6 +89,15 @@ const createProductionSharedResources = (stage: ReturnType<typeof parseMapleStag
  */
 const DEPLOY_AWS_INGEST = process.env.MAPLE_DEPLOY_AWS_INGEST === "1"
 
+type StackProviderServices =
+	| Layer.Services<ReturnType<typeof Cloudflare.providers>>
+	| Layer.Services<ReturnType<typeof AWS.providers>>
+
+const providers: Layer.Layer<StackProviderServices, never, Alchemy.StackServices> =
+	DEPLOY_AWS_INGEST
+		? Cloudflare.providers().pipe(Layer.provideMerge(AWS.providers()))
+		: Cloudflare.providers()
+
 export default Alchemy.Stack(
 	"maple",
 	{
@@ -104,9 +113,7 @@ export default Alchemy.Stack(
 		// they deploy in the same run. Unset, this stack is byte-identical to the
 		// last one that shipped (2m05s), so production keeps deploying while the
 		// hang is investigated with the flag on.
-		providers: DEPLOY_AWS_INGEST
-			? Layer.mergeAll(Cloudflare.providers(), AWS.providers())
-			: Cloudflare.providers(),
+		providers,
 		// Shared account-wide state store (Worker + DO SQLite) — bootstrapped once
 		// per Cloudflare account (`alchemy bootstrap cloudflare` or the first
 		// `deploy --yes`). ALCHEMY_LOCAL_STATE=1 opts into .alchemy/ file state for

--- a/apps/alerting/src/worker.ts
+++ b/apps/alerting/src/worker.ts
@@ -229,7 +229,12 @@ export const catchTickFailure = (label: string) =>
 	Effect.catchCause((cause: Cause.Cause<unknown>) =>
 		Cause.hasInterruptsOnly(cause)
 			? Effect.interrupt
-			: Effect.logError(label).pipe(Effect.annotateLogs({ error: Cause.pretty(cause) })),
+			: Effect.logError("Alerting tick failed").pipe(
+					Effect.annotateLogs({
+						"error.message": Cause.pretty(cause),
+						"maple.alerting.tick": label,
+					}),
+				),
 	)
 
 interface TickAnnotations {
@@ -239,25 +244,34 @@ interface TickAnnotations {
 const makeTick = <A, E, R>(
 	run: Effect.Effect<A, E, R>,
 	spanKey: string,
-	label: string,
 	annotationsFor: (result: A) => TickAnnotations | undefined,
 ): Effect.Effect<void, never, R> =>
 	run.pipe(
 		Effect.tap((result) => {
 			const annotations = annotationsFor(result)
-			return annotations === undefined
+			const namespacedAnnotations =
+				annotations === undefined
+					? undefined
+					: Object.fromEntries(
+							Object.entries(annotations).map(([key, value]) => [
+								`maple.alerting.${key}`,
+								value,
+							]),
+						)
+			return namespacedAnnotations === undefined
 				? Effect.succeed(undefined)
-				: Effect.logInfo(`${label} complete`).pipe(Effect.annotateLogs(annotations))
+				: Effect.logInfo("Alerting tick completed").pipe(
+						Effect.annotateLogs({ ...namespacedAnnotations, "maple.alerting.tick": spanKey }),
+					)
 		}),
 		Effect.asVoid,
 		Effect.withSpan(`alerting.${spanKey}_tick`),
-		catchTickFailure(`${label} failed`),
+		catchTickFailure(spanKey),
 	)
 
 const alertTick = makeTick(
 	AlertsService.use((alerts) => alerts.runSchedulerTick()),
 	"scheduler",
-	"Alerting worker tick",
 	(result) => ({
 		evaluatedCount: result.evaluatedCount,
 		processedCount: result.processedCount,
@@ -269,7 +283,6 @@ const alertTick = makeTick(
 const errorTick = makeTick(
 	ErrorsService.use((errors) => errors.runTick()),
 	"error",
-	"Errors worker tick",
 	(result) => ({
 		orgsProcessed: result.orgsProcessed,
 		issuesTouched: result.issuesTouched,
@@ -285,7 +298,6 @@ const errorTick = makeTick(
 const escalationTick = makeTick(
 	EscalationService.use((escalations) => escalations.runEscalationTick()),
 	"escalation",
-	"Escalation tick",
 	(result) =>
 		result.processed > 0
 			? {
@@ -301,7 +313,6 @@ const escalationTick = makeTick(
 const digestTick = makeTick(
 	DigestService.use((digest) => digest.runDigestTick()),
 	"digest",
-	"Digest tick",
 	(result) => ({
 		sentCount: result.sentCount,
 		errorCount: result.errorCount,
@@ -317,7 +328,6 @@ const digestTick = makeTick(
 const serviceMapRollupTick = makeTick(
 	ServiceMapRollupService.use((rollup) => rollup.runRollupTick()),
 	"service_map_rollup",
-	"Service map rollup tick",
 	(result) => ({
 		orgsProcessed: result.orgsProcessed,
 		hoursRolledUp: result.hoursRolledUp,
@@ -332,7 +342,6 @@ const serviceMapRollupTick = makeTick(
 const anomalyTick = makeTick(
 	AnomalyDetectionService.use((anomalies) => anomalies.runTick()),
 	"anomaly",
-	"Anomaly detection tick",
 	(result) => ({
 		orgsProcessed: result.orgsProcessed,
 		seriesEvaluated: result.seriesEvaluated,
@@ -348,7 +357,6 @@ const anomalyTick = makeTick(
 const cloudflareAnalyticsTick = makeTick(
 	CloudflareAnalyticsService.use((analytics) => analytics.pollAllOrgs()),
 	"cloudflare_analytics",
-	"Cloudflare analytics tick",
 	(result) => ({
 		orgs: result.orgs,
 		rowsIngested: result.rowsIngested,
@@ -361,7 +369,6 @@ const cloudflareAnalyticsTick = makeTick(
 const planetScaleTick = makeTick(
 	PlanetScaleService.use((planetscale) => planetscale.pollAllOrgs()),
 	"planetscale",
-	"PlanetScale poll tick",
 	(result) =>
 		result.orgs > 0
 			? {

--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -41,6 +41,34 @@ export interface CreateMapleApiOptions {
 /** Alchemy resource type for the API Worker, carrying its internal RPC surface. */
 export type MapleApiWorker = Cloudflare.Worker & Rpc<MapleApiRpcShape>
 
+const createManagedMapleDb = Effect.fnUntraced(function* (stage: MapleStage) {
+	const pgUrl = new URL(requireEnv("MAPLE_PG_URL"))
+	return yield* Cloudflare.Hyperdrive.Connection("maple-db", {
+		name: resolveHyperdriveName(stage),
+		origin: {
+			scheme: "postgres",
+			host: pgUrl.hostname,
+			port: Number(pgUrl.port || "5432"),
+			// Connect-time db (`postgres`, the PlanetScale cluster default),
+			// not the PS resource name.
+			database: pgUrl.pathname.replace(/^\//, "") || "postgres",
+			user: decodeURIComponent(pgUrl.username),
+			password: Redacted.make(decodeURIComponent(pgUrl.password)),
+		},
+		// Read-after-write everywhere (alert state CAS, dashboard versioning) —
+		// revisit caching once read paths that tolerate staleness are identified.
+		caching: { disabled: true },
+		dev: {
+			scheme: "postgres",
+			host: "localhost",
+			port: 5499,
+			database: "maple",
+			user: "maple",
+			password: Redacted.make("maple"),
+		},
+	})
+})
+
 export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 	Effect.gen(function* () {
 		// MAPLE_DB Hyperdrive comes in two flavors:
@@ -64,36 +92,7 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 		//   dying — so DB-backed routes 500 while everything else works.
 		const databaseMode = resolveDatabaseMode(stage)
 		const hyperdriveRefId = resolveHyperdriveRefId(stage, "api")
-		const mapleDb =
-			databaseMode !== "managed"
-				? undefined
-				: yield* Effect.gen(function* () {
-						const pgUrl = new URL(requireEnv("MAPLE_PG_URL"))
-						return yield* Cloudflare.Hyperdrive.Connection("maple-db", {
-							name: resolveHyperdriveName(stage),
-							origin: {
-								scheme: "postgres",
-								host: pgUrl.hostname,
-								port: Number(pgUrl.port || "5432"),
-								// Connect-time db (`postgres`, the PlanetScale cluster default),
-								// not the PS resource name.
-								database: pgUrl.pathname.replace(/^\//, "") || "postgres",
-								user: decodeURIComponent(pgUrl.username),
-								password: Redacted.make(decodeURIComponent(pgUrl.password)),
-							},
-							// Read-after-write everywhere (alert state CAS, dashboard versioning) —
-							// revisit caching once read paths that tolerate staleness are identified.
-							caching: { disabled: true },
-							dev: {
-								scheme: "postgres",
-								host: "localhost",
-								port: 5499,
-								database: "maple",
-								user: "maple",
-								password: Redacted.make("maple"),
-							},
-						})
-					})
+		const mapleDb = databaseMode !== "managed" ? undefined : yield* createManagedMapleDb(stage)
 
 		const mcpSessions = yield* Cloudflare.KV.Namespace("MCP_SESSIONS", {
 			title: resolveWorkerName("mcp-sessions", stage),

--- a/apps/api/src/chat/loop/delegate.test.ts
+++ b/apps/api/src/chat/loop/delegate.test.ts
@@ -8,7 +8,8 @@
 import { LLMClient, type LLMEvent, type LLMRequest, type Model } from "@maple/llm"
 import { CloudflareWorkersAI } from "@maple/llm/providers/cloudflare"
 import { Effect, Layer, Stream } from "effect"
-import { assert, describe, it } from "vitest"
+import { describe, it } from "@effect/vitest"
+import { assert } from "vitest"
 import { runChatTurn, type ChatTurnEvent } from "./index"
 import { AGENTS } from "../agents"
 import type { McpToolExecutorShape } from "@/mcp/dispatcher"
@@ -97,9 +98,9 @@ const resultsOf = (events: ReadonlyArray<ChatTurnEvent>) =>
 	events.filter((event) => event.type === "tool-result")
 
 describe("the task tool", () => {
-	it("returns the sub-agent's final text, wrapped, and none of its tool payloads", async () => {
-		const result = await Effect.runPromise(
-			run(
+	it.live("returns the sub-agent's final text, wrapped, and none of its tool payloads", () =>
+		Effect.gen(function* () {
+			const result = yield* run(
 				[
 					[taskCall("t1"), finish()],
 					[textDelta("Answered."), finish()],
@@ -108,22 +109,24 @@ describe("the task tool", () => {
 					[call("x1", "search_traces"), finish()],
 					[textDelta("p99 is 4.2s in checkout-api."), finish()],
 				],
-			),
-		)
+			)
 
-		const output = String(
-			resultsOf(result.events)[0]?.type === "tool-result" ? resultsOf(result.events)[0]!.output : "",
-		)
-		assert.include(output, "<task_result>")
-		assert.include(output, "p99 is 4.2s in checkout-api.")
-		// The firewall. If the child's raw output reached the parent, delegation would be strictly
-		// worse than calling the tools inline — it would cost an extra model call for nothing.
-		assert.notInclude(output, "search_traces")
-	})
+			const output = String(
+				resultsOf(result.events)[0]?.type === "tool-result"
+					? resultsOf(result.events)[0]!.output
+					: "",
+			)
+			assert.include(output, "<task_result>")
+			assert.include(output, "p99 is 4.2s in checkout-api.")
+			// The firewall. If the child's raw output reached the parent, delegation would be strictly
+			// worse than calling the tools inline — it would cost an extra model call for nothing.
+			assert.notInclude(output, "search_traces")
+		}),
+	)
 
-	it("drops narration that preceded a tool call, keeping only the report", async () => {
-		const result = await Effect.runPromise(
-			run(
+	it.live("drops narration that preceded a tool call, keeping only the report", () =>
+		Effect.gen(function* () {
+			const result = yield* run(
 				[
 					[taskCall("t1"), finish()],
 					[textDelta("ok"), finish()],
@@ -132,91 +135,101 @@ describe("the task tool", () => {
 					[textDelta("Let me check the traces."), call("x1", "search_traces"), finish()],
 					[textDelta("The answer."), finish()],
 				],
-			),
-		)
+			)
 
-		const output = String(
-			resultsOf(result.events)[0]?.type === "tool-result" ? resultsOf(result.events)[0]!.output : "",
-		)
-		assert.include(output, "The answer.")
-		assert.notInclude(output, "Let me check")
-	})
+			const output = String(
+				resultsOf(result.events)[0]?.type === "tool-result"
+					? resultsOf(result.events)[0]!.output
+					: "",
+			)
+			assert.include(output, "The answer.")
+			assert.notInclude(output, "Let me check")
+		}),
+	)
 
-	it("tags every sub-agent event so it lands in the card, not the conversation", async () => {
-		const result = await Effect.runPromise(
-			run(
+	it.live("tags every sub-agent event so it lands in the card, not the conversation", () =>
+		Effect.gen(function* () {
+			const result = yield* run(
 				[
 					[taskCall("t1"), finish()],
 					[textDelta("done"), finish()],
 				],
 				[[textDelta("child text"), finish()]],
-			),
-		)
-
-		assert.isNotEmpty(result.emitted)
-		for (const event of result.emitted) {
-			// `compaction` is turn-runner bookkeeping and never reaches this sink; every other
-			// member carries the ref.
-			assert.notEqual(event.type, "compaction")
-			assert.equal(
-				event.type === "compaction" ? undefined : event.task?.id,
-				"t1",
-				`untagged ${event.type} would surface as a stray top-level message`,
 			)
-		}
-		// And nothing from the child leaked into the parent's own stream.
-		const parentText = result.events
-			.filter((event) => event.type === "text-delta")
-			.map((event) => (event.type === "text-delta" ? event.text : ""))
-			.join("")
-		assert.equal(parentText, "done")
-	})
 
-	it("refuses to delegate past the per-turn budget, as a tool failure not a defect", async () => {
-		// Five task calls against a budget of four. The fifth must come back as a tool result the
-		// model can route around, not kill the turn.
-		const result = await Effect.runPromise(
-			run(
-				[
+			assert.isNotEmpty(result.emitted)
+			for (const event of result.emitted) {
+				// `compaction` is turn-runner bookkeeping and never reaches this sink; every other
+				// member carries the ref.
+				assert.notEqual(event.type, "compaction")
+				assert.equal(
+					event.type === "compaction" ? undefined : event.task?.id,
+					"t1",
+					`untagged ${event.type} would surface as a stray top-level message`,
+				)
+			}
+			// And nothing from the child leaked into the parent's own stream.
+			const parentText = result.events
+				.filter((event) => event.type === "text-delta")
+				.map((event) => (event.type === "text-delta" ? event.text : ""))
+				.join("")
+			assert.equal(parentText, "done")
+		}),
+	)
+
+	it.live(
+		"refuses to delegate past the per-turn budget, as a tool failure not a defect",
+		() =>
+			Effect.gen(function* () {
+				// Five task calls against a budget of four. The fifth must come back as a tool result the
+				// model can route around, not kill the turn.
+				const result = yield* run(
 					[
-						taskCall("t1"),
-						taskCall("t2"),
-						taskCall("t3"),
-						taskCall("t4"),
-						taskCall("t5"),
-						finish(),
+						[
+							taskCall("t1"),
+							taskCall("t2"),
+							taskCall("t3"),
+							taskCall("t4"),
+							taskCall("t5"),
+							finish(),
+						],
+						[textDelta("done"), finish()],
 					],
-					[textDelta("done"), finish()],
-				],
-				Array.from({ length: 6 }, () => [textDelta("child answer"), finish()]),
-			),
-		)
+					Array.from({ length: 6 }, () => [textDelta("child answer"), finish()]),
+				)
 
-		const results = resultsOf(result.events)
-		assert.lengthOf(results, 5)
-		const failures = results.filter((event) => event.type === "tool-result" && event.isError === true)
-		assert.lengthOf(failures, 1)
-		assert.include(String(failures[0]?.type === "tool-result" ? failures[0].output : ""), "slots left")
-		// The turn still completed normally.
-		assert.lengthOf(
-			result.events.filter((event) => event.type === "turn-end"),
-			1,
-		)
-	}, 30_000)
+				const results = resultsOf(result.events)
+				assert.lengthOf(results, 5)
+				const failures = results.filter(
+					(event) => event.type === "tool-result" && event.isError === true,
+				)
+				assert.lengthOf(failures, 1)
+				assert.include(
+					String(failures[0]?.type === "tool-result" ? failures[0].output : ""),
+					"slots left",
+				)
+				// The turn still completed normally.
+				assert.lengthOf(
+					result.events.filter((event) => event.type === "turn-end"),
+					1,
+				)
+			}),
+		30_000,
+	)
 
-	it("is not offered to an agent with no sub-agents", async () => {
-		let offered: ReadonlyArray<string> = []
-		const service = {
-			prepare: () => Effect.die(new Error("unused")),
-			generate: () => Effect.die(new Error("unused")),
-			stream: (request: LLMRequest) => {
-				offered = request.tools.map((tool) => tool.name)
-				return Stream.fromIterable([textDelta("hi"), finish()])
-			},
-		}
+	it.live("is not offered to an agent with no sub-agents", () =>
+		Effect.gen(function* () {
+			let offered: ReadonlyArray<string> = []
+			const service = {
+				prepare: () => Effect.die(new Error("unused")),
+				generate: () => Effect.die(new Error("unused")),
+				stream: (request: LLMRequest) => {
+					offered = request.tools.map((tool) => tool.name)
+					return Stream.fromIterable([textDelta("hi"), finish()])
+				},
+			}
 
-		await Effect.runPromise(
-			runChatTurn({
+			yield* runChatTurn({
 				sessionId: "org_test:tab",
 				tenant: TENANT,
 				toolExecutor: TOOL_EXECUTOR,
@@ -224,26 +237,26 @@ describe("the task tool", () => {
 				messages: [],
 				messageId: "m1",
 				agent: AGENTS["dashboard-builder"]!,
-			}).pipe(Stream.runCollect, Effect.provide(Layer.succeed(LLMClient.Service, service as never))),
-		)
+			}).pipe(Stream.runCollect, Effect.provide(Layer.succeed(LLMClient.Service, service as never)))
 
-		// Delegation is opt-in per agent: `dashboard-builder` has no `spawns`.
-		assert.notInclude(offered, "task")
-	})
+			// Delegation is opt-in per agent: `dashboard-builder` has no `spawns`.
+			assert.notInclude(offered, "task")
+		}),
+	)
 
-	it("is not offered to a sub-agent, capping nesting structurally", async () => {
-		let offered: ReadonlyArray<string> = []
-		const service = {
-			prepare: () => Effect.die(new Error("unused")),
-			generate: () => Effect.die(new Error("unused")),
-			stream: (request: LLMRequest) => {
-				offered = request.tools.map((tool) => tool.name)
-				return Stream.fromIterable([textDelta("hi"), finish()])
-			},
-		}
+	it.live("is not offered to a sub-agent, capping nesting structurally", () =>
+		Effect.gen(function* () {
+			let offered: ReadonlyArray<string> = []
+			const service = {
+				prepare: () => Effect.die(new Error("unused")),
+				generate: () => Effect.die(new Error("unused")),
+				stream: (request: LLMRequest) => {
+					offered = request.tools.map((tool) => tool.name)
+					return Stream.fromIterable([textDelta("hi"), finish()])
+				},
+			}
 
-		await Effect.runPromise(
-			runChatTurn({
+			yield* runChatTurn({
 				sessionId: "org_test:tab",
 				tenant: TENANT,
 				toolExecutor: TOOL_EXECUTOR,
@@ -252,106 +265,107 @@ describe("the task tool", () => {
 				messageId: "c1",
 				agent: AGENTS.explore!,
 				depth: 1,
-			}).pipe(Stream.runCollect, Effect.provide(Layer.succeed(LLMClient.Service, service as never))),
-		)
+			}).pipe(Stream.runCollect, Effect.provide(Layer.succeed(LLMClient.Service, service as never)))
 
-		assert.notInclude(offered, "task")
-		// And it really is read-only: no mutating tool is even visible.
-		assert.notInclude(offered, "create_alert_rule")
-	})
+			assert.notInclude(offered, "task")
+			// And it really is read-only: no mutating tool is even visible.
+			assert.notInclude(offered, "create_alert_rule")
+		}),
+	)
 
-	it("stops the sub-agent when the parent turn is superseded", async () => {
-		const result = await Effect.runPromise(
-			run([[taskCall("t1"), finish()]], [[textDelta("child"), finish()]], {
+	it.live("stops the sub-agent when the parent turn is superseded", () =>
+		Effect.gen(function* () {
+			const result = yield* run([[taskCall("t1"), finish()]], [[textDelta("child"), finish()]], {
 				isCurrent: () => false,
-			}),
-		)
+			})
 
-		// The child inherits the parent's `isCurrent` closure, so an abort reaches both without any
-		// separate cancellation path.
-		assert.equal(result.childCalls, 0)
-		assert.isEmpty(result.events.filter((event) => event.type === "turn-end"))
-	})
+			// The child inherits the parent's `isCurrent` closure, so an abort reaches both without any
+			// separate cancellation path.
+			assert.equal(result.childCalls, 0)
+			assert.isEmpty(result.events.filter((event) => event.type === "turn-end"))
+		}),
+	)
 })
 
 describe("the task tool's description", () => {
-	it("names exactly the sub-agents the caller may spawn", async () => {
-		let description: string | undefined
-		const service = {
-			prepare: () => Effect.die(new Error("unused")),
-			generate: () => Effect.die(new Error("unused")),
-			stream: (request: LLMRequest) => {
-				description = request.tools.find((tool) => tool.name === "task")?.description
-				return Stream.fromIterable([textDelta("hi"), finish()])
-			},
-		}
+	it.live("names exactly the sub-agents the caller may spawn", () =>
+		Effect.gen(function* () {
+			let description: string | undefined
+			const service = {
+				prepare: () => Effect.die(new Error("unused")),
+				generate: () => Effect.die(new Error("unused")),
+				stream: (request: LLMRequest) => {
+					description = request.tools.find((tool) => tool.name === "task")?.description
+					return Stream.fromIterable([textDelta("hi"), finish()])
+				},
+			}
 
-		await Effect.runPromise(
-			runChatTurn({
+			yield* runChatTurn({
 				sessionId: "org_test:tab",
 				tenant: TENANT,
 				toolExecutor: TOOL_EXECUTOR,
 				model: MODEL,
 				messages: [],
 				messageId: "m1",
-			}).pipe(Stream.runCollect, Effect.provide(Layer.succeed(LLMClient.Service, service as never))),
-		)
+			}).pipe(Stream.runCollect, Effect.provide(Layer.succeed(LLMClient.Service, service as never)))
 
-		// Generated from the registry, so the tool description and the system prompt cannot disagree
-		// about what is delegable.
-		assert.include(description ?? "", "explore")
-		assert.include(description ?? "", AGENTS.explore!.description)
-		// The one thing the model most needs to know, and the one it will otherwise get wrong.
-		assert.include(description ?? "", "sees NOTHING of this conversation")
-	})
+			// Generated from the registry, so the tool description and the system prompt cannot disagree
+			// about what is delegable.
+			assert.include(description ?? "", "explore")
+			assert.include(description ?? "", AGENTS.explore!.description)
+			// The one thing the model most needs to know, and the one it will otherwise get wrong.
+			assert.include(description ?? "", "sees NOTHING of this conversation")
+		}),
+	)
 })
 
 describe("the task tool's wire schema", () => {
-	it("compiles to JSON Schema a provider will accept", async () => {
-		// The closest thing to provider-contract verification available without a live call. Every
-		// other test here stubs the model, so nothing else would notice if `Schema.Literals` over a
-		// runtime-built name list produced something a provider rejects.
-		let schema: Record<string, unknown> | undefined
-		const service = {
-			prepare: () => Effect.die(new Error("unused")),
-			generate: () => Effect.die(new Error("unused")),
-			stream: (request: LLMRequest) => {
-				schema = request.tools.find((tool) => tool.name === "task")?.inputSchema as
-					| Record<string, unknown>
-					| undefined
-				return Stream.fromIterable([textDelta("hi"), finish()])
-			},
-		}
+	it.live("compiles to JSON Schema a provider will accept", () =>
+		Effect.gen(function* () {
+			// The closest thing to provider-contract verification available without a live call. Every
+			// other test here stubs the model, so nothing else would notice if `Schema.Literals` over a
+			// runtime-built name list produced something a provider rejects.
+			let schema: Record<string, unknown> | undefined
+			const service = {
+				prepare: () => Effect.die(new Error("unused")),
+				generate: () => Effect.die(new Error("unused")),
+				stream: (request: LLMRequest) => {
+					schema = request.tools.find((tool) => tool.name === "task")?.inputSchema as
+						| Record<string, unknown>
+						| undefined
+					return Stream.fromIterable([textDelta("hi"), finish()])
+				},
+			}
 
-		await Effect.runPromise(
-			runChatTurn({
+			yield* runChatTurn({
 				sessionId: "org_test:tab",
 				tenant: TENANT,
 				toolExecutor: TOOL_EXECUTOR,
 				model: MODEL,
 				messages: [],
 				messageId: "m1",
-			}).pipe(Stream.runCollect, Effect.provide(Layer.succeed(LLMClient.Service, service as never))),
-		)
+			}).pipe(Stream.runCollect, Effect.provide(Layer.succeed(LLMClient.Service, service as never)))
 
-		assert.equal(schema?.type, "object")
-		assert.deepEqual(schema?.required, ["description", "prompt", "subagent_type"])
-		assert.equal(schema?.additionalProperties, false)
+			assert.equal(schema?.type, "object")
+			assert.deepEqual(schema?.required, ["description", "prompt", "subagent_type"])
+			assert.equal(schema?.additionalProperties, false)
 
-		// `subagent_type` must constrain the model to real agent names — a free-form string here
-		// would let it invent one and turn every delegation into a tool failure.
-		const properties = schema?.properties as Record<string, Record<string, unknown>>
-		const subagentType = properties.subagent_type!
-		const enumValues =
-			(subagentType.enum as ReadonlyArray<string> | undefined) ??
-			(subagentType.anyOf as ReadonlyArray<{ enum?: ReadonlyArray<string> }> | undefined)?.[0]?.enum ??
-			[]
-		assert.include([...enumValues], "explore")
+			// `subagent_type` must constrain the model to real agent names — a free-form string here
+			// would let it invent one and turn every delegation into a tool failure.
+			const properties = schema?.properties as Record<string, Record<string, unknown>>
+			const subagentType = properties.subagent_type!
+			const enumValues =
+				(subagentType.enum as ReadonlyArray<string> | undefined) ??
+				(subagentType.anyOf as ReadonlyArray<{ enum?: ReadonlyArray<string> }> | undefined)?.[0]
+					?.enum ??
+				[]
+			assert.include([...enumValues], "explore")
 
-		// Known wart, pinned rather than fixed: Effect renders the literal union as a single-member
-		// `anyOf` wrapping the enum instead of a bare enum. Harmless on OpenRouter and Workers AI,
-		// but it is exactly the shape opencode's `tool/json-schema.ts` normalizes away because some
-		// providers reject a degenerate `anyOf`. If a provider ever does, collapse it here.
-		assert.isDefined(subagentType.anyOf ?? subagentType.enum)
-	})
+			// Known wart, pinned rather than fixed: Effect renders the literal union as a single-member
+			// `anyOf` wrapping the enum instead of a bare enum. Harmless on OpenRouter and Workers AI,
+			// but it is exactly the shape opencode's `tool/json-schema.ts` normalizes away because some
+			// providers reject a degenerate `anyOf`. If a provider ever does, collapse it here.
+			assert.isDefined(subagentType.anyOf ?? subagentType.enum)
+		}),
+	)
 })

--- a/apps/api/src/chat/loop/turn.test.ts
+++ b/apps/api/src/chat/loop/turn.test.ts
@@ -5,7 +5,8 @@
  * what order, and — the part that shipped wrong — what it does NOT emit once the turn is over.
  * Every failure mode here was invisible to `tsc` and to the branch's suite.
  */
-import { assert, describe, it } from "vitest"
+import { describe, it } from "@effect/vitest"
+import { assert } from "vitest"
 import { Effect, Layer, Schema, Stream } from "effect"
 import {
 	LLMClient,
@@ -160,318 +161,357 @@ const types = (events: ReadonlyArray<ChatTurnEvent>) => events.map((event) => ev
 const terminal = (events: ReadonlyArray<ChatTurnEvent>) => events.filter((event) => event.type === "turn-end")
 
 describe("runChatTurn", () => {
-	it("emits turn-start, the text, and exactly one turn-end", async () => {
-		const events = await Effect.runPromise(collectEvents([[textDelta("Hello"), finish()]]))
+	it.live("emits turn-start, the text, and exactly one turn-end", () =>
+		Effect.gen(function* () {
+			const events = yield* collectEvents([[textDelta("Hello"), finish()]])
 
-		assert.deepEqual(types(events), ["turn-start", "text-delta", "turn-end"])
-		assert.lengthOf(terminal(events), 1)
-	})
+			assert.deepEqual(types(events), ["turn-start", "text-delta", "turn-end"])
+			assert.lengthOf(terminal(events), 1)
+		}),
+	)
 
-	it("coalesces adjacent text deltas into one event without losing any text", async () => {
-		const chunks = ["Check", "ing ", "the ", "traces", "."]
-		const events = await Effect.runPromise(collectEvents([[...chunks.map(textDelta), finish()]]))
+	it.live("coalesces adjacent text deltas into one event without losing any text", () =>
+		Effect.gen(function* () {
+			const chunks = ["Check", "ing ", "the ", "traces", "."]
+			const events = yield* collectEvents([[...chunks.map(textDelta), finish()]])
 
-		// One durable row, one SSE frame and one React commit per token is more fidelity than a
-		// screen can show, and the transcript render cost is paid per commit.
-		const deltas = events.filter((event) => event.type === "text-delta")
-		assert.lengthOf(deltas, 1)
-		assert.equal(
-			deltas.map((event) => (event.type === "text-delta" ? event.text : "")).join(""),
-			chunks.join(""),
-		)
-	})
+			// One durable row, one SSE frame and one React commit per token is more fidelity than a
+			// screen can show, and the transcript render cost is paid per commit.
+			const deltas = events.filter((event) => event.type === "text-delta")
+			assert.lengthOf(deltas, 1)
+			assert.equal(
+				deltas.map((event) => (event.type === "text-delta" ? event.text : "")).join(""),
+				chunks.join(""),
+			)
+		}),
+	)
 
-	it("keeps text ahead of the tool calls it precedes", async () => {
-		const events = await Effect.runPromise(
-			collectEvents([
+	it.live("keeps text ahead of the tool calls it precedes", () =>
+		Effect.gen(function* () {
+			const events = yield* collectEvents([
 				[textDelta("Looking"), textDelta(" it up"), toolCall("c1", "create_alert_rule"), finish()],
-			]),
-		)
+			])
 
-		// Batching must never reorder: the deltas live in one stream segment and the tool events in
-		// the concatenated one after it, so a slow batch cannot overtake the call it introduced.
-		assert.deepEqual(types(events), ["turn-start", "text-delta", "tool-call", "turn-end"])
-		const delta = events.find((event) => event.type === "text-delta")
-		assert.equal(delta?.type === "text-delta" ? delta.text : undefined, "Looking it up")
-	})
+			// Batching must never reorder: the deltas live in one stream segment and the tool events in
+			// the concatenated one after it, so a slow batch cannot overtake the call it introduced.
+			assert.deepEqual(types(events), ["turn-start", "text-delta", "tool-call", "turn-end"])
+			const delta = events.find((event) => event.type === "text-delta")
+			assert.equal(delta?.type === "text-delta" ? delta.text : undefined, "Looking it up")
+		}),
+	)
 
-	it("emits exactly ONE turn-end when the model stream fails terminally", async () => {
-		const events = await Effect.runPromise(
-			collectEvents([{ events: [textDelta("part")], fail: true, reason: "Authentication" }]),
-		)
+	it.live("emits exactly ONE turn-end when the model stream fails terminally", () =>
+		Effect.gen(function* () {
+			const events = yield* collectEvents([
+				{ events: [textDelta("part")], fail: true, reason: "Authentication" },
+			])
 
-		// The regression: `Stream.concat`'s second half ran unconditionally, so a failed stream that
-		// still assembled a partial response emitted a second terminal event after the error one.
-		// Both landed in the durable log; the SSE route stops at the first, so it only surfaced on
-		// the next reload.
-		assert.lengthOf(terminal(events), 1)
-		const end = terminal(events)[0]
-		assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
-	})
+			// The regression: `Stream.concat`'s second half ran unconditionally, so a failed stream that
+			// still assembled a partial response emitted a second terminal event after the error one.
+			// Both landed in the durable log; the SSE route stops at the first, so it only surfaced on
+			// the next reload.
+			assert.lengthOf(terminal(events), 1)
+			const end = terminal(events)[0]
+			assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
+		}),
+	)
 
-	it("dispatches NO tools when the stream fails after announcing one", async () => {
-		// A partial stream that carries a tool call and then dies: `LLMResponse.fromEvents` will
-		// happily assemble it, which is exactly how the second half used to run past the error.
-		const events = await Effect.runPromise(
-			collectEvents([
+	it.live("dispatches NO tools when the stream fails after announcing one", () =>
+		Effect.gen(function* () {
+			// A partial stream that carries a tool call and then dies: `LLMResponse.fromEvents` will
+			// happily assemble it, which is exactly how the second half used to run past the error.
+			const events = yield* collectEvents([
 				{
 					events: [toolCall("c1", "find_errors"), textDelta("partial")],
 					fail: true,
 					reason: "Authentication",
 				},
-			]),
-		)
+			])
 
-		assert.isEmpty(
-			events.filter((event) => event.type === "tool-result"),
-			"a failed turn must not run tools past its terminal event",
-		)
-	})
+			assert.isEmpty(
+				events.filter((event) => event.type === "tool-result"),
+				"a failed turn must not run tools past its terminal event",
+			)
+		}),
+	)
 
-	it("stops on an approval-gated tool with a proposal and no result", async () => {
-		const events = await Effect.runPromise(
-			collectEvents([[toolCall("c1", "create_alert_rule"), finish()]]),
-		)
+	it.live("stops on an approval-gated tool with a proposal and no result", () =>
+		Effect.gen(function* () {
+			const events = yield* collectEvents([[toolCall("c1", "create_alert_rule"), finish()]])
 
-		const proposals = events.filter((event) => event.type === "tool-call")
-		assert.lengthOf(proposals, 1)
-		assert.equal(
-			proposals[0]?.type === "tool-call" ? proposals[0].proposed : undefined,
-			true,
-			"a gated call is a proposal, not an execution",
-		)
-		// Nothing fabricates an outcome: the model is never told the mutation happened.
-		assert.isEmpty(events.filter((event) => event.type === "tool-result"))
-		assert.lengthOf(terminal(events), 1)
-	})
+			const proposals = events.filter((event) => event.type === "tool-call")
+			assert.lengthOf(proposals, 1)
+			assert.equal(
+				proposals[0]?.type === "tool-call" ? proposals[0].proposed : undefined,
+				true,
+				"a gated call is a proposal, not an execution",
+			)
+			// Nothing fabricates an outcome: the model is never told the mutation happened.
+			assert.isEmpty(events.filter((event) => event.type === "tool-result"))
+			assert.lengthOf(terminal(events), 1)
+		}),
+	)
 
-	it("stops without a second terminal event when the turn is superseded", async () => {
-		const events = await Effect.runPromise(
-			collectEvents([[textDelta("hi"), finish()]], { isCurrent: () => false }),
-		)
+	it.live("stops without a second terminal event when the turn is superseded", () =>
+		Effect.gen(function* () {
+			const events = yield* collectEvents([[textDelta("hi"), finish()]], { isCurrent: () => false })
 
-		// An abort already recorded the terminal event on the session; emitting another here would
-		// double-close the turn in the durable log.
-		assert.isEmpty(terminal(events))
-	})
+			// An abort already recorded the terminal event on the session; emitting another here would
+			// double-close the turn in the durable log.
+			assert.isEmpty(terminal(events))
+		}),
+	)
 })
 
 describe("runChatTurn completion outcomes", () => {
-	it.each(["stop", "length"] as const)("recovers one blank %s completion", async (reason) => {
-		const result = await Effect.runPromise(
-			collect([[finish(reason)], [textDelta("Recovered answer."), finish()]]),
+	for (const reason of ["stop", "length"] as const) {
+		it.live(`recovers one blank ${reason} completion`, () =>
+			Effect.gen(function* () {
+				const result = yield* collect([[finish(reason)], [textDelta("Recovered answer."), finish()]])
+
+				assert.equal(result.calls, 2)
+				assert.equal(fold(result.events), "Recovered answer.")
+				assert.lengthOf(retries(result.events), 1)
+				const marker = retries(result.events)[0]
+				assert.equal(marker?.type === "turn-retry" ? marker.reason : undefined, "EmptyOutput")
+				assert.equal(marker?.type === "turn-retry" ? marker.delayMs : undefined, 0)
+				assert.equal(result.observability.emptyOutput, true)
+				assert.equal(result.observability.recoveryCount, 1)
+				assert.equal(result.observability.outcome, "stop")
+			}),
 		)
+	}
 
-		assert.equal(result.calls, 2)
-		assert.equal(fold(result.events), "Recovered answer.")
-		assert.lengthOf(retries(result.events), 1)
-		const marker = retries(result.events)[0]
-		assert.equal(marker?.type === "turn-retry" ? marker.reason : undefined, "EmptyOutput")
-		assert.equal(marker?.type === "turn-retry" ? marker.delayMs : undefined, 0)
-		assert.equal(result.observability.emptyOutput, true)
-		assert.equal(result.observability.recoveryCount, 1)
-		assert.equal(result.observability.outcome, "stop")
-	})
-
-	it("retracts whitespace before recovering", async () => {
-		const result = await Effect.runPromise(
-			collect([
+	it.live("retracts whitespace before recovering", () =>
+		Effect.gen(function* () {
+			const result = yield* collect([
 				[textDelta("   "), finish()],
 				[textDelta("Visible"), finish()],
-			]),
-		)
+			])
 
-		const marker = retries(result.events)[0]
-		assert.equal(marker?.type === "turn-retry" ? marker.retractChars : undefined, 3)
-		assert.equal(fold(result.events), "Visible")
-	})
+			const marker = retries(result.events)[0]
+			assert.equal(marker?.type === "turn-retry" ? marker.retractChars : undefined, 3)
+			assert.equal(fold(result.events), "Visible")
+		}),
+	)
 
-	it("preserves reasoning in the private recovery request", async () => {
-		const result = await Effect.runPromise(
-			collect([
+	it.live("preserves reasoning in the private recovery request", () =>
+		Effect.gen(function* () {
+			const result = yield* collect([
 				[reasoningDelta("analysis only"), finish()],
 				[textDelta("Visible"), finish()],
-			]),
+			])
+
+			const recovery = result.requests[1]
+			const reasoning = recovery?.messages
+				.flatMap((message) => message.content)
+				.filter((part) => part.type === "reasoning")
+				.map((part) => part.text)
+				.join("")
+			assert.equal(reasoning, "analysis only")
+			const instruction = recovery?.messages
+				.at(-1)
+				?.content.map((part) => (part.type === "text" ? part.text : ""))
+				.join("")
+			assert.include(instruction ?? "", "without any visible answer")
+			assert.isEmpty(result.events.filter((event) => event.type === "user-message"))
+		}),
+	)
+
+	it.live("fails visibly after the one blank recovery is exhausted", () =>
+		Effect.gen(function* () {
+			const result = yield* collect([[finish()], [finish()], [textDelta("never")]])
+
+			assert.equal(result.calls, 2)
+			assert.lengthOf(retries(result.events), 1)
+			assert.lengthOf(terminal(result.events), 1)
+			const end = terminal(result.events)[0]
+			assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
+			assert.equal(end?.type === "turn-end" ? end.error : undefined, "Maple didn't produce a response.")
+		}),
+	)
+
+	for (const reason of ["content-filter", "error", "unknown", "tool-calls"] as const) {
+		it.live(`does not auto-retry a ${reason} finish without deliverable output`, () =>
+			Effect.gen(function* () {
+				const result = yield* collect([[finish(reason)], [textDelta("never")]])
+				assert.equal(result.calls, 1)
+				assert.isEmpty(retries(result.events))
+				const end = terminal(result.events)[0]
+				assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
+				assert.equal(
+					end?.type === "turn-end" ? end.error : undefined,
+					reason === "content-filter"
+						? "Maple couldn't answer that request."
+						: "Maple couldn't complete this response.",
+				)
+			}),
 		)
+	}
 
-		const recovery = result.requests[1]
-		const reasoning = recovery?.messages
-			.flatMap((message) => message.content)
-			.filter((part) => part.type === "reasoning")
-			.map((part) => part.text)
-			.join("")
-		assert.equal(reasoning, "analysis only")
-		const instruction = recovery?.messages
-			.at(-1)
-			?.content.map((part) => (part.type === "text" ? part.text : ""))
-			.join("")
-		assert.include(instruction ?? "", "without any visible answer")
-		assert.isEmpty(result.events.filter((event) => event.type === "user-message"))
-	})
+	it.live(
+		"retries a response-level provider error only when marked retryable",
+		() =>
+			Effect.gen(function* () {
+				const retried = yield* collect([
+					[providerError("overloaded", { retryable: true })],
+					[textDelta("ok"), finish()],
+				])
+				assert.equal(retried.calls, 2)
+				assert.equal(fold(retried.events), "ok")
+				assert.lengthOf(retries(retried.events), 1)
 
-	it("fails visibly after the one blank recovery is exhausted", async () => {
-		const result = await Effect.runPromise(collect([[finish()], [finish()], [textDelta("never")]]))
+				const terminalFailure = yield* collect([
+					[providerError("invalid request")],
+					[textDelta("never"), finish()],
+				])
+				assert.equal(terminalFailure.calls, 1)
+				const end = terminal(terminalFailure.events)[0]
+				assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
+				assert.equal(
+					end?.type === "turn-end" ? end.error : undefined,
+					"Maple couldn't complete this response.",
+				)
+				assert.notInclude(end?.type === "turn-end" ? (end.error ?? "") : "", "invalid request")
+			}),
+		10_000,
+	)
 
-		assert.equal(result.calls, 2)
-		assert.lengthOf(retries(result.events), 1)
-		assert.lengthOf(terminal(result.events), 1)
-		const end = terminal(result.events)[0]
-		assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
-		assert.equal(end?.type === "turn-end" ? end.error : undefined, "Maple didn't produce a response.")
-	})
+	it.live("fails a blank closing step instead of escaping the step bound", () =>
+		Effect.gen(function* () {
+			const result = yield* collect([[toolCall("c1", "find_errors"), finish()], [finish()]], {
+				agent: agentWith({ steps: 1 }),
+			})
 
-	it.each(["content-filter", "error", "unknown", "tool-calls"] as const)(
-		"does not auto-retry a %s finish without deliverable output",
-		async (reason) => {
-			const result = await Effect.runPromise(collect([[finish(reason)], [textDelta("never")]]))
-			assert.equal(result.calls, 1)
+			assert.equal(result.calls, 2)
 			assert.isEmpty(retries(result.events))
 			const end = terminal(result.events)[0]
 			assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
-			assert.equal(
-				end?.type === "turn-end" ? end.error : undefined,
-				reason === "content-filter"
-					? "Maple couldn't answer that request."
-					: "Maple couldn't complete this response.",
-			)
-		},
+		}),
 	)
-
-	it("retries a response-level provider error only when marked retryable", async () => {
-		const retried = await Effect.runPromise(
-			collect([[providerError("overloaded", { retryable: true })], [textDelta("ok"), finish()]]),
-		)
-		assert.equal(retried.calls, 2)
-		assert.equal(fold(retried.events), "ok")
-		assert.lengthOf(retries(retried.events), 1)
-
-		const terminalFailure = await Effect.runPromise(
-			collect([[providerError("invalid request")], [textDelta("never"), finish()]]),
-		)
-		assert.equal(terminalFailure.calls, 1)
-		const end = terminal(terminalFailure.events)[0]
-		assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
-		assert.equal(
-			end?.type === "turn-end" ? end.error : undefined,
-			"Maple couldn't complete this response.",
-		)
-		assert.notInclude(end?.type === "turn-end" ? (end.error ?? "") : "", "invalid request")
-	}, 10_000)
-
-	it("fails a blank closing step instead of escaping the step bound", async () => {
-		const result = await Effect.runPromise(
-			collect([[toolCall("c1", "find_errors"), finish()], [finish()]], {
-				agent: agentWith({ steps: 1 }),
-			}),
-		)
-
-		assert.equal(result.calls, 2)
-		assert.isEmpty(retries(result.events))
-		const end = terminal(result.events)[0]
-		assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
-	})
 })
 
 describe("runChatTurn max steps", () => {
-	it("spends a final tool-less step answering instead of stopping dead", async () => {
-		// Ten steps that each call a read-only tool, then a text-only step. Each call carries
-		// different arguments: this is a model working through a wide search, not one stuck on the
-		// same question, and `stop.ts` must not confuse the two.
-		const result = await Effect.runPromise(
-			collect([
-				...Array.from(
-					{ length: 10 },
-					(_, i): Step => [toolCall("c1", "find_errors", { page: i }), finish()],
-				),
-				[textDelta("Here is what I found."), finish()],
-			]),
-		)
+	it.live(
+		"spends a final tool-less step answering instead of stopping dead",
+		() =>
+			Effect.gen(function* () {
+				// Ten steps that each call a read-only tool, then a text-only step. Each call carries
+				// different arguments: this is a model working through a wide search, not one stuck on the
+				// same question, and `stop.ts` must not confuse the two.
+				const result = yield* collect([
+					...Array.from(
+						{ length: 10 },
+						(_, i): Step => [toolCall("c1", "find_errors", { page: i }), finish()],
+					),
+					[textDelta("Here is what I found."), finish()],
+				])
 
-		// The turn used to end here on a wall of tool rows with no words at all.
-		const last = result.events[result.events.length - 2]
-		assert.equal(last?.type, "text-delta")
-		assert.equal(last?.type === "text-delta" ? last.text : undefined, "Here is what I found.")
+				// The turn used to end here on a wall of tool rows with no words at all.
+				const last = result.events[result.events.length - 2]
+				assert.equal(last?.type, "text-delta")
+				assert.equal(last?.type === "text-delta" ? last.text : undefined, "Here is what I found.")
 
-		// The closing step cannot loop even if the model ignores the instruction.
-		const closing = result.requests[result.requests.length - 1]
-		assert.isEmpty(closing?.tools ?? [{}])
-		assert.equal(closing?.toolChoice?.type, "none")
+				// The closing step cannot loop even if the model ignores the instruction.
+				const closing = result.requests[result.requests.length - 1]
+				assert.isEmpty(closing?.tools ?? [{}])
+				assert.equal(closing?.toolChoice?.type, "none")
 
-		// The signal the client badges on survives — it just arrives with an answer attached now.
-		assert.lengthOf(terminal(result.events), 1)
-		const end = terminal(result.events)[0]
-		assert.equal(end?.type === "turn-end" ? end.reason : undefined, "max-steps")
-	}, 30_000)
+				// The signal the client badges on survives — it just arrives with an answer attached now.
+				assert.lengthOf(terminal(result.events), 1)
+				const end = terminal(result.events)[0]
+				assert.equal(end?.type === "turn-end" ? end.reason : undefined, "max-steps")
+			}),
+		30_000,
+	)
 })
 
 describe("runChatTurn repeated tool calls", () => {
 	/** The same call, forever — a model that has stopped reading the results it is being handed. */
 	const stuck = (): Step => [toolCall("c1", "query_data", { sql: "select 1" }), finish()]
 
-	it("stops well short of the step budget and still answers", async () => {
-		const result = await Effect.runPromise(
-			collect([
-				...Array.from({ length: 3 }, stuck),
-				[textDelta("I keep getting the same empty result."), finish()],
-			]),
-		)
+	it.live(
+		"stops well short of the step budget and still answers",
+		() =>
+			Effect.gen(function* () {
+				const result = yield* collect([
+					...Array.from({ length: 3 }, stuck),
+					[textDelta("I keep getting the same empty result."), finish()],
+				])
 
-		// Three identical batches trip it, so the closing step is the fourth request. `MAX_STEPS` is
-		// 10 — compare the max-steps test above, where ten *varied* steps take eleven requests to
-		// reach the same closing step. Seven of those were going to return what the first already had.
-		assert.lengthOf(result.requests, 4)
+				// Three identical batches trip it, so the closing step is the fourth request. `MAX_STEPS` is
+				// 10 — compare the max-steps test above, where ten *varied* steps take eleven requests to
+				// reach the same closing step. Seven of those were going to return what the first already had.
+				assert.lengthOf(result.requests, 4)
 
-		const last = result.events[result.events.length - 2]
-		assert.equal(last?.type, "text-delta")
-		assert.equal(
-			last?.type === "text-delta" ? last.text : undefined,
-			"I keep getting the same empty result.",
-		)
-	}, 30_000)
+				const last = result.events[result.events.length - 2]
+				assert.equal(last?.type, "text-delta")
+				assert.equal(
+					last?.type === "text-delta" ? last.text : undefined,
+					"I keep getting the same empty result.",
+				)
+			}),
+		30_000,
+	)
 
-	it("settles the batch that tripped it rather than dropping it", async () => {
-		const result = await Effect.runPromise(
-			collect([...Array.from({ length: 3 }, stuck), [textDelta("Done."), finish()]]),
-		)
+	it.live(
+		"settles the batch that tripped it rather than dropping it",
+		() =>
+			Effect.gen(function* () {
+				const result = yield* collect([
+					...Array.from({ length: 3 }, stuck),
+					[textDelta("Done."), finish()],
+				])
 
-		// Stopping *before* dispatching would leave the model's last call unanswered in the
-		// transcript — a tool call with no result, which is exactly what the approval path is
-		// careful never to produce.
-		assert.lengthOf(
-			result.events.filter((event) => event.type === "tool-result"),
-			3,
-		)
-	}, 30_000)
+				// Stopping *before* dispatching would leave the model's last call unanswered in the
+				// transcript — a tool call with no result, which is exactly what the approval path is
+				// careful never to produce.
+				assert.lengthOf(
+					result.events.filter((event) => event.type === "tool-result"),
+					3,
+				)
+			}),
+		30_000,
+	)
 
-	it("tells the model why it is being stopped", async () => {
-		const result = await Effect.runPromise(
-			collect([...Array.from({ length: 3 }, stuck), [textDelta("Done."), finish()]]),
-		)
+	it.live(
+		"tells the model why it is being stopped",
+		() =>
+			Effect.gen(function* () {
+				const result = yield* collect([
+					...Array.from({ length: 3 }, stuck),
+					[textDelta("Done."), finish()],
+				])
 
-		const closing = result.requests[result.requests.length - 1]
-		const notice = closing?.messages[closing.messages.length - 1]
-		const text = notice?.content.map((part) => (part.type === "text" ? part.text : "")).join("")
-		// Named, not just forbidden: a model told only "stop" tends to report the plan it was
-		// looping on as though it had carried it out.
-		assert.include(text ?? "", "same tool calls several times")
-		assert.isEmpty(closing?.tools ?? [{}])
-		assert.equal(closing?.toolChoice?.type, "none")
-	}, 30_000)
+				const closing = result.requests[result.requests.length - 1]
+				const notice = closing?.messages[closing.messages.length - 1]
+				const text = notice?.content.map((part) => (part.type === "text" ? part.text : "")).join("")
+				// Named, not just forbidden: a model told only "stop" tends to report the plan it was
+				// looping on as though it had carried it out.
+				assert.include(text ?? "", "same tool calls several times")
+				assert.isEmpty(closing?.tools ?? [{}])
+				assert.equal(closing?.toolChoice?.type, "none")
+			}),
+		30_000,
+	)
 
-	it("does not fire when the model varies its arguments", async () => {
-		const result = await Effect.runPromise(
-			collect([
-				...Array.from(
-					{ length: 4 },
-					(_, i): Step => [toolCall("c1", "query_data", { sql: `select ${i}` }), finish()],
-				),
-				[textDelta("Found it."), finish()],
-			]),
-		)
+	it.live(
+		"does not fire when the model varies its arguments",
+		() =>
+			Effect.gen(function* () {
+				const result = yield* collect([
+					...Array.from(
+						{ length: 4 },
+						(_, i): Step => [toolCall("c1", "query_data", { sql: `select ${i}` }), finish()],
+					),
+					[textDelta("Found it."), finish()],
+				])
 
-		// Four working steps plus the answer — no closing step was forced.
-		assert.lengthOf(result.requests, 5)
-	}, 30_000)
+				// Four working steps plus the answer — no closing step was forced.
+				assert.lengthOf(result.requests, 5)
+			}),
+		30_000,
+	)
 })
 
 const retries = (events: ReadonlyArray<ChatTurnEvent>) =>
@@ -492,116 +532,137 @@ const fold = (events: ReadonlyArray<ChatTurnEvent>): string =>
 	}, "")
 
 describe("runChatTurn retry", () => {
-	it("retracts exactly what a sub-batch attempt had flushed, whatever that was", async () => {
-		const result = await Effect.runPromise(
-			collect([{ events: [textDelta("Hello wo")], fail: true }, [textDelta("Hello world."), finish()]]),
-		)
+	it.live("retracts exactly what a sub-batch attempt had flushed, whatever that was", () =>
+		Effect.gen(function* () {
+			const result = yield* collect([
+				{ events: [textDelta("Hello wo")], fail: true },
+				[textDelta("Hello world."), finish()],
+			])
 
-		// Below `DELTA_BATCH_SIZE`, so whether this attempt emitted anything is a race between the
-		// provider's failure and the 16ms window: `Stream.groupedWithin` drops a pending buffer on an
-		// upstream failure, but a window that fires first ships it. Both are correct — the invariant
-		// is that the marker takes back exactly what reached a consumer and no more, so the reader's
-		// fold lands on the retry's text alone. Asserting a literal count here would be asserting
-		// which fiber won.
-		const retracted = retries(result.events)
-		assert.lengthOf(retracted, 1)
-		const at = result.events.findIndex((event) => event.type === "turn-retry")
-		const marker = result.events[at]
-		const flushedBefore = textOf(result.events.slice(0, at))
-		assert.equal(marker?.type === "turn-retry" ? marker.retractChars : undefined, flushedBefore.length)
-		assert.equal(result.calls, 2)
-		assert.equal(fold(result.events), "Hello world.")
-		assert.lengthOf(terminal(result.events), 1)
-	})
+			// Below `DELTA_BATCH_SIZE`, so whether this attempt emitted anything is a race between the
+			// provider's failure and the 16ms window: `Stream.groupedWithin` drops a pending buffer on an
+			// upstream failure, but a window that fires first ships it. Both are correct — the invariant
+			// is that the marker takes back exactly what reached a consumer and no more, so the reader's
+			// fold lands on the retry's text alone. Asserting a literal count here would be asserting
+			// which fiber won.
+			const retracted = retries(result.events)
+			assert.lengthOf(retracted, 1)
+			const at = result.events.findIndex((event) => event.type === "turn-retry")
+			const marker = result.events[at]
+			const flushedBefore = textOf(result.events.slice(0, at))
+			assert.equal(
+				marker?.type === "turn-retry" ? marker.retractChars : undefined,
+				flushedBefore.length,
+			)
+			assert.equal(result.calls, 2)
+			assert.equal(fold(result.events), "Hello world.")
+			assert.lengthOf(terminal(result.events), 1)
+		}),
+	)
 
-	it("retracts exactly the text the failed attempt did flush", async () => {
-		// A full batch (`DELTA_BATCH_SIZE`) flushes on the size cap regardless of timing, so unlike
-		// the case above this attempt is guaranteed to have shipped text — the stand-in for a real
-		// provider stream, where the 16ms window fires constantly and most text has already shipped
-		// by the time the body dies. Only the size-capped batch is guaranteed: the trailing
-		// `"buffered"` delta is a pending partial batch, and on a slow runner the window fires
-		// before the failure and ships that too. So the floor is fixed; the exact count is not.
-		const flushed = Array.from({ length: 24 }, (_, i) => textDelta(String(i % 10)))
-		const result = await Effect.runPromise(
-			collect([
+	it.live("retracts exactly the text the failed attempt did flush", () =>
+		Effect.gen(function* () {
+			// A full batch (`DELTA_BATCH_SIZE`) flushes on the size cap regardless of timing, so unlike
+			// the case above this attempt is guaranteed to have shipped text — the stand-in for a real
+			// provider stream, where the 16ms window fires constantly and most text has already shipped
+			// by the time the body dies. Only the size-capped batch is guaranteed: the trailing
+			// `"buffered"` delta is a pending partial batch, and on a slow runner the window fires
+			// before the failure and ships that too. So the floor is fixed; the exact count is not.
+			const flushed = Array.from({ length: 24 }, (_, i) => textDelta(String(i % 10)))
+			const result = yield* collect([
 				{ events: [...flushed, textDelta("buffered")], fail: true },
 				[textDelta("the real answer"), finish()],
-			]),
-		)
+			])
 
-		// The test that catches duplicated text: without the retraction the durable fold reads the
-		// abandoned prefix followed by the retry's text — permanently, because deltas concatenate
-		// and the log is durable.
-		const retracted = retries(result.events)
-		assert.lengthOf(retracted, 1)
-		const at = result.events.findIndex((event) => event.type === "turn-retry")
-		const marker = result.events[at]
-		const flushedBefore = textOf(result.events.slice(0, at))
-		assert.equal(marker?.type === "turn-retry" ? marker.retractChars : undefined, flushedBefore.length)
-		assert.isAtLeast(flushedBefore.length, 24)
-		assert.equal(marker?.type === "turn-retry" ? marker.attempt : undefined, 2)
-
-		// Fold the whole event list the way `ChatSession.history()` does, and check the reader lands
-		// on the retry's text alone — the abandoned prefix is gone, not doubled.
-		assert.equal(fold(result.events), "the real answer")
-	})
-
-	it("retries a Transport failure even though it reports retryable: false", async () => {
-		// The whole point of `./retry.ts`. `TransportReason` and `InvalidProviderOutputReason`
-		// hardcode `retryable = false`, and they are exactly how a body that dies mid-stream
-		// surfaces — a classifier that trusted the flag would pass a naive test and do nothing.
-		for (const reason of ["Transport", "InvalidProviderOutput"]) {
-			const result = await Effect.runPromise(
-				collect([{ events: [], fail: true, reason, retryable: false }, [textDelta("ok"), finish()]]),
+			// The test that catches duplicated text: without the retraction the durable fold reads the
+			// abandoned prefix followed by the retry's text — permanently, because deltas concatenate
+			// and the log is durable.
+			const retracted = retries(result.events)
+			assert.lengthOf(retracted, 1)
+			const at = result.events.findIndex((event) => event.type === "turn-retry")
+			const marker = result.events[at]
+			const flushedBefore = textOf(result.events.slice(0, at))
+			assert.equal(
+				marker?.type === "turn-retry" ? marker.retractChars : undefined,
+				flushedBefore.length,
 			)
-			assert.equal(result.calls, 2, `${reason} should have been retried`)
-			assert.equal(textOf(result.events), "ok")
-		}
-	})
+			assert.isAtLeast(flushedBefore.length, 24)
+			assert.equal(marker?.type === "turn-retry" ? marker.attempt : undefined, 2)
 
-	it("does not retry a failure that would fail identically", async () => {
-		const result = await Effect.runPromise(
-			collect([{ events: [], fail: true, reason: "Authentication" }, [textDelta("never"), finish()]]),
-		)
+			// Fold the whole event list the way `ChatSession.history()` does, and check the reader lands
+			// on the retry's text alone — the abandoned prefix is gone, not doubled.
+			assert.equal(fold(result.events), "the real answer")
+		}),
+	)
 
-		assert.equal(result.calls, 1)
-		assert.isEmpty(retries(result.events))
-		const end = terminal(result.events)[0]
-		assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
-	})
+	it.live("retries a Transport failure even though it reports retryable: false", () =>
+		Effect.gen(function* () {
+			// The whole point of `./retry.ts`. `TransportReason` and `InvalidProviderOutputReason`
+			// hardcode `retryable = false`, and they are exactly how a body that dies mid-stream
+			// surfaces — a classifier that trusted the flag would pass a naive test and do nothing.
+			for (const reason of ["Transport", "InvalidProviderOutput"]) {
+				const result = yield* collect([
+					{ events: [], fail: true, reason, retryable: false },
+					[textDelta("ok"), finish()],
+				])
+				assert.equal(result.calls, 2, `${reason} should have been retried`)
+				assert.equal(textOf(result.events), "ok")
+			}
+		}),
+	)
 
-	it("gives up after the attempt budget and ends the turn once", async () => {
-		const failing: Step = { events: [], fail: true }
-		const result = await Effect.runPromise(
-			collect([failing, failing, failing, failing, failing, failing]),
-		)
+	it.live("does not retry a failure that would fail identically", () =>
+		Effect.gen(function* () {
+			const result = yield* collect([
+				{ events: [], fail: true, reason: "Authentication" },
+				[textDelta("never"), finish()],
+			])
 
-		assert.equal(result.calls, MAX_STEP_ATTEMPTS)
-		assert.lengthOf(retries(result.events), MAX_STEP_ATTEMPTS - 1)
-		assert.lengthOf(terminal(result.events), 1)
-		const end = terminal(result.events)[0]
-		assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
-	}, 30_000)
+			assert.equal(result.calls, 1)
+			assert.isEmpty(retries(result.events))
+			const end = terminal(result.events)[0]
+			assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
+		}),
+	)
 
-	it("stops during backoff without emitting a terminal event", async () => {
-		// `isCurrent` is re-checked after the sleep, so an abort landing mid-backoff wins. The DO
-		// already wrote the terminal event when it cleared the claim.
-		let current = true
-		const result = await Effect.runPromise(
-			collect([{ events: [textDelta("partial")], fail: true }, [textDelta("never"), finish()]], {
-				isCurrent: () => {
-					const value = current
-					// Still current when the stream fails (so the retry is scheduled), superseded by
-					// the time the backoff elapses.
-					current = false
-					return value
-				},
+	it.live(
+		"gives up after the attempt budget and ends the turn once",
+		() =>
+			Effect.gen(function* () {
+				const failing: Step = { events: [], fail: true }
+				const result = yield* collect([failing, failing, failing, failing, failing, failing])
+
+				assert.equal(result.calls, MAX_STEP_ATTEMPTS)
+				assert.lengthOf(retries(result.events), MAX_STEP_ATTEMPTS - 1)
+				assert.lengthOf(terminal(result.events), 1)
+				const end = terminal(result.events)[0]
+				assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
 			}),
-		)
+		30_000,
+	)
 
-		assert.equal(result.calls, 1)
-		assert.isEmpty(terminal(result.events))
-	})
+	it.live("stops during backoff without emitting a terminal event", () =>
+		Effect.gen(function* () {
+			// `isCurrent` is re-checked after the sleep, so an abort landing mid-backoff wins. The DO
+			// already wrote the terminal event when it cleared the claim.
+			let current = true
+			const result = yield* collect(
+				[{ events: [textDelta("partial")], fail: true }, [textDelta("never"), finish()]],
+				{
+					isCurrent: () => {
+						const value = current
+						// Still current when the stream fails (so the retry is scheduled), superseded by
+						// the time the backoff elapses.
+						current = false
+						return value
+					},
+				},
+			)
+
+			assert.equal(result.calls, 1)
+			assert.isEmpty(terminal(result.events))
+		}),
+	)
 })
 
 const agentWith = (overrides: Partial<AgentDefinition>): AgentDefinition => ({
@@ -616,41 +677,41 @@ const agentWith = (overrides: Partial<AgentDefinition>): AgentDefinition => ({
 const toolNames = (request: LLMRequest | undefined) => (request?.tools ?? []).map((tool) => tool.name)
 
 describe("runChatTurn permissions", () => {
-	it("never offers the model a denied tool", () => {
+	it.live("never offers the model a denied tool", () => {
 		// Stronger and cheaper than refusing the call afterwards: a tool the model cannot see is a
 		// tool it cannot be talked into trying.
 		const ruleset = [
 			new PermissionRule({ tool: "*", action: "allow" }),
 			new PermissionRule({ tool: "create_*", action: "deny" }),
 		]
-		return Effect.runPromise(
-			collect([[textDelta("ok"), finish()]], { agent: agentWith({ permission: ruleset }) }).pipe(
-				Effect.map((result) => {
-					const offered = toolNames(result.requests[0])
-					assert.notInclude(offered, "create_alert_rule")
-					assert.include(offered, "find_errors")
-				}),
-			),
+		return collect([[textDelta("ok"), finish()]], { agent: agentWith({ permission: ruleset }) }).pipe(
+			Effect.map((result) => {
+				const offered = toolNames(result.requests[0])
+				assert.notInclude(offered, "create_alert_rule")
+				assert.include(offered, "find_errors")
+			}),
 		)
 	})
 
-	it("still offers an approval-gated tool, and still stops on it", async () => {
-		// `ask` is visible-but-interrupting. Hiding it would make the model unable to propose the
-		// mutation at all, which is not what approval means.
-		const result = await Effect.runPromise(collect([[toolCall("c1", "create_alert_rule"), finish()]]))
+	it.live("still offers an approval-gated tool, and still stops on it", () =>
+		Effect.gen(function* () {
+			// `ask` is visible-but-interrupting. Hiding it would make the model unable to propose the
+			// mutation at all, which is not what approval means.
+			const result = yield* collect([[toolCall("c1", "create_alert_rule"), finish()]])
 
-		assert.include(toolNames(result.requests[0]), "create_alert_rule")
-		const proposals = result.events.filter((event) => event.type === "tool-call")
-		assert.lengthOf(proposals, 1)
-		assert.equal(proposals[0]?.type === "tool-call" ? proposals[0].proposed : undefined, true)
-	})
+			assert.include(toolNames(result.requests[0]), "create_alert_rule")
+			const proposals = result.events.filter((event) => event.type === "tool-call")
+			assert.lengthOf(proposals, 1)
+			assert.equal(proposals[0]?.type === "tool-call" ? proposals[0].proposed : undefined, true)
+		}),
+	)
 
-	it("executes a mutation when the ruleset allows it outright", async () => {
-		// The capability rulesets unlock: an agent that is trusted with a tool no longer has to
-		// round-trip through an approval card for it.
-		const ruleset = [new PermissionRule({ tool: "*", action: "allow" })]
-		const result = await Effect.runPromise(
-			collect(
+	it.live("executes a mutation when the ruleset allows it outright", () =>
+		Effect.gen(function* () {
+			// The capability rulesets unlock: an agent that is trusted with a tool no longer has to
+			// round-trip through an approval card for it.
+			const ruleset = [new PermissionRule({ tool: "*", action: "allow" })]
+			const result = yield* collect(
 				[
 					[toolCall("c1", "create_alert_rule"), finish()],
 					[textDelta("done"), finish()],
@@ -658,47 +719,56 @@ describe("runChatTurn permissions", () => {
 				{
 					agent: agentWith({ permission: ruleset }),
 				},
-			),
-		)
+			)
 
-		const announced = result.events.filter((event) => event.type === "tool-call")
-		assert.equal(announced[0]?.type === "tool-call" ? announced[0].proposed : undefined, undefined)
-		assert.isNotEmpty(result.events.filter((event) => event.type === "tool-result"))
-	})
+			const announced = result.events.filter((event) => event.type === "tool-call")
+			assert.equal(announced[0]?.type === "tool-call" ? announced[0].proposed : undefined, undefined)
+			assert.isNotEmpty(result.events.filter((event) => event.type === "tool-result"))
+		}),
+	)
 
-	it("honours an agent's own step budget", async () => {
-		const looping: Step = [toolCall("c1", "find_errors"), finish()]
-		const result = await Effect.runPromise(
-			collect([...Array.from({ length: 3 }, () => looping), [textDelta("summary"), finish()]], {
-				agent: agentWith({ steps: 3 }),
+	it.live(
+		"honours an agent's own step budget",
+		() =>
+			Effect.gen(function* () {
+				const looping: Step = [toolCall("c1", "find_errors"), finish()]
+				const result = yield* collect(
+					[...Array.from({ length: 3 }, () => looping), [textDelta("summary"), finish()]],
+					{
+						agent: agentWith({ steps: 3 }),
+					},
+				)
+
+				// Three tool-calling steps, then the tool-less closing one.
+				assert.equal(result.calls, 4)
+				const end = terminal(result.events)[0]
+				assert.equal(end?.type === "turn-end" ? end.reason : undefined, "max-steps")
 			}),
-		)
-
-		// Three tool-calling steps, then the tool-less closing one.
-		assert.equal(result.calls, 4)
-		const end = terminal(result.events)[0]
-		assert.equal(end?.type === "turn-end" ? end.reason : undefined, "max-steps")
-	}, 30_000)
+		30_000,
+	)
 })
 
 describe("runChatTurn max steps, defensively", () => {
-	it("ends rather than looping when a provider calls tools on the closing step", async () => {
-		// The closing step is sent with `tools: []` and `toolChoice: "none"`. A provider that emits a
-		// call anyway must not get another closing step, or `MAX_STEPS` stops being a bound at all.
-		const looping: Step = [toolCall("c1", "find_errors"), finish()]
-		const result = await Effect.runPromise(
-			collect(
-				Array.from({ length: 20 }, () => looping),
-				{ agent: agentWith({ steps: 2 }) },
-			),
-		)
+	it.live(
+		"ends rather than looping when a provider calls tools on the closing step",
+		() =>
+			Effect.gen(function* () {
+				// The closing step is sent with `tools: []` and `toolChoice: "none"`. A provider that emits a
+				// call anyway must not get another closing step, or `MAX_STEPS` stops being a bound at all.
+				const looping: Step = [toolCall("c1", "find_errors"), finish()]
+				const result = yield* collect(
+					Array.from({ length: 20 }, () => looping),
+					{ agent: agentWith({ steps: 2 }) },
+				)
 
-		// Two tool-calling steps, one closing step, then stop — not twenty.
-		assert.equal(result.calls, 3)
-		assert.lengthOf(terminal(result.events), 1)
-		const end = terminal(result.events)[0]
-		assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
-	}, 30_000)
+				// Two tool-calling steps, one closing step, then stop — not twenty.
+				assert.equal(result.calls, 3)
+				assert.lengthOf(terminal(result.events), 1)
+				const end = terminal(result.events)[0]
+				assert.equal(end?.type === "turn-end" ? end.reason : undefined, "error")
+			}),
+		30_000,
+	)
 })
 
 /**
@@ -731,70 +801,79 @@ describe("runChatTurn closing submit", () => {
 		[toolCall("s1", SUBMIT, { claim: "pool exhaustion" }), finish()],
 	]
 
-	it("offers the submit tool, forced, when the turn runs out of steps", async () => {
-		const submitted: Array<unknown> = []
-		const result = await Effect.runPromise(
-			collect(exhaustingSteps(), {
-				extraTools: submitTool(submitted),
-				closingSubmit: { toolName: SUBMIT },
+	it.live(
+		"offers the submit tool, forced, when the turn runs out of steps",
+		() =>
+			Effect.gen(function* () {
+				const submitted: Array<unknown> = []
+				const result = yield* collect(exhaustingSteps(), {
+					extraTools: submitTool(submitted),
+					closingSubmit: { toolName: SUBMIT },
+				})
+
+				const closing = result.requests[result.requests.length - 1]
+				assert.lengthOf(closing?.tools ?? [], 1)
+				assert.equal(closing?.tools?.[0]?.name, SUBMIT)
+				assert.equal(closing?.toolChoice?.type, "tool")
+				assert.equal(closing?.toolChoice?.name, SUBMIT)
 			}),
-		)
+		30_000,
+	)
 
-		const closing = result.requests[result.requests.length - 1]
-		assert.lengthOf(closing?.tools ?? [], 1)
-		assert.equal(closing?.tools?.[0]?.name, SUBMIT)
-		assert.equal(closing?.toolChoice?.type, "tool")
-		assert.equal(closing?.toolChoice?.name, SUBMIT)
-	}, 30_000)
+	it.live(
+		"dispatches the forced call, then ends without another step",
+		() =>
+			Effect.gen(function* () {
+				const submitted: Array<unknown> = []
+				const result = yield* collect(exhaustingSteps(), {
+					extraTools: submitTool(submitted),
+					closingSubmit: { toolName: SUBMIT },
+				})
 
-	it("dispatches the forced call, then ends without another step", async () => {
-		const submitted: Array<unknown> = []
-		const result = await Effect.runPromise(
-			collect(exhaustingSteps(), {
-				extraTools: submitTool(submitted),
-				closingSubmit: { toolName: SUBMIT },
+				// The regression: the answer actually reaches the tool.
+				assert.deepEqual(submitted, [{ claim: "pool exhaustion" }])
+				// And the bound still holds — the closing step never recurses.
+				assert.lengthOf(terminal(result.events), 1)
+				const end = terminal(result.events)[0]
+				assert.equal(end?.type === "turn-end" ? end.reason : undefined, "max-steps")
+				assert.equal(result.calls, 11)
 			}),
-		)
-
-		// The regression: the answer actually reaches the tool.
-		assert.deepEqual(submitted, [{ claim: "pool exhaustion" }])
-		// And the bound still holds — the closing step never recurses.
-		assert.lengthOf(terminal(result.events), 1)
-		const end = terminal(result.events)[0]
-		assert.equal(end?.type === "turn-end" ? end.reason : undefined, "max-steps")
-		assert.equal(result.calls, 11)
-	}, 30_000)
+		30_000,
+	)
 
 	/**
 	 * The deadline path. It used to ride on `isCurrent`, which is the *abort* hook,
 	 * so a pass past its wall clock returned an empty stream and submitted nothing —
 	 * indistinguishable from a pass that found nothing.
 	 */
-	it("closes with the submit tool when a soft stop fires mid-run", async () => {
-		const submitted: Array<unknown> = []
-		const result = await Effect.runPromise(
-			collect(
-				[
-					[toolCall("c1", "find_errors", { page: 0 }), finish()],
-					[toolCall("s1", SUBMIT, { claim: "out of clock" }), finish()],
-				],
-				{
-					extraTools: submitTool(submitted),
-					closingSubmit: { toolName: SUBMIT },
-					// Checked after the first real tool step, which is when the forced submit closes it.
-					softStop: () => true,
-				},
-			),
-		)
+	it.live(
+		"closes with the submit tool when a soft stop fires mid-run",
+		() =>
+			Effect.gen(function* () {
+				const submitted: Array<unknown> = []
+				const result = yield* collect(
+					[
+						[toolCall("c1", "find_errors", { page: 0 }), finish()],
+						[toolCall("s1", SUBMIT, { claim: "out of clock" }), finish()],
+					],
+					{
+						extraTools: submitTool(submitted),
+						closingSubmit: { toolName: SUBMIT },
+						// Checked after the first real tool step, which is when the forced submit closes it.
+						softStop: () => true,
+					},
+				)
 
-		assert.deepEqual(submitted, [{ claim: "out of clock" }])
-		assert.equal(
-			terminal(result.events)[0]?.type === "turn-end"
-				? (terminal(result.events)[0] as { reason: string }).reason
-				: undefined,
-			"max-steps",
-		)
-	}, 30_000)
+				assert.deepEqual(submitted, [{ claim: "out of clock" }])
+				assert.equal(
+					terminal(result.events)[0]?.type === "turn-end"
+						? (terminal(result.events)[0] as { reason: string }).reason
+						: undefined,
+					"max-steps",
+				)
+			}),
+		30_000,
+	)
 
 	/**
 	 * The `validation_inconclusive` bug. The validator has no tools but its submit
@@ -802,94 +881,109 @@ describe("runChatTurn closing submit", () => {
 	 * tool call, so it never reached the branch that offers the forced submit. The
 	 * turn ended with text nobody reads and an empty verdict.
 	 */
-	it("closes with the forced submit when the model answers in prose instead of calling it", async () => {
-		const submitted: Array<unknown> = []
-		const result = await Effect.runPromise(
-			collect(
-				[
-					[textDelta("The strongest candidate is the pool."), finish()],
-					[toolCall("s1", SUBMIT, { claim: "pool exhaustion" }), finish()],
-				],
-				{ extraTools: submitTool(submitted), closingSubmit: { toolName: SUBMIT } },
-			),
-		)
+	it.live(
+		"closes with the forced submit when the model answers in prose instead of calling it",
+		() =>
+			Effect.gen(function* () {
+				const submitted: Array<unknown> = []
+				const result = yield* collect(
+					[
+						[textDelta("The strongest candidate is the pool."), finish()],
+						[toolCall("s1", SUBMIT, { claim: "pool exhaustion" }), finish()],
+					],
+					{ extraTools: submitTool(submitted), closingSubmit: { toolName: SUBMIT } },
+				)
 
-		assert.deepEqual(submitted, [{ claim: "pool exhaustion" }])
-		const closing = result.requests[result.requests.length - 1]
-		assert.equal(closing?.toolChoice?.name, SUBMIT)
-		assert.lengthOf(terminal(result.events), 1)
-	}, 30_000)
+				assert.deepEqual(submitted, [{ claim: "pool exhaustion" }])
+				const closing = result.requests[result.requests.length - 1]
+				assert.equal(closing?.toolChoice?.name, SUBMIT)
+				assert.lengthOf(terminal(result.events), 1)
+			}),
+		30_000,
+	)
 
 	/** Same gap, silent shape: an empty completion is no more an answer than prose is. */
-	it("closes with the forced submit after an empty completion exhausts its recovery", async () => {
-		const submitted: Array<unknown> = []
-		await Effect.runPromise(
-			collect([[finish()], [finish()], [toolCall("s1", SUBMIT, { claim: "recovered" }), finish()]], {
-				extraTools: submitTool(submitted),
-				closingSubmit: { toolName: SUBMIT },
-			}),
-		)
+	it.live(
+		"closes with the forced submit after an empty completion exhausts its recovery",
+		() =>
+			Effect.gen(function* () {
+				const submitted: Array<unknown> = []
+				yield* collect(
+					[[finish()], [finish()], [toolCall("s1", SUBMIT, { claim: "recovered" }), finish()]],
+					{
+						extraTools: submitTool(submitted),
+						closingSubmit: { toolName: SUBMIT },
+					},
+				)
 
-		assert.deepEqual(submitted, [{ claim: "recovered" }])
-	}, 30_000)
+				assert.deepEqual(submitted, [{ claim: "recovered" }])
+			}),
+		30_000,
+	)
 
 	/** And it cannot loop: a closing step that answers in prose too just ends. */
-	it("does not offer the submit tool twice when the closing step ignores it", async () => {
-		const submitted: Array<unknown> = []
-		const result = await Effect.runPromise(
-			collect(
-				[
-					[textDelta("prose"), finish()],
-					[textDelta("prose again"), finish()],
-				],
-				{
-					extraTools: submitTool(submitted),
-					closingSubmit: { toolName: SUBMIT },
-				},
-			),
-		)
+	it.live(
+		"does not offer the submit tool twice when the closing step ignores it",
+		() =>
+			Effect.gen(function* () {
+				const submitted: Array<unknown> = []
+				const result = yield* collect(
+					[
+						[textDelta("prose"), finish()],
+						[textDelta("prose again"), finish()],
+					],
+					{
+						extraTools: submitTool(submitted),
+						closingSubmit: { toolName: SUBMIT },
+					},
+				)
 
-		assert.isEmpty(submitted)
-		assert.equal(result.calls, 2)
-		assert.lengthOf(terminal(result.events), 1)
-	}, 30_000)
+				assert.isEmpty(submitted)
+				assert.equal(result.calls, 2)
+				assert.lengthOf(terminal(result.events), 1)
+			}),
+		30_000,
+	)
 
 	/**
 	 * The submit call is the answer, so the turn is over. Recursing would spend
 	 * another model call — and under the validator's one-step budget that call is the
 	 * forced closing step, which asks for a second verdict and overwrites the first.
 	 */
-	it("ends the turn once the submit tool has been called, without another step", async () => {
-		const submitted: Array<unknown> = []
-		const result = await Effect.runPromise(
-			collect(
-				[
-					[toolCall("s1", SUBMIT, { claim: "first" }), finish()],
-					[toolCall("s2", SUBMIT, { claim: "second" }), finish()],
-				],
-				{ extraTools: submitTool(submitted), closingSubmit: { toolName: SUBMIT } },
-			),
-		)
+	it.live(
+		"ends the turn once the submit tool has been called, without another step",
+		() =>
+			Effect.gen(function* () {
+				const submitted: Array<unknown> = []
+				const result = yield* collect(
+					[
+						[toolCall("s1", SUBMIT, { claim: "first" }), finish()],
+						[toolCall("s2", SUBMIT, { claim: "second" }), finish()],
+					],
+					{ extraTools: submitTool(submitted), closingSubmit: { toolName: SUBMIT } },
+				)
 
-		assert.deepEqual(submitted, [{ claim: "first" }])
-		assert.equal(result.calls, 1)
-		assert.lengthOf(terminal(result.events), 1)
-	}, 30_000)
+				assert.deepEqual(submitted, [{ claim: "first" }])
+				assert.equal(result.calls, 1)
+				assert.lengthOf(terminal(result.events), 1)
+			}),
+		30_000,
+	)
 
 	/**
 	 * A hard abort is still a hard abort: the session already wrote a terminal
 	 * event, so this turn must write nothing more — no closing step, no submit.
 	 */
-	it("still writes nothing when isCurrent goes false", async () => {
-		const submitted: Array<unknown> = []
-		const events = await Effect.runPromise(
-			collectEvents([[textDelta("hi"), finish()]], {
+	it.live("still writes nothing when isCurrent goes false", () =>
+		Effect.gen(function* () {
+			const submitted: Array<unknown> = []
+			const events = yield* collectEvents([[textDelta("hi"), finish()]], {
 				extraTools: submitTool(submitted),
 				closingSubmit: { toolName: SUBMIT },
 				isCurrent: () => false,
-			}),
-		)
-		assert.isEmpty(terminal(events))
-		assert.isEmpty(submitted)
-	})
+			})
+			assert.isEmpty(terminal(events))
+			assert.isEmpty(submitted)
+		}),
+	)
 })

--- a/apps/api/src/internal-rpc.test.ts
+++ b/apps/api/src/internal-rpc.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest"
 import { Effect } from "effect"
-import type { InternalRpcInvalidInputError } from "@maple/domain/internal-rpc"
 import { callMcpToolRpc, submitDiagnosisRpc } from "./internal-rpc"
+import { McpToolExecutor, type McpToolExecutorShape } from "./mcp/dispatcher"
 import { InvestigationService, type InvestigationServiceShape } from "./services/errors/InvestigationService"
 
 const investigationId = "00000000-0000-4000-8000-000000000001"
@@ -32,17 +32,22 @@ const unusedInvestigationService: InvestigationServiceShape = {
 	submitDiagnosis: () => Effect.die("unused"),
 }
 
+const unusedMcpToolExecutor: McpToolExecutorShape = {
+	execute: () => Effect.die("unused"),
+}
+
 describe("internal RPC boundary", () => {
 	it.effect("rejects invalid org IDs before MCP dispatch", () =>
 		Effect.gen(function* () {
 			const error = yield* Effect.flip(
-				callMcpToolRpc({ orgId: " ", name: "inspect_trace", input: {} }) as Effect.Effect<
-					never,
-					InternalRpcInvalidInputError,
-					never
-				>,
+				callMcpToolRpc({ orgId: " ", name: "inspect_trace", input: {} }).pipe(
+					Effect.provideService(McpToolExecutor, unusedMcpToolExecutor),
+				),
 			)
 			expect(error._tag).toBe("@maple/internal-rpc/InvalidInputError")
+			if (error._tag !== "@maple/internal-rpc/InvalidInputError") {
+				throw new Error(`Expected invalid input, received ${error._tag}`)
+			}
 			expect(error.method).toBe("callMcpTool")
 		}),
 	)

--- a/apps/api/src/mcp/app.ts
+++ b/apps/api/src/mcp/app.ts
@@ -1,5 +1,5 @@
 import { McpProtocol, McpServer } from "effect/unstable/ai"
-import { Effect, Layer } from "effect"
+import { Cause, Effect, Layer } from "effect"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { McpToolsLive } from "./server"
 import { DebugErrorsPrompt } from "./prompts/debug-errors"
@@ -7,6 +7,7 @@ import { LatencyAnalysisPrompt } from "./prompts/latency-analysis"
 import { IncidentTriagePrompt } from "./prompts/incident-triage"
 import { InstructionsResource } from "./resources/instructions"
 import { sessionStore } from "./lib/session-store"
+import type { McpToolExecutor } from "./dispatcher"
 import { CurrentMcpRequestTenant, CurrentMcpTenant, resolveHttpMcpTenant } from "./lib/query-warehouse"
 import { ApiKeysService } from "@/services/org/ApiKeysService"
 import { AuthService } from "@/services/auth/AuthService"
@@ -78,7 +79,11 @@ const McpHttpLive = McpServer.layerHttp({
 	clientSessions: sessionStore,
 }).pipe(Layer.provide(McpAuthorizationMiddleware.layer))
 
-export const McpLive = Layer.mergeAll(
+export const McpLive: Layer.Layer<
+	never,
+	Cause.IllegalArgumentError,
+	HttpRouter.HttpRouter | ApiKeysService | AuthService | Env | McpToolExecutor
+> = Layer.mergeAll(
 	McpToolsLive,
 	DebugErrorsPrompt,
 	LatencyAnalysisPrompt,

--- a/apps/api/src/mcp/dispatcher.ts
+++ b/apps/api/src/mcp/dispatcher.ts
@@ -45,48 +45,56 @@ const callMcpToolUnscoped = Effect.fn("McpToolDispatcher.call")(function* (name:
 		),
 		Effect.catchTags({
 			"@maple/mcp/errors/McpQueryError": (error) =>
-				Effect.logError(`Tool error: ${error.message}`).pipe(
-					Effect.annotateLogs({ errorTag: error._tag, pipe: error.pipeName }),
+				Effect.logError("MCP tool execution failed").pipe(
+					Effect.annotateLogs({
+						"error.message": error.message,
+						"error.type": error._tag,
+						"maple.mcp.pipe": error.pipeName,
+					}),
 					Effect.as({
 						isError: true,
 						content: [{ type: "text", text: `${error._tag}: ${error.message}` }],
 					} satisfies McpToolResult),
 				),
 			"@maple/mcp/errors/McpTenantError": (error) =>
-				Effect.logError(`Tool error: ${error.message}`).pipe(
-					Effect.annotateLogs({ errorTag: error._tag }),
+				Effect.logError("MCP tool execution failed").pipe(
+					Effect.annotateLogs({ "error.message": error.message, "error.type": error._tag }),
 					Effect.as({
 						isError: true,
 						content: [{ type: "text", text: `${error._tag}: ${error.message}` }],
 					} satisfies McpToolResult),
 				),
 			"@maple/mcp/errors/McpAuthMissingError": (error) =>
-				Effect.logError(`Auth error: ${error.message}`).pipe(
-					Effect.annotateLogs({ errorTag: error._tag }),
+				Effect.logError("MCP authentication failed").pipe(
+					Effect.annotateLogs({ "error.message": error.message, "error.type": error._tag }),
 					Effect.as({
 						isError: true,
 						content: [{ type: "text", text: `${error._tag}: ${error.message}` }],
 					} satisfies McpToolResult),
 				),
 			"@maple/mcp/errors/McpAuthInvalidError": (error) =>
-				Effect.logError(`Auth error: ${error.message}`).pipe(
-					Effect.annotateLogs({ errorTag: error._tag }),
+				Effect.logError("MCP authentication failed").pipe(
+					Effect.annotateLogs({ "error.message": error.message, "error.type": error._tag }),
 					Effect.as({
 						isError: true,
 						content: [{ type: "text", text: `${error._tag}: ${error.message}` }],
 					} satisfies McpToolResult),
 				),
 			"@maple/mcp/errors/McpAuthUnavailableError": (error) =>
-				Effect.logError(`Auth dependency error: ${error.message}`).pipe(
-					Effect.annotateLogs({ errorTag: error._tag }),
+				Effect.logError("MCP authentication dependency failed").pipe(
+					Effect.annotateLogs({ "error.message": error.message, "error.type": error._tag }),
 					Effect.as({
 						isError: true,
 						content: [{ type: "text", text: "Authentication is temporarily unavailable." }],
 					} satisfies McpToolResult),
 				),
 			"@maple/mcp/errors/McpInvalidTenantError": (error) =>
-				Effect.logError(`Tenant validation error [${error.field}]: ${error.message}`).pipe(
-					Effect.annotateLogs({ errorTag: error._tag, field: error.field }),
+				Effect.logError("MCP tenant validation failed").pipe(
+					Effect.annotateLogs({
+						"error.message": error.message,
+						"error.type": error._tag,
+						"maple.mcp.field": error.field,
+					}),
 					Effect.as({
 						isError: true,
 						content: [
@@ -98,7 +106,7 @@ const callMcpToolUnscoped = Effect.fn("McpToolDispatcher.call")(function* (name:
 					} satisfies McpToolResult),
 				),
 		}),
-		Effect.annotateLogs({ tool: name }),
+		Effect.annotateLogs({ "maple.mcp.tool": name }),
 	)
 })
 

--- a/apps/api/src/mcp/lib/render-trace.test.ts
+++ b/apps/api/src/mcp/lib/render-trace.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from "vitest"
-import type { SpanId } from "@maple/domain"
+import { SpanId } from "@maple/domain"
 import type { SpanNode } from "@maple/query-engine/observability"
+import { Schema } from "effect"
 import { renderTraceOverview, type TraceOverviewLog } from "./render-trace"
+
+const decodeSpanId = Schema.decodeSync(SpanId)
 
 function span(
 	id: string,
 	opts: Partial<Omit<SpanNode, "spanId" | "children">> & { children?: SpanNode[] } = {},
 ): SpanNode {
 	return {
-		spanId: id as unknown as SpanId,
+		spanId: decodeSpanId(id),
 		parentSpanId: opts.parentSpanId ?? "",
 		spanName: opts.spanName ?? id,
 		serviceName: opts.serviceName ?? "svc",

--- a/apps/api/src/mcp/lib/span-tree.test.ts
+++ b/apps/api/src/mcp/lib/span-tree.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from "vitest"
-import type { SpanId } from "@maple/domain"
+import { SpanId } from "@maple/domain"
 import type { SpanNode } from "@maple/query-engine/observability"
+import { Schema } from "effect"
 import { selectOverviewSpans } from "./span-tree"
+
+const decodeSpanId = Schema.decodeSync(SpanId)
 
 function span(
 	id: string,
 	opts: Partial<Omit<SpanNode, "spanId" | "children">> & { children?: SpanNode[] } = {},
 ): SpanNode {
 	return {
-		spanId: id as unknown as SpanId,
+		spanId: decodeSpanId(id),
 		parentSpanId: opts.parentSpanId ?? "",
 		spanName: opts.spanName ?? id,
 		serviceName: opts.serviceName ?? "svc",
@@ -26,7 +29,7 @@ function span(
 function ids(roots: ReadonlyArray<SpanNode>): Set<string> {
 	const out = new Set<string>()
 	const walk = (n: SpanNode) => {
-		out.add(n.spanId as string)
+		out.add(n.spanId)
 		n.children.forEach(walk)
 	}
 	roots.forEach(walk)
@@ -109,7 +112,7 @@ describe("selectOverviewSpans", () => {
 		const kept = ids(result.roots)
 		const checkConnected = (n: SpanNode) => {
 			for (const child of n.children) {
-				expect(kept.has(child.spanId as string)).toBe(true)
+				expect(kept.has(child.spanId)).toBe(true)
 				checkConnected(child)
 			}
 		}

--- a/apps/api/src/platform/EmailService.ts
+++ b/apps/api/src/platform/EmailService.ts
@@ -1,13 +1,10 @@
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
-import { Duration, Effect, Layer, Schema, Context } from "effect"
+import { Context, Data, Duration, Effect, Layer } from "effect"
 import { Env } from "./Env"
 
-class EmailDeliveryError extends Schema.TaggedError<EmailDeliveryError>()(
-	"@maple/errors/EmailDeliveryError",
-	{
-		message: Schema.String,
-	},
-) {}
+class EmailDeliveryError extends Data.TaggedError("@maple/api/platform/EmailDeliveryError")<{
+	readonly message: string
+}> {}
 
 export interface EmailServiceShape {
 	readonly isConfigured: boolean

--- a/apps/api/src/platform/Env.ts
+++ b/apps/api/src/platform/Env.ts
@@ -1,11 +1,10 @@
 import { optionalRedacted, optionalString, stringWithDefault } from "@maple/effect-cloudflare/config-helpers"
-import { Config, Context, Effect, Layer, Option, Redacted, Schema } from "effect"
+import { Config, Context, Data, Effect, Layer, Option, Redacted, Schema } from "effect"
 
 /** Fatal misconfiguration discovered at startup — surfaces as a tagged defect in the Cause. */
-class EnvValidationError extends Schema.TaggedError<EnvValidationError>()(
-	"@maple/api/lib/EnvValidationError",
-	{ message: Schema.String },
-) {}
+class EnvValidationError extends Data.TaggedError("@maple/api/lib/EnvValidationError")<{
+	readonly message: string
+}> {}
 
 export interface EnvShape {
 	readonly PORT: number

--- a/apps/api/src/platform/Llm.test.ts
+++ b/apps/api/src/platform/Llm.test.ts
@@ -12,7 +12,8 @@
 import { LLM, type Model } from "@maple/llm"
 import { Effect, Layer } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
-import { describe, expect, it } from "vitest"
+import { describe, it } from "@effect/vitest"
+import { expect } from "vitest"
 import {
 	contextLimitOf,
 	layerLlm,
@@ -35,166 +36,189 @@ interface CapturedRequest {
  * `resolve` picks which resolver builds the model, because the lens stage differs from triage in its
  * defaults and the only honest way to check a default is to watch what leaves.
  */
-const captureRequest = async (
+const captureRequest = (
 	env: LlmEnv,
 	tags?: LlmCallTags,
 	resolve: (env: LlmEnv, tags?: LlmCallTags) => Model = resolveTriageModel,
-): Promise<CapturedRequest> => {
-	let captured: CapturedRequest | undefined
+): Effect.Effect<CapturedRequest> =>
+	Effect.gen(function* () {
+		let captured: CapturedRequest | undefined
 
-	const fakeFetch: typeof globalThis.fetch = async (input, init) => {
-		const headers: Record<string, string> = {}
-		new Headers(init?.headers).forEach((value, key) => {
-			headers[key.toLowerCase()] = value
-		})
-		// The body arrives as bytes, not a string — `Response` is the cheapest correct decoder.
-		const bodyText = await new Response(init?.body ?? "{}").text()
-		captured = {
-			url: String(input),
-			headers,
-			body: JSON.parse(bodyText) as Record<string, unknown>,
+		const fakeFetch: typeof globalThis.fetch = async (input, init) => {
+			const headers: Record<string, string> = {}
+			new Headers(init?.headers).forEach((value, key) => {
+				headers[key.toLowerCase()] = value
+			})
+			// The body arrives as bytes, not a string — `Response` is the cheapest correct decoder.
+			const bodyText = await new Response(init?.body ?? "{}").text()
+			captured = {
+				url: String(input),
+				headers,
+				body: JSON.parse(bodyText) as Record<string, unknown>,
+			}
+			return new Response(JSON.stringify({ error: "captured" }), { status: 400 })
 		}
-		return new Response(JSON.stringify({ error: "captured" }), { status: 400 })
-	}
 
-	const request = LLM.request({
-		model: resolve(env, tags),
-		system: "You are concise.",
-		prompt: "hi",
-	})
+		const request = LLM.request({
+			model: resolve(env, tags),
+			system: "You are concise.",
+			prompt: "hi",
+		})
 
-	await Effect.runPromise(
-		LLM.generate(request).pipe(
+		yield* LLM.generate(request).pipe(
 			Effect.ignore,
 			Effect.provide(
 				layerLlm(env).pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch, fakeFetch))),
 			),
-		),
-	)
+		)
 
-	if (captured === undefined) throw new Error("no request reached the transport")
-	return captured
-}
+		if (captured === undefined) return yield* Effect.die("no request reached the transport")
+		return captured
+	})
 
 const openRouterEnv: LlmEnv = { OPENROUTER_API_KEY: "test-key" }
 
 const tags: LlmCallTags = { surface: "chat", orgId: "org_123", sessionId: "chat_abc" }
 
 describe("resolveTriageModel — OpenRouter attribution", () => {
-	it("sends the app-attribution headers on every OpenRouter call", async () => {
-		const captured = await captureRequest(openRouterEnv)
+	it.live("sends the app-attribution headers on every OpenRouter call", () =>
+		Effect.gen(function* () {
+			const captured = yield* captureRequest(openRouterEnv)
 
-		expect(captured.url).toContain("openrouter.ai")
-		// `HTTP-Referer` is what creates the app page — a title alone does nothing.
-		expect(captured.headers["http-referer"]).toBe("https://maple.dev")
-		expect(captured.headers["x-title"]).toBe("Maple")
-	})
+			expect(captured.url).toContain("openrouter.ai")
+			// `HTTP-Referer` is what creates the app page — a title alone does nothing.
+			expect(captured.headers["http-referer"]).toBe("https://maple.dev")
+			expect(captured.headers["x-title"]).toBe("Maple")
+		}),
+	)
 
-	it("tags the request body with surface, org and session", async () => {
-		const captured = await captureRequest(openRouterEnv, tags)
+	it.live("tags the request body with surface, org and session", () =>
+		Effect.gen(function* () {
+			const captured = yield* captureRequest(openRouterEnv, tags)
 
-		expect(captured.body).toMatchObject({
-			user: "org_123",
-			session_id: "chat_abc",
-			trace: { trace_name: "chat" },
-		})
-	})
+			expect(captured.body).toMatchObject({
+				user: "org_123",
+				session_id: "chat_abc",
+				trace: { trace_name: "chat" },
+			})
+		}),
+	)
 
-	it("omits session_id when the caller has no session to group by", async () => {
-		const captured = await captureRequest(openRouterEnv, { surface: "ai-triage", orgId: "org_123" })
+	it.live("omits session_id when the caller has no session to group by", () =>
+		Effect.gen(function* () {
+			const captured = yield* captureRequest(openRouterEnv, { surface: "ai-triage", orgId: "org_123" })
 
-		expect(captured.body).toMatchObject({ user: "org_123", trace: { trace_name: "ai-triage" } })
-		expect(captured.body).not.toHaveProperty("session_id")
-	})
+			expect(captured.body).toMatchObject({ user: "org_123", trace: { trace_name: "ai-triage" } })
+			expect(captured.body).not.toHaveProperty("session_id")
+		}),
+	)
 
-	it("truncates an over-long session id to OpenRouter's 256-character limit", async () => {
-		const captured = await captureRequest(openRouterEnv, { ...tags, sessionId: "s".repeat(400) })
+	it.live("truncates an over-long session id to OpenRouter's 256-character limit", () =>
+		Effect.gen(function* () {
+			const captured = yield* captureRequest(openRouterEnv, { ...tags, sessionId: "s".repeat(400) })
 
-		expect(captured.body.session_id).toHaveLength(256)
-	})
+			expect(captured.body.session_id).toHaveLength(256)
+		}),
+	)
 
-	it("keeps the headers and tags off the Workers AI path", async () => {
-		const captured = await captureRequest(
-			{ MAPLE_LLM_PROVIDER: "workers-ai", CLOUDFLARE_API_KEY: "test-key" },
-			tags,
-		)
+	it.live("keeps the headers and tags off the Workers AI path", () =>
+		Effect.gen(function* () {
+			const captured = yield* captureRequest(
+				{ MAPLE_LLM_PROVIDER: "workers-ai", CLOUDFLARE_API_KEY: "test-key" },
+				tags,
+			)
 
-		expect(captured.url).not.toContain("openrouter.ai")
-		expect(captured.headers).not.toHaveProperty("http-referer")
-		expect(captured.headers).not.toHaveProperty("x-title")
-		// These are OpenRouter's body fields; Cloudflare must never be sent them.
-		expect(captured.body).not.toHaveProperty("user")
-		expect(captured.body).not.toHaveProperty("session_id")
-		expect(captured.body).not.toHaveProperty("trace")
-	})
+			expect(captured.url).not.toContain("openrouter.ai")
+			expect(captured.headers).not.toHaveProperty("http-referer")
+			expect(captured.headers).not.toHaveProperty("x-title")
+			// These are OpenRouter's body fields; Cloudflare must never be sent them.
+			expect(captured.body).not.toHaveProperty("user")
+			expect(captured.body).not.toHaveProperty("session_id")
+			expect(captured.body).not.toHaveProperty("trace")
+		}),
+	)
 })
 
 describe("reasoning effort", () => {
-	it("sends no reasoning field for triage unless one is configured", async () => {
-		// This resolver serves chat, AI triage and the validator at once. Adding the knob must not
-		// retune three stages as a side effect.
-		const captured = await captureRequest(openRouterEnv, tags)
+	it.live("sends no reasoning field for triage unless one is configured", () =>
+		Effect.gen(function* () {
+			// This resolver serves chat, AI triage and the validator at once. Adding the knob must not
+			// retune three stages as a side effect.
+			const captured = yield* captureRequest(openRouterEnv, tags)
 
-		expect(captured.body).not.toHaveProperty("reasoning")
-	})
+			expect(captured.body).not.toHaveProperty("reasoning")
+		}),
+	)
 
-	it("sends the configured triage effort", async () => {
-		const captured = await captureRequest(
-			{ ...openRouterEnv, MAPLE_TRIAGE_REASONING_EFFORT: "high" },
-			tags,
-		)
+	it.live("sends the configured triage effort", () =>
+		Effect.gen(function* () {
+			const captured = yield* captureRequest(
+				{ ...openRouterEnv, MAPLE_TRIAGE_REASONING_EFFORT: "high" },
+				tags,
+			)
 
-		expect(captured.body).toMatchObject({ reasoning: { effort: "high" } })
-	})
+			expect(captured.body).toMatchObject({ reasoning: { effort: "high" } })
+		}),
+	)
 
-	it("defaults a lens pass to low, because a fan-out of five multiplies whatever it spends", async () => {
-		const captured = await captureRequest(openRouterEnv, tags, resolveLensModel)
+	it.live("defaults a lens pass to low, because a fan-out of five multiplies whatever it spends", () =>
+		Effect.gen(function* () {
+			const captured = yield* captureRequest(openRouterEnv, tags, resolveLensModel)
 
-		expect(captured.body).toMatchObject({ reasoning: { effort: "low" } })
-	})
+			expect(captured.body).toMatchObject({ reasoning: { effort: "low" } })
+		}),
+	)
 
-	it("lets a lens be raised past the default", async () => {
-		const captured = await captureRequest(
-			{ ...openRouterEnv, MAPLE_LENS_REASONING_EFFORT: "medium" },
-			tags,
-			resolveLensModel,
-		)
+	it.live("lets a lens be raised past the default", () =>
+		Effect.gen(function* () {
+			const captured = yield* captureRequest(
+				{ ...openRouterEnv, MAPLE_LENS_REASONING_EFFORT: "medium" },
+				tags,
+				resolveLensModel,
+			)
 
-		expect(captured.body).toMatchObject({ reasoning: { effort: "medium" } })
-	})
+			expect(captured.body).toMatchObject({ reasoning: { effort: "medium" } })
+		}),
+	)
 
-	it("omits the field entirely on `off`, rather than sending a zero budget", async () => {
-		// The escape hatch: a model that does not support reasoning must see no `reasoning` key.
-		const captured = await captureRequest(
-			{ ...openRouterEnv, MAPLE_LENS_REASONING_EFFORT: "off" },
-			tags,
-			resolveLensModel,
-		)
+	it.live("omits the field entirely on `off`, rather than sending a zero budget", () =>
+		Effect.gen(function* () {
+			// The escape hatch: a model that does not support reasoning must see no `reasoning` key.
+			const captured = yield* captureRequest(
+				{ ...openRouterEnv, MAPLE_LENS_REASONING_EFFORT: "off" },
+				tags,
+				resolveLensModel,
+			)
 
-		expect(captured.body).not.toHaveProperty("reasoning")
-	})
+			expect(captured.body).not.toHaveProperty("reasoning")
+		}),
+	)
 
-	it("falls back to the default on an unrecognized value rather than failing the call", async () => {
-		// Read on a request path in a Worker: a typo'd env var must not take the agent down.
-		const captured = await captureRequest(
-			{ ...openRouterEnv, MAPLE_LENS_REASONING_EFFORT: "maximum" },
-			tags,
-			resolveLensModel,
-		)
+	it.live("falls back to the default on an unrecognized value rather than failing the call", () =>
+		Effect.gen(function* () {
+			// Read on a request path in a Worker: a typo'd env var must not take the agent down.
+			const captured = yield* captureRequest(
+				{ ...openRouterEnv, MAPLE_LENS_REASONING_EFFORT: "maximum" },
+				tags,
+				resolveLensModel,
+			)
 
-		expect(captured.body).toMatchObject({ reasoning: { effort: "low" } })
-	})
+			expect(captured.body).toMatchObject({ reasoning: { effort: "low" } })
+		}),
+	)
 
-	it("keeps reasoning off the Workers AI path", async () => {
-		const captured = await captureRequest(
-			{ MAPLE_LLM_PROVIDER: "workers-ai", CLOUDFLARE_API_KEY: "test-key" },
-			tags,
-			resolveLensModel,
-		)
+	it.live("keeps reasoning off the Workers AI path", () =>
+		Effect.gen(function* () {
+			const captured = yield* captureRequest(
+				{ MAPLE_LLM_PROVIDER: "workers-ai", CLOUDFLARE_API_KEY: "test-key" },
+				tags,
+				resolveLensModel,
+			)
 
-		// `reasoning` is OpenRouter's field, namespaced under its own provider options.
-		expect(captured.body).not.toHaveProperty("reasoning")
-	})
+			// `reasoning` is OpenRouter's field, namespaced under its own provider options.
+			expect(captured.body).not.toHaveProperty("reasoning")
+		}),
+	)
 })
 
 describe("resolveTriageModel — context limits", () => {

--- a/apps/api/src/platform/ReplayBlobStore.test.ts
+++ b/apps/api/src/platform/ReplayBlobStore.test.ts
@@ -1,12 +1,14 @@
-import { describe, expect, it } from "vitest"
+import { describe, it } from "@effect/vitest"
+import { expect } from "vitest"
 import { Effect, Layer } from "effect"
 import { layerFromEnvRecord } from "@maple/effect-cloudflare/worker-environment"
 import { ReplayBlobStore, replayObjectKey, REPLAY_BLOBS_BINDING } from "./ReplayBlobStore"
 
-const gzip = async (text: string): Promise<Uint8Array> => {
-	const stream = new Blob([text]).stream().pipeThrough(new CompressionStream("gzip"))
-	return new Uint8Array(await new Response(stream).arrayBuffer())
-}
+const gzip = (text: string): Effect.Effect<Uint8Array> =>
+	Effect.promise(async () => {
+		const stream = new Blob([text]).stream().pipeThrough(new CompressionStream("gzip"))
+		return new Uint8Array(await new Response(stream).arrayBuffer())
+	})
 
 /** Minimal stand-in for the R2 binding: only `get` is exercised. */
 const fakeBucket = (objects: Record<string, Uint8Array>, onGet?: (key: string) => void) => ({
@@ -22,16 +24,12 @@ const runWithBucket = <A>(
 	bucket: unknown,
 	program: (store: typeof ReplayBlobStore.Service) => Effect.Effect<A>,
 ) =>
-	Effect.runPromise(
-		Effect.gen(function* () {
-			const store = yield* ReplayBlobStore
-			return yield* program(store)
-		}).pipe(
-			Effect.provide(
-				ReplayBlobStore.layer.pipe(
-					Layer.provide(layerFromEnvRecord({ [REPLAY_BLOBS_BINDING]: bucket })),
-				),
-			),
+	Effect.gen(function* () {
+		const store = yield* ReplayBlobStore
+		return yield* program(store)
+	}).pipe(
+		Effect.provide(
+			ReplayBlobStore.layer.pipe(Layer.provide(layerFromEnvRecord({ [REPLAY_BLOBS_BINDING]: bucket }))),
 		),
 	)
 
@@ -66,70 +64,78 @@ describe("replayObjectKey", () => {
 describe("ReplayBlobStore.hydrate", () => {
 	const events = '[{"type":2,"timestamp":1}]'
 
-	it("fills in payloads for blob-backed chunks", async () => {
-		const bucket = fakeBucket({
-			"v1/org_1/sess_1/00000000.json.gz": await gzip(events),
-		})
-		const result = await runWithBucket(bucket, (store) =>
-			store.hydrate("org_1", "sess_1", [{ chunkSeq: 0, events: "", byteSize: 26 }]),
-		)
-		expect(result).toEqual([{ chunkSeq: 0, events, byteSize: 26 }])
-	})
+	it.live("fills in payloads for blob-backed chunks", () =>
+		Effect.gen(function* () {
+			const bucket = fakeBucket({
+				"v1/org_1/sess_1/00000000.json.gz": yield* gzip(events),
+			})
+			const result = yield* runWithBucket(bucket, (store) =>
+				store.hydrate("org_1", "sess_1", [{ chunkSeq: 0, events: "", byteSize: 26 }]),
+			)
+			expect(result).toEqual([{ chunkSeq: 0, events, byteSize: 26 }])
+		}),
+	)
 
-	it("leaves pre-cutover chunks untouched and never fetches them", async () => {
-		// The dual-read. A row written before the R2 cutover carries its payload
-		// inline; going to the bucket for it would 404 and silently drop a chunk
-		// that was there all along.
-		const fetched: string[] = []
-		const bucket = fakeBucket({}, (key) => fetched.push(key))
-		const result = await runWithBucket(bucket, (store) =>
-			store.hydrate("org_1", "sess_1", [{ chunkSeq: 0, events }]),
-		)
-		expect(result).toEqual([{ chunkSeq: 0, events }])
-		expect(fetched).toEqual([])
-	})
+	it.live("leaves pre-cutover chunks untouched and never fetches them", () =>
+		Effect.gen(function* () {
+			// The dual-read. A row written before the R2 cutover carries its payload
+			// inline; going to the bucket for it would 404 and silently drop a chunk
+			// that was there all along.
+			const fetched: string[] = []
+			const bucket = fakeBucket({}, (key) => fetched.push(key))
+			const result = yield* runWithBucket(bucket, (store) =>
+				store.hydrate("org_1", "sess_1", [{ chunkSeq: 0, events }]),
+			)
+			expect(result).toEqual([{ chunkSeq: 0, events }])
+			expect(fetched).toEqual([])
+		}),
+	)
 
-	it("drops a chunk whose object is missing rather than failing the request", async () => {
-		const bucket = fakeBucket({
-			"v1/org_1/sess_1/00000001.json.gz": await gzip(events),
-		})
-		const result = await runWithBucket(bucket, (store) =>
-			store.hydrate("org_1", "sess_1", [
-				{ chunkSeq: 0, events: "" },
-				{ chunkSeq: 1, events: "" },
-			]),
-		)
-		expect(result).toEqual([{ chunkSeq: 1, events }])
-	})
+	it.live("drops a chunk whose object is missing rather than failing the request", () =>
+		Effect.gen(function* () {
+			const bucket = fakeBucket({
+				"v1/org_1/sess_1/00000001.json.gz": yield* gzip(events),
+			})
+			const result = yield* runWithBucket(bucket, (store) =>
+				store.hydrate("org_1", "sess_1", [
+					{ chunkSeq: 0, events: "" },
+					{ chunkSeq: 1, events: "" },
+				]),
+			)
+			expect(result).toEqual([{ chunkSeq: 1, events }])
+		}),
+	)
 
-	it("preserves chunk order despite concurrent fetches", async () => {
-		const objects: Record<string, Uint8Array> = {}
-		for (let seq = 0; seq < 20; seq++) {
-			objects[replayObjectKey("org_1", "sess_1", seq)] = await gzip(`[${seq}]`)
-		}
-		const result = await runWithBucket(objects && fakeBucket(objects), (store) =>
-			store.hydrate(
-				"org_1",
-				"sess_1",
-				Array.from({ length: 20 }, (_, seq) => ({ chunkSeq: seq, events: "" })),
-			),
-		)
-		expect(result.map((chunk) => chunk.events)).toEqual(
-			Array.from({ length: 20 }, (_, seq) => `[${seq}]`),
-		)
-	})
+	it.live("preserves chunk order despite concurrent fetches", () =>
+		Effect.gen(function* () {
+			const objects: Record<string, Uint8Array> = {}
+			for (let seq = 0; seq < 20; seq++) {
+				objects[replayObjectKey("org_1", "sess_1", seq)] = yield* gzip(`[${seq}]`)
+			}
+			const result = yield* runWithBucket(objects && fakeBucket(objects), (store) =>
+				store.hydrate(
+					"org_1",
+					"sess_1",
+					Array.from({ length: 20 }, (_, seq) => ({ chunkSeq: seq, events: "" })),
+				),
+			)
+			expect(result.map((chunk) => chunk.events)).toEqual(
+				Array.from({ length: 20 }, (_, seq) => `[${seq}]`),
+			)
+		}),
+	)
 
-	it("is a no-op when the binding is absent", async () => {
-		// Self-hosted and the Docker image of this API have no R2 at all. Every
-		// row there carries its payload inline, so hydration must pass through
-		// rather than erroring on a missing binding.
-		const chunks = [{ chunkSeq: 0, events }]
-		const result = await Effect.runPromise(
-			Effect.gen(function* () {
+	it.live("is a no-op when the binding is absent", () =>
+		Effect.gen(function* () {
+			// Self-hosted and the Docker image of this API have no R2 at all. Every
+			// row there carries its payload inline, so hydration must pass through
+			// rather than erroring on a missing binding.
+			const chunks = [{ chunkSeq: 0, events }]
+			const result = yield* Effect.gen(function* () {
 				const store = yield* ReplayBlobStore
 				return yield* store.hydrate("org_1", "sess_1", chunks)
-			}).pipe(Effect.provide(ReplayBlobStore.layer.pipe(Layer.provide(layerFromEnvRecord({}))))),
-		)
-		expect(result).toEqual(chunks)
-	})
+			}).pipe(Effect.provide(ReplayBlobStore.layer.pipe(Layer.provide(layerFromEnvRecord({})))))
+			expect(result).toEqual(chunks)
+		}),
+	)
 })

--- a/apps/api/src/platform/WorkersAiHttpClient.test.ts
+++ b/apps/api/src/platform/WorkersAiHttpClient.test.ts
@@ -7,7 +7,8 @@
  * at the *end* of a turn. Worth pinning, especially since prod attaches an AI Gateway resource
  * while local dev declares a plain `ai` binding.
  */
-import { assert, describe, it } from "vitest"
+import { describe, it } from "@effect/vitest"
+import { assert } from "vitest"
 import { Effect } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { isWorkersAiBinding, workersAiHttpClient } from "./WorkersAiHttpClient"
@@ -43,124 +44,124 @@ describe("isWorkersAiBinding", () => {
 })
 
 describe("workersAiHttpClient", () => {
-	it("routes a Workers AI chat completion through the binding, hoisting `model`", async () => {
-		const calls: Array<{ model: string; inputs: Record<string, unknown> }> = []
-		const binding = {
-			run: async (model: string, inputs: Record<string, unknown>) => {
-				calls.push({ model, inputs })
-				return new Response("ok", { status: 200 })
-			},
-		}
-		const { client, seen } = recordingFallback()
+	it.live("routes a Workers AI chat completion through the binding, hoisting `model`", () =>
+		Effect.gen(function* () {
+			const calls: Array<{ model: string; inputs: Record<string, unknown> }> = []
+			const binding = {
+				run: async (model: string, inputs: Record<string, unknown>) => {
+					calls.push({ model, inputs })
+					return new Response("ok", { status: 200 })
+				},
+			}
+			const { client, seen } = recordingFallback()
 
-		const response = await Effect.runPromise(
-			workersAiHttpClient(client, binding).execute(
+			const response = yield* workersAiHttpClient(client, binding).execute(
 				jsonRequest(WORKERS_AI_URL, {
 					model: "@cf/moonshotai/kimi-k2.6",
 					messages: [{ role: "user", content: "hi" }],
 					stream: true,
 				}),
-			),
-		)
+			)
 
-		assert.equal(response.status, 200)
-		assert.isEmpty(seen, "the REST fallback must not see this request")
-		assert.lengthOf(calls, 1)
-		// `model` is the one field that moves: the binding takes it positionally and the rest of the
-		// OpenAI-compatible body passes through untouched.
-		assert.equal(calls[0]?.model, "@cf/moonshotai/kimi-k2.6")
-		assert.isUndefined(calls[0]?.inputs.model)
-		assert.deepEqual(calls[0]?.inputs.messages, [{ role: "user", content: "hi" }])
-		assert.equal(calls[0]?.inputs.stream, true)
-	})
+			assert.equal(response.status, 200)
+			assert.isEmpty(seen, "the REST fallback must not see this request")
+			assert.lengthOf(calls, 1)
+			// `model` is the one field that moves: the binding takes it positionally and the rest of the
+			// OpenAI-compatible body passes through untouched.
+			assert.equal(calls[0]?.model, "@cf/moonshotai/kimi-k2.6")
+			assert.isUndefined(calls[0]?.inputs.model)
+			assert.deepEqual(calls[0]?.inputs.messages, [{ role: "user", content: "hi" }])
+			assert.equal(calls[0]?.inputs.stream, true)
+		}),
+	)
 
-	it("also matches the AI Gateway compat path", async () => {
-		let ran = false
-		const binding = {
-			run: async () => {
-				ran = true
-				return new Response("ok")
-			},
-		}
-		const { client } = recordingFallback()
+	it.live("also matches the AI Gateway compat path", () =>
+		Effect.gen(function* () {
+			let ran = false
+			const binding = {
+				run: async () => {
+					ran = true
+					return new Response("ok")
+				},
+			}
+			const { client } = recordingFallback()
 
-		await Effect.runPromise(
-			workersAiHttpClient(client, binding).execute(
+			yield* workersAiHttpClient(client, binding).execute(
 				jsonRequest(GATEWAY_URL, { model: "@cf/test", messages: [] }),
-			),
-		)
+			)
 
-		assert.isTrue(ran)
-	})
+			assert.isTrue(ran)
+		}),
+	)
 
-	it("passes non-Workers-AI requests straight through", async () => {
-		const binding = {
-			run: async () => {
-				throw new Error("the binding must not be used for unrelated hosts")
-			},
-		}
-		const { client, seen } = recordingFallback()
+	it.live("passes non-Workers-AI requests straight through", () =>
+		Effect.gen(function* () {
+			const binding = {
+				run: async () => {
+					throw new Error("the binding must not be used for unrelated hosts")
+				},
+			}
+			const { client, seen } = recordingFallback()
 
-		await Effect.runPromise(
-			workersAiHttpClient(client, binding).execute(
+			yield* workersAiHttpClient(client, binding).execute(
 				jsonRequest("https://api.openai.com/v1/chat/completions", { model: "gpt", messages: [] }),
-			),
-		)
+			)
 
-		assert.deepEqual(seen, ["https://api.openai.com/v1/chat/completions"])
-	})
+			assert.deepEqual(seen, ["https://api.openai.com/v1/chat/completions"])
+		}),
+	)
 
-	it("strips Workers AI's native accounting trailer but keeps every OpenAI chunk", async () => {
-		// Found end-to-end, not by types: `env.AI.run` streams OpenAI-shaped deltas and then appends
-		// one frame of its OWN native accounting, which the vendored provider rejects with
-		// "Invalid ... stream event". Because it arrives last, the whole reply streams fine and then
-		// the turn dies on the final frame — every chat turn ended in `reason: "error"`.
-		const chunk = (payload: string) => `data: ${payload}\n\n`
-		const openAiDelta = JSON.stringify({
-			choices: [{ delta: { content: "PONG" }, index: 0 }],
-			object: "chat.completion.chunk",
-		})
-		// The `include_usage` chunk also carries `neurons`, so the filter must not eat it: it has
-		// `choices` and `object`, which the native trailer does not.
-		const usageChunk = JSON.stringify({
-			choices: [],
-			object: "chat.completion.chunk",
-			usage: { prompt_tokens: 10, completion_tokens: 1, neurons: 0.36 },
-		})
-		const nativeTrailer = JSON.stringify({
-			response: "",
-			usage: { prompt_tokens: 16804, completion_tokens: 36, neurons: 260.1 },
-		})
+	it.live("strips Workers AI's native accounting trailer but keeps every OpenAI chunk", () =>
+		Effect.gen(function* () {
+			// Found end-to-end, not by types: `env.AI.run` streams OpenAI-shaped deltas and then appends
+			// one frame of its OWN native accounting, which the vendored provider rejects with
+			// "Invalid ... stream event". Because it arrives last, the whole reply streams fine and then
+			// the turn dies on the final frame — every chat turn ended in `reason: "error"`.
+			const chunk = (payload: string) => `data: ${payload}\n\n`
+			const openAiDelta = JSON.stringify({
+				choices: [{ delta: { content: "PONG" }, index: 0 }],
+				object: "chat.completion.chunk",
+			})
+			// The `include_usage` chunk also carries `neurons`, so the filter must not eat it: it has
+			// `choices` and `object`, which the native trailer does not.
+			const usageChunk = JSON.stringify({
+				choices: [],
+				object: "chat.completion.chunk",
+				usage: { prompt_tokens: 10, completion_tokens: 1, neurons: 0.36 },
+			})
+			const nativeTrailer = JSON.stringify({
+				response: "",
+				usage: { prompt_tokens: 16804, completion_tokens: 36, neurons: 260.1 },
+			})
 
-		const binding = {
-			run: async () =>
-				new Response(
-					new ReadableStream<Uint8Array>({
-						start(controller) {
-							const encoder = new TextEncoder()
-							controller.enqueue(encoder.encode(chunk(openAiDelta)))
-							controller.enqueue(encoder.encode(chunk(usageChunk)))
-							controller.enqueue(encoder.encode(chunk("[DONE]")))
-							controller.enqueue(encoder.encode(chunk(nativeTrailer)))
-							controller.close()
-						},
-					}),
-				),
-		}
-		const { client } = recordingFallback()
+			const binding = {
+				run: async () =>
+					new Response(
+						new ReadableStream<Uint8Array>({
+							start(controller) {
+								const encoder = new TextEncoder()
+								controller.enqueue(encoder.encode(chunk(openAiDelta)))
+								controller.enqueue(encoder.encode(chunk(usageChunk)))
+								controller.enqueue(encoder.encode(chunk("[DONE]")))
+								controller.enqueue(encoder.encode(chunk(nativeTrailer)))
+								controller.close()
+							},
+						}),
+					),
+			}
+			const { client } = recordingFallback()
 
-		const response = await Effect.runPromise(
-			workersAiHttpClient(client, binding).execute(
+			const response = yield* workersAiHttpClient(client, binding).execute(
 				jsonRequest(WORKERS_AI_URL, { model: "@cf/test", messages: [] }),
-			),
-		)
-		const body = await Effect.runPromise(response.text)
+			)
+			const body = yield* response.text
 
-		assert.include(body, openAiDelta, "the content delta passes through")
-		assert.include(body, usageChunk, "the OpenAI usage chunk is NOT mistaken for the trailer")
-		assert.include(body, "[DONE]", "the terminator passes through")
-		assert.notInclude(body, "260.1", "the native trailer is dropped")
-	})
+			assert.include(body, openAiDelta, "the content delta passes through")
+			assert.include(body, usageChunk, "the OpenAI usage chunk is NOT mistaken for the trailer")
+			assert.include(body, "[DONE]", "the terminator passes through")
+			assert.notInclude(body, "260.1", "the native trailer is dropped")
+		}),
+	)
 
 	it("is a no-op without a usable binding", () => {
 		const { client } = recordingFallback()
@@ -169,20 +170,22 @@ describe("workersAiHttpClient", () => {
 		assert.strictEqual(workersAiHttpClient(client, undefined), client)
 	})
 
-	it("fails the request rather than the turn when the binding rejects", async () => {
-		const binding = {
-			run: async () => {
-				throw new Error("neuron budget exhausted")
-			},
-		}
-		const { client } = recordingFallback()
+	it.live("fails the request rather than the turn when the binding rejects", () =>
+		Effect.gen(function* () {
+			const binding = {
+				run: async () => {
+					throw new Error("neuron budget exhausted")
+				},
+			}
+			const { client } = recordingFallback()
 
-		const exit = await Effect.runPromiseExit(
-			workersAiHttpClient(client, binding).execute(
-				jsonRequest(WORKERS_AI_URL, { model: "@cf/test", messages: [] }),
-			),
-		)
+			const exit = yield* Effect.exit(
+				workersAiHttpClient(client, binding).execute(
+					jsonRequest(WORKERS_AI_URL, { model: "@cf/test", messages: [] }),
+				),
+			)
 
-		assert.isTrue(exit._tag === "Failure", "a binding error is a typed failure, not a defect")
-	})
+			assert.isTrue(exit._tag === "Failure", "a binding error is a typed failure, not a defect")
+		}),
+	)
 })

--- a/apps/api/src/platform/distinct-org-ids.ts
+++ b/apps/api/src/platform/distinct-org-ids.ts
@@ -1,4 +1,6 @@
+import { OrgId, type OrgId as OrgIdType } from "@maple/domain"
 import { sql } from "drizzle-orm"
+import { Schema } from "effect"
 import type { PgColumn, PgTable } from "drizzle-orm/pg-core"
 import type { DatabaseClient } from "./DatabaseLive"
 
@@ -22,7 +24,7 @@ export const selectDistinctOrgIds = async (
 	db: DatabaseClient,
 	table: PgTable,
 	column: PgColumn,
-): Promise<ReadonlyArray<string>> => {
+): Promise<ReadonlyArray<OrgIdType>> => {
 	const result = await db.execute(sql`
 		with recursive t as (
 			(
@@ -54,11 +56,13 @@ export const selectDistinctOrgIds = async (
  * client and the PGlite layer casts into it, so the declared array type is a lie
  * under test — normalize both shapes instead of trusting it.
  */
-const toOrgIds = (result: unknown): ReadonlyArray<string> => {
+const decodeOrgIdSync = Schema.decodeUnknownSync(OrgId)
+
+const toOrgIds = (result: unknown): ReadonlyArray<OrgIdType> => {
 	const rows: ReadonlyArray<unknown> = Array.isArray(result) ? result : hasRows(result) ? result.rows : []
 	return rows.flatMap((row) =>
 		typeof row === "object" && row !== null && "org_id" in row && typeof row.org_id === "string"
-			? [row.org_id]
+			? [decodeOrgIdSync(row.org_id)]
 			: [],
 	)
 }

--- a/apps/api/src/routes/v1/planetscale-webhook.http.ts
+++ b/apps/api/src/routes/v1/planetscale-webhook.http.ts
@@ -2,7 +2,7 @@ import { HttpRouter, HttpServerResponse, type HttpServerRequest } from "effect/u
 import { IntegrationsPersistenceError, OrgId } from "@maple/domain/http"
 import { planetscaleConnections } from "@maple/db"
 import { eq } from "drizzle-orm"
-import { Clock, Effect, Option, Redacted, Schema } from "effect"
+import { Clock, Data, Effect, Option, Redacted, Schema } from "effect"
 import { decryptAes256Gcm, parseBase64Aes256GcmKey } from "@/platform/Crypto"
 import { Database } from "@/platform/DatabaseLive"
 import { Env } from "@/platform/Env"
@@ -28,10 +28,9 @@ const textResponse = (body: string, status: number) => HttpServerResponse.text(b
 
 const decodeOrgIdSync = Schema.decodeUnknownSync(OrgId)
 
-class PlanetScaleWebhookUnavailable extends Schema.TaggedError<PlanetScaleWebhookUnavailable>()(
-	"PlanetScaleWebhookUnavailable",
-	{ body: Schema.String },
-) {
+class PlanetScaleWebhookUnavailable extends Data.TaggedError(
+	"@maple/api/routes/PlanetScaleWebhookUnavailable",
+)<{ readonly body: string }> {
 	override get message(): string {
 		return this.body
 	}
@@ -71,7 +70,7 @@ export const PlanetScaleWebhookRouter = HttpRouter.use((router) =>
 				Effect.gen(function* () {
 					yield* Effect.annotateCurrentSpan({
 						"http.response.status_code": 503,
-						"error.type": "PlanetScaleWebhookUnavailable",
+						"error.type": "@maple/api/routes/PlanetScaleWebhookUnavailable",
 						"maple.planetscale.webhook.outcome": "enqueue_failed",
 						"maple.planetscale.webhook.reason": reason,
 					})
@@ -217,7 +216,7 @@ export const PlanetScaleWebhookRouter = HttpRouter.use((router) =>
 
 		yield* router.add("POST", ROUTE, (req) =>
 			handle(req).pipe(
-				Effect.catchTag("PlanetScaleWebhookUnavailable", ({ body }) =>
+				Effect.catchTag("@maple/api/routes/PlanetScaleWebhookUnavailable", ({ body }) =>
 					Effect.succeed(textResponse(body, 503)),
 				),
 			),

--- a/apps/api/src/routes/v1/scraper-internal.http.ts
+++ b/apps/api/src/routes/v1/scraper-internal.http.ts
@@ -112,8 +112,8 @@ export const ScraperInternalRouter = HttpRouter.use((router) =>
 			return undefined
 		}
 
-		const listTargets = (req: HttpServerRequest.HttpServerRequest) =>
-			Effect.gen(function* () {
+		const listTargets = Effect.fn("ScraperInternal.listTargets")(
+			function* (req: HttpServerRequest.HttpServerRequest) {
 				const denied = unauthorized(req)
 				if (denied) return denied
 
@@ -195,15 +195,14 @@ export const ScraperInternalRouter = HttpRouter.use((router) =>
 				)
 
 				return yield* HttpServerResponse.json(targets)
-			}).pipe(
-				Effect.catch((error) =>
-					Effect.logError("Failed to build scraper target list").pipe(
-						Effect.annotateLogs({ error: error.message }),
-						Effect.as(errorText("Scraper target list unavailable", 503)),
-					),
+			},
+			Effect.catch((error) =>
+				Effect.logError("Failed to build scraper target list").pipe(
+					Effect.annotateLogs({ error: error.message }),
+					Effect.as(errorText("Scraper target list unavailable", 503)),
 				),
-				Effect.withSpan("ScraperInternal.listTargets"),
-			)
+			),
+		)
 
 		const recordResults = (req: HttpServerRequest.HttpServerRequest) =>
 			Effect.gen(function* () {

--- a/apps/api/src/routes/v1/vcs-webhook.http.ts
+++ b/apps/api/src/routes/v1/vcs-webhook.http.ts
@@ -9,7 +9,7 @@ import { VcsSyncQueue } from "@/services/integrations/vcs/VcsSyncQueue"
  * 500. Failed immediately after the span annotation, then caught outside the
  * span (never serialized).
  */
-class EnqueueFailure extends Data.TaggedError("EnqueueFailure")<{
+class EnqueueFailure extends Data.TaggedError("@maple/api/routes/VcsWebhookEnqueueFailure")<{
 	readonly message: string
 }> {}
 
@@ -108,7 +108,7 @@ export const VcsWebhookRouter = HttpRouter.use((router) =>
 						attributes: { "vcs.provider": provider.id },
 					}),
 					// Catch OUTSIDE the span so the span exits Error but HTTP gets a 500.
-					Effect.catchTag("EnqueueFailure", () =>
+					Effect.catchTag("@maple/api/routes/VcsWebhookEnqueueFailure", () =>
 						Effect.succeed(textResponse("enqueue failed", 500)),
 					),
 				)

--- a/apps/api/src/routes/v2/alerts-error-map.ts
+++ b/apps/api/src/routes/v2/alerts-error-map.ts
@@ -40,20 +40,15 @@ type V2ReachableAlertError =
 	| AlertDeliveryError
 	| WarehouseError
 
-type UpstreamMappedWarehouseError = Exclude<
-	WarehouseError,
-	WarehouseValidationError | WarehouseQuotaExceededError | WarehouseUpstreamError
->
+type V2AlertReadError = V2InvalidRequestError | V2RateLimitError | V2ServiceUnavailableError
 
-type MappedV2AlertError<E> =
-	| (E extends AlertForbiddenError ? V2PermissionError : never)
-	| (E extends AlertValidationError | WarehouseValidationError ? V2InvalidRequestError : never)
-	| (E extends AlertNotFoundError ? V2NotFoundError : never)
-	| (E extends AlertDestinationInUseError ? V2ConflictError : never)
-	| (E extends WarehouseQuotaExceededError ? V2RateLimitError : never)
-	| (E extends WarehouseUpstreamError ? V2ServiceUnavailableError : never)
-	| (E extends AlertDeliveryError | UpstreamMappedWarehouseError ? V2UpstreamError : never)
-	| (E extends AlertPersistenceError ? V2ServiceUnavailableError : never)
+type V2AlertCommonError = V2AlertReadError | V2UpstreamError
+
+type V2AlertWriteError = V2AlertCommonError | V2PermissionError
+
+type V2AlertMutationError = V2AlertWriteError | V2NotFoundError
+
+type V2AlertMappedError = V2AlertMutationError | V2ConflictError | V2RateLimitError
 
 const normalizeAlertResourceType = (resourceType: string) =>
 	Match.value(resourceType).pipe(
@@ -78,9 +73,9 @@ const makeAlertErrorMatcher = (operation: string) => {
 					"insufficient_permissions",
 					"You do not have permission to perform this alert operation.",
 				),
-			"@maple/http/errors/AlertValidationError": (error) =>
+			"@maple/http/errors/AlertValidationError": (error: AlertValidationError) =>
 				invalidRequest("parameter_invalid", error.message),
-			"@maple/http/errors/AlertNotFoundError": (error) => {
+			"@maple/http/errors/AlertNotFoundError": (error: AlertNotFoundError) => {
 				const resource = normalizeAlertResourceType(error.resourceType)
 				return resourceNotFound(resource, `No such ${resource.replaceAll("_", " ")}.`)
 			},
@@ -103,23 +98,63 @@ const makeAlertErrorMatcher = (operation: string) => {
 			// Maple generated SQL its own warehouse refused to plan: a server fault,
 			// not the caller's, so it stays a 5xx rather than becoming a 400 — but
 			// under its own code so on-call stops chasing the customer's warehouse.
-			"@maple/http/errors/WarehouseMalformedQueryError": (error) =>
+			"@maple/http/errors/WarehouseMalformedQueryError": (error: WarehouseErrorLike) =>
 				upstreamError(`alert_${operation}_query_bug`, presentWarehouseErrorPublic(error).description),
 			// A quota breach is the caller exceeding cost limits (429), and a
 			// validation failure is a malformed request (400) — neither is an
 			// upstream outage.
 			"@maple/http/errors/WarehouseQuotaExceededError": () => rateLimited(),
-			"@maple/http/errors/WarehouseValidationError": (error) =>
+			"@maple/http/errors/WarehouseValidationError": (error: WarehouseValidationError) =>
 				invalidRequest("parameter_invalid", error.message),
 		}),
 	)
 }
 
 /** Exhaustive, tag-local v1 alert error translation for v2 handlers. */
-export const mapAlertError = (operation: string) => {
+export function mapAlertError(
+	operation: "delivery_list" | "incident_list",
+): <A, E extends V2ReachableAlertError, R>(
+	effect: Effect.Effect<A, E, R>,
+) => Effect.Effect<A, V2AlertReadError, R>
+export function mapAlertError(
+	operation: "incident_retrieve",
+): <A, E extends V2ReachableAlertError, R>(
+	effect: Effect.Effect<A, E, R>,
+) => Effect.Effect<A, V2AlertReadError | V2NotFoundError, R>
+export function mapAlertError(
+	operation: "destination_list" | "rule_list",
+): <A, E extends V2ReachableAlertError, R>(
+	effect: Effect.Effect<A, E, R>,
+) => Effect.Effect<A, V2AlertCommonError, R>
+export function mapAlertError(
+	operation:
+		| "destination_update"
+		| "destination_test"
+		| "rule_create"
+		| "rule_update"
+		| "rule_delete"
+		| "rule_test",
+): <A, E extends V2ReachableAlertError, R>(
+	effect: Effect.Effect<A, E, R>,
+) => Effect.Effect<A, V2AlertMutationError, R>
+export function mapAlertError(
+	operation: "destination_create",
+): <A, E extends V2ReachableAlertError, R>(
+	effect: Effect.Effect<A, E, R>,
+) => Effect.Effect<A, V2AlertWriteError, R>
+export function mapAlertError(
+	operation: "destination_delete",
+): <A, E extends V2ReachableAlertError, R>(
+	effect: Effect.Effect<A, E, R>,
+) => Effect.Effect<A, V2AlertMutationError | V2ConflictError, R>
+export function mapAlertError(
+	operation: "rule_preview" | "rule_checks_list",
+): <A, E extends V2ReachableAlertError, R>(
+	effect: Effect.Effect<A, E, R>,
+) => Effect.Effect<A, V2AlertCommonError | V2NotFoundError, R>
+export function mapAlertError(operation: string) {
 	const match = makeAlertErrorMatcher(operation)
 	return <A, E extends V2ReachableAlertError, R>(
 		effect: Effect.Effect<A, E, R>,
-	): Effect.Effect<A, MappedV2AlertError<E>, R> =>
-		effect.pipe(Effect.mapError((error) => match(error) as MappedV2AlertError<E>))
+	): Effect.Effect<A, V2AlertMappedError, R> => effect.pipe(Effect.mapError(match))
 }

--- a/apps/api/src/services/alerts/AlertDeliveryDispatch.ts
+++ b/apps/api/src/services/alerts/AlertDeliveryDispatch.ts
@@ -4,6 +4,7 @@ import {
 	type AlertComparator,
 	type AlertDestinationType,
 	type AlertEventType,
+	type OrgId,
 	type AlertSignalType,
 	type AlertSeverity,
 } from "@maple/domain/http"
@@ -669,7 +670,7 @@ export interface DispatchDeps {
 	 * dependency-free — only the `slack-bot` destination arm invokes it. Fails
 	 * (AlertDeliveryError) when the org has no active Slack installation.
 	 */
-	readonly resolveSlackBotToken: (orgId: string) => Effect.Effect<string, AlertDeliveryError>
+	readonly resolveSlackBotToken: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryError>
 }
 
 export const dispatchDelivery = (

--- a/apps/api/src/services/alerts/AlertReadModelsService.ts
+++ b/apps/api/src/services/alerts/AlertReadModelsService.ts
@@ -272,6 +272,7 @@ export class AlertReadModelsService extends Context.Service<
 				readonly beforeGroupKey?: string
 			},
 		) {
+			yield* Effect.annotateCurrentSpan({ orgId, "maple.alert.rule_id": ruleId })
 			// Verify the rule exists and belongs to this org before querying Tinybird.
 			const ruleRow = yield* dbExecute((db) =>
 				db
@@ -397,6 +398,7 @@ export class AlertReadModelsService extends Context.Service<
 			ruleId: AlertRuleId,
 			options: { readonly since: string; readonly until: string },
 		) {
+			yield* Effect.annotateCurrentSpan({ orgId, "maple.alert.rule_id": ruleId })
 			const ruleRow = yield* dbExecute((db) =>
 				db
 					.select({ id: alertRules.id })
@@ -506,6 +508,7 @@ export class AlertReadModelsService extends Context.Service<
 			orgId: OrgId,
 			options: ListAlertDeliveryEventsOptions = {},
 		) {
+			yield* Effect.annotateCurrentSpan("orgId", orgId)
 			const rows = yield* dbExecute((db) =>
 				db
 					.select()

--- a/apps/api/src/services/alerts/AlertsService.test.ts
+++ b/apps/api/src/services/alerts/AlertsService.test.ts
@@ -228,23 +228,19 @@ const makeLayer = (
 	)
 
 	const alertsLive = AlertsService.layer.pipe(
-		Layer.provide(
-			Layer.mergeAll(
-				envLive,
-				databaseLive,
-				queryEngineLive,
-				warehouseLive,
-				runtimeLive,
-				hazelOAuthLive,
-				emailLive,
-				orgMembersLive,
-				orgChSettingsLive,
-				investigationsLive,
-				alertDestinationsLive,
-				alertReadModelsLive,
-				alertRulesLive,
-			),
-		),
+		Layer.provide(envLive),
+		Layer.provide(databaseLive),
+		Layer.provide(queryEngineLive),
+		Layer.provide(warehouseLive),
+		Layer.provide(runtimeLive),
+		Layer.provide(hazelOAuthLive),
+		Layer.provide(emailLive),
+		Layer.provide(orgMembersLive),
+		Layer.provide(orgChSettingsLive),
+		Layer.provide(investigationsLive),
+		Layer.provide(alertDestinationsLive),
+		Layer.provide(alertReadModelsLive),
+		Layer.provide(alertRulesLive),
 	)
 	return Layer.mergeAll(alertDestinationsLive, alertReadModelsLive, alertRulesLive, alertsLive)
 }

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -466,6 +466,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				incidentOpenedAtMs: number,
 				timestamp: number,
 			) {
+				yield* Effect.annotateCurrentSpan("orgId", orgId)
 				const windowMs = Math.max(normalized.windowMinutes, 1) * 60_000
 				return yield* probeLiveness({
 					warehouse,
@@ -526,6 +527,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				ReadonlyArray<{ evaluation: EvaluatedRule; groupKey: string }>,
 				AlertValidationError | AlertDeliveryError | WarehouseError
 			> {
+				yield* Effect.annotateCurrentSpan({ orgId, "maple.alert.rule_id": rule.id })
 				const endMs = yield* now
 				const startMs = endMs - rule.windowMinutes * 60_000
 				const plan = rule.compiledPlan
@@ -675,6 +677,11 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				deliveryKey: string,
 				attemptNumber: number,
 			) {
+				yield* Effect.annotateCurrentSpan({
+					orgId,
+					"maple.alert.rule_id": ruleId,
+					"maple.alert.destination_id": destinationId,
+				})
 				yield* dbExecute((db) =>
 					insertDeliveryEventRecord(
 						db,
@@ -816,6 +823,11 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				ruleId: AlertRuleDocument["id"],
 				request: AlertRuleUpsertRequest,
 			) {
+				yield* Effect.annotateCurrentSpan({
+					orgId,
+					"tenant.userId": userId,
+					"maple.alert.rule_id": ruleId,
+				})
 				yield* requireAdmin(roles)
 				const oldRow = yield* requireRuleRow(orgId, ruleId)
 				const result = yield* upsertRuleRow(orgId, userId, ruleId, request)
@@ -854,6 +866,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				request: AlertRuleUpsertRequest,
 				sendNotification = false,
 			) {
+				yield* Effect.annotateCurrentSpan({ orgId, "tenant.userId": userId })
 				yield* requireAdmin(roles)
 				const normalized = yield* normalizeRule(orgId, request)
 				yield* requireDestinationIds(orgId, normalized.destinationIds)
@@ -995,6 +1008,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				| AlertPersistenceError
 				| WarehouseError
 			> {
+				yield* Effect.annotateCurrentSpan("orgId", orgId)
 				const normalized = yield* normalizeRule(orgId, request.rule, {
 					forPreview: true,
 				})
@@ -1572,7 +1586,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 				// sequential writes (no transaction) and stay idempotent on retry: state
 				// upsert via onConflictDoUpdate, incident insert keyed on unique
 				// incidentKey, delivery events via onConflictDoNothing on deliveryKey.
-				const outcome = yield* Effect.gen(function* () {
+				const evaluateTransition = Effect.fnUntraced(function* () {
 					// Both reads come from the tick-head prefetch rather than a query per
 					// group. Safe because this function is the only writer of either key
 					// and runs at most once per key per tick — see `loadTickPrefetch`.
@@ -1939,6 +1953,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 						consecutiveHealthy,
 					}
 				})
+				const outcome = yield* evaluateTransition()
 
 				if (outcome.transition === "opened") {
 					yield* Metric.update(AlertingMetrics.incidentsOpenedTotal, 1)
@@ -2101,6 +2116,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					readonly resolveAll?: boolean
 				},
 			) {
+				yield* Effect.annotateCurrentSpan({ orgId, "maple.alert.rule_id": ruleId })
 				const openIncidents = yield* dbExecute((db) =>
 					db
 						.select()

--- a/apps/api/src/services/billing/DailySpendService.ts
+++ b/apps/api/src/services/billing/DailySpendService.ts
@@ -58,6 +58,7 @@ export class DailySpendService extends Context.Service<DailySpendService, DailyS
 				cycle: { readonly startMs: number; readonly endMs: number },
 			) {
 				const orgId = tenant.orgId
+				yield* Effect.annotateCurrentSpan("orgId", orgId)
 				const params = {
 					orgId,
 					startTime: formatWarehouseDateTime(cycle.startMs),

--- a/apps/api/src/services/billing/autumn-client.ts
+++ b/apps/api/src/services/billing/autumn-client.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect"
+import { Data, Effect, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { autumnHandler, type CustomerData } from "autumn-js/backend"
 import type { EdgeCacheServiceShape } from "@maple/cache"
@@ -49,12 +49,9 @@ export const responseHasActivePlan = (response: unknown): boolean => {
 // Sentinel keeping non-200 Autumn responses out of the edge cache: the compute
 // fails with this so `getOrCompute` never stores it, then the caller recovers it
 // into the normal path. Mirrors `AutumnResult` so `.result` stays typed.
-class UncacheableAutumnResult extends Schema.TaggedError<UncacheableAutumnResult>()(
-	"@maple/api/billing/UncacheableAutumnResult",
-	{
-		result: Schema.Struct({ statusCode: Schema.Number, response: Schema.Unknown }),
-	},
-) {}
+class UncacheableAutumnResult extends Data.TaggedError("@maple/api/billing/UncacheableAutumnResult")<{
+	readonly result: AutumnResult
+}> {}
 
 /**
  * Run `getOrCreateCustomer` through the per-org edge cache (200-only). Active-plan

--- a/apps/api/src/services/dashboards/ServiceMapRollupService.ts
+++ b/apps/api/src/services/dashboards/ServiceMapRollupService.ts
@@ -82,6 +82,7 @@ export class ServiceMapRollupService extends Context.Service<
 		})
 
 		const processOrg = Effect.fn("ServiceMapRollupService.processOrg")(function* (orgId: OrgId) {
+			yield* Effect.annotateCurrentSpan("orgId", orgId)
 			const tenant = systemTenant(orgId)
 			const currentHourMs = Math.floor((yield* Clock.currentTimeMillis) / HOUR_MS) * HOUR_MS
 			const oldestHourMs = currentHourMs - LOOKBACK_HOURS * HOUR_MS
@@ -242,12 +243,16 @@ export class ServiceMapRollupService extends Context.Service<
 				.execute((db) =>
 					db.selectDistinct({ orgId: orgClickHouseSettings.orgId }).from(orgClickHouseSettings),
 				)
-				.pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<{ orgId: string }>))
+				.pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<{ orgId: OrgId }>))
 
 			return yield* warehouse
 				.crossOrgQuery(
 					systemTenant(knownOrgs[0]!),
-					CH.compile(CH.activeOrgsByTracesQuery(), { startTime }),
+					CH.compile(
+						CH.activeOrgsByTracesQuery(),
+						{ startTime },
+						{ rowSchema: CH.ActiveOrgsOutputSchema },
+					),
 					{
 						profile: "discovery",
 						context: "serviceMapRollupActiveOrgs",
@@ -257,12 +262,11 @@ export class ServiceMapRollupService extends Context.Service<
 				)
 				.pipe(
 					Effect.map((rows) => {
-						const active = new Set<string>(byoRows.map((row) => row.orgId))
+						const active = new Set<OrgId>(byoRows.map((row) => row.orgId))
 						for (const row of rows) {
-							const orgId = String((row as { orgId?: unknown }).orgId ?? "")
-							if (orgId) active.add(orgId)
+							active.add(row.orgId)
 						}
-						return active as ReadonlySet<string>
+						return active as ReadonlySet<OrgId>
 					}),
 					Effect.catchCause((cause) =>
 						Cause.hasInterruptsOnly(cause)
@@ -284,7 +288,7 @@ export class ServiceMapRollupService extends Context.Service<
 				db.selectDistinct({ orgId: orgIngestKeys.orgId }).from(orgIngestKeys),
 			)
 
-			const knownOrgs = orgRows.map((row) => row.orgId as OrgId)
+			const knownOrgs = orgRows.map((row) => row.orgId)
 			const active = yield* resolveActiveOrgs(knownOrgs)
 			const targetOrgs =
 				active === undefined ? knownOrgs : knownOrgs.filter((orgId) => active.has(orgId))

--- a/apps/api/src/services/digest/DigestService.ts
+++ b/apps/api/src/services/digest/DigestService.ts
@@ -564,7 +564,13 @@ export class DigestService extends Context.Service<DigestService>()("@maple/api/
 						const memberEmail = member.publicUserData?.identifier
 						const memberUserId = member.publicUserData?.userId
 						if (!memberEmail || !memberUserId) return []
-						return [{ orgId: org.id, userId: memberUserId, email: memberEmail }]
+						return [
+							{
+								orgId: OrgId.make(org.id),
+								userId: UserId.make(memberUserId),
+								email: memberEmail,
+							},
+						]
 					})
 				}),
 			)
@@ -573,7 +579,7 @@ export class DigestService extends Context.Service<DigestService>()("@maple/api/
 		})
 
 		const reconcileSubscriptions = Effect.fn("DigestService.reconcileSubscriptions")(function* (
-			clerkMemberships: Array<{ orgId: string; userId: string; email: string }>,
+			clerkMemberships: Array<{ orgId: OrgId; userId: UserId; email: string }>,
 		) {
 			const now = yield* Clock.currentTimeMillis
 

--- a/apps/api/src/services/errors/ErrorIssueReadModelsService.test.ts
+++ b/apps/api/src/services/errors/ErrorIssueReadModelsService.test.ts
@@ -64,9 +64,13 @@ const makeWarehouseStub = (contexts: Array<string>): WarehouseQueryServiceShape 
 const makeLayer = (contexts: Array<string>) => {
 	const database = createTestDb(createdDbs).layer
 	const actors = ErrorActorsService.layer.pipe(Layer.provide(database))
-	const workflow = ErrorIssueWorkflowService.layer.pipe(Layer.provide(Layer.mergeAll(database, actors)))
+	const workflow = ErrorIssueWorkflowService.layer.pipe(Layer.provide(database), Layer.provide(actors))
 	const warehouse = Layer.succeed(WarehouseQueryService, makeWarehouseStub(contexts))
-	const readModels = readRequirements.pipe(Layer.provide(Layer.mergeAll(database, warehouse, workflow)))
+	const readModels = readRequirements.pipe(
+		Layer.provide(database),
+		Layer.provide(warehouse),
+		Layer.provide(workflow),
+	)
 	return Layer.mergeAll(readModels, workflow, actors).pipe(Layer.provideMerge(database))
 }
 

--- a/apps/api/src/services/errors/ErrorIssueReadModelsService.ts
+++ b/apps/api/src/services/errors/ErrorIssueReadModelsService.ts
@@ -18,8 +18,6 @@ import {
 	type IssueSeverity,
 	type OrgId,
 	RoleName,
-	SpanId as SpanIdSchema,
-	TraceId as TraceIdSchema,
 	UserId as UserIdSchema,
 	type WorkflowState,
 } from "@maple/domain/http"
@@ -47,8 +45,6 @@ const encodeIssueSeverityListCursor = (fields: IssueSeverityListCursorFields): s
 const decodeIsoDateTimeStringSync = Schema.decodeUnknownSync(ErrorIssueDocument.fields.firstSeenAt)
 const decodeRoleNameSync = Schema.decodeUnknownSync(RoleName)
 const decodeUserIdSync = Schema.decodeUnknownSync(UserIdSchema)
-const decodeTraceIdSync = Schema.decodeUnknownSync(TraceIdSchema)
-const decodeSpanIdSync = Schema.decodeUnknownSync(SpanIdSchema)
 
 const DEFAULT_DETAIL_WINDOW_MS = 24 * 60 * 60 * 1000
 /** Fallback fingerprint-scan window for the issue list's env filter when the
@@ -346,12 +342,16 @@ const make: Effect.Effect<
 						.pipe(Effect.mapError(makePersistenceError))
 				: Effect.succeed([])
 
-			const samplesCompiled = CH.compile(CH.errorIssueSampleTracesQuery({ limit: sampleLimit }), {
-				orgId,
-				fingerprintHash: issueRow.fingerprintHash,
-				startTime: formatWarehouseDateTime(startMs),
-				endTime: formatWarehouseDateTime(endMs),
-			})
+			const samplesCompiled = CH.compile(
+				CH.errorIssueSampleTracesQuery({ limit: sampleLimit }),
+				{
+					orgId,
+					fingerprintHash: issueRow.fingerprintHash,
+					startTime: formatWarehouseDateTime(startMs),
+					endTime: formatWarehouseDateTime(endMs),
+				},
+				{ rowSchema: CH.ErrorIssueSampleTracesOutputSchema },
+			)
 			const samplesEffect = isErrorKind
 				? warehouse
 						.compiledQuery(tenant, samplesCompiled, {
@@ -384,12 +384,12 @@ const make: Effect.Effect<
 			const sampleTraces = sampleRows.map(
 				(row) =>
 					new ErrorIssueSampleTrace({
-						traceId: decodeTraceIdSync(String(row.traceId ?? "")),
-						spanId: decodeSpanIdSync(String(row.spanId ?? "")),
-						serviceName: String(row.serviceName ?? ""),
+						traceId: row.traceId,
+						spanId: row.spanId,
+						serviceName: row.serviceName,
 						timestamp: decodeIsoDateTimeStringSync(warehouseDateTimeToIso(String(row.timestamp))),
-						exceptionMessage: String(row.exceptionMessage ?? ""),
-						durationMicros: Number(row.durationMicros ?? 0),
+						exceptionMessage: row.exceptionMessage,
+						durationMicros: row.durationMicros,
 					}),
 			)
 

--- a/apps/api/src/services/errors/ErrorsService.test.ts
+++ b/apps/api/src/services/errors/ErrorsService.test.ts
@@ -203,7 +203,8 @@ const makeErrorsLayer = (
 	const databaseLive = testDb.layer
 	const errorActorsLive = ErrorActorsService.layer.pipe(Layer.provide(databaseLive))
 	const errorIssueWorkflowLive = ErrorIssueWorkflowService.layer.pipe(
-		Layer.provide(Layer.mergeAll(databaseLive, errorActorsLive)),
+		Layer.provide(databaseLive),
+		Layer.provide(errorActorsLive),
 	)
 	const errorPolicyLive = ErrorPolicyService.layer.pipe(Layer.provide(databaseLive))
 	const warehouseLive = Layer.succeed(
@@ -211,13 +212,16 @@ const makeErrorsLayer = (
 		makeWarehouseStub(scanRows, onScan, fingerprintRows),
 	)
 	const errorIssueReadModelsLive = ErrorIssueReadModelsService.layer.pipe(
-		Layer.provide(Layer.mergeAll(databaseLive, warehouseLive, errorIssueWorkflowLive)),
+		Layer.provide(databaseLive),
+		Layer.provide(warehouseLive),
+		Layer.provide(errorIssueWorkflowLive),
 	)
 	// Held only so the service can hand an autonomous investigation turn its `submit_diagnosis`
 	// tool; no test here starts one. The real layer is cheap — it depends on nothing beyond Env
 	// and the database already wired above.
 	const investigationsLive = InvestigationService.layer.pipe(
-		Layer.provide(Layer.mergeAll(envLive, databaseLive)),
+		Layer.provide(envLive),
+		Layer.provide(databaseLive),
 	)
 	const dispatcherStub = Layer.succeed(
 		NotificationDispatcher,
@@ -226,20 +230,18 @@ const makeErrorsLayer = (
 		},
 	)
 	const errorsLive = ErrorsService.layer.pipe(
+		Layer.provide(envLive),
+		Layer.provide(databaseLive),
+		Layer.provide(warehouseLive),
 		Layer.provide(
-			Layer.mergeAll(
-				envLive,
-				databaseLive,
-				warehouseLive,
-				Layer.succeed(EdgeCacheService, makeEdgeCacheService(edgeBackend ?? makeMemoryBackend())),
-				dispatcherStub,
-				errorActorsLive,
-				errorIssueReadModelsLive,
-				errorIssueWorkflowLive,
-				errorPolicyLive,
-				investigationsLive,
-			),
+			Layer.succeed(EdgeCacheService, makeEdgeCacheService(edgeBackend ?? makeMemoryBackend())),
 		),
+		Layer.provide(dispatcherStub),
+		Layer.provide(errorActorsLive),
+		Layer.provide(errorIssueReadModelsLive),
+		Layer.provide(errorIssueWorkflowLive),
+		Layer.provide(errorPolicyLive),
+		Layer.provide(investigationsLive),
 	)
 	return Layer.mergeAll(
 		errorsLive,
@@ -291,7 +293,8 @@ const makeGatingLayer = (opts: {
 	const databaseLive = testDb.layer
 	const errorActorsLive = ErrorActorsService.layer.pipe(Layer.provide(databaseLive))
 	const errorIssueWorkflowLive = ErrorIssueWorkflowService.layer.pipe(
-		Layer.provide(Layer.mergeAll(databaseLive, errorActorsLive)),
+		Layer.provide(databaseLive),
+		Layer.provide(errorActorsLive),
 	)
 	const errorPolicyLive = ErrorPolicyService.layer.pipe(Layer.provide(databaseLive))
 	// Held only so the service can hand an autonomous investigation turn its `submit_diagnosis`
@@ -342,23 +345,21 @@ const makeGatingLayer = (opts: {
 	}
 	const warehouseLive = Layer.succeed(WarehouseQueryService, warehouseStub)
 	const errorIssueReadModelsLive = ErrorIssueReadModelsService.layer.pipe(
-		Layer.provide(Layer.mergeAll(databaseLive, warehouseLive, errorIssueWorkflowLive)),
+		Layer.provide(databaseLive),
+		Layer.provide(warehouseLive),
+		Layer.provide(errorIssueWorkflowLive),
 	)
 	return ErrorsService.layer.pipe(
-		Layer.provide(
-			Layer.mergeAll(
-				envLive,
-				databaseLive,
-				warehouseLive,
-				Layer.succeed(EdgeCacheService, makeEdgeCacheService(makeMemoryBackend())),
-				dispatcherStub,
-				errorActorsLive,
-				errorIssueReadModelsLive,
-				errorIssueWorkflowLive,
-				errorPolicyLive,
-				investigationsLive,
-			),
-		),
+		Layer.provide(envLive),
+		Layer.provide(databaseLive),
+		Layer.provide(warehouseLive),
+		Layer.provide(Layer.succeed(EdgeCacheService, makeEdgeCacheService(makeMemoryBackend()))),
+		Layer.provide(dispatcherStub),
+		Layer.provide(errorActorsLive),
+		Layer.provide(errorIssueReadModelsLive),
+		Layer.provide(errorIssueWorkflowLive),
+		Layer.provide(errorPolicyLive),
+		Layer.provide(investigationsLive),
 		Layer.provideMerge(databaseLive),
 	)
 }

--- a/apps/api/src/services/errors/ErrorsService.ts
+++ b/apps/api/src/services/errors/ErrorsService.ts
@@ -262,25 +262,27 @@ const make: Effect.Effect<
 	// keeps working even when discovery is down.
 
 	const resolveActiveOrgs = Effect.fn("ErrorsService.resolveActiveOrgs")(function* (
-		knownOrgs: ReadonlyArray<string>,
+		knownOrgs: ReadonlyArray<OrgId>,
 		nowMs: number,
 	) {
 		yield* Effect.annotateCurrentSpan("knownOrgs", knownOrgs.length)
 		const byoRows = yield* dbExecute((db) =>
 			db.selectDistinct({ orgId: orgClickHouseSettings.orgId }).from(orgClickHouseSettings),
-		).pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<{ orgId: string }>))
-		const byo = new Set<string>(byoRows.map((r) => r.orgId))
+		).pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<{ orgId: OrgId }>))
+		const byo = new Set<OrgId>(byoRows.map((r) => r.orgId))
 
 		if (knownOrgs.length === 0) {
 			yield* Effect.annotateCurrentSpan({ activeOrgs: byo.size, failedClosed: false })
-			return byo as ReadonlySet<string>
+			return byo as ReadonlySet<OrgId>
 		}
 
-		const compiled = CH.compile(CH.activeOrgsByErrorEventsQuery(), {
-			startTime: formatWarehouseDateTime(nowMs - ERROR_ACTIVE_DISCOVERY_WINDOW_MS),
-		})
+		const compiled = CH.compile(
+			CH.activeOrgsByErrorEventsQuery(),
+			{ startTime: formatWarehouseDateTime(nowMs - ERROR_ACTIVE_DISCOVERY_WINDOW_MS) },
+			{ rowSchema: CH.ActiveOrgsOutputSchema },
+		)
 		return yield* warehouse
-			.crossOrgQuery(systemTenant(knownOrgs[0] as OrgId), compiled, {
+			.crossOrgQuery(systemTenant(knownOrgs[0]!), compiled, {
 				// Bound the one cross-org scan (no OrgId predicate ⇒ can't prune the
 				// primary key): abort server-side at 5s instead of riding the ~30s
 				// client timeout when the warehouse is slow.
@@ -291,12 +293,11 @@ const make: Effect.Effect<
 			})
 			.pipe(
 				Effect.map((rows) => {
-					const active = new Set<string>(byo)
+					const active = new Set<OrgId>(byo)
 					for (const row of rows) {
-						const orgId = String((row as { orgId?: unknown }).orgId ?? "")
-						if (orgId) active.add(orgId)
+						active.add(row.orgId)
 					}
-					return active as ReadonlySet<string>
+					return active as ReadonlySet<OrgId>
 				}),
 				Effect.tap((active) =>
 					Effect.annotateCurrentSpan({ activeOrgs: active.size, failedClosed: false }),
@@ -1245,15 +1246,15 @@ const make: Effect.Effect<
 		const ingestOrgs = yield* dbExecute((db) =>
 			db.selectDistinct({ orgId: orgIngestKeys.orgId }).from(orgIngestKeys),
 		)
-		const knownOrgs = new Set<string>([...stateOrgs, ...issueOrgs, ...ingestOrgs.map((r) => r.orgId)])
+		const knownOrgs = new Set<OrgId>([...stateOrgs, ...issueOrgs, ...ingestOrgs.map((r) => r.orgId)])
 
 		const activeOrgs = yield* resolveActiveOrgs([...knownOrgs], nowMs)
 		// Orgs that hold issue/incident state must be scanned even with no recent
 		// errors: the scan returning empty is what drives auto-resolution and
 		// aging. Only pure ingest-key-only orgs with neither recent errors nor
 		// existing state are skipped.
-		const withState = new Set<string>([...stateOrgs, ...issueOrgs])
-		const isActive = (org: string) => activeOrgs.has(org) || withState.has(org)
+		const withState = new Set<OrgId>([...stateOrgs, ...issueOrgs])
+		const isActive = (org: OrgId) => activeOrgs.has(org) || withState.has(org)
 		// Everything `processOrg` does for an inactive org is a no-op read: lease
 		// expiry, snooze wake-up and stale-incident resolution can only match rows
 		// in error_issues / error_issue_states / error_incidents, and an org holding
@@ -1286,7 +1287,7 @@ const make: Effect.Effect<
 						)
 						return emptyResult
 					}
-					return yield* processOrg(org as OrgId, cutoffMs, nowMs, retentionRan)
+					return yield* processOrg(org, cutoffMs, nowMs, retentionRan)
 				}).pipe(
 					// Isolate genuine per-org failures/defects so one bad org can't fail the
 					// whole tick. Interrupts (isolate teardown) are NOT per-org failures —

--- a/apps/api/src/services/errors/RecommendationIssueService.ts
+++ b/apps/api/src/services/errors/RecommendationIssueService.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import {
 	IsoDateTimeString,
+	OrgId,
 	RecommendationIssue,
 	RecommendationIssueId,
 	RecommendationIssueKind,
@@ -85,7 +86,7 @@ export class RecommendationIssueService extends Context.Service<
 				Effect.mapError(toPersistenceError),
 			)
 
-		const selectAll = (orgId: string) =>
+		const selectAll = (orgId: OrgId) =>
 			runDb(
 				"list",
 				database.execute((db) =>
@@ -97,7 +98,7 @@ export class RecommendationIssueService extends Context.Service<
 				),
 			)
 
-		const listResponse = (orgId: string) =>
+		const listResponse = (orgId: OrgId) =>
 			selectAll(orgId).pipe(
 				Effect.map((rows) => new RecommendationIssuesListResponse({ issues: rows.map(rowToIssue) })),
 			)
@@ -137,6 +138,7 @@ export class RecommendationIssueService extends Context.Service<
 			tenant: TenantContext,
 		) {
 			const orgId = tenant.orgId
+			yield* Effect.annotateCurrentSpan("orgId", orgId)
 
 			// Reconcile needs live span keys. If the warehouse is unavailable, degrade gracefully:
 			// return the stored issues unchanged rather than failing the whole settings page.
@@ -235,6 +237,7 @@ export class RecommendationIssueService extends Context.Service<
 			fields: Record<string, unknown>,
 		) {
 			const orgId = tenant.orgId
+			yield* Effect.annotateCurrentSpan({ orgId, "maple.recommendation_issue.id": id })
 			const existing = yield* runDb(
 				"selectById",
 				database.execute((db) =>

--- a/apps/api/src/services/errors/investigation-fanout-error.ts
+++ b/apps/api/src/services/errors/investigation-fanout-error.ts
@@ -1,7 +1,7 @@
 import { Data } from "effect"
 
 /** Internal workflow-start failure shared by both investigation entry points. */
-export class FanoutStartError extends Data.TaggedError("FanoutStartError")<{
+export class FanoutStartError extends Data.TaggedError("@maple/api/errors/FanoutStartError")<{
 	readonly cause: string
 }> {
 	override get message(): string {

--- a/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
+++ b/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
@@ -52,6 +52,7 @@ import {
 	Cause,
 	Clock,
 	Context,
+	Data,
 	Effect,
 	Layer,
 	Match,
@@ -824,15 +825,14 @@ interface DatasetPollFailure {
  * `find_errors` / the errors page through the SAME pipeline as every other error, instead of being
  * buried in `cloudflare_analytics_state.lastError` where nothing watches it.
  */
-class CloudflareAnalyticsPollError extends Schema.TaggedError<CloudflareAnalyticsPollError>()(
-	"@maple/cloudflare/AnalyticsPollError",
-	{
-		message: Schema.String,
-		orgId: OrgId,
-		dataset: Schema.String,
-		kind: Schema.Literals(["authz", "upstream", "revoked", "billing", "other"]),
-	},
-) {}
+class CloudflareAnalyticsPollError extends Data.TaggedError(
+	"@maple/api/integrations/CloudflareAnalyticsPollError",
+)<{
+	readonly message: string
+	readonly orgId: OrgId
+	readonly dataset: string
+	readonly kind: DatasetPollFailure["kind"]
+}> {}
 
 type PollOutcome =
 	| { readonly kind: "advanced"; readonly ingested: number }

--- a/apps/api/src/services/integrations/PlanetScaleService.ts
+++ b/apps/api/src/services/integrations/PlanetScaleService.ts
@@ -403,7 +403,7 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 			 * collapsing them into one invisible boolean.
 			 */
 			const claimPollWork = Effect.fn("PlanetScaleService.claimPollWork")(function* (
-				orgId: string,
+				orgId: OrgId,
 				dataset: string,
 				databaseId: string,
 				ttlMs: number,
@@ -471,7 +471,7 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 			})
 
 			/** The org-wide inventory anchor row — also the tick-overlap lease. */
-			const claimInventoryWork = (orgId: string) =>
+			const claimInventoryWork = (orgId: OrgId) =>
 				claimPollWork(orgId, INVENTORY_DATASET, "", INVENTORY_TTL_MS)
 
 			/**
@@ -484,7 +484,7 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 				insertPlanetScaleEvent(input).pipe(Effect.provideService(Database, database))
 
 			const readPollState = Effect.fn("PlanetScaleService.readPollState")(function* (
-				orgId: string,
+				orgId: OrgId,
 				dataset: string,
 				databaseId: string,
 			) {
@@ -508,7 +508,7 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 
 			/** `databaseId → lastSuccessAt`, for round-robining a budgeted sweep. */
 			const pollStateByDatabaseId = Effect.fn("PlanetScaleService.pollStateByDatabaseId")(function* (
-				orgId: string,
+				orgId: OrgId,
 				dataset: string,
 			) {
 				const rows = yield* database
@@ -535,7 +535,7 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 			 * success is what keeps a failed page from being skipped forever.
 			 */
 			const recordPollResult = Effect.fn("PlanetScaleService.recordPollResult")(function* (
-				orgId: string,
+				orgId: OrgId,
 				dataset: string,
 				databaseId: string,
 				error: string | null,
@@ -575,7 +575,7 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 			})
 
 			const recordInventoryResult = Effect.fn("PlanetScaleService.recordInventoryResult")(function* (
-				orgId: string,
+				orgId: OrgId,
 				connectionId: string,
 				error: string | null,
 			) {

--- a/apps/api/src/services/integrations/SlackIntegrationService.ts
+++ b/apps/api/src/services/integrations/SlackIntegrationService.ts
@@ -167,7 +167,7 @@ export const missingBotScopes = (grantedScope: string | null): ReadonlyArray<str
  * `DatabaseError` wrapping the failed `execute`, where `completeInstall`
  * branches on it — it never leaves `completeInstall`.
  */
-class SlackCrossOrgConflict extends Data.TaggedError("SlackCrossOrgConflict")<{
+class SlackCrossOrgConflict extends Data.TaggedError("@maple/api/integrations/SlackCrossOrgConflict")<{
 	readonly teamId: string
 	readonly orgId: string
 }> {

--- a/apps/api/src/services/integrations/TinybirdOrgTokenService.ts
+++ b/apps/api/src/services/integrations/TinybirdOrgTokenService.ts
@@ -1,5 +1,5 @@
 import type { OrgId } from "@maple/domain"
-import { Clock, Context, Effect, Layer, Option, Redacted, Schema } from "effect"
+import { Clock, Context, Data, Effect, Layer, Option, Redacted } from "effect"
 import { listOrgScopedDatasourceNames } from "@/services/warehouse/warehouse-catalog"
 import { mintOrgReadJwt } from "@/services/auth/tinybird-jwt"
 import { Env } from "@/platform/Env"
@@ -29,13 +29,10 @@ export interface TinybirdOrgTokenServiceShape {
 	readonly getOrgReadToken: (orgId: OrgId) => Effect.Effect<string, TinybirdOrgTokenError>
 }
 
-export class TinybirdOrgTokenError extends Schema.TaggedError<TinybirdOrgTokenError>()(
-	"@maple/api/services/TinybirdOrgTokenError",
-	{
-		reason: Schema.Literals(["MissingSigningKey", "MissingWorkspaceId", "MintFailed"]),
-		message: Schema.String,
-	},
-) {}
+export class TinybirdOrgTokenError extends Data.TaggedError("@maple/api/services/TinybirdOrgTokenError")<{
+	readonly reason: "MissingSigningKey" | "MissingWorkspaceId" | "MintFailed"
+	readonly message: string
+}> {}
 
 export class TinybirdOrgTokenService extends Context.Service<
 	TinybirdOrgTokenService,
@@ -62,6 +59,7 @@ export class TinybirdOrgTokenService extends Context.Service<
 		const getOrgReadToken = Effect.fn("TinybirdOrgTokenService.getOrgReadToken")(function* (
 			orgId: OrgId,
 		) {
+			yield* Effect.annotateCurrentSpan("orgId", orgId)
 			const nowMs = yield* Clock.currentTimeMillis
 			const cached = cache.get(orgId)
 			if (cached !== undefined && cached.expiresAt > nowMs) {

--- a/apps/api/src/services/integrations/slack-bot-token.ts
+++ b/apps/api/src/services/integrations/slack-bot-token.ts
@@ -1,7 +1,7 @@
 import { slackWorkspaces } from "@maple/db"
-import { AlertDeliveryError } from "@maple/domain/http"
+import { AlertDeliveryError, OrgId } from "@maple/domain/http"
 import { and, eq, isNull } from "drizzle-orm"
-import { Context, Data, Effect, Layer, Option, Redacted } from "effect"
+import { Context, Data, Effect, Layer, Option, Redacted, Schema } from "effect"
 import { decryptAes256Gcm, parseBase64Aes256GcmKey } from "@/platform/Crypto"
 import { Database, type DatabaseShape } from "@/platform/DatabaseLive"
 import { Env } from "@/platform/Env"
@@ -28,7 +28,7 @@ export const slackSecretAad = (orgId: string, teamId: string, column: SlackSecre
 	Buffer.from(`slack_workspaces:v1:${orgId}:${teamId}:${column}`, "utf8")
 
 /** The single active (non-revoked) installation for an org, if any. */
-export const loadActiveWorkspaceByOrg = Effect.fnUntraced(function* (database: DatabaseShape, orgId: string) {
+export const loadActiveWorkspaceByOrg = Effect.fnUntraced(function* (database: DatabaseShape, orgId: OrgId) {
 	const rows = yield* database.execute((db) =>
 		db
 			.select()
@@ -50,8 +50,9 @@ export const resolveSlackBotTokenForDispatch = Effect.fn("SlackBotTokenResolver.
 	encryptionKey: Buffer,
 	orgId: string,
 ) {
-	yield* Effect.annotateCurrentSpan({ orgId })
-	const rowOption = yield* loadActiveWorkspaceByOrg(database, orgId).pipe(
+	const decodedOrgId = yield* Schema.decodeEffect(OrgId)(orgId).pipe(Effect.orDie)
+	yield* Effect.annotateCurrentSpan({ orgId: decodedOrgId })
+	const rowOption = yield* loadActiveWorkspaceByOrg(database, decodedOrgId).pipe(
 		Effect.mapError((error) => notConnected(`Failed to load Slack installation: ${error.message}`)),
 	)
 	if (Option.isNone(rowOption)) {
@@ -78,7 +79,7 @@ class SlackBotTokenConfigError extends Data.TaggedError("@maple/api/services/Sla
 }> {}
 
 export interface SlackBotTokenResolverShape {
-	readonly resolve: (orgId: string) => Effect.Effect<string, AlertDeliveryError>
+	readonly resolve: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryError>
 }
 
 const make: Effect.Effect<SlackBotTokenResolverShape, SlackBotTokenConfigError, Database | Env> = Effect.gen(

--- a/apps/api/src/services/integrations/vcs/vendor/github/GithubAppClient.ts
+++ b/apps/api/src/services/integrations/vcs/vendor/github/GithubAppClient.ts
@@ -10,7 +10,7 @@ import { GithubHttp } from "./GithubHttp"
 // `GithubAppError` is internal to the GitHub layer; `GithubProvider` maps it to
 // the generic `VcsProviderError` at the port boundary.
 
-export class GithubAppError extends Data.TaggedError("GithubAppError")<{
+export class GithubAppError extends Data.TaggedError("@maple/api/vcs/GithubAppError")<{
 	message: string
 	status?: number
 	// Which resource the failing call addressed, so the provider can tell an

--- a/apps/api/src/services/integrations/vcs/vendor/github/GithubProvider.ts
+++ b/apps/api/src/services/integrations/vcs/vendor/github/GithubProvider.ts
@@ -233,8 +233,8 @@ export class GithubProvider extends Context.Service<GithubProvider, VcsProviderC
 					return yield* new VcsWebhookSignatureError({ message })
 				})
 
-			const verifySignature = (rawBody: string, signatureHeader: string | undefined) =>
-				Effect.gen(function* () {
+			const verifySignature = Effect.fn("GithubProvider.verifySignature")(
+				function* (rawBody: string, signatureHeader: string | undefined) {
 					const secret = env.GITHUB_APP_WEBHOOK_SECRET
 					if (Option.isNone(secret)) {
 						yield* Effect.logWarning(
@@ -292,11 +292,9 @@ export class GithubProvider extends Context.Service<GithubProvider, VcsProviderC
 						return yield* signatureRejected("mismatch", "Webhook signature mismatch")
 					}
 					yield* Effect.annotateCurrentSpan({ "vcs.webhook.signature_result": "ok" })
-				}).pipe(
-					Effect.withSpan("GithubProvider.verifySignature", {
-						attributes: { "vcs.provider": PROVIDER },
-					}),
-				)
+				},
+				Effect.annotateSpans({ "vcs.provider": PROVIDER }),
+			)
 
 			const mapPush = (raw: unknown, now: number) =>
 				Effect.gen(function* () {
@@ -602,7 +600,7 @@ export class GithubProvider extends Context.Service<GithubProvider, VcsProviderC
 							// A 404 means this repo doesn't contain the SHA (or access was lost) —
 							// for a SHA-only probe that's "look in the next repo", not a failure.
 							// Every other GitHub failure is mapped to the port's semantic errors.
-							Effect.catchTag("GithubAppError", (error) =>
+							Effect.catchTag("@maple/api/vcs/GithubAppError", (error) =>
 								error.status === 404
 									? Effect.succeed(Option.none<CommitUpsertInput>())
 									: Effect.fail(toVcsCommitError(error)),
@@ -666,7 +664,7 @@ export class GithubProvider extends Context.Service<GithubProvider, VcsProviderC
 										: file.content,
 							}),
 						),
-						Effect.catchTag("GithubAppError", (error) =>
+						Effect.catchTag("@maple/api/vcs/GithubAppError", (error) =>
 							error.status === 404
 								? Effect.succeed(Option.none())
 								: Effect.fail(toVcsCommitError(error)),

--- a/apps/api/src/workflows/ClickHouseSchemaApplyWorkflow.run.ts
+++ b/apps/api/src/workflows/ClickHouseSchemaApplyWorkflow.run.ts
@@ -28,8 +28,9 @@ import {
 	type ActualTable,
 	type DesiredTable,
 } from "@maple/domain/clickhouse"
+import { OrgId } from "@maple/domain/http"
 import { eq } from "drizzle-orm"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
 import { resolveDbConnectionSource } from "@/platform/pg-connection-source"
 import { makeTracedPgConnection, type TracedPgConnection } from "@/platform/pg-execute"
@@ -46,7 +47,7 @@ import { invalidateOrgRuntimeConfigMemo } from "@/services/org/OrgClickHouseSett
  * exactly as they do for every other writer. This call keeps the invariant
  * "every writer of the row busts its own memo" true at every write site.
  */
-const bustRuntimeConfigCache = (orgId: string): void => invalidateOrgRuntimeConfigMemo(orgId)
+const bustRuntimeConfigCache = (orgId: OrgId): void => invalidateOrgRuntimeConfigMemo(orgId)
 
 /**
  * This workflow runs outside the worker's layer graph, so it owns its telemetry
@@ -228,7 +229,7 @@ const normalizeExpression = (value: string): string =>
 
 // --- config load + decrypt (imperative mirror of the service helper) --------
 
-const loadConfig = async (dbStep: DbStep, orgId: string, encryptionKey: Buffer): Promise<ChConfig> => {
+const loadConfig = async (dbStep: DbStep, orgId: OrgId, encryptionKey: Buffer): Promise<ChConfig> => {
 	const rows = await dbStep((db) =>
 		db.select().from(orgClickHouseSettings).where(eq(orgClickHouseSettings.orgId, orgId)).limit(1),
 	)
@@ -280,7 +281,7 @@ type RunPatch = Partial<{
 	finishedAt: Date | null
 }>
 
-const updateRun = async (dbStep: DbStep, orgId: string, patch: RunPatch, now: number): Promise<void> => {
+const updateRun = async (dbStep: DbStep, orgId: OrgId, patch: RunPatch, now: number): Promise<void> => {
 	await dbStep((db) =>
 		db
 			.update(orgClickHouseSchemaApplyRuns)
@@ -371,7 +372,7 @@ async function runWithDb(
 	event: WorkflowEventLike<SchemaApplyWorkflowPayload>,
 	step: WorkflowStepLike,
 ): Promise<SchemaApplyWorkflowResult> {
-	const orgId = event.payload.orgId
+	const orgId = Schema.decodeUnknownSync(OrgId)(event.payload.orgId)
 	const dbStep: DbStep = (fn) =>
 		Effect.runPromise(connection.step(fn).pipe(Effect.provide(schemaApplyTelemetry.layer)))
 	const encryptionKey = Buffer.from(env.MAPLE_INGEST_KEY_ENCRYPTION_KEY.trim(), "base64")

--- a/apps/api/src/workflows/agent-pass.test.ts
+++ b/apps/api/src/workflows/agent-pass.test.ts
@@ -12,19 +12,21 @@
  * The three cases below are the whole contract: out of steps still submits, out
  * of clock still submits, and genuine silence is still reported as silence.
  */
-import { assert, describe, it } from "vitest"
+import { describe, it } from "@effect/vitest"
+import { assert } from "vitest"
 import { Effect, Layer, Option, Schema, Stream } from "effect"
 import { LLMClient, LLMEvent, type LLMRequest, type Model } from "@maple/llm"
 import { CloudflareWorkersAI } from "@maple/llm/providers/cloudflare"
 import { PermissionRule } from "@maple/domain/permission"
+import { OrgId, UserId } from "@maple/domain"
 import type { AgentDefinition } from "@/chat/agents"
 import { McpToolExecutor } from "@/mcp/dispatcher"
 import type { TenantContext } from "@/services/auth/tenant-context"
 import { runAgentPass } from "./agent-pass"
 
 const TENANT: TenantContext = {
-	orgId: "org_test" as TenantContext["orgId"],
-	userId: "user_test" as TenantContext["userId"],
+	orgId: Schema.decodeSync(OrgId)("org_test"),
+	userId: Schema.decodeSync(UserId)("user_test"),
 	roles: [],
 	authMode: "self_hosted",
 }
@@ -79,72 +81,78 @@ const pass = (
 	steps: ReadonlyArray<ReadonlyArray<LLMEvent>>,
 	options: { readonly deadlineAtMs?: number } = {},
 ) =>
-	Effect.runPromise(
-		runAgentPass({
-			id: "inv_test_pass",
-			agent: AGENT,
-			tenant: TENANT,
-			model: MODEL,
-			prompt: "Test it.",
-			submitToolName: "submit_candidate",
-			submitToolDescription: "Record the candidate.",
-			schema: SCHEMA,
-			...(options.deadlineAtMs === undefined ? {} : { deadlineAtMs: options.deadlineAtMs }),
-		}).pipe(Effect.provide(stub(steps)), Effect.provide(ToolExecutorStubLayer)),
-	)
+	runAgentPass({
+		id: "inv_test_pass",
+		agent: AGENT,
+		tenant: TENANT,
+		model: MODEL,
+		prompt: "Test it.",
+		submitToolName: "submit_candidate",
+		submitToolDescription: "Record the candidate.",
+		schema: SCHEMA,
+		...(options.deadlineAtMs === undefined ? {} : { deadlineAtMs: options.deadlineAtMs }),
+	}).pipe(Effect.provide(stub(steps)), Effect.provide(ToolExecutorStubLayer))
 
 /** Every step calls a tool, so the agent never voluntarily stops. */
 const grinding = (count: number): ReadonlyArray<ReadonlyArray<LLMEvent>> =>
 	Array.from({ length: count }, (_, i) => [toolCall("c1", "query_data", { page: i }), finish()])
 
 describe("runAgentPass", () => {
-	it("returns the answer when the agent submits on its own", async () => {
-		const result = await pass([
-			[toolCall("c1", "query_data", { page: 0 }), finish()],
-			[toolCall("s1", "submit_candidate", { claim: "pool exhaustion" }), finish()],
-		])
-		assert.deepEqual(Option.getOrUndefined(result.answer), { claim: "pool exhaustion" })
-		assert.equal(result.deadlineHit, false)
-		// The submit call itself is not evidence gathering, so it is not counted.
-		assert.equal(result.toolCalls, 1)
-	})
+	it.live("returns the answer when the agent submits on its own", () =>
+		Effect.gen(function* () {
+			const result = yield* pass([
+				[toolCall("c1", "query_data", { page: 0 }), finish()],
+				[toolCall("s1", "submit_candidate", { claim: "pool exhaustion" }), finish()],
+			])
+			assert.deepEqual(Option.getOrUndefined(result.answer), { claim: "pool exhaustion" })
+			assert.equal(result.deadlineHit, false)
+			// The submit call itself is not evidence gathering, so it is not counted.
+			assert.equal(result.toolCalls, 1)
+		}),
+	)
 
 	/**
 	 * The core regression. The agent grinds through its whole step budget and only
 	 * gets to answer on the forced closing step — which used to be handed no tools.
 	 */
-	it("still submits after exhausting its step budget", async () => {
-		const result = await pass([
-			...grinding(3),
-			[toolCall("s1", "submit_candidate", { claim: "out of steps" }), finish()],
-		])
-		assert.deepEqual(Option.getOrUndefined(result.answer), { claim: "out of steps" })
-	})
+	it.live("still submits after exhausting its step budget", () =>
+		Effect.gen(function* () {
+			const result = yield* pass([
+				...grinding(3),
+				[toolCall("s1", "submit_candidate", { claim: "out of steps" }), finish()],
+			])
+			assert.deepEqual(Option.getOrUndefined(result.answer), { claim: "out of steps" })
+		}),
+	)
 
 	/**
 	 * The other half of the same defect. The deadline used to ride on `isCurrent`,
 	 * the abort hook, so the loop returned an empty stream rather than closing.
 	 */
-	it("still submits, and reports deadlineHit, when the clock runs out", async () => {
-		const result = await pass(
-			[
-				[toolCall("c1", "query_data", { page: 0 }), finish()],
-				[toolCall("s1", "submit_candidate", { claim: "out of clock" }), finish()],
-			],
-			// Already past. The first check fires after the opening step's tools settle.
-			{ deadlineAtMs: 0 },
-		)
-		assert.deepEqual(Option.getOrUndefined(result.answer), { claim: "out of clock" })
-		assert.equal(result.deadlineHit, true)
-	})
+	it.live("still submits, and reports deadlineHit, when the clock runs out", () =>
+		Effect.gen(function* () {
+			const result = yield* pass(
+				[
+					[toolCall("c1", "query_data", { page: 0 }), finish()],
+					[toolCall("s1", "submit_candidate", { claim: "out of clock" }), finish()],
+				],
+				// Already past. The first check fires after the opening step's tools settle.
+				{ deadlineAtMs: 0 },
+			)
+			assert.deepEqual(Option.getOrUndefined(result.answer), { claim: "out of clock" })
+			assert.equal(result.deadlineHit, true)
+		}),
+	)
 
 	/**
 	 * Genuine silence is still silence. A pass that answers in prose and never
 	 * calls its submit tool has produced no candidate, and the workflow is right to
 	 * record a no-finding lane for it.
 	 */
-	it("returns None when the agent never submits", async () => {
-		const result = await pass([[textDelta("I could not determine a cause."), finish()]])
-		assert.isTrue(Option.isNone(result.answer))
-	})
+	it.live("returns None when the agent never submits", () =>
+		Effect.gen(function* () {
+			const result = yield* pass([[textDelta("I could not determine a cause."), finish()]])
+			assert.isTrue(Option.isNone(result.answer))
+		}),
+	)
 })

--- a/apps/scraper/src/ScrapeScheduler.ts
+++ b/apps/scraper/src/ScrapeScheduler.ts
@@ -2,6 +2,7 @@ import {
 	Cause,
 	Clock,
 	Context,
+	Data,
 	Duration,
 	Effect,
 	Fiber,
@@ -76,24 +77,16 @@ export interface ScrapeOutcome {
 	readonly retryAfterMs: number | null
 }
 
-class ScrapeAttemptFailed extends Schema.TaggedError<ScrapeAttemptFailed>()("ScrapeAttemptFailed", {
+class ScrapeAttemptFailed extends Data.TaggedError("@maple/scraper/ScrapeAttemptFailed")<{
 	/**
 	 * The SDK derives a span's `status.message` from the failure's `Error.message`
 	 * (`Cause.prettyErrors`), so without this field every failed scrape produced an
 	 * Error span with a blank description and the reason lived only in the log line
 	 * emitted after the span had already closed.
 	 */
-	message: Schema.String,
-	outcome: Schema.Struct({
-		error: Schema.NullOr(Schema.String),
-		samplesScraped: Schema.optional(Schema.Number),
-		samplesPostMetricRelabeling: Schema.optional(Schema.Number),
-		rateLimited: Schema.Boolean,
-		authFailed: Schema.Boolean,
-		deliveryBlocked: Schema.Boolean,
-		retryAfterMs: Schema.NullOr(Schema.Number),
-	}),
-}) {}
+	readonly message: string
+	readonly outcome: ScrapeOutcome
+}> {}
 
 /** A scrape outcome that must escalate the delay instead of holding cadence. */
 export const shouldBackOff = (outcome: ScrapeOutcome): boolean =>
@@ -352,7 +345,9 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 										: {}),
 								},
 							}),
-							Effect.catchTag("ScrapeAttemptFailed", ({ outcome }) => Effect.succeed(outcome)),
+							Effect.catchTag("@maple/scraper/ScrapeAttemptFailed", ({ outcome }) =>
+								Effect.succeed(outcome),
+							),
 						)
 
 						const durationMs = (yield* Clock.currentTimeMillis) - scrapeTimeMs

--- a/apps/web/src/lib/collections/org-collections.ts
+++ b/apps/web/src/lib/collections/org-collections.ts
@@ -200,7 +200,7 @@ const scheduleBoundedHeal = (source: HealSource): void => {
 		// paths' recreate has no other trace, so log it here for dev consoles/telemetry.
 		if (source === "stuck-loading" || source === "auth-error") {
 			mapleRuntime.runFork(
-				Effect.logWarning(`Electric sync self-heal: recreating org collections (${source})`).pipe(
+				Effect.logWarning("Electric sync self-heal is recreating organization collections").pipe(
 					Effect.annotateLogs({
 						source,
 						attempt: schemaHealAttempts,

--- a/apps/web/src/lib/services/common/retry-policy.test.ts
+++ b/apps/web/src/lib/services/common/retry-policy.test.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect"
 import { HttpClient, HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
-import { describe, expect, it } from "vitest"
+import { describe, it } from "@effect/vitest"
+import { expect } from "vitest"
 import { isRetryableResponse, isRetryableTransportError, withMapleRetryPolicy } from "./retry-policy"
 
 const transportError = (request: HttpClientRequest.HttpClientRequest, cause?: unknown) =>
@@ -62,35 +63,39 @@ describe("isRetryableResponse", () => {
 		).toBe(false)
 	})
 
-	it("replays a raw transient response before API error decoding", async () => {
-		let attempts = 0
-		const client = withMapleRetryPolicy(
-			HttpClient.make((request) =>
-				Effect.sync(() => {
-					attempts += 1
-					return response(request, attempts === 1 ? 503 : 200)
-				}),
-			),
-		)
+	it.live("replays a raw transient response before API error decoding", () =>
+		Effect.gen(function* () {
+			let attempts = 0
+			const client = withMapleRetryPolicy(
+				HttpClient.make((request) =>
+					Effect.sync(() => {
+						attempts += 1
+						return response(request, attempts === 1 ? 503 : 200)
+					}),
+				),
+			)
 
-		const result = await Effect.runPromise(client.get("https://api.maple.dev/v1/services"))
-		expect(result.status).toBe(200)
-		expect(attempts).toBe(2)
-	})
+			const result = yield* client.get("https://api.maple.dev/v1/services")
+			expect(result.status).toBe(200)
+			expect(attempts).toBe(2)
+		}),
+	)
 
-	it("returns a mutation failure response without replaying it", async () => {
-		let attempts = 0
-		const client = withMapleRetryPolicy(
-			HttpClient.make((request) =>
-				Effect.sync(() => {
-					attempts += 1
-					return response(request, 503)
-				}),
-			),
-		)
+	it.live("returns a mutation failure response without replaying it", () =>
+		Effect.gen(function* () {
+			let attempts = 0
+			const client = withMapleRetryPolicy(
+				HttpClient.make((request) =>
+					Effect.sync(() => {
+						attempts += 1
+						return response(request, 503)
+					}),
+				),
+			)
 
-		const result = await Effect.runPromise(client.post("https://api.maple.dev/v1/dashboards"))
-		expect(result.status).toBe(503)
-		expect(attempts).toBe(1)
-	})
+			const result = yield* client.post("https://api.maple.dev/v1/dashboards")
+			expect(result.status).toBe(503)
+			expect(attempts).toBe(1)
+		}),
+	)
 })

--- a/apps/web/src/lib/services/common/telemetry.ts
+++ b/apps/web/src/lib/services/common/telemetry.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect"
+import { Data, Effect } from "effect"
 import { runtime } from "./runtime"
 
 const requestUrl = (input: RequestInfo | URL): string =>
@@ -38,6 +38,10 @@ export const isCancellation = (cause: unknown, signal: AbortSignal | null | unde
 type FetchOutcome =
 	| { readonly ok: true; readonly response: Response }
 	| { readonly ok: false; readonly cause: unknown }
+
+class TracedFetchError extends Data.TaggedError("@maple/web/TracedFetchError")<{
+	readonly cause: unknown
+}> {}
 
 export const tracedFetch = (
 	peerService: string,
@@ -84,7 +88,7 @@ export const tracedFetch = (
 						yield* Effect.annotateCurrentSpan("maple.http.cancelled", true)
 						return outcome
 					}
-					return yield* Effect.fail(outcome.cause)
+					return yield* new TracedFetchError({ cause: outcome.cause })
 				}).pipe(
 					Effect.withSpan("http.client", {
 						kind: "client",
@@ -100,19 +104,23 @@ export const tracedFetch = (
 			// Cancellations resolved the effect to keep the span `Ok`, so rethrow the
 			// original rejection verbatim here — Electric's pause/resume and every other
 			// caller must see exactly the value `fetch` rejected with.
-			.then((outcome) => (outcome.ok ? outcome.response : Promise.reject(outcome.cause)))
+			.then(
+				(outcome) => (outcome.ok ? outcome.response : Promise.reject(outcome.cause)),
+				(error) => Promise.reject(error instanceof TracedFetchError ? error.cause : error),
+			)
 	)
 }
 
 export const logClientError = (
-	message: string,
+	event: string,
 	error: unknown,
 	attributes: Record<string, string | number | boolean> = {},
 ): void => {
 	runtime.runFork(
-		Effect.logError(message).pipe(
+		Effect.logError("Client operation failed").pipe(
 			Effect.annotateLogs({
 				...attributes,
+				"maple.client.event": event,
 				"error.type": error instanceof Error ? error.name : "UnknownError",
 				"error.message": error instanceof Error ? error.message : String(error),
 			}),
@@ -121,14 +129,15 @@ export const logClientError = (
 }
 
 export const logClientWarning = (
-	message: string,
+	event: string,
 	error: unknown,
 	attributes: Record<string, string | number | boolean> = {},
 ): void => {
 	runtime.runFork(
-		Effect.logWarning(message).pipe(
+		Effect.logWarning("Client operation degraded").pipe(
 			Effect.annotateLogs({
 				...attributes,
+				"maple.client.event": event,
 				"error.type": error instanceof Error ? error.name : "UnknownError",
 				"error.message": error instanceof Error ? error.message : String(error),
 			}),

--- a/apps/web/src/lib/services/common/v2-pagination.ts
+++ b/apps/web/src/lib/services/common/v2-pagination.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect"
+import { Data, Effect } from "effect"
 
 export interface V2Page<T> {
 	readonly data: ReadonlyArray<T>
@@ -6,13 +6,12 @@ export interface V2Page<T> {
 	readonly next_cursor: string | null
 }
 
-export class V2PaginationCursorLoopError extends Schema.TaggedError<V2PaginationCursorLoopError>()(
+export class V2PaginationCursorLoopError extends Data.TaggedError(
 	"@maple/web/services/V2PaginationCursorLoopError",
-	{
-		cursor: Schema.String,
-		message: Schema.String,
-	},
-) {
+)<{
+	readonly cursor: string
+	readonly message: string
+}> {
 	static repeated(cursor: string): V2PaginationCursorLoopError {
 		return new V2PaginationCursorLoopError({
 			cursor,

--- a/bun.lock
+++ b/bun.lock
@@ -493,6 +493,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@effect/language-service": "catalog:effect",
+        "@effect/vitest": "4.0.0-beta.105",
         "@maple/domain": "workspace:*",
         "@types/node": "catalog:tooling",
         "alchemy": "2.0.0-beta.70",
@@ -608,6 +609,7 @@
       },
       "devDependencies": {
         "@effect/language-service": "catalog:effect",
+        "@effect/vitest": "4.0.0-beta.105",
         "@maple/browser-session": "workspace:*",
         "@types/node": "catalog:tooling",
         "effect": "catalog:effect",

--- a/lib/effect-db/src/atom/types.ts
+++ b/lib/effect-db/src/atom/types.ts
@@ -72,8 +72,11 @@ export type TanStackDBErrorReason = "load-failed" | "cleaned-up"
  * atoms. Carries a `reason` so a consumer can discriminate a load failure from
  * a cleaned-up collection by tag/field rather than by parsing the message.
  */
-export class TanStackDBError extends Schema.TaggedError<TanStackDBError>()("TanStackDBError", {
-	message: Schema.String,
-	reason: Schema.Literals(["load-failed", "cleaned-up"]),
-	cause: Schema.optional(Schema.Unknown),
-}) {}
+export class TanStackDBError extends Schema.TaggedError<TanStackDBError>()(
+	"@maple/effect-db/TanStackDBError",
+	{
+		message: Schema.String,
+		reason: Schema.Literals(["load-failed", "cleaned-up"]),
+		cause: Schema.optional(Schema.Unknown),
+	},
+) {}

--- a/lib/effect-db/src/electric/collection.ts
+++ b/lib/effect-db/src/electric/collection.ts
@@ -84,22 +84,15 @@ function dispatchSyncFailed(collectionId: string | undefined): void {
  */
 function logVia(
 	runtime: ManagedRuntime.ManagedRuntime<unknown, unknown> | undefined,
-	level: "warning" | "error" | "debug",
-	message: string,
+	log: Effect.Effect<void>,
 	annotations: Record<string, unknown>,
 ): void {
-	const log = (
-		level === "warning"
-			? Effect.logWarning(message)
-			: level === "error"
-				? Effect.logError(message)
-				: Effect.logDebug(message)
-	).pipe(Effect.annotateLogs(annotations))
+	const annotatedLog = log.pipe(Effect.annotateLogs(annotations))
 	if (runtime) {
-		runtime.runFork(log)
+		runtime.runFork(annotatedLog)
 		return
 	}
-	Effect.runFork(log)
+	Effect.runFork(annotatedLog)
 }
 
 /**
@@ -136,8 +129,7 @@ function createBackoffOnError(
 		if (errorStatus === 401) {
 			logVia(
 				runtime,
-				"warning",
-				"Authentication error (401), stopping stream and requesting recovery",
+				Effect.logWarning("Authentication error (401), stopping stream and requesting recovery"),
 				{
 					collectionId,
 					status: 401,
@@ -152,7 +144,7 @@ function createBackoffOnError(
 		// A schema mismatch usually means the client retained a pre-deploy shape.
 		const errorName = (error as Error)?.name || (error as { _tag?: string })?._tag
 		if (errorName === "SchemaValidationError") {
-			logVia(runtime, "warning", "Schema validation error, dispatching recovery event", {
+			logVia(runtime, Effect.logWarning("Schema validation error, dispatching recovery event"), {
 				collectionId,
 				errorName,
 			})
@@ -163,7 +155,7 @@ function createBackoffOnError(
 		}
 
 		if (retryCount > backoffConfig.maxRetries) {
-			logVia(runtime, "error", "Max retries exceeded, stopping sync", {
+			logVia(runtime, Effect.logError("Max retries exceeded, stopping sync"), {
 				collectionId,
 				maxRetries: backoffConfig.maxRetries,
 				retryCount,
@@ -177,7 +169,7 @@ function createBackoffOnError(
 
 		const delay = backoffConfig.jitter ? currentDelay * (0.5 + Math.random()) : currentDelay
 
-		logVia(runtime, "warning", "Connection error, retrying", {
+		logVia(runtime, Effect.logWarning("Connection error, retrying"), {
 			collectionId,
 			delayMs: Math.round(delay),
 			retryCount,

--- a/lib/effect-db/src/electric/errors.ts
+++ b/lib/effect-db/src/electric/errors.ts
@@ -4,7 +4,7 @@ import { Schema } from "effect"
  * Base error for Electric Collection operations
  */
 export class ElectricCollectionError extends Schema.TaggedError<ElectricCollectionError>()(
-	"ElectricCollectionError",
+	"@maple/effect-db/ElectricCollectionError",
 	{
 		message: Schema.String,
 		cause: Schema.optional(Schema.Unknown),
@@ -14,7 +14,7 @@ export class ElectricCollectionError extends Schema.TaggedError<ElectricCollecti
 /**
  * Error thrown when an insert operation fails
  */
-export class InsertError extends Schema.TaggedError<InsertError>()("InsertError", {
+export class InsertError extends Schema.TaggedError<InsertError>()("@maple/effect-db/InsertError", {
 	message: Schema.String,
 	data: Schema.optional(Schema.Unknown),
 	cause: Schema.optional(Schema.Unknown),
@@ -23,7 +23,7 @@ export class InsertError extends Schema.TaggedError<InsertError>()("InsertError"
 /**
  * Error thrown when an update operation fails
  */
-export class UpdateError extends Schema.TaggedError<UpdateError>()("UpdateError", {
+export class UpdateError extends Schema.TaggedError<UpdateError>()("@maple/effect-db/UpdateError", {
 	message: Schema.String,
 	key: Schema.optional(Schema.Unknown),
 	cause: Schema.optional(Schema.Unknown),
@@ -32,7 +32,7 @@ export class UpdateError extends Schema.TaggedError<UpdateError>()("UpdateError"
 /**
  * Error thrown when a delete operation fails
  */
-export class DeleteError extends Schema.TaggedError<DeleteError>()("DeleteError", {
+export class DeleteError extends Schema.TaggedError<DeleteError>()("@maple/effect-db/DeleteError", {
 	message: Schema.String,
 	key: Schema.optional(Schema.Unknown),
 	cause: Schema.optional(Schema.Unknown),
@@ -41,34 +41,43 @@ export class DeleteError extends Schema.TaggedError<DeleteError>()("DeleteError"
 /**
  * Error thrown when waiting for a transaction ID times out
  */
-export class TxIdTimeoutError extends Schema.TaggedError<TxIdTimeoutError>()("TxIdTimeoutError", {
-	message: Schema.String,
-	txid: Schema.Number,
-	timeout: Schema.Number,
-}) {}
+export class TxIdTimeoutError extends Schema.TaggedError<TxIdTimeoutError>()(
+	"@maple/effect-db/TxIdTimeoutError",
+	{
+		message: Schema.String,
+		txid: Schema.Number,
+		timeout: Schema.Number,
+	},
+) {}
 
 /**
  * Error thrown when a required transaction ID is missing from handler result
  */
-export class MissingTxIdError extends Schema.TaggedError<MissingTxIdError>()("MissingTxIdError", {
-	message: Schema.String,
-	operation: Schema.Literals(["insert", "update", "delete"]),
-}) {}
+export class MissingTxIdError extends Schema.TaggedError<MissingTxIdError>()(
+	"@maple/effect-db/MissingTxIdError",
+	{
+		message: Schema.String,
+		operation: Schema.Literals(["insert", "update", "delete"]),
+	},
+) {}
 
 /**
  * Error thrown when an invalid transaction ID type is provided
  */
-export class InvalidTxIdError extends Schema.TaggedError<InvalidTxIdError>()("InvalidTxIdError", {
-	message: Schema.String,
-	receivedType: Schema.String,
-}) {}
+export class InvalidTxIdError extends Schema.TaggedError<InvalidTxIdError>()(
+	"@maple/effect-db/InvalidTxIdError",
+	{
+		message: Schema.String,
+		receivedType: Schema.String,
+	},
+) {}
 
 /**
  * Error thrown when the underlying `awaitTxId` rejects for any reason other
  * than a timeout. Carries the original rejection in `cause` so callers can
  * inspect it without parsing error strings.
  */
-export class AwaitTxIdError extends Schema.TaggedError<AwaitTxIdError>()("AwaitTxIdError", {
+export class AwaitTxIdError extends Schema.TaggedError<AwaitTxIdError>()("@maple/effect-db/AwaitTxIdError", {
 	message: Schema.String,
 	txid: Schema.Number,
 	collectionId: Schema.optional(Schema.String),
@@ -79,7 +88,7 @@ export class AwaitTxIdError extends Schema.TaggedError<AwaitTxIdError>()("AwaitT
  * Error thrown when the backoff retry budget is exhausted for a collection.
  */
 export class MaxRetriesExceededError extends Schema.TaggedError<MaxRetriesExceededError>()(
-	"MaxRetriesExceededError",
+	"@maple/effect-db/MaxRetriesExceededError",
 	{
 		message: Schema.String,
 		collectionId: Schema.optional(Schema.String),
@@ -91,16 +100,19 @@ export class MaxRetriesExceededError extends Schema.TaggedError<MaxRetriesExceed
 /**
  * Error thrown when sync configuration is invalid
  */
-export class SyncConfigError extends Schema.TaggedError<SyncConfigError>()("SyncConfigError", {
-	message: Schema.String,
-	cause: Schema.optional(Schema.Unknown),
-}) {}
+export class SyncConfigError extends Schema.TaggedError<SyncConfigError>()(
+	"@maple/effect-db/SyncConfigError",
+	{
+		message: Schema.String,
+		cause: Schema.optional(Schema.Unknown),
+	},
+) {}
 
 /**
  * Error thrown when an optimistic action fails
  */
 export class OptimisticActionError extends Schema.TaggedError<OptimisticActionError>()(
-	"OptimisticActionError",
+	"@maple/effect-db/OptimisticActionError",
 	{
 		message: Schema.String,
 		cause: Schema.optional(Schema.Unknown),
@@ -110,7 +122,7 @@ export class OptimisticActionError extends Schema.TaggedError<OptimisticActionEr
 /**
  * Error thrown when collection sync fails during optimistic action
  */
-export class SyncError extends Schema.TaggedError<SyncError>()("SyncError", {
+export class SyncError extends Schema.TaggedError<SyncError>()("@maple/effect-db/SyncError", {
 	message: Schema.String,
 	txid: Schema.optional(Schema.Number),
 	collectionName: Schema.optional(Schema.String),

--- a/lib/unitflow/src/core/persistence.ts
+++ b/lib/unitflow/src/core/persistence.ts
@@ -48,8 +48,9 @@ export const makeSlot = <A, I>(
 			return Option.some(entry.value.value)
 		}).pipe(
 			Effect.catchCause((cause) =>
-				Effect.map(Effect.logWarning(`persist(${options.key}): restore failed`, cause), () =>
-					Option.none<A>(),
+				Effect.logWarning("Persisted state restore failed", cause).pipe(
+					Effect.annotateLogs({ "unitflow.persistence.key": options.key }),
+					Effect.as(Option.none<A>()),
 				),
 			),
 		)
@@ -59,7 +60,9 @@ export const makeSlot = <A, I>(
 				store.set(options.key, { savedAt, value }),
 			).pipe(
 				Effect.catchCause((cause) =>
-					Effect.logWarning(`persist(${options.key}): save failed`, cause),
+					Effect.logWarning("Persisted state save failed", cause).pipe(
+						Effect.annotateLogs({ "unitflow.persistence.key": options.key }),
+					),
 				),
 			)
 

--- a/lib/unitflow/src/db/index.ts
+++ b/lib/unitflow/src/db/index.ts
@@ -38,7 +38,7 @@ import * as Store from "../core/store.js"
  * - `load-timeout` — the collection sat in `loading` with no emissions for the
  *   configured `stuckTimeoutMs` (see {@link CollectionWatchOptions}).
  */
-export class CollectionError extends Data.TaggedError("unitflow/db/CollectionError")<{
+export class CollectionError extends Data.TaggedError("@unitflow/db/CollectionError")<{
 	readonly reason: "load-failed" | "cleaned-up" | "load-timeout"
 	readonly message: string
 }> {}

--- a/packages/alchemy-maple/package.json
+++ b/packages/alchemy-maple/package.json
@@ -42,6 +42,7 @@
 	},
 	"devDependencies": {
 		"@effect/language-service": "catalog:effect",
+		"@effect/vitest": "4.0.0-beta.105",
 		"@maple/domain": "workspace:*",
 		"@types/node": "catalog:tooling",
 		"alchemy": "2.0.0-beta.70",

--- a/packages/alchemy-maple/test/provider-layers.test.ts
+++ b/packages/alchemy-maple/test/provider-layers.test.ts
@@ -1,7 +1,8 @@
 import type { ScopedPlanStatusSession } from "alchemy/Cli/Cli"
 import { ConfigProvider, Effect, Layer, Redacted } from "effect"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
-import { describe, expect, it } from "vitest"
+import { describe, it } from "@effect/vitest"
+import { expect } from "vitest"
 import { Dashboard, type Dashboard as DashboardResource } from "../src/Dashboard"
 import { MapleEnvironment } from "../src/MapleEnvironment"
 import { Providers, providers, providersWithDependencies } from "../src/Providers"
@@ -26,36 +27,36 @@ const wireDashboard = {
 }
 
 describe("Maple provider layers", () => {
-	it("uses the caller-supplied environment and HTTP client", async () => {
-		const requests: Array<{ url: string; authorization: string | undefined }> = []
-		const httpClient = HttpClient.make((request, url) => {
-			requests.push({
-				url: url.toString(),
-				authorization: request.headers.authorization,
+	it.live("uses the caller-supplied environment and HTTP client", () =>
+		Effect.gen(function* () {
+			const requests: Array<{ url: string; authorization: string | undefined }> = []
+			const httpClient = HttpClient.make((request, url) => {
+				requests.push({
+					url: url.toString(),
+					authorization: request.headers.authorization,
+				})
+				return Effect.succeed(
+					HttpClientResponse.fromWeb(
+						request,
+						new Response(JSON.stringify(wireDashboard), {
+							status: 201,
+							headers: { "content-type": "application/json" },
+						}),
+					),
+				)
 			})
-			return Effect.succeed(
-				HttpClientResponse.fromWeb(
-					request,
-					new Response(JSON.stringify(wireDashboard), {
-						status: 201,
-						headers: { "content-type": "application/json" },
+
+			const customProviders = providersWithDependencies().pipe(
+				Layer.provide(
+					Layer.succeed(MapleEnvironment, {
+						baseUrl: "https://maple.override.test",
+						apiKey: Redacted.make("maple_ak_override"),
 					}),
 				),
+				Layer.provide(Layer.succeed(HttpClient.HttpClient, httpClient)),
 			)
-		})
 
-		const customProviders = providersWithDependencies().pipe(
-			Layer.provide(
-				Layer.succeed(MapleEnvironment, {
-					baseUrl: "https://maple.override.test",
-					apiKey: Redacted.make("maple_ak_override"),
-				}),
-			),
-			Layer.provide(Layer.succeed(HttpClient.HttpClient, httpClient)),
-		)
-
-		const attributes = await Effect.runPromise(
-			Effect.gen(function* () {
+			const attributes = yield* Effect.gen(function* () {
 				const collection = yield* Providers
 				const provider = collection.get<DashboardResource>(Dashboard.Type)
 				if (provider === undefined) return yield* Effect.die("Dashboard provider is missing")
@@ -69,43 +70,43 @@ describe("Maple provider layers", () => {
 					session,
 					bindings: [],
 				})
-			}).pipe(Effect.provide(customProviders)),
-		)
+			}).pipe(Effect.provide(customProviders))
 
-		expect(attributes).toEqual({ dashboardId: "dash_override", name: "Override proof" })
-		expect(requests).toEqual([
-			{
-				url: "https://maple.override.test/v2/dashboards",
-				authorization: "Bearer maple_ak_override",
-			},
-		])
-	})
+			expect(attributes).toEqual({ dashboardId: "dash_override", name: "Override proof" })
+			expect(requests).toEqual([
+				{
+					url: "https://maple.override.test/v2/dashboards",
+					authorization: "Bearer maple_ak_override",
+				},
+			])
+		}),
+	)
 
-	it("keeps providers() as a closed env-backed default", async () => {
-		const defaultProviders = providers().pipe(
-			Layer.provide(
-				ConfigProvider.layer(
-					ConfigProvider.fromUnknown({
-						MAPLE_API_KEY: "maple_ak_default",
-						MAPLE_API_URL: "https://api.default.test",
-					}),
+	it.live("keeps providers() as a closed env-backed default", () =>
+		Effect.gen(function* () {
+			const defaultProviders = providers().pipe(
+				Layer.provide(
+					ConfigProvider.layer(
+						ConfigProvider.fromUnknown({
+							MAPLE_API_KEY: "maple_ak_default",
+							MAPLE_API_URL: "https://api.default.test",
+						}),
+					),
 				),
-			),
-		)
+			)
 
-		const providerTypes = await Effect.runPromise(
-			Effect.gen(function* () {
+			const providerTypes = yield* Effect.gen(function* () {
 				const collection = yield* Providers
 				return Object.keys(collection.providers).sort()
-			}).pipe(Effect.provide(defaultProviders)),
-		)
+			}).pipe(Effect.provide(defaultProviders))
 
-		expect(providerTypes).toEqual([
-			"Maple.AlertDestination",
-			"Maple.AlertRule",
-			"Maple.ApiKey",
-			"Maple.Dashboard",
-			"Maple.IngestKeys",
-		])
-	})
+			expect(providerTypes).toEqual([
+				"Maple.AlertDestination",
+				"Maple.AlertRule",
+				"Maple.ApiKey",
+				"Maple.Dashboard",
+				"Maple.IngestKeys",
+			])
+		}),
+	)
 })

--- a/packages/alchemy-maple/test/providers.test.ts
+++ b/packages/alchemy-maple/test/providers.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest"
+import { describe, it } from "@effect/vitest"
+import { expect } from "vitest"
 import { Effect, Layer, Redacted } from "effect"
 import type { ScopedPlanStatusSession } from "alchemy/Cli/Cli"
 import { ApiKey, ApiKeyProvider } from "../src/ApiKey"
@@ -51,130 +52,138 @@ const wireDashboard = {
 	updated_at: "2026-07-01T12:00:00.000Z",
 }
 
-const runWithProvider = <A>(api: MapleApiShape, program: Effect.Effect<A, unknown, any>): Promise<A> =>
-	Effect.runPromise(
-		program.pipe(
-			Effect.provide(DashboardProvider().pipe(Layer.provide(Layer.succeed(MapleApi, api)))),
-			Effect.provide(ApiKeyProvider().pipe(Layer.provide(Layer.succeed(MapleApi, api)))),
-		) as Effect.Effect<A>,
+const runWithProvider = <A, E, R>(api: MapleApiShape, program: Effect.Effect<A, E, R>) =>
+	program.pipe(
+		Effect.provide(DashboardProvider().pipe(Layer.provide(Layer.succeed(MapleApi, api)))),
+		Effect.provide(ApiKeyProvider().pipe(Layer.provide(Layer.succeed(MapleApi, api)))),
 	)
 
 describe("DashboardProvider", () => {
-	it("creates when there is no prior state", async () => {
-		const stub = makeStub({
-			"POST /v2/dashboards": () => Effect.succeed(wireDashboard),
-		})
-		const attributes = await runWithProvider(
-			stub.api,
-			Effect.gen(function* () {
-				const provider = yield* Dashboard.Provider
-				return yield* provider.reconcile({
-					id: "service-health",
-					fqn: "test/service-health",
-					instanceId: "i-1",
-					news: { name: "Service health" },
-					olds: undefined,
-					output: undefined,
-					session,
-					bindings: [],
-				})
-			}),
-		)
-		expect(attributes).toEqual({ dashboardId: "dash_abc", name: "Service health" })
-		expect(stub.calls).toEqual(["POST /v2/dashboards"])
-	})
+	it.live("creates when there is no prior state", () =>
+		Effect.gen(function* () {
+			const stub = makeStub({
+				"POST /v2/dashboards": () => Effect.succeed(wireDashboard),
+			})
+			const attributes = yield* runWithProvider(
+				stub.api,
+				Effect.gen(function* () {
+					const provider = yield* Dashboard.Provider
+					return yield* provider.reconcile({
+						id: "service-health",
+						fqn: "test/service-health",
+						instanceId: "i-1",
+						news: { name: "Service health" },
+						olds: undefined,
+						output: undefined,
+						session,
+						bindings: [],
+					})
+				}),
+			)
+			expect(attributes).toEqual({ dashboardId: "dash_abc", name: "Service health" })
+			expect(stub.calls).toEqual(["POST /v2/dashboards"])
+		}),
+	)
 
-	it("observes without mutating when nothing drifted", async () => {
-		const stub = makeStub({
-			"GET /v2/dashboards/dash_abc": () => Effect.succeed(wireDashboard),
-		})
-		await runWithProvider(
-			stub.api,
-			Effect.gen(function* () {
-				const provider = yield* Dashboard.Provider
-				return yield* provider.reconcile({
-					id: "service-health",
-					fqn: "test/service-health",
-					instanceId: "i-1",
-					news: { name: "Service health" },
-					olds: { name: "Service health" },
-					output: { dashboardId: "dash_abc", name: "Service health" },
-					session,
-					bindings: [],
-				})
-			}),
-		)
-		expect(stub.calls).toEqual(["GET /v2/dashboards/dash_abc"])
-	})
+	it.live("observes without mutating when nothing drifted", () =>
+		Effect.gen(function* () {
+			const stub = makeStub({
+				"GET /v2/dashboards/dash_abc": () => Effect.succeed(wireDashboard),
+			})
+			yield* runWithProvider(
+				stub.api,
+				Effect.gen(function* () {
+					const provider = yield* Dashboard.Provider
+					return yield* provider.reconcile({
+						id: "service-health",
+						fqn: "test/service-health",
+						instanceId: "i-1",
+						news: { name: "Service health" },
+						olds: { name: "Service health" },
+						output: { dashboardId: "dash_abc", name: "Service health" },
+						session,
+						bindings: [],
+					})
+				}),
+			)
+			expect(stub.calls).toEqual(["GET /v2/dashboards/dash_abc"])
+		}),
+	)
 
-	it("patches when a declared field drifted", async () => {
-		const stub = makeStub({
-			"GET /v2/dashboards/dash_abc": () => Effect.succeed(wireDashboard),
-			"PATCH /v2/dashboards/dash_abc": (body) =>
-				Effect.succeed({ ...wireDashboard, ...(body as object) }),
-		})
-		const attributes = await runWithProvider(
-			stub.api,
-			Effect.gen(function* () {
-				const provider = yield* Dashboard.Provider
-				return yield* provider.reconcile({
-					id: "service-health",
-					fqn: "test/service-health",
-					instanceId: "i-1",
-					news: { name: "Renamed", tags: ["golden"] },
-					olds: { name: "Service health" },
-					output: { dashboardId: "dash_abc", name: "Service health" },
-					session,
-					bindings: [],
-				})
-			}),
-		)
-		expect(attributes.name).toBe("Renamed")
-		expect(stub.calls).toEqual(["GET /v2/dashboards/dash_abc", "PATCH /v2/dashboards/dash_abc"])
-	})
+	it.live("patches when a declared field drifted", () =>
+		Effect.gen(function* () {
+			const stub = makeStub({
+				"GET /v2/dashboards/dash_abc": () => Effect.succeed(wireDashboard),
+				"PATCH /v2/dashboards/dash_abc": (body) =>
+					Effect.succeed({ ...wireDashboard, ...(body as object) }),
+			})
+			const attributes = yield* runWithProvider(
+				stub.api,
+				Effect.gen(function* () {
+					const provider = yield* Dashboard.Provider
+					return yield* provider.reconcile({
+						id: "service-health",
+						fqn: "test/service-health",
+						instanceId: "i-1",
+						news: { name: "Renamed", tags: ["golden"] },
+						olds: { name: "Service health" },
+						output: { dashboardId: "dash_abc", name: "Service health" },
+						session,
+						bindings: [],
+					})
+				}),
+			)
+			expect(attributes.name).toBe("Renamed")
+			expect(stub.calls).toEqual(["GET /v2/dashboards/dash_abc", "PATCH /v2/dashboards/dash_abc"])
+		}),
+	)
 
-	it("recreates after an out-of-band delete", async () => {
-		const stub = makeStub({
-			"POST /v2/dashboards": () => Effect.succeed(wireDashboard),
-		})
-		await runWithProvider(
-			stub.api,
-			Effect.gen(function* () {
-				const provider = yield* Dashboard.Provider
-				return yield* provider.reconcile({
-					id: "service-health",
-					fqn: "test/service-health",
-					instanceId: "i-1",
-					news: { name: "Service health" },
-					olds: { name: "Service health" },
-					output: { dashboardId: "dash_gone", name: "Service health" },
-					session,
-					bindings: [],
-				})
-			}),
-		)
-		expect(stub.calls).toEqual(["GET /v2/dashboards/dash_gone", "POST /v2/dashboards"])
-	})
+	it.live("recreates after an out-of-band delete", () =>
+		Effect.gen(function* () {
+			const stub = makeStub({
+				"POST /v2/dashboards": () => Effect.succeed(wireDashboard),
+			})
+			yield* runWithProvider(
+				stub.api,
+				Effect.gen(function* () {
+					const provider = yield* Dashboard.Provider
+					return yield* provider.reconcile({
+						id: "service-health",
+						fqn: "test/service-health",
+						instanceId: "i-1",
+						news: { name: "Service health" },
+						olds: { name: "Service health" },
+						output: { dashboardId: "dash_gone", name: "Service health" },
+						session,
+						bindings: [],
+					})
+				}),
+			)
+			expect(stub.calls).toEqual(["GET /v2/dashboards/dash_gone", "POST /v2/dashboards"])
+		}),
+	)
 
-	it("delete tolerates 404", async () => {
-		const stub = makeStub({})
-		await runWithProvider(
-			stub.api,
-			Effect.gen(function* () {
-				const provider = yield* Dashboard.Provider
-				yield* provider.delete({
-					id: "service-health",
-					fqn: "test/service-health",
-					instanceId: "i-1",
-					olds: { name: "Service health" },
-					output: { dashboardId: "dash_gone", name: "Service health" },
-					session,
-					bindings: [],
-				})
-			}),
-		)
-		expect(stub.calls).toEqual(["DELETE /v2/dashboards/dash_gone"])
-	})
+	it.live("delete tolerates 404", () =>
+		Effect.gen(function* () {
+			const stub = makeStub({})
+			yield* runWithProvider(
+				stub.api,
+				Effect.gen(function* () {
+					const provider = yield* Dashboard.Provider
+					yield* provider.delete({
+						id: "service-health",
+						fqn: "test/service-health",
+						instanceId: "i-1",
+						olds: { name: "Service health" },
+						output: { dashboardId: "dash_gone", name: "Service health" },
+						session,
+						bindings: [],
+					})
+				}),
+			)
+			expect(stub.calls).toEqual(["DELETE /v2/dashboards/dash_gone"])
+		}),
+	)
 })
 
 const wireApiKey = {
@@ -186,112 +195,120 @@ const wireApiKey = {
 }
 
 describe("ApiKeyProvider", () => {
-	it("captures the one-time secret on create", async () => {
-		const stub = makeStub({
-			"POST /v2/api_keys": () => Effect.succeed({ ...wireApiKey, secret: "maple_ak_secret1" }),
-		})
-		const attributes = await runWithProvider(
-			stub.api,
-			Effect.gen(function* () {
-				const provider = yield* ApiKey.Provider
-				return yield* provider.reconcile({
-					id: "ci",
-					fqn: "test/ci",
-					instanceId: "i-1",
-					news: { name: "ci" },
-					olds: undefined,
-					output: undefined,
-					session,
-					bindings: [],
-				})
-			}),
-		)
-		expect(Redacted.value(attributes.secret)).toBe("maple_ak_secret1")
-	})
+	it.live("captures the one-time secret on create", () =>
+		Effect.gen(function* () {
+			const stub = makeStub({
+				"POST /v2/api_keys": () => Effect.succeed({ ...wireApiKey, secret: "maple_ak_secret1" }),
+			})
+			const attributes = yield* runWithProvider(
+				stub.api,
+				Effect.gen(function* () {
+					const provider = yield* ApiKey.Provider
+					return yield* provider.reconcile({
+						id: "ci",
+						fqn: "test/ci",
+						instanceId: "i-1",
+						news: { name: "ci" },
+						olds: undefined,
+						output: undefined,
+						session,
+						bindings: [],
+					})
+				}),
+			)
+			expect(Redacted.value(attributes.secret)).toBe("maple_ak_secret1")
+		}),
+	)
 
-	it("preserves the stored secret on steady-state reconcile", async () => {
-		const stub = makeStub({
-			"GET /v2/api_keys/key_abc": () => Effect.succeed(wireApiKey),
-		})
-		const secret = Redacted.make("maple_ak_secret1")
-		const attributes = await runWithProvider(
-			stub.api,
-			Effect.gen(function* () {
-				const provider = yield* ApiKey.Provider
-				return yield* provider.reconcile({
-					id: "ci",
-					fqn: "test/ci",
-					instanceId: "i-1",
-					news: { name: "ci" },
-					olds: { name: "ci" },
-					output: { keyId: "key_abc", name: "ci", keyPrefix: "maple_ak_9f2c", secret },
-					session,
-					bindings: [],
-				})
-			}),
-		)
-		expect(Redacted.value(attributes.secret)).toBe("maple_ak_secret1")
-		expect(stub.calls).toEqual(["GET /v2/api_keys/key_abc"])
-	})
+	it.live("preserves the stored secret on steady-state reconcile", () =>
+		Effect.gen(function* () {
+			const stub = makeStub({
+				"GET /v2/api_keys/key_abc": () => Effect.succeed(wireApiKey),
+			})
+			const secret = Redacted.make("maple_ak_secret1")
+			const attributes = yield* runWithProvider(
+				stub.api,
+				Effect.gen(function* () {
+					const provider = yield* ApiKey.Provider
+					return yield* provider.reconcile({
+						id: "ci",
+						fqn: "test/ci",
+						instanceId: "i-1",
+						news: { name: "ci" },
+						olds: { name: "ci" },
+						output: { keyId: "key_abc", name: "ci", keyPrefix: "maple_ak_9f2c", secret },
+						session,
+						bindings: [],
+					})
+				}),
+			)
+			expect(Redacted.value(attributes.secret)).toBe("maple_ak_secret1")
+			expect(stub.calls).toEqual(["GET /v2/api_keys/key_abc"])
+		}),
+	)
 
-	it("rolls in place when `rotate` is bumped", async () => {
-		const stub = makeStub({
-			"GET /v2/api_keys/key_abc": () => Effect.succeed(wireApiKey),
-			"POST /v2/api_keys/key_abc/roll": () =>
-				Effect.succeed({ ...wireApiKey, id: "key_new", secret: "maple_ak_secret2" }),
-		})
-		const attributes = await runWithProvider(
-			stub.api,
-			Effect.gen(function* () {
-				const provider = yield* ApiKey.Provider
-				return yield* provider.reconcile({
-					id: "ci",
-					fqn: "test/ci",
-					instanceId: "i-1",
-					news: { name: "ci", rotate: 2 },
-					olds: { name: "ci", rotate: 1 },
-					output: {
-						keyId: "key_abc",
-						name: "ci",
-						keyPrefix: "maple_ak_9f2c",
-						secret: Redacted.make("maple_ak_secret1"),
-					},
-					session,
-					bindings: [],
-				})
-			}),
-		)
-		expect(attributes.keyId).toBe("key_new")
-		expect(Redacted.value(attributes.secret)).toBe("maple_ak_secret2")
-	})
+	it.live("rolls in place when `rotate` is bumped", () =>
+		Effect.gen(function* () {
+			const stub = makeStub({
+				"GET /v2/api_keys/key_abc": () => Effect.succeed(wireApiKey),
+				"POST /v2/api_keys/key_abc/roll": () =>
+					Effect.succeed({ ...wireApiKey, id: "key_new", secret: "maple_ak_secret2" }),
+			})
+			const attributes = yield* runWithProvider(
+				stub.api,
+				Effect.gen(function* () {
+					const provider = yield* ApiKey.Provider
+					return yield* provider.reconcile({
+						id: "ci",
+						fqn: "test/ci",
+						instanceId: "i-1",
+						news: { name: "ci", rotate: 2 },
+						olds: { name: "ci", rotate: 1 },
+						output: {
+							keyId: "key_abc",
+							name: "ci",
+							keyPrefix: "maple_ak_9f2c",
+							secret: Redacted.make("maple_ak_secret1"),
+						},
+						session,
+						bindings: [],
+					})
+				}),
+			)
+			expect(attributes.keyId).toBe("key_new")
+			expect(Redacted.value(attributes.secret)).toBe("maple_ak_secret2")
+		}),
+	)
 
-	it("recreates when the key was revoked out-of-band", async () => {
-		const stub = makeStub({
-			"GET /v2/api_keys/key_abc": () => Effect.succeed({ ...wireApiKey, revoked: true }),
-			"POST /v2/api_keys": () =>
-				Effect.succeed({ ...wireApiKey, id: "key_new", secret: "maple_ak_secret2" }),
-		})
-		const attributes = await runWithProvider(
-			stub.api,
-			Effect.gen(function* () {
-				const provider = yield* ApiKey.Provider
-				return yield* provider.reconcile({
-					id: "ci",
-					fqn: "test/ci",
-					instanceId: "i-1",
-					news: { name: "ci" },
-					olds: { name: "ci" },
-					output: {
-						keyId: "key_abc",
-						name: "ci",
-						keyPrefix: "maple_ak_9f2c",
-						secret: Redacted.make("maple_ak_secret1"),
-					},
-					session,
-					bindings: [],
-				})
-			}),
-		)
-		expect(attributes.keyId).toBe("key_new")
-	})
+	it.live("recreates when the key was revoked out-of-band", () =>
+		Effect.gen(function* () {
+			const stub = makeStub({
+				"GET /v2/api_keys/key_abc": () => Effect.succeed({ ...wireApiKey, revoked: true }),
+				"POST /v2/api_keys": () =>
+					Effect.succeed({ ...wireApiKey, id: "key_new", secret: "maple_ak_secret2" }),
+			})
+			const attributes = yield* runWithProvider(
+				stub.api,
+				Effect.gen(function* () {
+					const provider = yield* ApiKey.Provider
+					return yield* provider.reconcile({
+						id: "ci",
+						fqn: "test/ci",
+						instanceId: "i-1",
+						news: { name: "ci" },
+						olds: { name: "ci" },
+						output: {
+							keyId: "key_abc",
+							name: "ci",
+							keyPrefix: "maple_ak_9f2c",
+							secret: Redacted.make("maple_ak_secret1"),
+						},
+						session,
+						bindings: [],
+					})
+				}),
+			)
+			expect(attributes.keyId).toBe("key_new")
+		}),
+	)
 })

--- a/packages/db/src/schema/cloudflare-analytics-state.ts
+++ b/packages/db/src/schema/cloudflare-analytics-state.ts
@@ -1,3 +1,4 @@
+import type { OrgId } from "@maple/domain"
 import { boolean, index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 // Poll-state for the Cloudflare GraphQL Analytics collector. One row per (org, dataset, zone):
@@ -9,7 +10,7 @@ export const cloudflareAnalyticsState = pgTable(
 	"cloudflare_analytics_state",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		dataset: text("dataset").notNull(),
 		// "" for account-scoped datasets — kept NOT NULL so the (org, dataset, zone) unique index
 		// treats the account row like any other.

--- a/packages/db/src/schema/cloudflare-hyperdrive-configs.ts
+++ b/packages/db/src/schema/cloudflare-hyperdrive-configs.ts
@@ -1,3 +1,4 @@
+import type { OrgId } from "@maple/domain"
 import { index, integer, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 /**
@@ -11,7 +12,7 @@ export const cloudflareHyperdriveConfigs = pgTable(
 	"cloudflare_hyperdrive_configs",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		/** Cloudflare's 32-hex Hyperdrive config id (what `db.namespace` collapses from). */
 		configId: text("config_id").notNull(),
 		name: text("name").notNull(),

--- a/packages/db/src/schema/cloudflare-logpush-connectors.ts
+++ b/packages/db/src/schema/cloudflare-logpush-connectors.ts
@@ -1,3 +1,4 @@
+import type { OrgId } from "@maple/domain"
 import { boolean, index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 // NOTE: the manual connector CRUD (CloudflareLogpushService + UI) was removed in favor of the
@@ -9,7 +10,7 @@ export const cloudflareLogpushConnectors = pgTable(
 	"cloudflare_logpush_connectors",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		name: text("name").notNull(),
 		zoneName: text("zone_name").notNull(),
 		serviceName: text("service_name").notNull(),

--- a/packages/db/src/schema/digest.ts
+++ b/packages/db/src/schema/digest.ts
@@ -1,10 +1,11 @@
+import type { OrgId } from "@maple/domain"
 import { boolean, index, integer, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 export const digestSubscriptions = pgTable(
 	"digest_subscriptions",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		userId: text("user_id").notNull(),
 		email: text("email").notNull(),
 		enabled: boolean("enabled").notNull().default(true),

--- a/packages/db/src/schema/onboarding.ts
+++ b/packages/db/src/schema/onboarding.ts
@@ -1,7 +1,8 @@
+import type { OrgId } from "@maple/domain"
 import { boolean, pgTable, text, timestamp } from "drizzle-orm/pg-core"
 
 export const orgOnboardingState = pgTable("org_onboarding_state", {
-	orgId: text("org_id").notNull().primaryKey(),
+	orgId: text("org_id").$type<OrgId>().notNull().primaryKey(),
 	userId: text("user_id"),
 	email: text("email"),
 	role: text("role"),

--- a/packages/db/src/schema/org-clickhouse-schema-apply-runs.ts
+++ b/packages/db/src/schema/org-clickhouse-schema-apply-runs.ts
@@ -1,3 +1,4 @@
+import type { OrgId } from "@maple/domain"
 import { integer, jsonb, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core"
 
 /**
@@ -12,7 +13,7 @@ import { integer, jsonb, pgTable, primaryKey, text, timestamp } from "drizzle-or
 export const orgClickHouseSchemaApplyRuns = pgTable(
 	"org_clickhouse_schema_apply_runs",
 	{
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		// Cloudflare Workflow instance id (for status()/dedup), null before kickoff.
 		workflowInstanceId: text("workflow_instance_id"),
 		// "queued" | "running" | "succeeded" | "failed"

--- a/packages/db/src/schema/org-clickhouse-settings.ts
+++ b/packages/db/src/schema/org-clickhouse-settings.ts
@@ -1,9 +1,10 @@
+import type { OrgId } from "@maple/domain"
 import { pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core"
 
 export const orgClickHouseSettings = pgTable(
 	"org_clickhouse_settings",
 	{
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		chUrl: text("ch_url").notNull(),
 		chUser: text("ch_user").notNull(),
 		chPasswordCiphertext: text("ch_password_ciphertext"),

--- a/packages/db/src/schema/org-ingest-attribute-mappings.ts
+++ b/packages/db/src/schema/org-ingest-attribute-mappings.ts
@@ -1,10 +1,11 @@
+import type { OrgId } from "@maple/domain"
 import { boolean, index, pgTable, text, timestamp } from "drizzle-orm/pg-core"
 
 export const orgIngestAttributeMappings = pgTable(
 	"org_ingest_attribute_mappings",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		name: text("name").notNull(),
 		sourceContext: text("source_context").notNull(),
 		sourceKey: text("source_key").notNull(),

--- a/packages/db/src/schema/org-ingest-keys.ts
+++ b/packages/db/src/schema/org-ingest-keys.ts
@@ -1,9 +1,10 @@
+import type { OrgId } from "@maple/domain"
 import { pgTable, primaryKey, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 export const orgIngestKeys = pgTable(
 	"org_ingest_keys",
 	{
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		publicKey: text("public_key").notNull(),
 		publicKeyHash: text("public_key_hash").notNull(),
 		privateKeyCiphertext: text("private_key_ciphertext").notNull(),

--- a/packages/db/src/schema/org-ingest-sampling-policies.ts
+++ b/packages/db/src/schema/org-ingest-sampling-policies.ts
@@ -1,7 +1,8 @@
+import type { OrgId } from "@maple/domain"
 import { boolean, doublePrecision, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core"
 
 export const orgIngestSamplingPolicies = pgTable("org_ingest_sampling_policies", {
-	orgId: text("org_id").primaryKey().notNull(),
+	orgId: text("org_id").$type<OrgId>().primaryKey().notNull(),
 	traceSampleRatio: doublePrecision("trace_sample_ratio").notNull().default(1),
 	alwaysKeepErrorSpans: boolean("always_keep_error_spans").notNull().default(true),
 	alwaysKeepSlowSpansMs: integer("always_keep_slow_spans_ms"),

--- a/packages/db/src/schema/org-recommendation-issues.ts
+++ b/packages/db/src/schema/org-recommendation-issues.ts
@@ -1,3 +1,4 @@
+import type { OrgId } from "@maple/domain"
 import { index, integer, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 // Durable, numbered attribute-recommendation issues (PlanetScale-style). Recommendations are
@@ -13,7 +14,7 @@ export const orgRecommendationIssues = pgTable(
 	"org_recommendation_issues",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		/** Per-org monotonic display number (`#1`, `#2`, …). */
 		number: integer("number").notNull(),
 		/** Stable dedupe key from the detector, e.g. `rename:http.status_code`. */

--- a/packages/db/src/schema/planetscale-connections.ts
+++ b/packages/db/src/schema/planetscale-connections.ts
@@ -1,3 +1,4 @@
+import type { OrgId } from "@maple/domain"
 import { jsonb, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 /**
@@ -14,7 +15,7 @@ export const planetscaleConnections = pgTable(
 	"planetscale_connections",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		/** PlanetScale organization slug the connection is bound to. */
 		psOrganization: text("ps_organization").notNull(),
 		connectedByUserId: text("connected_by_user_id").notNull(),

--- a/packages/db/src/schema/planetscale-inventory.ts
+++ b/packages/db/src/schema/planetscale-inventory.ts
@@ -1,3 +1,4 @@
+import type { OrgId } from "@maple/domain"
 import { boolean, index, jsonb, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 /**
@@ -19,7 +20,7 @@ export const planetscalePollState = pgTable(
 	"planetscale_poll_state",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		dataset: text("dataset").notNull(),
 		// "" for the org-wide inventory anchor row — kept NOT NULL so the unique
 		// index treats it like any other row.
@@ -68,7 +69,7 @@ export const planetscaleDatabases = pgTable(
 	"planetscale_databases",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		/** PlanetScale's database id. */
 		databaseId: text("database_id").notNull(),
 		name: text("name").notNull(),
@@ -118,7 +119,7 @@ export const planetscaleEvents = pgTable(
 	"planetscale_events",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		/** PlanetScale's database id when resolvable; "" for webhooks that carry only the name. */
 		databaseId: text("database_id").notNull().default(""),
 		databaseName: text("database_name").notNull(),

--- a/packages/db/src/schema/scrape-targets.ts
+++ b/packages/db/src/schema/scrape-targets.ts
@@ -1,10 +1,11 @@
+import type { OrgId } from "@maple/domain"
 import { boolean, index, integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core"
 
 export const scrapeTargets = pgTable(
 	"scrape_targets",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		name: text("name").notNull(),
 		serviceName: text("service_name"),
 		url: text("url").notNull(),
@@ -52,7 +53,7 @@ export const scrapeTargetChecks = pgTable(
 		targetId: text("target_id")
 			.notNull()
 			.references(() => scrapeTargets.id, { onDelete: "cascade" }),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		/** Sub-target discriminator (e.g. PlanetScale branch); empty string for plain targets. */
 		subTargetKey: text("sub_target_key").notNull().default(""),
 		checkedAt: timestamp("checked_at", { withTimezone: true, mode: "date" }).notNull(),

--- a/packages/db/src/schema/slack-workspaces.ts
+++ b/packages/db/src/schema/slack-workspaces.ts
@@ -1,3 +1,4 @@
+import type { OrgId } from "@maple/domain"
 import { sql } from "drizzle-orm"
 import { index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
@@ -22,7 +23,7 @@ export const slackWorkspaces = pgTable(
 	"slack_workspaces",
 	{
 		id: text("id").notNull().primaryKey(),
-		orgId: text("org_id").notNull(),
+		orgId: text("org_id").$type<OrgId>().notNull(),
 		/** Slack workspace (team) id, e.g. `T0123ABCD`. Unique across all orgs. */
 		teamId: text("team_id").notNull(),
 		teamName: text("team_name"),

--- a/packages/effect-sdk/package.json
+++ b/packages/effect-sdk/package.json
@@ -42,6 +42,7 @@
 	},
 	"devDependencies": {
 		"@effect/language-service": "catalog:effect",
+		"@effect/vitest": "4.0.0-beta.105",
 		"@maple/browser-session": "workspace:*",
 		"@types/node": "catalog:tooling",
 		"effect": "catalog:effect",

--- a/packages/effect-sdk/src/shared/flush-core.test.ts
+++ b/packages/effect-sdk/src/shared/flush-core.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { describe, it } from "@effect/vitest"
+import { afterEach, expect, it as vitestIt, vi } from "vitest"
 import { Effect, Metric, Redacted } from "effect"
 import {
 	buildResolved,
@@ -21,81 +22,81 @@ const resolved = buildResolved(
 )
 
 const recordSpan = (spans: ReturnType<typeof makeSpanBuffer>, name: string) =>
-	Effect.runPromise(
-		Effect.succeed(undefined).pipe(Effect.withSpan(name), Effect.provide(spans.tracerLayer)),
-	)
+	Effect.succeed(undefined).pipe(Effect.withSpan(name), Effect.provide(spans.tracerLayer))
 
 const recordLog = (logs: ReturnType<typeof makeLogBuffer>, message: string) =>
-	Effect.runPromise(Effect.logInfo(message).pipe(Effect.provide(logs.loggerLayer)))
+	Effect.logInfo(message).pipe(Effect.provide(logs.loggerLayer))
 
 describe("runFlush", () => {
 	afterEach(() => {
 		vi.useRealTimers()
 	})
 
-	it("retains failed and cooldown batches while allowing the other signal to succeed", async () => {
-		vi.useFakeTimers()
-		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
-		const spans = makeSpanBuffer()
-		const logs = makeLogBuffer()
-		const metrics = makeMetricBuffer()
-		const tracesState: SignalState = { disabledUntil: 0 }
-		const logsState: SignalState = { disabledUntil: 0 }
-		const metricsState: SignalState = { disabledUntil: 0 }
-		const traceBodies: unknown[] = []
-		const logBodies: unknown[] = []
-		let failTraces = true
-		const transport: FlushTransport = {
-			post: async (url, _headers, body) => {
-				if (url.endsWith("/v1/traces")) {
-					if (failTraces) throw new Error("collector unavailable")
-					traceBodies.push(body)
-				} else if (url.endsWith("/v1/logs")) {
-					logBodies.push(body)
-				}
-			},
-		}
-		const flush = () =>
-			runFlush({
-				resolved,
-				spans,
-				logs,
-				metrics,
-				tracesState,
-				logsState,
-				metricsState,
-				transport,
-				logPrefix: "[test]",
-				onNoOp: () => undefined,
-			})
+	it.live("retains failed and cooldown batches while allowing the other signal to succeed", () =>
+		Effect.gen(function* () {
+			vi.useFakeTimers()
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+			const spans = makeSpanBuffer()
+			const logs = makeLogBuffer()
+			const metrics = makeMetricBuffer()
+			const tracesState: SignalState = { disabledUntil: 0 }
+			const logsState: SignalState = { disabledUntil: 0 }
+			const metricsState: SignalState = { disabledUntil: 0 }
+			const traceBodies: unknown[] = []
+			const logBodies: unknown[] = []
+			let failTraces = true
+			const transport: FlushTransport = {
+				post: async (url, _headers, body) => {
+					if (url.endsWith("/v1/traces")) {
+						if (failTraces) throw new Error("collector unavailable")
+						traceBodies.push(body)
+					} else if (url.endsWith("/v1/logs")) {
+						logBodies.push(body)
+					}
+				},
+			}
+			const flush = () =>
+				runFlush({
+					resolved,
+					spans,
+					logs,
+					metrics,
+					tracesState,
+					logsState,
+					metricsState,
+					transport,
+					logPrefix: "[test]",
+					onNoOp: () => undefined,
+				})
 
-		await recordSpan(spans, "first")
-		await recordLog(logs, "first-log")
-		await flush()
-		expect(spans.size()).toBe(1)
-		expect(logs.size()).toBe(0)
-		expect(logBodies).toHaveLength(1)
+			yield* recordSpan(spans, "first")
+			yield* recordLog(logs, "first-log")
+			yield* Effect.promise(flush)
+			expect(spans.size()).toBe(1)
+			expect(logs.size()).toBe(0)
+			expect(logBodies).toHaveLength(1)
 
-		await recordSpan(spans, "second")
-		await flush()
-		expect(spans.size()).toBe(2)
-		expect(traceBodies).toHaveLength(0)
+			yield* recordSpan(spans, "second")
+			yield* Effect.promise(flush)
+			expect(spans.size()).toBe(2)
+			expect(traceBodies).toHaveLength(0)
 
-		failTraces = false
-		vi.advanceTimersByTime(60_000)
-		await flush()
-		expect(spans.size()).toBe(0)
-		expect(traceBodies).toHaveLength(1)
-		const body = traceBodies[0] as {
-			resourceSpans: Array<{ scopeSpans: Array<{ spans: Array<{ name: string }> }> }>
-		}
-		expect(body.resourceSpans[0]!.scopeSpans[0]!.spans.map((span) => span.name)).toEqual([
-			"first",
-			"second",
-		])
-	})
+			failTraces = false
+			vi.advanceTimersByTime(60_000)
+			yield* Effect.promise(flush)
+			expect(spans.size()).toBe(0)
+			expect(traceBodies).toHaveLength(1)
+			const body = traceBodies[0] as {
+				resourceSpans: Array<{ scopeSpans: Array<{ spans: Array<{ name: string }> }> }>
+			}
+			expect(body.resourceSpans[0]!.scopeSpans[0]!.spans.map((span) => span.name)).toEqual([
+				"first",
+				"second",
+			])
+		}),
+	)
 
-	it("serializes overlapping flush calls", async () => {
+	vitestIt("serializes overlapping flush calls", async () => {
 		let active = 0
 		let peak = 0
 		let release: (() => void) | undefined
@@ -118,89 +119,95 @@ describe("runFlush", () => {
 		expect(peak).toBe(1)
 	})
 
-	it("exports Effect metric snapshots as OTLP metrics", async () => {
-		const spans = makeSpanBuffer()
-		const logs = makeLogBuffer()
-		const metrics = makeMetricBuffer()
-		const counter = Metric.counter("test.requests_total", {
-			description: "Test requests",
-			incremental: true,
-		})
-		await Effect.runPromise(Metric.update(counter, 3).pipe(Effect.provide(metrics.layer)))
+	it.live("exports Effect metric snapshots as OTLP metrics", () =>
+		Effect.gen(function* () {
+			const spans = makeSpanBuffer()
+			const logs = makeLogBuffer()
+			const metrics = makeMetricBuffer()
+			const counter = Metric.counter("test.requests_total", {
+				description: "Test requests",
+				incremental: true,
+			})
+			yield* Metric.update(counter, 3).pipe(Effect.provide(metrics.layer))
 
-		let metricsBody: unknown
-		await runFlush({
-			resolved,
-			spans,
-			logs,
-			metrics,
-			tracesState: { disabledUntil: 0 },
-			logsState: { disabledUntil: 0 },
-			metricsState: { disabledUntil: 0 },
-			transport: {
-				post: async (url, _headers, body) => {
-					if (url.endsWith("/v1/metrics")) metricsBody = body
-				},
-			},
-			logPrefix: "[test]",
-			onNoOp: () => undefined,
-		})
+			let metricsBody: unknown
+			yield* Effect.promise(() =>
+				runFlush({
+					resolved,
+					spans,
+					logs,
+					metrics,
+					tracesState: { disabledUntil: 0 },
+					logsState: { disabledUntil: 0 },
+					metricsState: { disabledUntil: 0 },
+					transport: {
+						post: async (url, _headers, body) => {
+							if (url.endsWith("/v1/metrics")) metricsBody = body
+						},
+					},
+					logPrefix: "[test]",
+					onNoOp: () => undefined,
+				}),
+			)
 
-		const body = metricsBody as {
-			resourceMetrics: Array<{
-				scopeMetrics: Array<{
-					metrics: Array<{
-						name: string
-						sum: { dataPoints: Array<{ asDouble: number }> }
+			const body = metricsBody as {
+				resourceMetrics: Array<{
+					scopeMetrics: Array<{
+						metrics: Array<{
+							name: string
+							sum: { dataPoints: Array<{ asDouble: number }> }
+						}>
 					}>
 				}>
-			}>
-		}
-		const exported = body.resourceMetrics[0]!.scopeMetrics[0]!.metrics[0]!
-		expect(exported.name).toBe("test.requests_total")
-		expect(exported.sum.dataPoints[0]!.asDouble).toBe(3)
-	})
+			}
+			const exported = body.resourceMetrics[0]!.scopeMetrics[0]!.metrics[0]!
+			expect(exported.name).toBe("test.requests_total")
+			expect(exported.sum.dataPoints[0]!.asDouble).toBe(3)
+		}),
+	)
 
-	it("retries a changed metric after a failed export", async () => {
-		vi.useFakeTimers()
-		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
-		const spans = makeSpanBuffer()
-		const logs = makeLogBuffer()
-		const metrics = makeMetricBuffer()
-		const counter = Metric.counter("test.retry_total")
-		await Effect.runPromise(Metric.update(counter, 1).pipe(Effect.provide(metrics.layer)))
+	it.live("retries a changed metric after a failed export", () =>
+		Effect.gen(function* () {
+			vi.useFakeTimers()
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+			const spans = makeSpanBuffer()
+			const logs = makeLogBuffer()
+			const metrics = makeMetricBuffer()
+			const counter = Metric.counter("test.retry_total")
+			yield* Metric.update(counter, 1).pipe(Effect.provide(metrics.layer))
 
-		let attempts = 0
-		const tracesState: SignalState = { disabledUntil: 0 }
-		const logsState: SignalState = { disabledUntil: 0 }
-		const metricsState: SignalState = { disabledUntil: 0 }
-		const flush = () =>
-			runFlush({
-				resolved,
-				spans,
-				logs,
-				metrics,
-				tracesState,
-				logsState,
-				metricsState,
-				transport: {
-					post: async (url) => {
-						if (!url.endsWith("/v1/metrics")) return
-						attempts += 1
-						if (attempts === 1) throw new Error("collector unavailable")
+			let attempts = 0
+			const tracesState: SignalState = { disabledUntil: 0 }
+			const logsState: SignalState = { disabledUntil: 0 }
+			const metricsState: SignalState = { disabledUntil: 0 }
+			const flush = () =>
+				runFlush({
+					resolved,
+					spans,
+					logs,
+					metrics,
+					tracesState,
+					logsState,
+					metricsState,
+					transport: {
+						post: async (url) => {
+							if (!url.endsWith("/v1/metrics")) return
+							attempts += 1
+							if (attempts === 1) throw new Error("collector unavailable")
+						},
 					},
-				},
-				logPrefix: "[test]",
-				onNoOp: () => undefined,
-			})
+					logPrefix: "[test]",
+					onNoOp: () => undefined,
+				})
 
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-		await flush()
-		await flush()
-		vi.advanceTimersByTime(60_000)
-		await flush()
-		errorSpy.mockRestore()
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+			yield* Effect.promise(flush)
+			yield* Effect.promise(flush)
+			vi.advanceTimersByTime(60_000)
+			yield* Effect.promise(flush)
+			errorSpy.mockRestore()
 
-		expect(attempts).toBe(2)
-	})
+			expect(attempts).toBe(2)
+		}),
+	)
 })

--- a/packages/query-engine/src/ch/index.ts
+++ b/packages/query-engine/src/ch/index.ts
@@ -228,6 +228,7 @@ export {
 	errorFingerprintsQuery,
 	errorIssueTimeseriesQuery,
 	errorIssueSampleTracesQuery,
+	ErrorIssueSampleTracesOutputSchema,
 	type ErrorsByTypeOpts,
 	type ErrorsByTypeOutput,
 	type ErrorsTimeseriesOpts,
@@ -281,6 +282,7 @@ export {
 	activeOrgsByErrorEventsQuery,
 	activeOrgsByTracesQuery,
 	activeOrgsByLogsQuery,
+	ActiveOrgsOutputSchema,
 	type ActiveOrgsOutput,
 } from "./queries/activity"
 

--- a/packages/query-engine/src/ch/queries/activity.ts
+++ b/packages/query-engine/src/ch/queries/activity.ts
@@ -18,11 +18,12 @@
 // active org is missed for the tick.
 
 import { from, param } from "@maple-dev/clickhouse-builder"
+import { OrgId } from "@maple/domain"
+import { Schema } from "effect"
 import { ErrorEventsByTime, LogsAggregatesHourly, TracesAggregatesHourly } from "../tables"
 
-export interface ActiveOrgsOutput {
-	readonly orgId: string
-}
+export const ActiveOrgsOutputSchema = Schema.Struct({ orgId: OrgId })
+export type ActiveOrgsOutput = Schema.Schema.Type<typeof ActiveOrgsOutputSchema>
 
 /** Orgs with any error events since `startTime` (gates the error-issue detector). */
 export function activeOrgsByErrorEventsQuery() {

--- a/packages/query-engine/src/ch/queries/errors.ts
+++ b/packages/query-engine/src/ch/queries/errors.ts
@@ -10,6 +10,8 @@ import { param } from "@maple-dev/clickhouse-builder"
 import { from, fromQuery, type CHQuery, type ColumnAccessor } from "@maple-dev/clickhouse-builder"
 import type { ColumnDefs } from "@maple-dev/clickhouse-builder/types"
 import { unionAll, type CHUnionQuery } from "@maple-dev/clickhouse-builder"
+import { SpanId, TraceId } from "@maple/domain"
+import { Schema } from "effect"
 import {
 	ErrorEvents,
 	ErrorEventsByTime,
@@ -27,6 +29,7 @@ import {
 	type FacetOutput,
 } from "./query-helpers"
 import { httpDisplaySpanName } from "../../traces-shared"
+import { CHNumber } from "../schema"
 
 function errorEventsTableForRecentScan(opts: {
 	fingerprintHashes?: readonly string[]
@@ -960,14 +963,15 @@ export function errorIssueTimeseriesQuery() {
 
 // Error Issue sample traces — most recent occurrences for one issue
 
-export interface ErrorIssueSampleTracesOutput {
-	readonly traceId: string
-	readonly spanId: string
-	readonly serviceName: string
-	readonly timestamp: string
-	readonly exceptionMessage: string
-	readonly durationMicros: number
-}
+export const ErrorIssueSampleTracesOutputSchema = Schema.Struct({
+	traceId: TraceId,
+	spanId: SpanId,
+	serviceName: Schema.String,
+	timestamp: Schema.String,
+	exceptionMessage: Schema.String,
+	durationMicros: CHNumber,
+})
+export type ErrorIssueSampleTracesOutput = Schema.Schema.Type<typeof ErrorIssueSampleTracesOutputSchema>
 
 export function errorIssueSampleTracesQuery(opts: { limit?: number }) {
 	return from(ErrorEvents)

--- a/packages/query-engine/src/execution/errors.test.ts
+++ b/packages/query-engine/src/execution/errors.test.ts
@@ -113,7 +113,7 @@ describe("mapWarehouseError", () => {
 		it("classifies a 401 leaked in the message and keeps the status", () => {
 			const mapped = mapWarehouseError("p", "Request failed with status 401")
 			expect(mapped).toBeInstanceOf(WarehouseAuthError)
-			expect((mapped as WarehouseAuthError).upstreamStatus).toBe(401)
+			expect(mapped).toMatchObject({ upstreamStatus: 401 })
 		})
 
 		it("classifies Tinybird's invalid-token workspace-not-found message", () => {
@@ -129,7 +129,7 @@ describe("mapWarehouseError", () => {
 		it("classifies a 503 and extracts the upstream status", () => {
 			const mapped = mapWarehouseError("p", "Request failed with status 503")
 			expect(mapped).toBeInstanceOf(WarehouseUpstreamError)
-			expect((mapped as WarehouseUpstreamError).upstreamStatus).toBe(503)
+			expect(mapped).toMatchObject({ upstreamStatus: 503 })
 		})
 
 		it("classifies a transient ClickHouse type", () => {

--- a/packages/query-engine/src/execution/executor.ts
+++ b/packages/query-engine/src/execution/executor.ts
@@ -1,4 +1,4 @@
-import { Cause, Clock, Duration, Effect, HashMap, Option, Ref, Schedule, Schema } from "effect"
+import { Cause, Clock, Data, Duration, Effect, HashMap, Option, Ref, Schedule, Schema } from "effect"
 import {
 	MAX_RAW_SQL_RESULT_BYTES,
 	MAX_RAW_SQL_RESULT_ROWS,
@@ -62,14 +62,13 @@ const CAPABILITIES_INSPECTION_TIMEOUT = Duration.seconds(2)
 const WarehouseCapabilityMetadataTarget = Schema.Literals(["version", "indexes", "columns", "settings"])
 type WarehouseCapabilityMetadataTarget = Schema.Schema.Type<typeof WarehouseCapabilityMetadataTarget>
 
-class WarehouseCapabilityProbeError extends Schema.TaggedError<WarehouseCapabilityProbeError>()(
+class WarehouseCapabilityProbeError extends Data.TaggedError(
 	"@maple/query-engine/execution/WarehouseCapabilityProbeError",
-	{
-		target: WarehouseCapabilityMetadataTarget,
-		message: Schema.String,
-		cause: Schema.Unknown,
-	},
-) {}
+)<{
+	readonly target: WarehouseCapabilityMetadataTarget
+	readonly message: string
+	readonly cause: unknown
+}> {}
 
 const CAPABILITY_AWARE_PIPES: ReadonlySet<string> = new Set([
 	"list_logs",


### PR DESCRIPTION
## Summary

- tighten Effect layer composition, explicit requirements, and operation-specific error channels
- preserve branded org, trace, and span identifiers across database, query, workflow, and test boundaries
- align internal errors, namespaced tags, stable structured logs, and span attributes with repo conventions
- migrate the affected Effect-running tests to `@effect/vitest`, retaining real-clock behavior where native timers are under test

## Verification

- `bun run lint:effect`
- `bun run typecheck`
- `bun run test`
- focused MCP, Effect SDK, API chat/platform, query-engine, and Alchemy provider tests
- `git diff --check`

## Notes

The generic repo-wide Oxlint invocation still reports the existing restricted vendor-import findings in `apps/api/src/runtime/{mcp-service-graph,service-graph}.ts`; this branch does not modify either composition root.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789047012&installation_model_id=427786&pr_number=419&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F419&signature=93077e70266e06bded1bd47272da83c3b6d96f013bb626fb6a71fb933e27067c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->