### PR TITLE
perf(api): serve org ClickHouse config from a shared edge-cache tier

### DIFF
--- a/apps/api/src/services/org/OrgClickHouseSettingsService.test.ts
+++ b/apps/api/src/services/org/OrgClickHouseSettingsService.test.ts
@@ -7,6 +7,12 @@ import {
 	OrgId,
 	RoleName,
 } from "@maple/domain/http"
+import {
+	EdgeCacheService,
+	type EdgeCacheBackend,
+	makeEdgeCacheService,
+	MemoryCacheBackendLive,
+} from "@maple/cache"
 import { Cause, ConfigProvider, Effect, Exit, Layer, Option, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import { FetchHttpClient } from "effect/unstable/http"
@@ -405,6 +411,180 @@ describe("resolveRuntimeConfig caching", () => {
 			const after = yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(orgId))
 			// Would still be a stale `Some` if the write had not busted the cache.
 			expect(Option.isNone(after)).toBe(true)
+		}).pipe(Effect.provide(buildLayer(testDb)))
+	})
+
+	// --- shared edge-cache tier ---------------------------------------------
+	//
+	// The tier between the memo and Postgres. What makes these tests meaningful
+	// is `invalidateOrgRuntimeConfigMemo`, which drops ONLY the memo — so it
+	// simulates the case the tier exists for: a second, cold isolate resolving
+	// the same org while the shared entry is already warm.
+	//
+	// Every assertion is therefore "Postgres moved and the resolve did not see
+	// it", which is only possible if the value came from the shared cache.
+	const buildCachedLayer = (testDb: TestDb) => {
+		const envLive = Env.layer.pipe(Layer.provide(configLive))
+		const edgeCacheLive = EdgeCacheService.layer.pipe(Layer.provide(MemoryCacheBackendLive))
+		return OrgClickHouseSettingsService.layer.pipe(
+			Layer.provide(Layer.mergeAll(envLive, testDb.layer, edgeCacheLive)),
+		)
+	}
+
+	it.effect("a managed org is a shared-cache hit on a cold isolate, not a Postgres read", () => {
+		const testDb = createTestDb(cacheTrackedDbs)
+		const orgId = "org_ch_edge_managed"
+		return Effect.gen(function* () {
+			// No settings row at all — the common case, and the one that caches
+			// `null`. If the envelope ever stopped round-tripping, this is the test
+			// that catches it: the majority of orgs would silently never cache.
+			const first = yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(orgId))
+			expect(Option.isNone(first)).toBe(true)
+
+			// Cold isolate: memo gone, shared entry still warm.
+			invalidateOrgRuntimeConfigMemo(orgId)
+			yield* Effect.promise(() => seedRow(testDb, orgId, "https://appeared.example"))
+
+			const second = yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(orgId))
+			// Still none → the cached `null` answered, Postgres was never dialled.
+			expect(Option.isNone(second)).toBe(true)
+		}).pipe(Effect.provide(buildCachedLayer(testDb)))
+	})
+
+	it.effect("a BYO org is a shared-cache hit on a cold isolate", () => {
+		const testDb = createTestDb(cacheTrackedDbs)
+		const orgId = "org_ch_edge_byo"
+		return Effect.gen(function* () {
+			yield* Effect.promise(() => seedRow(testDb, orgId, "https://cached.example"))
+			const first = yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(orgId))
+			expect(expectSome(first).url).toBe("https://cached.example")
+
+			invalidateOrgRuntimeConfigMemo(orgId)
+			yield* Effect.promise(() =>
+				executeSql(testDb, "UPDATE org_clickhouse_settings SET ch_url = $2 WHERE org_id = $1", [
+					orgId,
+					"https://moved.example",
+				]),
+			)
+
+			const second = yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(orgId))
+			expect(expectSome(second).url).toBe("https://cached.example")
+		}).pipe(Effect.provide(buildCachedLayer(testDb)))
+	})
+
+	it.effect("a settings write busts the SHARED entry, not just the writing isolate's memo", () => {
+		const testDb = createTestDb(cacheTrackedDbs)
+		const orgId = "org_ch_edge_invalidate"
+		return Effect.gen(function* () {
+			yield* Effect.promise(() => seedRow(testDb, orgId, "https://a.example"))
+			expect(
+				Option.isSome(yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(orgId))),
+			).toBe(true)
+
+			yield* OrgClickHouseSettingsService.delete(asOrgId(orgId), [asRole("org:admin")])
+
+			// Drop the memo the write just cleared anyway, so this resolve can only
+			// be answered by the shared tier or Postgres. If the write had evicted
+			// the memo alone, the stale `Some` would come straight back here — and
+			// every other isolate would serve it for the full 6h TTL.
+			invalidateOrgRuntimeConfigMemo(orgId)
+
+			const after = yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(orgId))
+			expect(Option.isNone(after)).toBe(true)
+		}).pipe(Effect.provide(buildCachedLayer(testDb)))
+	})
+
+	// The memory backend stores the encoded value BY REFERENCE, so it cannot
+	// catch a value that survives `Schema.encode` but not the wire. The real
+	// Workers backend round-trips through `JSON.stringify` / `response.json()`
+	// and returns `undefined` — never `null` — for a miss
+	// (`makeWorkersBackend` in `platform/CacheBackendLive.ts`). This backend
+	// reproduces exactly that, which is what actually exercises the envelope.
+	const makeJsonRoundTripBackend = () => {
+		const store = new Map<string, string>()
+		const stats = { puts: 0, hits: 0, misses: 0 }
+		const backend: EdgeCacheBackend = {
+			name: "memory",
+			get: async (bucket, hash) => {
+				const raw = store.get(`${bucket}/${hash}`)
+				if (raw === undefined) {
+					stats.misses += 1
+					return undefined
+				}
+				stats.hits += 1
+				return JSON.parse(raw) as unknown
+			},
+			put: async (bucket, hash, value) => {
+				stats.puts += 1
+				store.set(`${bucket}/${hash}`, JSON.stringify(value))
+			},
+			delete: async (bucket, hash) => {
+				store.delete(`${bucket}/${hash}`)
+			},
+		}
+		return { backend, stats }
+	}
+
+	it.effect("survives the JSON wire format the Workers cache actually uses", () => {
+		const testDb = createTestDb(cacheTrackedDbs)
+		const managedOrg = "org_ch_wire_managed"
+		const byoOrg = "org_ch_wire_byo"
+		const { backend, stats } = makeJsonRoundTripBackend()
+		const layer = (() => {
+			const envLive = Env.layer.pipe(Layer.provide(configLive))
+			const edgeCacheLive = Layer.succeed(EdgeCacheService)(makeEdgeCacheService(backend))
+			return OrgClickHouseSettingsService.layer.pipe(
+				Layer.provide(Layer.mergeAll(envLive, testDb.layer, edgeCacheLive)),
+			)
+		})()
+		return Effect.gen(function* () {
+			yield* Effect.promise(() => seedPasswordRow(testDb, byoOrg, "https://wire.example"))
+
+			// Populate both shapes: the `null` envelope and a fully-populated one
+			// carrying the encrypted password material.
+			expect(
+				Option.isNone(yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(managedOrg))),
+			).toBe(true)
+			expect(
+				expectSome(yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(byoOrg))).url,
+			).toBe("https://wire.example")
+			expect(stats.puts).toBe(2)
+
+			// Cold isolates. Move Postgres so a fallthrough would be visible.
+			invalidateOrgRuntimeConfigMemo(managedOrg)
+			invalidateOrgRuntimeConfigMemo(byoOrg)
+			yield* Effect.promise(() => seedRow(testDb, managedOrg, "https://appeared.example"))
+			yield* Effect.promise(() =>
+				executeSql(testDb, "UPDATE org_clickhouse_settings SET ch_url = $2 WHERE org_id = $1", [
+					byoOrg,
+					"https://moved.example",
+				]),
+			)
+
+			const managed = yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(managedOrg))
+			expect(Option.isNone(managed)).toBe(true)
+
+			// Decodes back to the same config, password included — proof the
+			// encrypted material survived the round trip and still decrypts.
+			const byo = yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(byoOrg))
+			expect(expectSome(byo).url).toBe("https://wire.example")
+			expect(expectSome(byo).password).toBe("legacy-password")
+
+			// Both reads were served by the cache; nothing was recomputed.
+			expect(stats.puts).toBe(2)
+			expect(stats.hits).toBe(2)
+		}).pipe(Effect.provide(layer))
+	})
+
+	it.effect("resolves normally when no EdgeCacheService is provided", () => {
+		const testDb = createTestDb(cacheTrackedDbs)
+		const orgId = "org_ch_edge_absent"
+		return Effect.gen(function* () {
+			yield* Effect.promise(() => seedRow(testDb, orgId, "https://nocache.example"))
+			// `buildLayer` deliberately omits EdgeCacheService — the tier is an
+			// optimization, and alerting/CLI contexts build this service without it.
+			const resolved = yield* OrgClickHouseSettingsService.resolveRuntimeConfig(asOrgId(orgId))
+			expect(expectSome(resolved).url).toBe("https://nocache.example")
 		}).pipe(Effect.provide(buildLayer(testDb)))
 	})
 

--- a/apps/api/src/services/org/OrgClickHouseSettingsService.ts
+++ b/apps/api/src/services/org/OrgClickHouseSettingsService.ts
@@ -27,6 +27,7 @@ import {
 	type DesiredTable,
 	type TableDiffEntry,
 } from "@maple/domain/clickhouse"
+import { EdgeCacheService } from "@maple/cache"
 import { orgClickHouseSchemaApplyRuns, orgClickHouseSettings } from "@maple/db"
 import { eq, inArray } from "drizzle-orm"
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
@@ -104,12 +105,13 @@ type CachedSettingsRow = Pick<
 //                         that no background refresh ever completed)
 //
 // The SOFT TTL is what bounds staleness. Every write through this service busts
-// the memo, but only in the isolate that served the write — other isolates
-// converge by re-reading at the soft TTL. That degree of staleness is safe
-// because the warehouse executor self-heals on `WarehouseAuthError`: it calls
-// `invalidateRuntimeConfig` and retries once, so a credential rotation costs the
-// first request one extra round-trip instead of costing the org every request
-// until the entry ages out.
+// the memo AND the shared edge-cache entry, but the memo only in the isolate
+// that served the write — other isolates converge by re-reading at the soft TTL
+// (which now hits the shared entry, not Postgres). That degree of staleness is
+// safe because the warehouse executor self-heals on `WarehouseAuthError`: it
+// calls `invalidateRuntimeConfig` and retries once, so a credential rotation
+// costs the first request one extra round-trip instead of costing the org every
+// request until the entry ages out.
 //
 // The HARD ceiling is not a staleness bound — it is an isolate-lifetime backstop.
 // A background refresh is best-effort: it is forked into the triggering request's
@@ -122,6 +124,26 @@ type CachedSettingsRow = Pick<
 // the rest of the fan-out queued behind it.
 const ORG_CH_CONFIG_MEMO_TTL_MS = 300_000
 const ORG_CH_CONFIG_MEMO_HARD_MS = 21_600_000
+
+/**
+ * Shared tier between the in-isolate memo and Postgres, on the Workers Cache
+ * API. This is the tier that keeps queries off the database; the memo in front
+ * of it only saves the ~10ms read.
+ *
+ * Six hours here, five minutes on the memo, and the asymmetry is the point.
+ * Lengthening the MEMO would not avoid a single database read — past its soft
+ * TTL the refresh lands on this entry, not Postgres — it would only widen the
+ * window in which an isolate that missed a write keeps serving the old value,
+ * since a write can evict this shared entry for everyone but can only evict the
+ * memo of the isolate that served it. So the long TTL belongs on the tier that
+ * can be invalidated globally, and the short one on the tier that cannot.
+ *
+ * Holds the ENCRYPTED projection, exactly as the memo does — see
+ * `CachedChSettings`. That property matters more here than in an isolate-local
+ * map, so the envelope must never be flattened into plaintext.
+ */
+export const ORG_CH_CONFIG_CACHE_BUCKET = "org-ch-config"
+const ORG_CH_CONFIG_CACHE_TTL_SECONDS = 21_600
 interface RuntimeConfigMemoEntry {
 	readonly value: CachedChSettings | null
 	readonly freshUntil: number
@@ -208,6 +230,21 @@ const CachedChSettings = Schema.Struct({
 	chPasswordTag: Schema.NullOr(Schema.String),
 })
 type CachedChSettings = typeof CachedChSettings.Type
+
+/**
+ * What actually goes into the edge cache.
+ *
+ * Deliberately an envelope rather than a bare `CachedChSettings | null`.
+ * `getOrCompute` treats `read.value !== undefined` as a hit, so a stored `null`
+ * would work only for as long as the backend keeps distinguishing "no entry"
+ * from "entry holding null" through a JSON round-trip. Managed orgs — the
+ * common case — are exactly the ones that cache `null`, so if that distinction
+ * ever slipped, the majority of orgs would silently never cache and the tier
+ * would look like it was working while doing nothing.
+ */
+const CachedChSettingsEnvelope = Schema.Struct({
+	settings: Schema.NullOr(CachedChSettings),
+})
 
 const toCachedChSettings = (row: CachedSettingsRow): CachedChSettings => ({
 	schemaVersion: row.schemaVersion,
@@ -872,6 +909,9 @@ export class OrgClickHouseSettingsService extends Context.Service<
 		// background schema-apply Workflow. Read optionally so non-worker/test
 		// contexts (where the binding is absent) still construct the service.
 		const workerEnv = yield* Effect.serviceOption(WorkerEnvironment)
+		// Optional for the same reason: the shared cache tier is an optimisation,
+		// and every path below still resolves correctly without it.
+		const edgeCache = yield* Effect.serviceOption(EdgeCacheService)
 
 		// Memoize the parsed desired-schema snapshot per service instance. The
 		// snapshot is static, so we parse it at most once and reuse it.
@@ -938,9 +978,24 @@ export class OrgClickHouseSettingsService extends Context.Service<
 			return Option.fromNullishOr(rows[0])
 		})
 
+		/**
+		 * Drop the shared edge-cache entry for an org. Best-effort by contract —
+		 * `invalidate` logs and swallows backend failures, and the entry expires on
+		 * its TTL regardless.
+		 */
+		const invalidateSharedRuntimeConfig = (orgId: OrgId): Effect.Effect<void> =>
+			Option.isSome(edgeCache)
+				? edgeCache.value.invalidate({ bucket: ORG_CH_CONFIG_CACHE_BUCKET, key: orgId })
+				: Effect.void
+
 		// Bust the cached runtime config for an org after any write to its settings
 		// row, so the next warehouse query re-resolves rather than serving a stale
-		// value. Other isolates fall off within ORG_CH_CONFIG_MEMO_TTL_MS.
+		// value.
+		//
+		// Both tiers, always. Dropping only the memo would leave the shared entry
+		// to serve the pre-write value back to every OTHER isolate for the full
+		// six hours — the write would look applied to whoever made it and to
+		// nobody else.
 		const invalidateRuntimeConfigCache = (orgId: OrgId): Effect.Effect<boolean> =>
 			Effect.gen(function* () {
 				// Whether this org had a BYO row cached is the caller's retry gate (see
@@ -950,6 +1005,7 @@ export class OrgClickHouseSettingsService extends Context.Service<
 				const memoized = runtimeConfigMemo.get(orgId)
 				const hadOverride = memoized !== undefined && memoized.value !== null
 				invalidateOrgRuntimeConfigMemo(orgId)
+				yield* invalidateSharedRuntimeConfig(orgId)
 				return hadOverride
 			})
 
@@ -1449,7 +1505,13 @@ export class OrgClickHouseSettingsService extends Context.Service<
 			if (startedAt !== undefined && nowMs - startedAt < REFRESH_MARKER_STALE_MS) return false
 			refreshInFlight.set(orgId, nowMs)
 
-			const work = readSettingsFromPostgres(orgId).pipe(
+			// Through the shared tier, not straight to Postgres. This fires once per
+			// isolate per org per soft TTL, so sending it to Postgres would mean
+			// every isolate re-dialling the database every five minutes for a row
+			// that changes on onboarding — most of the reads this tier exists to
+			// remove. Refreshing the memo from a shared entry that writes evict is
+			// the intended convergence path, not a staleness leak.
+			const work = readSharedOrPostgres(orgId).pipe(
 				Effect.flatMap((value) =>
 					Clock.currentTimeMillis.pipe(
 						Effect.map((writeNowMs) => storeCachedSettings(orgId, value, writeNowMs)),
@@ -1481,35 +1543,73 @@ export class OrgClickHouseSettingsService extends Context.Service<
 		// answers it with zero network, and past its soft TTL it keeps answering
 		// from the stale value while a background fiber refreshes it.
 		//
-		// There is deliberately no cache layer between the memo and Postgres. One
-		// used to sit here (a 1h edge-cache entry) on the theory that it removed the
-		// cold Postgres round-trip for a fresh isolate. Production measurement over
-		// 7 days said otherwise: the read completed 241 times at a span p50 of 26ms
-		// and was abandoned at its 40ms deadline 1079 times, and the abandoned reads
-		// cost a p50 of 2547ms — because `cache.match()` cannot be cancelled, so the
-		// abandoned read kept holding one of the Worker's six connection slots and
-		// the fallback Postgres read queued behind it. The layer meant to avoid a
-		// ~26ms round-trip was manufacturing a ~2.5s one 82% of the time.
+		// Behind the memo sits ONE shared tier, on the Workers Cache API. Two
+		// earlier attempts at this were reverted, and the difference is worth
+		// spelling out, because the naive reading of that history ("a shared cache
+		// cannot work here") is too strong and would rule out the case it does fix.
 		//
-		// A SECOND attempt (#387) put the same tier on Workers KV instead, on the
-		// theory that a KV `get` is a cancellable subrequest and so cheap to
-		// abandon. Measured over 24h on the live deploy it was worse, and removed:
-		// KV reads that COMPLETE take 92ms (vs 6ms on the Cache API) and 79% of them
-		// still hit their deadline. It also could not reach the cost it was aimed
-		// at. 94% of the Postgres fallback is `apps/alerting` (4,646 resolutions/day
-		// at p50 573ms, ~44min of blocked wall time) which has no KV binding and so
-		// could never use the tier; `apps/api`, which had it, falls back at p50 24ms
-		// — cheaper than a KV read.
+		// The first attempt (a 1h edge-cache entry) measured, over 7 days: 241
+		// completed reads at a span p50 of 26ms, against 1079 abandoned at the 40ms
+		// deadline costing a p50 of 2547ms — because `cache.match()` cannot be
+		// cancelled, so the abandoned read kept holding one of the Worker's six
+		// connection slots and the Postgres fallback queued behind it. The second
+		// (#387) moved the tier to Workers KV on the theory that a KV `get` is a
+		// cancellable subrequest; it was worse (92ms completed vs 6ms on the Cache
+		// API, 79% still hitting the deadline) and `apps/alerting`, which was most
+		// of the volume, has no KV binding at all.
 		//
-		// The reason both attempts failed is that this is not a cold-isolate miss.
-		// Grouping alerting's Postgres resolutions by trace: 1,033 traces do zero,
-		// while 106 traces do 22 EACH (half of all of them). It is an in-request
-		// fan-out where every branch misses the memo because none has finished
-		// writing it yet. No shared cache can fix concurrent siblings — it just
-		// turns N Postgres reads into N cache reads contending for the same six
-		// connection slots. The fix is to resolve the config once BEFORE the
-		// fan-out, the way `warehouse.warmRoute` already does in
-		// `routes/v1/query-engine.http.ts`.
+		// What actually drove that 82% abandonment was CONCURRENCY WITHIN ONE
+		// REQUEST, not the tier. A `cache.match()` occupies one of the six
+		// connection slots while it waits for headers, so the timeout rate scales
+		// with how many reads a single request issues — measured at 8.4% for one
+		// read and 35.9% for four (see `DEFAULT_EDGE_CACHE_READ_TIMEOUT_MS`). The
+		// org-config bucket was being read 22 times in a single alerting request
+		// (106 traces doing 22 resolutions each, half of all of them). Those reads
+		// congested each other, and each abandoned one held a slot the Postgres
+		// fallback then queued behind.
+		//
+		// That fan-out is gone: `AlertsService` now calls `primeRuntimeConfigs` to
+		// resolve the whole set in one statement, and the HTTP query paths call
+		// `warehouse.warmRoute` once per request before fanning out. What remains is
+		// the opposite shape — a dashboard load fires 5-17 parallel requests that
+		// land on DIFFERENT cold isolates, one config read each, before any
+		// warehouse `fetch()` is holding a slot. Measured in bursts of 17, 9, 9, 9,
+		// 8, 8 blocking reads in a single second. A per-isolate memo cannot help
+		// across isolates and neither can `warmRoute`; a shared entry can, because
+		// the first isolate to resolve populates it for the rest.
+		//
+		// So: one read per request, issued before the warehouse queries. Do NOT
+		// reintroduce a per-org cache read inside a fan-out — prime instead.
+		//
+		// The read deadline is deliberately left at the default. Raising it looks
+		// tempting given how expensive `compute` is here, but the latency
+		// distribution is bimodal, not long-tailed: a read that will succeed has
+		// done so by ~20ms, the entire 40-249ms band is 0.5% of reads, and anything
+		// past that is hung rather than slow. A longer deadline would buy almost no
+		// extra hits and charge the full deadline to every hung read.
+		const readSharedOrPostgres = (orgId: OrgId) =>
+			Option.isNone(edgeCache)
+				? readSettingsFromPostgres(orgId)
+				: edgeCache.value
+						.getOrCompute(
+							{
+								bucket: ORG_CH_CONFIG_CACHE_BUCKET,
+								key: orgId,
+								ttlSeconds: ORG_CH_CONFIG_CACHE_TTL_SECONDS,
+								schema: CachedChSettingsEnvelope,
+							},
+							readSettingsFromPostgres(orgId).pipe(Effect.map((settings) => ({ settings }))),
+						)
+						.pipe(
+							Effect.tap((result) =>
+								Effect.annotateCurrentSpan(
+									"clickhouse.config.source",
+									result.hit ? "edge_cache" : "postgres",
+								),
+							),
+							Effect.map((result) => result.value.settings),
+						)
+
 		const resolveCachedSettings = Effect.fn("OrgClickHouseSettingsService.resolveCachedSettings")(
 			function* (orgId: OrgId) {
 				const nowMs = yield* Clock.currentTimeMillis
@@ -1551,11 +1651,14 @@ export class OrgClickHouseSettingsService extends Context.Service<
 					return yield* Effect.fail(failed.error)
 				}
 
+				// Overwritten by `readSharedOrPostgres` with `edge_cache` on a hit; set
+				// here so the uncached path (no `EdgeCacheService`) still reports a
+				// source, and so a failure below leaves an accurate one.
 				yield* Effect.annotateCurrentSpan({
 					"clickhouse.config.source": "postgres",
 					"clickhouse.config.memoHit": false,
 				})
-				const cached = yield* readSettingsFromPostgres(orgId).pipe(
+				const cached = yield* readSharedOrPostgres(orgId).pipe(
 					Effect.tapError((error) =>
 						Effect.sync(() => runtimeConfigFailures.set(orgId, { error, atMs: nowMs })),
 					),

--- a/apps/api/src/workflows/ClickHouseSchemaApplyWorkflow.run.ts
+++ b/apps/api/src/workflows/ClickHouseSchemaApplyWorkflow.run.ts
@@ -30,24 +30,41 @@ import {
 } from "@maple/domain/clickhouse"
 import { OrgId } from "@maple/domain/http"
 import { eq } from "drizzle-orm"
-import { Effect, Schema } from "effect"
+import { Effect, Layer, Schema } from "effect"
 import { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
 import { resolveDbConnectionSource } from "@/platform/pg-connection-source"
 import { makePgConnectionScope, type PgConnectionScopeShape } from "@/platform/pg-connection-scope"
-import { invalidateOrgRuntimeConfigMemo } from "@/services/org/OrgClickHouseSettingsService"
+import { EdgeCacheService } from "@maple/cache"
+import { CacheBackendLive } from "@/platform/CacheBackendLive"
+import {
+	invalidateOrgRuntimeConfigMemo,
+	ORG_CH_CONFIG_CACHE_BUCKET,
+} from "@/services/org/OrgClickHouseSettingsService"
 
 /**
- * Bust this isolate's cached runtime config after the workflow writes to
+ * Bust the cached runtime config after the workflow writes to
  * `org_clickhouse_settings` (it stamps `schema_version`, part of the cached
  * projection).
  *
- * Isolate-local, and that is the whole story now that the durable tier is gone:
- * the workflow runs in its own isolate, so API isolates converge on the new
- * `schema_version` at the memo's soft TTL (`ORG_CH_CONFIG_MEMO_TTL_MS`, 300s)
- * exactly as they do for every other writer. This call keeps the invariant
- * "every writer of the row busts its own memo" true at every write site.
+ * Both tiers. The memo call is isolate-local and therefore almost decorative
+ * here — the workflow runs in its own isolate, so it clears a memo no API
+ * request will ever read — but the shared edge-cache entry is the one that
+ * matters: it is what every API isolate reads on a memo miss, and at a 6h TTL
+ * it would otherwise hand back the pre-apply `schema_version` (and so a wrong
+ * `clickhouse.schemaDrift`) for the rest of the day.
+ *
+ * Best-effort by design: `invalidate` already swallows backend failures, and
+ * `Effect.ignore` covers the case where this isolate has no Cache API at all.
+ * A missed eviction costs an annotation, never a routing decision.
  */
-const bustRuntimeConfigCache = (orgId: OrgId): void => invalidateOrgRuntimeConfigMemo(orgId)
+const bustRuntimeConfigCache = (orgId: OrgId): Promise<void> =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			invalidateOrgRuntimeConfigMemo(orgId)
+			const cache = yield* EdgeCacheService
+			yield* cache.invalidate({ bucket: ORG_CH_CONFIG_CACHE_BUCKET, key: orgId })
+		}).pipe(Effect.provide(EdgeCacheService.layer.pipe(Layer.provide(CacheBackendLive))), Effect.ignore),
+	)
 
 /**
  * This workflow runs outside the worker's layer graph, so it owns its telemetry
@@ -475,7 +492,7 @@ async function runWithDb(
 					})
 					.where(eq(orgClickHouseSettings.orgId, orgId)),
 			)
-			bustRuntimeConfigCache(orgId)
+			await bustRuntimeConfigCache(orgId)
 		})
 
 		for (const migration of clickHouseMigrations) {
@@ -634,7 +651,7 @@ async function runWithDb(
 				.set({ syncStatus: "error", lastSyncError: message, updatedAt: new Date(finishedAt) })
 				.where(eq(orgClickHouseSettings.orgId, orgId)),
 		).catch(() => undefined)
-		bustRuntimeConfigCache(orgId)
+		await bustRuntimeConfigCache(orgId)
 		throw error
 	}
 }


### PR DESCRIPTION
## Why

Every warehouse query resolves one bit — "does this org have BYO ClickHouse?" — from `org_clickhouse_settings` in PlanetScale. A warm isolate answers from the module-scoped memo with zero network. A **cold** one dials the database, and a dashboard load fires 5–17 parallel requests that land on *different* cold isolates, each dialling independently. A per-isolate memo can't help across isolates, and neither can `warmRoute` — the fan-out is across requests.

Measured in production bursts: **17, 9, 9, 9, 8, 8** blocking reads in a single second.

Over a 30h window (`maple-api`):

| `clickhouse.config.source` | status | count | p50 | p95 |
|---|---|---|---|---|
| `memo` | Ok | 2185 | 0ms | 0ms |
| `postgres` | Ok | 436 | 149ms | 9714ms |
| `memo_stale` | Ok | 88 | 0ms | 0ms |
| `postgres` | **Error** | **79** | **10000ms** | 10150ms |

Every failure is on the blocking branch, all `CONNECT_TIMEOUT` to Hyperdrive/PSBouncer, surfacing as `OrgClickHouseSettingsPersistenceError` — 245 events over 7 days.

## What

One shared tier on the Workers Cache API between the memo and Postgres: bucket `org-ch-config`, 6h TTL, so the first isolate to resolve populates the entry for the rest. Both tiers are evicted on every write, including from `ClickHouseSchemaApplyWorkflow`, which stamps `schema_version` into the cached projection and previously could only clear a memo no API request would ever read.

Holds the **encrypted** projection, exactly as the memo does — decryption stays per-request, and plaintext never enters a cache.

The cached value is an envelope (`{ settings: … | null }`) rather than a bare nullable. `getOrCompute` treats `read.value !== undefined` as a hit, so a bare `null` would work only as long as the backend keeps distinguishing "no entry" from "entry holding null" across a JSON round-trip — and managed orgs, the common case, are exactly the ones that cache `null`. If that ever slipped, most orgs would silently never cache while the tier looked healthy.

## Answering the two reverted attempts

`resolveCachedSettings` carried a comment saying no shared cache can work here. That reading is too strong, and the comment is rewritten rather than worked around.

What drove the 82% read abandonment was **concurrency within a single request**, not the tier. `cache.match()` holds one of the Worker's six connection slots while waiting for headers, so the timeout rate scales with reads per request — 8.4% at one, 35.9% at four — and org-config was being read **22 times in a single alerting request**. Those reads congested each other, and each abandoned one held a slot the Postgres fallback then queued behind.

That fan-out is gone: `AlertsService` now primes the whole set in one statement, and the HTTP query paths call `warmRoute` once before fanning out. What remains is the opposite shape — one read per request, before any warehouse `fetch()` holds a slot.

Workers KV (#387) stays rejected: 92ms completed reads vs 6ms on the Cache API, and `apps/alerting` has no KV binding.

## Two deliberate non-changes

**The read deadline is left at the default (40ms).** Raising it is tempting given how expensive `compute` is, but the latency distribution is bimodal: a read that will succeed has done so by ~20ms, the entire 40–249ms band is 0.5% of reads, and anything past that is hung rather than slow. A longer deadline buys almost no hits and charges the full deadline to every hung read.

**The memo TTL stays at 5 minutes.** Lengthening it avoids zero database reads — past its soft TTL the refresh now lands on the shared entry — and would only widen the window in which an isolate that missed a write serves stale, since a write can evict the shared entry globally but only the memo of the isolate that served it. The long TTL belongs on the tier that can be invalidated globally.

## Verification

Full local stack (`bun dev`, signed in at `https://web.localhost`), with `log_statement='all'` on the dev Postgres, forcing fresh isolates by touching `worker.ts`:

| | API reads of `org_clickhouse_settings` |
|---|---|
| Cold isolate, cold cache | 4 |
| Cold isolate, **warm cache** | **0** |

A brand-new isolate rendered the entire dashboard without touching the settings table once, while 11 other statements ran in the same window. The 4 on a cold cache is the expected shape — parallel requests all miss, since `getOrCompute` deliberately has no single-flight on Workers.

Tests cover the managed-org (`null`) hit, the BYO hit, write-evicts-the-shared-entry, absent `EdgeCacheService`, and a backend that reproduces `makeWorkersBackend`'s JSON wire format exactly (asserting the encrypted password still decrypts after the round trip, and `puts === 2 / hits === 2`).

`bun typecheck` 37/37; 89 tests passing across the settings service and workflows.

## Reviewer notes

- **This is an availability and tail-latency fix, not a throughput one.** 81% of resolutions already hit the memo at 0ms and are unaffected. It does not speed up the warehouse queries themselves; it removes a serial pre-step.
- **Most of the current win exists because the database is unhealthy.** `Database.execute` in `maple-api` is **513 Error / 7 Ok**, while `alerting` — same Postgres, its own Hyperdrive config — is **5044 Ok / 5 Error**. Repairing the `maple-prd` Hyperdrive config is still the larger lever; this only makes warehouse routing survive the outage, and every other Postgres read in the API still pays it.
- **The risk to watch after deploy** is the failure mode that killed the earlier attempts. If `cache.read_status` on the `org-ch-config` bucket shows material `timeout`/`skipped`, this is net-negative and should come back out:

```sql
SELECT SpanAttributes['cache.read_status'] AS status, count() AS c,
       round(quantile(0.5)(toFloat64OrNull(SpanAttributes['cache.read_ms'])),1) AS p50_read_ms
FROM traces WHERE $__orgFilter AND $__timeFilter(Timestamp)
  AND SpanName='EdgeCacheService.getOrCompute'
  AND SpanAttributes['cache.bucket']='org-ch-config'
GROUP BY status ORDER BY c DESC
```

- Do not reintroduce a per-org config cache read inside a fan-out — prime instead. The one-read-per-request precondition is what makes this safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789057911&installation_model_id=427786&pr_number=422&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F422&signature=812663bec73ae5a61172e70b6df7f5859722ced365d76cb446a62023cbdd73fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->