### PR TITLE
Tighten remaining Effect runtime boundaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,14 @@ Workers via the Hyperdrive binding `MAPLE_DB`.
   `any` as a type-level placeholder in variance positions. `Record<string, unknown>` is _not_ banned —
   it forces narrowing at every read, which is the point.
 - **Effect:** source is vendored at `.context/effect/` (subtree of Effect-TS/effect-smol).
+- **Effect errors:** new expected failures always use `Schema.TaggedError`, including internal-only
+  failures; `Data.TaggedError` is legacy and is not a precedent for new Maple code. Give every
+  failure a namespaced tag, `message`, and useful schema-backed context (`Schema.Defect()` for an
+  unknown cause), then keep it in the typed Effect error channel. At HTTP/RPC boundaries, define
+  public failures in the domain contract and preserve their distinct tags until the route's existing
+  error mapper/envelope handles them; use `catchTag`/`catchTags` for deliberate remapping. Plain
+  `Error`, thrown failures, route-local `Data.TaggedError`, and early generic error/response mapping
+  bypass this flow. Unexpected defects alone belong in `catchDefect`/the unexpected-error envelope.
 - **Alchemy:** read `node_modules/alchemy/src/` — the package ships its own TypeScript source,
   so it always matches the version actually running. There is deliberately no vendored copy:
   `.context/alchemy-effect` held `alchemy-effect@0.11.0`, a package upstream renamed into

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,9 @@ Workers via the Hyperdrive binding `MAPLE_DB`.
   public failures in the domain contract and preserve their distinct tags until the route's existing
   error mapper/envelope handles them; use `catchTag`/`catchTags` for deliberate remapping. Plain
   `Error`, thrown failures, route-local `Data.TaggedError`, and early generic error/response mapping
-  bypass this flow. Unexpected defects alone belong in `catchDefect`/the unexpected-error envelope.
+  bypass this flow. Valid entity IDs in error context use their branded domain schemas; rejected
+  undecodable inputs use an explicitly named `raw*` string and must never be cast into a brand.
+  Unexpected defects alone belong in `catchDefect`/the unexpected-error envelope.
 - **Alchemy:** read `node_modules/alchemy/src/` — the package ships its own TypeScript source,
   so it always matches the version actually running. There is deliberately no vendored copy:
   `.context/alchemy-effect` held `alchemy-effect@0.11.0`, a package upstream renamed into

--- a/apps/api/src/routes/v1/scraper-internal.http.ts
+++ b/apps/api/src/routes/v1/scraper-internal.http.ts
@@ -1,5 +1,5 @@
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
-import { Effect, Option, Redacted, Schema } from "effect"
+import { Data, Effect, Option, Redacted, Schema } from "effect"
 import {
 	InternalScrapeTarget,
 	OrgId,
@@ -50,6 +50,12 @@ export interface SubTargetOverride {
 	readonly labels: Record<string, string>
 }
 
+class InvalidScrapeTargetRow extends Data.TaggedError("@maple/api/routes/InvalidScrapeTargetRow")<{
+	readonly message: string
+	readonly targetId: string
+	readonly cause: unknown
+}> {}
+
 /**
  * Marshal a DB row into the internal wire shape. Unparseable labels degrade
  * to `{}`; a row that fails the schema brands (interval out of range, bad id)
@@ -82,7 +88,12 @@ export const toInternalScrapeTarget = (
 					labels,
 					ingestKey,
 				}),
-			catch: () => new Error("invalid scrape target row"),
+			catch: (cause) =>
+				new InvalidScrapeTargetRow({
+					message: "Invalid scrape target row",
+					targetId: row.id,
+					cause,
+				}),
 		}).pipe(Effect.option)
 	})
 

--- a/apps/api/src/routes/v1/scraper-internal.http.ts
+++ b/apps/api/src/routes/v1/scraper-internal.http.ts
@@ -1,5 +1,5 @@
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
-import { Data, Effect, Option, Redacted, Schema } from "effect"
+import { Effect, Option, Redacted, Schema } from "effect"
 import {
 	InternalScrapeTarget,
 	OrgId,
@@ -50,11 +50,14 @@ export interface SubTargetOverride {
 	readonly labels: Record<string, string>
 }
 
-class InvalidScrapeTargetRow extends Data.TaggedError("@maple/api/routes/InvalidScrapeTargetRow")<{
-	readonly message: string
-	readonly targetId: string
-	readonly cause: unknown
-}> {}
+class InvalidScrapeTargetRow extends Schema.TaggedError<InvalidScrapeTargetRow>()(
+	"@maple/api/routes/InvalidScrapeTargetRow",
+	{
+		message: Schema.String,
+		targetId: Schema.String,
+		cause: Schema.Defect(),
+	},
+) {}
 
 /**
  * Marshal a DB row into the internal wire shape. Unparseable labels degrade

--- a/apps/api/src/routes/v1/scraper-internal.http.ts
+++ b/apps/api/src/routes/v1/scraper-internal.http.ts
@@ -54,7 +54,7 @@ class InvalidScrapeTargetRow extends Schema.TaggedError<InvalidScrapeTargetRow>(
 	"@maple/api/routes/InvalidScrapeTargetRow",
 	{
 		message: Schema.String,
-		targetId: Schema.String,
+		rawTargetId: Schema.String,
 		cause: Schema.Defect(),
 	},
 ) {}
@@ -94,7 +94,7 @@ export const toInternalScrapeTarget = (
 			catch: (cause) =>
 				new InvalidScrapeTargetRow({
 					message: "Invalid scrape target row",
-					targetId: row.id,
+					rawTargetId: row.id,
 					cause,
 				}),
 		}).pipe(Effect.option)

--- a/apps/web/src/api/warehouse/effect-utils.ts
+++ b/apps/web/src/api/warehouse/effect-utils.ts
@@ -152,6 +152,8 @@ export function runWarehouseQuery<A>(
 ): Effect.Effect<A, WarehouseApiError | BackendError> {
 	return Effect.suspend(execute).pipe(
 		Effect.withSpan(operation),
+		// Warehouse adapters are imperative server-function entrypoints and own this runtime layer.
+		// oxlint-disable-next-line effecttsgo/strict-effect-provide
 		Effect.provide(mapleApiClientLayer),
 		Effect.mapError((cause) => normalizeWarehouseError(operation, cause)),
 	)
@@ -172,6 +174,8 @@ export function runWarehouseQueryV2<A, E>(
 ): Effect.Effect<A, WarehouseApiError | BackendError> {
 	return Effect.suspend(execute).pipe(
 		Effect.withSpan(operation),
+		// Warehouse adapters are imperative server-function entrypoints and own this runtime layer.
+		// oxlint-disable-next-line effecttsgo/strict-effect-provide
 		Effect.provide(mapleApiV2ClientLayer),
 		Effect.mapError((cause) => normalizeWarehouseError(operation, cause)),
 	)

--- a/apps/web/src/api/warehouse/query-builder-timeseries.ts
+++ b/apps/web/src/api/warehouse/query-builder-timeseries.ts
@@ -1,7 +1,11 @@
 import { Effect, Result, Schema } from "effect"
-import { QueryEngineExecuteRequest, type QuerySpec } from "@maple/query-engine"
+import {
+	formatWarehouseDateTime,
+	parseWarehouseDateTime,
+	QueryEngineExecuteRequest,
+	type QuerySpec,
+} from "@maple/query-engine"
 import { NO_QUERY_DATA_MESSAGE } from "@/lib/alerts/preview-failure"
-import { formatForTinybird } from "@/lib/time-utils"
 import {
 	buildFormulaResults,
 	type FormulaDraft,
@@ -114,7 +118,7 @@ interface QueryBuilderTimeseriesResponse {
 	debug?: QueryBuilderTimeseriesDebug
 }
 
-const toEpochMs = (value: string): number => new Date(value.replace(" ", "T") + "Z").getTime()
+const toEpochMs = parseWarehouseDateTime
 
 function computeAutoBucketSeconds(startTime: string, endTime: string): number {
 	return computeBucketSeconds(startTime, endTime)
@@ -232,8 +236,8 @@ function buildExecutionWindows(
 		}
 
 		const windowStartMs = endMs - seconds * 1000
-		const nextStart = formatForTinybird(new Date(windowStartMs))
-		const nextEnd = formatForTinybird(new Date(endMs))
+		const nextStart = formatWarehouseDateTime(windowStartMs)
+		const nextEnd = formatWarehouseDateTime(endMs)
 		const key = `${nextStart}|${nextEnd}`
 
 		if (seen.has(key)) {
@@ -809,8 +813,8 @@ const getQueryBuilderTimeseriesEffect = Effect.fn("QueryEngine.getQueryBuilderTi
 	let previousDebug: QueryExecutionDebug[] = []
 
 	if (comparison.mode === "previous_period" && shiftMs > 0) {
-		previousStartTime = formatForTinybird(new Date(startMs - shiftMs))
-		previousEndTime = formatForTinybird(new Date(endMs - shiftMs))
+		previousStartTime = formatWarehouseDateTime(startMs - shiftMs)
+		previousEndTime = formatWarehouseDateTime(endMs - shiftMs)
 
 		const previousWindow = yield* runQueryWindow(
 			previousStartTime,

--- a/apps/web/src/api/warehouse/service-map.ts
+++ b/apps/web/src/api/warehouse/service-map.ts
@@ -14,7 +14,7 @@ import { WarehouseDateTimeString, decodeInput, runWarehouseQuery } from "@/api/w
 import { transformExternalEdge } from "@/api/warehouse/service-external-edges"
 import { aggregateByServiceEnvironment, coerceRow } from "@/api/warehouse/services"
 
-import { formatWarehouseDateTime } from "@maple/query-engine"
+import { formatWarehouseDateTime, parseWarehouseDateTime } from "@maple/query-engine"
 export interface ServiceEdge {
 	sourceService: string
 	targetService: string
@@ -175,8 +175,8 @@ export const getServiceDependenciesBundle = Effect.fn("QueryEngine.getServiceDep
 		}),
 	)
 
-	const startMs = new Date(startTime.replace(" ", "T") + "Z").getTime()
-	const endMs = new Date(endTime.replace(" ", "T") + "Z").getTime()
+	const startMs = parseWarehouseDateTime(startTime)
+	const endMs = parseWarehouseDateTime(endTime)
 	const durationSeconds = startMs > 0 && endMs > 0 ? Math.max((endMs - startMs) / 1000, 1) : 3600
 
 	return {
@@ -272,8 +272,8 @@ export const getServiceMapCloudflare = Effect.fn("QueryEngine.getServiceMapCloud
 		}),
 	)
 
-	const startMs = input.startTime ? new Date(input.startTime.replace(" ", "T") + "Z").getTime() : 0
-	const endMs = input.endTime ? new Date(input.endTime.replace(" ", "T") + "Z").getTime() : 0
+	const startMs = input.startTime ? parseWarehouseDateTime(input.startTime) : 0
+	const endMs = input.endTime ? parseWarehouseDateTime(input.endTime) : 0
 	const durationSeconds = startMs > 0 && endMs > 0 ? Math.max((endMs - startMs) / 1000, 1) : 3600
 
 	return {
@@ -443,8 +443,8 @@ export const getServiceMapBundle = Effect.fn("QueryEngine.getServiceMapBundle")(
 		}),
 	)
 
-	const startMs = new Date(`${startTime.replace(" ", "T")}Z`).getTime()
-	const endMs = new Date(`${endTime.replace(" ", "T")}Z`).getTime()
+	const startMs = parseWarehouseDateTime(startTime)
+	const endMs = parseWarehouseDateTime(endTime)
 	const durationSeconds = startMs > 0 && endMs > 0 ? Math.max((endMs - startMs) / 1000, 1) : 3600
 
 	return {

--- a/apps/web/src/api/warehouse/services.ts
+++ b/apps/web/src/api/warehouse/services.ts
@@ -1,5 +1,9 @@
 import { Clock, Effect, Schema } from "effect"
-import { QueryEngineExecuteRequest, formatWarehouseDateTime } from "@maple/query-engine"
+import {
+	QueryEngineExecuteRequest,
+	formatWarehouseDateTime,
+	parseWarehouseDateTime,
+} from "@maple/query-engine"
 import {
 	CommitSha,
 	DeploymentEnvironment,
@@ -251,8 +255,8 @@ const getServiceOverviewEffect = Effect.fn("QueryEngine.getServiceOverview")(fun
 		}),
 	)
 
-	const startMs = input.startTime ? new Date(input.startTime.replace(" ", "T") + "Z").getTime() : 0
-	const endMs = input.endTime ? new Date(input.endTime.replace(" ", "T") + "Z").getTime() : 0
+	const startMs = input.startTime ? parseWarehouseDateTime(input.startTime) : 0
+	const endMs = input.endTime ? parseWarehouseDateTime(input.endTime) : 0
 	const durationSeconds = startMs > 0 && endMs > 0 ? Math.max((endMs - startMs) / 1000, 1) : 3600
 
 	const coercedRows = result.data.map(coerceRow)
@@ -359,7 +363,7 @@ const BASELINE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
 // stable for up to an hour regardless of small range changes.
 const floorToHour = (dateTime: string) => `${dateTime.slice(0, 13)}:00:00`
 
-const warehouseDateTimeToMs = (dateTime: string) => new Date(`${dateTime.replace(" ", "T")}Z`).getTime()
+const warehouseDateTimeToMs = parseWarehouseDateTime
 
 export function getServiceHealthBaseline({ data }: { data: GetServiceHealthBaselineInput }) {
 	return getServiceHealthBaselineEffect({ data })

--- a/apps/web/src/components/ingest/use-ingest-connection.test.ts
+++ b/apps/web/src/components/ingest/use-ingest-connection.test.ts
@@ -60,7 +60,7 @@ describe("sendTestEventEffect", () => {
 		}),
 	)
 
-	it.effect("fails with a tagged rejection on a non-2xx response", () =>
+	it.effect("fails with a schema-backed rejection on a non-2xx response", () =>
 		Effect.gen(function* () {
 			const error = yield* runWithResponse([], new Response(null, { status: 401 })).pipe(Effect.flip)
 			if (error._tag !== "@maple/web/TestEventIngestRejected") {

--- a/apps/web/src/components/ingest/use-ingest-connection.test.ts
+++ b/apps/web/src/components/ingest/use-ingest-connection.test.ts
@@ -1,0 +1,72 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { TestClock } from "effect/testing"
+import { FetchHttpClient } from "effect/unstable/http"
+import { sendTestEventEffect } from "./use-ingest-connection"
+
+interface RecordedRequest {
+	readonly url: string
+	readonly method: string
+	readonly headers: Headers
+	readonly body: unknown
+}
+
+const runWithResponse = (recorded: Array<RecordedRequest>, response: Response) => {
+	const fetchStub: typeof globalThis.fetch = async (input, init) => {
+		const body =
+			typeof init?.body === "string"
+				? JSON.parse(init.body)
+				: init?.body instanceof Uint8Array
+					? JSON.parse(new TextDecoder().decode(init.body))
+					: undefined
+		recorded.push({
+			url: input instanceof Request ? input.url : String(input),
+			method: init?.method ?? "GET",
+			headers: new Headers(init?.headers),
+			body,
+		})
+		return response
+	}
+
+	return sendTestEventEffect("maple_pk_test").pipe(
+		Effect.provide(FetchHttpClient.layer),
+		Effect.provideService(FetchHttpClient.Fetch, fetchStub),
+	)
+}
+
+describe("sendTestEventEffect", () => {
+	it.effect("posts a deterministic synthetic trace using the Effect clock", () =>
+		Effect.gen(function* () {
+			const now = Date.UTC(2026, 7, 11, 12, 0, 0)
+			yield* TestClock.setTime(now)
+			const recorded: Array<RecordedRequest> = []
+
+			yield* runWithResponse(recorded, new Response(null, { status: 202 }))
+
+			assert.lengthOf(recorded, 1)
+			assert.strictEqual(recorded[0]?.url, "https://ingest.maple.dev/v1/traces")
+			assert.strictEqual(recorded[0]?.method, "POST")
+			assert.strictEqual(recorded[0]?.headers.get("authorization"), "Bearer maple_pk_test")
+			const payload = recorded[0]?.body as {
+				resourceSpans: Array<{
+					scopeSpans: Array<{
+						spans: Array<{ startTimeUnixNano: string; endTimeUnixNano: string }>
+					}>
+				}>
+			}
+			const span = payload.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+			assert.strictEqual(span.startTimeUnixNano, `${now - 87}000000`)
+			assert.strictEqual(span.endTimeUnixNano, `${now}000000`)
+		}),
+	)
+
+	it.effect("fails with a tagged rejection on a non-2xx response", () =>
+		Effect.gen(function* () {
+			const error = yield* runWithResponse([], new Response(null, { status: 401 })).pipe(Effect.flip)
+			if (error._tag !== "@maple/web/TestEventIngestRejected") {
+				return assert.fail(`Expected tagged ingest rejection, got ${error._tag}`)
+			}
+			assert.strictEqual(error.status, 401)
+		}),
+	)
+})

--- a/apps/web/src/components/ingest/use-ingest-connection.ts
+++ b/apps/web/src/components/ingest/use-ingest-connection.ts
@@ -1,4 +1,4 @@
-import { Clock, Data, Effect } from "effect"
+import { Clock, Effect, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { Result, useAtomRefresh, useAtomValue } from "@/lib/effect-atom"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
@@ -72,10 +72,13 @@ function randomHex(byteLength: number): string {
 
 const TEST_EVENT_SERVICE = "maple-onboarding-test"
 
-class TestEventIngestRejected extends Data.TaggedError("@maple/web/TestEventIngestRejected")<{
-	readonly message: string
-	readonly status: number
-}> {}
+class TestEventIngestRejected extends Schema.TaggedError<TestEventIngestRejected>()(
+	"@maple/web/TestEventIngestRejected",
+	{
+		message: Schema.String,
+		status: Schema.Number,
+	},
+) {}
 
 export const sendTestEventEffect = Effect.fn("Onboarding.sendTestEvent")(function* (apiKey: string) {
 	const now = yield* Clock.currentTimeMillis

--- a/apps/web/src/components/ingest/use-ingest-connection.ts
+++ b/apps/web/src/components/ingest/use-ingest-connection.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect"
+import { Clock, Data, Effect } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { Result, useAtomRefresh, useAtomValue } from "@/lib/effect-atom"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
@@ -72,9 +72,13 @@ function randomHex(byteLength: number): string {
 
 const TEST_EVENT_SERVICE = "maple-onboarding-test"
 
-/** POST a single synthetic trace to the ingest gateway to prove the key works. */
-export async function sendTestEvent(apiKey: string): Promise<void> {
-	const now = Date.now()
+class TestEventIngestRejected extends Data.TaggedError("@maple/web/TestEventIngestRejected")<{
+	readonly message: string
+	readonly status: number
+}> {}
+
+export const sendTestEventEffect = Effect.fn("Onboarding.sendTestEvent")(function* (apiKey: string) {
+	const now = yield* Clock.currentTimeMillis
 	const endNano = `${now}000000`
 	const startNano = `${now - 87}000000`
 	const payload = {
@@ -111,17 +115,29 @@ export async function sendTestEvent(apiKey: string): Promise<void> {
 		],
 	}
 
-	await Effect.gen(function* () {
-		const client = yield* HttpClient.HttpClient
-		const response = yield* client.execute(
-			HttpClientRequest.post(`${ingestUrl}/v1/traces`, {
-				headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-			}).pipe(HttpClientRequest.bodyText(JSON.stringify(payload))),
-		)
-		// HttpClient does not fail on non-2xx, so surface it explicitly — runPromise
-		// rejects, preserving the throw-on-failure contract the click handler relies on.
-		if (response.status < 200 || response.status >= 300) {
-			return yield* Effect.fail(new Error(`Ingest gateway returned ${response.status}`))
-		}
-	}).pipe(Effect.provide(FetchHttpClient.layer), Effect.runPromise)
-}
+	const client = yield* HttpClient.HttpClient
+	const request = yield* HttpClientRequest.bodyJson(
+		HttpClientRequest.post(`${ingestUrl}/v1/traces`, {
+			headers: { Authorization: `Bearer ${apiKey}` },
+		}),
+		payload,
+	)
+	const response = yield* client.execute(request)
+	// HttpClient does not fail on non-2xx, so surface it explicitly — runPromise
+	// rejects, preserving the throw-on-failure contract the click handler relies on.
+	if (response.status < 200 || response.status >= 300) {
+		return yield* new TestEventIngestRejected({
+			message: `Ingest gateway returned ${response.status}`,
+			status: response.status,
+		})
+	}
+})
+
+/** POST a single synthetic trace to the ingest gateway to prove the key works. */
+export const sendTestEvent = (apiKey: string): Promise<void> =>
+	sendTestEventEffect(apiKey).pipe(
+		// This is the Promise bridge used by click handlers, so it owns the HTTP layer.
+		// oxlint-disable-next-line effecttsgo/strict-effect-provide
+		Effect.provide(FetchHttpClient.layer),
+		Effect.runPromise,
+	)

--- a/apps/web/src/lib/services/common/telemetry.ts
+++ b/apps/web/src/lib/services/common/telemetry.ts
@@ -72,6 +72,9 @@ export const tracedFetch = (
 					// to walk an `Error` back once the effect has failed. Cancellations
 					// therefore return normally and only real failures are re-failed below.
 					const outcome: FetchOutcome = yield* Effect.promise(() =>
+						// This function is Electric's injectable fetch port; preserving the platform
+						// rejection value is required for pause-stream cancellation semantics.
+						// oxlint-disable-next-line effecttsgo/global-fetch-in-effect
 						globalThis.fetch(input, { ...init, headers }).then(
 							(response) => ({ ok: true, response }) as const,
 							(cause) => ({ ok: false, cause }) as const,

--- a/lib/unitflow/src/core/runtime.ts
+++ b/lib/unitflow/src/core/runtime.ts
@@ -162,6 +162,7 @@ export const make = <R, ER>(
 		// The model's service identifier cannot be tied to the runtime's `R`
 		// statically — the runtime layer must include the model's layer.
 		// eslint-disable-next-line revizo/no-type-assertion
+		// oxlint-disable-next-line effecttsgo/unsafe-effect-type-assertion
 		const load = Model.get(model, ...keyArgs) as Effect.Effect<Model.PortsOf<M>, Model.ErrorOf<M>>
 		runtime.runFork(
 			load.pipe(

--- a/packages/domain/src/tinybird/project-sync.ts
+++ b/packages/domain/src/tinybird/project-sync.ts
@@ -1,6 +1,6 @@
 import { datasources, pipes, projectRevision } from "../generated/tinybird-project-manifest"
 import { TinybirdApi, TinybirdApiError } from "@tinybirdco/sdk"
-import { Duration, Effect, Schema } from "effect"
+import { Data, Duration, Effect, Schema } from "effect"
 import {
 	applyRawTtlOverrides,
 	computeEffectiveRevision,
@@ -72,6 +72,12 @@ type FeedbackEntry = typeof FeedbackEntrySchema.Type
 
 const READY_STATUSES = new Set(["data_ready", "live"])
 const FAILURE_STATUSES = new Set(["failed", "error", "deleting", "deleted"])
+
+class StaleDeploymentCleanupError extends Data.TaggedError("@maple/tinybird/StaleDeploymentCleanupError")<{
+	readonly message: string
+	readonly deploymentId: string
+	readonly cause: unknown
+}> {}
 
 export interface TinybirdProjectSyncParams {
 	readonly baseUrl: string
@@ -425,7 +431,12 @@ export const makeTinybirdProjectSync = (options: TinybirdProjectSyncOptions): Ti
 			(deployment) =>
 				Effect.tryPromise({
 					try: () => api.request(`/v1/deployments/${deployment.id}`, { method: "DELETE" }),
-					catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+					catch: (cause) =>
+						new StaleDeploymentCleanupError({
+							message: "Tinybird stale-deployment cleanup failed",
+							deploymentId: deployment.id,
+							cause,
+						}),
 				}).pipe(
 					Effect.tapError((error) =>
 						Effect.logWarning("Tinybird stale-deployment cleanup failed").pipe(

--- a/packages/domain/src/tinybird/project-sync.ts
+++ b/packages/domain/src/tinybird/project-sync.ts
@@ -1,6 +1,6 @@
 import { datasources, pipes, projectRevision } from "../generated/tinybird-project-manifest"
 import { TinybirdApi, TinybirdApiError } from "@tinybirdco/sdk"
-import { Data, Duration, Effect, Schema } from "effect"
+import { Duration, Effect, Schema } from "effect"
 import {
 	applyRawTtlOverrides,
 	computeEffectiveRevision,
@@ -73,11 +73,14 @@ type FeedbackEntry = typeof FeedbackEntrySchema.Type
 const READY_STATUSES = new Set(["data_ready", "live"])
 const FAILURE_STATUSES = new Set(["failed", "error", "deleting", "deleted"])
 
-class StaleDeploymentCleanupError extends Data.TaggedError("@maple/tinybird/StaleDeploymentCleanupError")<{
-	readonly message: string
-	readonly deploymentId: string
-	readonly cause: unknown
-}> {}
+class StaleDeploymentCleanupError extends Schema.TaggedError<StaleDeploymentCleanupError>()(
+	"@maple/tinybird/StaleDeploymentCleanupError",
+	{
+		message: Schema.String,
+		deploymentId: Schema.String,
+		cause: Schema.Defect(),
+	},
+) {}
 
 export interface TinybirdProjectSyncParams {
 	readonly baseUrl: string


### PR DESCRIPTION
## Summary

- replace ad hoc warehouse `Date` parsing/formatting inside Effects with the shared UTC helpers
- replace the remaining production plain-`Error` failure sites found by the follow-up scan with namespaced tagged errors
- move the onboarding synthetic trace sender into a named Effect using `Clock` and typed JSON request encoding
- document verified runtime-entrypoint and injectable-fetch exceptions so the Effect audit does not repeatedly flag intentional boundaries
- add deterministic TestClock coverage for the synthetic trace request and tagged non-2xx rejection

## Verification

- `bun run lint:effect`
- `bun run typecheck`
- `bun run test`
- focused web warehouse/onboarding, API scraper, Tinybird project-sync, and Unitflow tests
- regular Oxlint on every changed file
- `git diff --check`

## Review notes

The follow-up deliberately leaves generic library variance channels and native fetch/runtime boundaries unchanged where the Effect v4 audit guidance identifies them as intentional exceptions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789059098&installation_model_id=427786&pr_number=423&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F423&signature=686c6f32325324c131680a52901d8d97dbf344f02293d8cb0be0d8398862a4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->