### PR TITLE
fix(api): wire EdgeCacheService into the org ClickHouse config tier

### DIFF
--- a/apps/api/src/runtime/service-graph.ts
+++ b/apps/api/src/runtime/service-graph.ts
@@ -70,6 +70,18 @@ const ScrapeTargetsLive = ScrapeTargetsService.layer.pipe(
 	Layer.provide(Layer.mergeAll(PlanetScaleDiscoveryLive, PlanetScaleOAuthLive)),
 )
 
+// Hoisted above `CoreServicesLive` because `OrgClickHouseSettingsService` needs
+// it, and `CoreServicesLive` closes its inputs with `provideMerge(InfraLive)` —
+// anything not supplied by then is simply absent for every service inside it.
+//
+// That mattered silently: the settings service reads this with
+// `Effect.serviceOption`, so an unwired cache is not a build error, it is an
+// `Option.none()` and a straight fall-through to Postgres. Its shared tier sat
+// dormant in `maple-api` while working correctly in `apps/alerting`, whose
+// graph happens to compose the two in the other order — zero `edge_cache`
+// resolutions against 21 Postgres reads in the first 15 minutes after deploy.
+const EdgeCacheServiceLive = EdgeCacheService.layer.pipe(Layer.provide(CacheBackendLive))
+
 const CoreServicesLive = Layer.mergeAll(
 	AuthService.layer,
 	ApiKeysService.layer,
@@ -80,7 +92,7 @@ const CoreServicesLive = Layer.mergeAll(
 	HazelOAuthService.layer,
 	OnboardingService.layer,
 	OrgIngestKeysService.layer,
-	OrgClickHouseSettingsService.layer,
+	OrgClickHouseSettingsService.layer.pipe(Layer.provide(EdgeCacheServiceLive)),
 	TinybirdOrgTokenService.layer,
 	OrganizationService.layer,
 	PlanetScaleOAuthLive,
@@ -106,11 +118,10 @@ const DemoServiceLive = DemoService.layer.pipe(
 	Layer.provideMerge(Layer.mergeAll(CoreServicesLive, WarehouseQueryServiceLive)),
 )
 
-// EdgeCacheService's storage backend (Workers KV / in-memory) is injected via
-// the CacheBackend port. Define the wired layer once so it memoizes to a single
-// instance shared by the bucket cache and the direct edge cache.
-const EdgeCacheServiceLive = EdgeCacheService.layer.pipe(Layer.provide(CacheBackendLive))
-
+// `EdgeCacheServiceLive` is defined above, ahead of `CoreServicesLive`, so the
+// single memoized instance is shared by the bucket cache, the direct edge cache
+// and the org-config tier. Its storage backend is injected via the CacheBackend
+// port.
 const BucketCacheServiceLive = BucketCacheService.layer.pipe(Layer.provideMerge(EdgeCacheServiceLive))
 
 const QueryEngineServiceLive = QueryEngineService.layer.pipe(


### PR DESCRIPTION
## The bug

The shared edge-cache tier from #422 is **dormant in `maple-api`** — the exact service the change was aimed at.

`OrgClickHouseSettingsService` takes the cache with `Effect.serviceOption`, so an unwired cache isn't a build error. It's an `Option.none()` and a silent fall-through to Postgres. `CoreServicesLive` closes its inputs with `Layer.provideMerge(InfraLive)`, and `EdgeCacheServiceLive` was defined *after* it, so nothing inside `CoreServicesLive` could ever see the cache. `apps/alerting` composes the two in the other order, which is why the tier works there and not here.

## Evidence

First 15 minutes after the #422 deploy, `resolveCachedSettings` grouped by service:

| service | memo | edge_cache | memo_stale | postgres |
|---|---|---|---|---|
| `alerting` | 996 | **75** (p50 5ms, p95 7.6ms) | 14 | 2 (p50 986ms) |
| `maple-api` | 207 | **0** | 0 | 21 (p50 19ms, **p95 5152ms**) |

Cache reads on the `org-ch-config` bucket are healthy where the tier is live — 68 hits at p50 4ms / p95 7ms against 2 timeouts, a 97% hit rate, well inside the budget that sank the earlier attempts.

## The fix

Hoist `EdgeCacheServiceLive` above `CoreServicesLive` and provide it explicitly to `OrgClickHouseSettingsService`. Still one memoized instance, shared with the bucket cache and the direct edge cache.

## Reviewer notes

- **The failure mode is the design.** `serviceOption` is right here — alerting, the CLI and tests legitimately build this service without a cache — but it means a wiring mistake is invisible at compile time and shows up only as a missing span-attribute value. Worth a follow-up guard; the short-term answer is that `clickhouse.config.source` is the signal and it belongs on a dashboard.
- **Any perceived improvement in the API since #422 is not this tier.** It never ran. That window also contains #418 and #420, which reworked the Postgres dial and concurrency directly.
- After deploy, `maple-api` should show `edge_cache` in the table above, and its `postgres` p95 should drop off the multi-second ceiling.
- `oxlint` reports 4 pre-existing `no-restricted-imports` errors in this file — the VCS vendor allowlist still names `app.ts`, which was renamed to `runtime/service-graph.ts`. Identical count on `origin/main`; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789060645&installation_model_id=427786&pr_number=425&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F425&signature=55fe793836a8d14510aca866d846be75a154adbf25a57651196efdd367359d72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->