### PR TITLE
perf(web): stale-while-revalidate for client-side query data

### DIFF
--- a/apps/web/src/atoms/dashboard-time-range-atoms.ts
+++ b/apps/web/src/atoms/dashboard-time-range-atoms.ts
@@ -2,25 +2,42 @@ import { type ReactNode, createElement, useCallback, useMemo } from "react"
 import { Atom, ScopedAtom, useAtom } from "@/lib/effect-atom"
 import { useOptionalPageRefreshContext } from "@/components/time-range-picker/page-refresh-context"
 import type { TimeRange } from "@/components/dashboard-builder/types"
-import { relativeToAbsolute } from "@/lib/time-utils"
+import { relativeToAbsolute, snapRangeForCache } from "@/lib/time-utils"
 
 type ResolvedTimeRange = { startTime: string; endTime: string }
 
 const DEFAULT_RELATIVE_FALLBACK = "1h"
 
-export function resolveTimeRange(timeRange: TimeRange): ResolvedTimeRange | null {
+export interface ResolveTimeRangeOptions {
+	/**
+	 * Floor the endpoint to the cache-key grid. Default `true`; pass `false` on
+	 * an explicit reload so the window actually advances to "now".
+	 */
+	snap?: boolean
+}
+
+export function resolveTimeRange(
+	timeRange: TimeRange,
+	options?: ResolveTimeRangeOptions,
+): ResolvedTimeRange | null {
 	if (timeRange.type === "absolute") {
 		return { startTime: timeRange.startTime, endTime: timeRange.endTime }
 	}
+
+	// Every widget on the dashboard keys its fetch off this range, so an unsnapped
+	// `now` hands all of them a fresh cache key on each mount at once.
+	const snap = (range: ResolvedTimeRange) => (options?.snap === false ? range : snapRangeForCache(range))
+
 	const resolved = relativeToAbsolute(timeRange.value)
-	if (resolved) return resolved
+	if (resolved) return snap(resolved)
 
 	if (import.meta.env.DEV) {
 		console.warn(
 			`[resolveTimeRange] Invalid relative time range value "${timeRange.value}", falling back to "${DEFAULT_RELATIVE_FALLBACK}"`,
 		)
 	}
-	return relativeToAbsolute(DEFAULT_RELATIVE_FALLBACK)
+	const fallback = relativeToAbsolute(DEFAULT_RELATIVE_FALLBACK)
+	return fallback ? snap(fallback) : null
 }
 
 function timeRangesEqual(a: TimeRange, b: TimeRange): boolean {
@@ -50,7 +67,10 @@ export function useDashboardTimeRange() {
 	// re-runs their queries).
 	const refreshVersion = useOptionalPageRefreshContext()?.refreshVersion ?? 0
 	const resolvedTimeRange = useMemo(
-		() => resolveTimeRange(timeRange),
+		// Snapped while idle so navigating back to a dashboard reuses every tile's
+		// cached result; unsnapped once the user reloads, so the window advances to
+		// the real "now" rather than staying inside the previous grid cell.
+		() => resolveTimeRange(timeRange, { snap: refreshVersion === 0 }),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[timeRange, refreshVersion],
 	)

--- a/apps/web/src/components/alerts/destination-dialog.tsx
+++ b/apps/web/src/components/alerts/destination-dialog.tsx
@@ -24,8 +24,8 @@ import {
 	channelPickerView,
 	resolveSearchQuery,
 } from "@/components/alerts/slack-channel-search"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { v2ErrorInfo } from "@/lib/error-messages"
 import { disabledResultAtom } from "@/lib/services/atoms/disabled-result-atom"
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
@@ -284,11 +284,11 @@ function HazelOAuthFields({
 	isEditing: boolean
 }) {
 	const statusResult = useAtomValue(
-		MapleApiAtomClient.query("integrations", "hazelStatus", {
+		retainedQuery("integrations", "hazelStatus", {
 			reactivityKeys: ["hazelIntegrationStatus"],
 		}),
 	)
-	const organizationsAtom = MapleApiAtomClient.query("integrations", "hazelOrganizations", {
+	const organizationsAtom = retainedQuery("integrations", "hazelOrganizations", {
 		reactivityKeys: ["hazelIntegrationStatus", "hazelOrganizations"],
 	})
 	const organizationsResult = useAtomValue(organizationsAtom)
@@ -296,7 +296,7 @@ function HazelOAuthFields({
 	const orgIdForChannels = form.hazelOrganizationId.trim()
 	const channelsAtom =
 		orgIdForChannels.length > 0
-			? MapleApiAtomClient.query("integrations", "hazelChannels", {
+			? retainedQuery("integrations", "hazelChannels", {
 					params: { organizationId: orgIdForChannels },
 					reactivityKeys: ["hazelIntegrationStatus", "hazelChannels", orgIdForChannels],
 				})
@@ -559,7 +559,7 @@ function SlackBotFields({
 	isEditing: boolean
 }) {
 	const statusResult = useAtomValue(
-		MapleApiV2AtomClient.query("slackIntegration", "status", {
+		retainedQueryV2("slackIntegration", "status", {
 			reactivityKeys: ["slackIntegration"],
 		}),
 	)
@@ -576,7 +576,7 @@ function SlackBotFields({
 	const installed = status?.installed === true
 
 	const channelsAtom = installed
-		? MapleApiV2AtomClient.query("slackIntegration", "channels", {
+		? retainedQueryV2("slackIntegration", "channels", {
 				reactivityKeys: ["slackIntegration", "slackChannels"],
 			})
 		: disabledResultAtom<V2SlackChannelList>()

--- a/apps/web/src/components/alerts/overview/alerts-overview-tab.tsx
+++ b/apps/web/src/components/alerts/overview/alerts-overview-tab.tsx
@@ -30,7 +30,7 @@ import { useAlertDestinationsList } from "@/hooks/use-alerts-list"
 import { Result, useAtomValue } from "@/lib/effect-atom"
 import { AlertsOverviewModel, type AlertsOverviewReady } from "@/lib/models/alerts-overview-model"
 import { unitflowRuntime } from "@/lib/models/runtime"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@maple/ui/components/ui/empty"
 import { ErrorState } from "@/components/common/error-state"
 import {
@@ -132,7 +132,7 @@ const AlertsOverviewContent = memo(function AlertsOverviewContent({
 		timelineRange,
 	} = data
 
-	const sessionResult = useAtomValue(MapleApiAtomClient.query("auth", "session", {}))
+	const sessionResult = useAtomValue(retainedQuery("auth", "session", {}))
 	const { result: destinationsResult } = useAlertDestinationsList()
 
 	const destinations = Result.builder(destinationsResult)

--- a/apps/web/src/components/alerts/overview/settings-tab.tsx
+++ b/apps/web/src/components/alerts/overview/settings-tab.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/lib/alerts/form-utils"
 import { v2ErrorInfo } from "@/lib/error-messages"
 import { useAlertDestinationsList } from "@/hooks/use-alerts-list"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { Result, useAtomSet, useAtomValue } from "@/lib/effect-atom"
 import { Badge } from "@maple/ui/components/ui/badge"
 import { Button } from "@maple/ui/components/ui/button"
@@ -202,7 +202,7 @@ export function useDestinationManager(): DestinationManager {
 export function AlertsSettingsTab({ manager, isAdmin }: { manager: DestinationManager; isAdmin: boolean }) {
 	const { result: destinationsResult } = useAlertDestinationsList()
 	const deliveryEventsResult = useAtomValue(
-		MapleApiV2AtomClient.query("alertDeliveries", "list", {
+		retainedQueryV2("alertDeliveries", "list", {
 			query: { limit: 100 },
 			reactivityKeys: ["alertDeliveryEvents"],
 		}),

--- a/apps/web/src/components/anomalies/anomaly-link-issue-dialog.tsx
+++ b/apps/web/src/components/anomalies/anomaly-link-issue-dialog.tsx
@@ -17,7 +17,7 @@ import { Spinner } from "@maple/ui/components/ui/spinner"
 import { shortIssueId } from "@/components/errors/issue-id"
 import { WorkflowRingIcon } from "@/components/icons"
 import { formatRelativeTime } from "@maple/ui/lib/time-format"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 
 export function AnomalyLinkIssueDialog({
 	incident,
@@ -49,7 +49,7 @@ function DialogContent({
 	const [query, setQuery] = useState("")
 	const [allServices, setAllServices] = useState(false)
 
-	const issuesQueryAtom = MapleApiAtomClient.query("errors", "listIssues", {
+	const issuesQueryAtom = retainedQuery("errors", "listIssues", {
 		query: allServices ? { limit: 100 } : { service: incident.serviceName, limit: 100 },
 		reactivityKeys: ["errorIssues"],
 	})

--- a/apps/web/src/components/anomalies/anomaly-linked-issue-card.tsx
+++ b/apps/web/src/components/anomalies/anomaly-linked-issue-card.tsx
@@ -10,7 +10,7 @@ import { shortIssueId } from "@/components/errors/issue-id"
 import { WorkflowBadge } from "@/components/errors/workflow-badge"
 import { ArrowRightIcon, LinkIcon, XmarkIcon } from "@/components/icons"
 import { formatNumber } from "@maple/ui/lib/format"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 import { ServiceDot } from "@maple/ui/components/service-dot"
 
 export function AnomalyLinkedIssueCard({
@@ -71,7 +71,7 @@ function LinkedIssueBody({
 	onUnlink: () => void
 	busy: boolean
 }) {
-	const issueQueryAtom = MapleApiAtomClient.query("errors", "getIssue", {
+	const issueQueryAtom = retainedQuery("errors", "getIssue", {
 		params: { issueId },
 		query: {},
 		reactivityKeys: ["errorIssues", `errorIssue:${issueId}`],

--- a/apps/web/src/components/anomalies/related-anomalies-section.tsx
+++ b/apps/web/src/components/anomalies/related-anomalies-section.tsx
@@ -4,12 +4,12 @@ import { Badge } from "@maple/ui/components/ui/badge"
 import { cn } from "@maple/ui/lib/utils"
 
 import { SectionHeader } from "@/components/layout/section-header"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 import { AnomalyRow } from "./anomaly-row"
 import { SEVERITY_TONE } from "./anomaly-format"
 
 function useRelatedAnomalies(issueId: ErrorIssueId) {
-	const incidentsQueryAtom = MapleApiAtomClient.query("anomalies", "listIncidents", {
+	const incidentsQueryAtom = retainedQuery("anomalies", "listIncidents", {
 		query: { errorIssueId: issueId, limit: 50 },
 		reactivityKeys: ["anomalyIncidents", `errorIssue:${issueId}:anomalies`],
 	})

--- a/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.tsx
+++ b/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.tsx
@@ -46,8 +46,8 @@ interface DashboardCanvasProps {
 /**
  * Latches `true` the first time the element scrolls into (near) the viewport,
  * then stays latched. Tiles fetch their data lazily on first reveal and keep it
- * — the widget fetch atoms set no staleTime, so a non-sticky flag would refetch
- * every time a tile scrolled back into view. The 200ms debounce absorbs
+ * — unlatching would unmount the tile's atom, and a non-sticky flag would then
+ * refetch every time it scrolled back into view. The 200ms debounce absorbs
  * react-grid-layout's mount-time reflow, where tiles can briefly flash into
  * view before the layout settles.
  */

--- a/apps/web/src/components/dashboard-builder/history/use-dashboard-history.ts
+++ b/apps/web/src/components/dashboard-builder/history/use-dashboard-history.ts
@@ -1,11 +1,11 @@
 import { useAtomSet, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { DashboardId, DashboardVersionId } from "@maple/domain/http"
 
 const dashboardVersionsKey = (dashboardId: DashboardId) => `dashboard:${dashboardId}:versions`
 
 export function useDashboardVersions(dashboardId: DashboardId) {
-	const queryAtom = MapleApiV2AtomClient.query("dashboards", "listVersions", {
+	const queryAtom = retainedQueryV2("dashboards", "listVersions", {
 		params: { id: dashboardId },
 		query: { limit: 100 },
 		reactivityKeys: [dashboardVersionsKey(dashboardId)],
@@ -18,7 +18,7 @@ export function useDashboardVersions(dashboardId: DashboardId) {
  * mount the consuming component — this hook is always called on mount.
  */
 export function useDashboardVersionDetail(dashboardId: DashboardId, versionId: DashboardVersionId) {
-	const queryAtom = MapleApiV2AtomClient.query("dashboards", "retrieveVersion", {
+	const queryAtom = retainedQueryV2("dashboards", "retrieveVersion", {
 		params: {
 			id: dashboardId,
 			version_id: versionId,

--- a/apps/web/src/components/dashboard-builder/templates/template-live-preview.tsx
+++ b/apps/web/src/components/dashboard-builder/templates/template-live-preview.tsx
@@ -5,7 +5,7 @@ import { useContainerSize } from "@maple/ui/hooks/use-container-size"
 import type { V2DashboardTemplate } from "@maple/domain/http/v2"
 import { Atom, Result, useAtomValue } from "@/lib/effect-atom"
 import { useMountEffect } from "@/hooks/use-mount-effect"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { DashboardTimeRangeWrapper } from "@/components/dashboard-builder/dashboard-providers"
 import { visualizationFor } from "@/components/dashboard-builder/widgets/types"
 import { WidgetTimeRangeProvider } from "@/components/dashboard-builder/widgets/widget-time-range-context"
@@ -188,7 +188,7 @@ export function TemplateLivePreview({ template, parameters, className }: Templat
 
 	const result = useAtomValue(
 		armed
-			? MapleApiV2AtomClient.query("dashboards", "previewTemplate", {
+			? retainedQueryV2("dashboards", "previewTemplate", {
 					params: { template_id: template.id },
 					payload,
 					// Abandoned parameter variants shouldn't accumulate.

--- a/apps/web/src/components/infra/infra-correlation-panel.tsx
+++ b/apps/web/src/components/infra/infra-correlation-panel.tsx
@@ -2,7 +2,7 @@ import { addMinutes, subMinutes } from "date-fns"
 import { Link } from "@tanstack/react-router"
 
 import { ExternalLinkIcon } from "@/components/icons"
-import { formatForTinybird, relativeToAbsolute } from "@/lib/time-utils"
+import { formatForTinybird, relativeToAbsolute, snapRangeForCache } from "@/lib/time-utils"
 import { normalizeTimestampInput } from "@/lib/timezone-format"
 
 import { NodeDetailChart, PodDetailChart } from "./k8s-detail-chart"
@@ -28,7 +28,9 @@ export function infraCorrelationWindow(
 ): { startTime: string; endTime: string } {
 	const date = new Date(normalizeTimestampInput(anchor))
 	if (Number.isNaN(date.getTime())) {
-		return relativeToAbsolute("30m")!
+		// Snapped: unlike the anchored window below, this fallback is clock-derived
+		// and would otherwise give every mount a fresh cache key.
+		return snapRangeForCache(relativeToAbsolute("30m")!)
 	}
 	const pad = opts?.padMinutes ?? DEFAULT_PAD_MINUTES
 	const end = addMinutes(new Date(date.getTime() + (opts?.spanDurationMs ?? 0)), pad)

--- a/apps/web/src/components/infra/install-modal.tsx
+++ b/apps/web/src/components/infra/install-modal.tsx
@@ -22,7 +22,7 @@ import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { EyeIcon } from "@/components/icons"
 import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import { ingestUrl } from "@/lib/services/common/ingest-url"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 
 const HOSTED_INGEST_URL = "https://ingest.maple.dev"
 const DOCS_URL = "https://maple.dev/docs/guides/kubernetes-infrastructure"
@@ -60,7 +60,7 @@ function helmCommand(token: string) {
 export function InstallHostModal({ open, onOpenChange }: InstallModalProps) {
 	const [revealed, setRevealed] = useState(false)
 
-	const keysResult = useAtomValue(MapleApiV2AtomClient.query("ingestKeys", "retrieve", {}))
+	const keysResult = useAtomValue(retainedQueryV2("ingestKeys", "retrieve", {}))
 
 	const token = useMemo(
 		() =>

--- a/apps/web/src/components/ingest/connect-credentials.tsx
+++ b/apps/web/src/components/ingest/connect-credentials.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router"
 
 import { Result, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { ingestUrl } from "@/lib/services/common/ingest-url"
 import { CopyableField } from "@maple/ui/components/ui/copyable-field"
 
@@ -11,7 +11,7 @@ import { CopyableField } from "@maple/ui/components/ui/copyable-field"
  * the Connect popover and any compact credentials surface.
  */
 export function ConnectCredentials() {
-	const keysResult = useAtomValue(MapleApiV2AtomClient.query("ingestKeys", "retrieve", {}))
+	const keysResult = useAtomValue(retainedQueryV2("ingestKeys", "retrieve", {}))
 
 	return (
 		<div className="space-y-3">

--- a/apps/web/src/components/ingest/use-ingest-connection.ts
+++ b/apps/web/src/components/ingest/use-ingest-connection.ts
@@ -1,7 +1,7 @@
 import { Clock, Effect, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { Result, useAtomRefresh, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { ingestUrl } from "@/lib/services/common/ingest-url"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useIntervalRefresh } from "@/hooks/use-interval-refresh"
@@ -36,7 +36,7 @@ interface UseIngestConnectionOptions {
 export function useIngestConnection({ poll = true }: UseIngestConnectionOptions = {}): IngestConnection {
 	const { startTime, endTime } = useEffectiveTimeRange(undefined, undefined, "1h")
 
-	const keysResult = useAtomValue(MapleApiV2AtomClient.query("ingestKeys", "retrieve", {}))
+	const keysResult = useAtomValue(retainedQueryV2("ingestKeys", "retrieve", {}))
 	const apiKey = Result.isSuccess(keysResult) ? keysResult.value.public_key : ""
 
 	const overviewAtom = getServiceOverviewResultAtom({ data: { startTime, endTime } })

--- a/apps/web/src/components/integrations/cloudflare-account-card.tsx
+++ b/apps/web/src/components/integrations/cloudflare-account-card.tsx
@@ -8,7 +8,7 @@ import { toastManager } from "@maple/ui/components/ui/toast"
 
 import { CircleWarningIcon, CloudflareIcon, CloudflareMonoIcon, LoaderIcon } from "@/components/icons"
 import { Result, useAtomSet, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
 import { CLOUDFLARE_ACCENT, IntegrationIconPlate } from "./integration-catalog"
 import { useIntegrationConnect } from "./integration-connect"
 import {
@@ -42,14 +42,14 @@ const EMPTY_USAGE: RowUsage = { totalRequests: 0, lastDataAt: null, points: [] }
  */
 export function CloudflareAccountCard() {
 	// Assigned once so the refresh hooks target the same memoized query atoms.
-	const statusQuery = MapleApiAtomClient.query("integrations", "cloudflareStatus", {
+	const statusQuery = retainedQuery("integrations", "cloudflareStatus", {
 		reactivityKeys: ["cloudflareIntegrationStatus"],
 	})
 	const statusResult = useAtomValue(statusQuery)
 
 	// Warehouse-derived ingest volume: loads independently so the card renders instantly
 	// from status and the usage columns hydrate (or silently stay absent) afterwards.
-	const usageQuery = MapleApiAtomClient.query("integrations", "cloudflareUsage", {
+	const usageQuery = retainedQuery("integrations", "cloudflareUsage", {
 		reactivityKeys: ["cloudflareIntegrationUsage"],
 	})
 	const usageResult = useAtomValue(usageQuery)

--- a/apps/web/src/components/integrations/github-integration-card.tsx
+++ b/apps/web/src/components/integrations/github-integration-card.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/components/icons"
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
 import { useIntervalRefresh } from "@/hooks/use-interval-refresh"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
 import { GITHUB_ACCENT, IntegrationIconPlate } from "./integration-catalog"
 import { useIntegrationConnect, type IntegrationConnect } from "./integration-connect"
 import {
@@ -71,7 +71,7 @@ const SYNC_PRESENTATION: Record<
 
 export function GithubIntegrationCard() {
 	// Assigned once so the refresh hook targets the same memoized query atom.
-	const statusQuery = MapleApiAtomClient.query("integrations", "githubStatus", {
+	const statusQuery = retainedQuery("integrations", "githubStatus", {
 		reactivityKeys: ["githubIntegrationStatus"],
 	})
 	const statusResult = useAtomValue(statusQuery)

--- a/apps/web/src/components/integrations/hazel-integration-card.tsx
+++ b/apps/web/src/components/integrations/hazel-integration-card.tsx
@@ -8,7 +8,7 @@ import { toastManager } from "@maple/ui/components/ui/toast"
 import { ErrorState } from "@/components/common/error-state"
 import { HazelIcon, LoaderIcon } from "@/components/icons"
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
 import { HAZEL_ACCENT, IntegrationIconPlate } from "./integration-catalog"
 import { useIntegrationConnect } from "./integration-connect"
 import {
@@ -22,7 +22,7 @@ import {
 } from "./integration-empty-state"
 
 export function HazelIntegrationCard() {
-	const statusAtom = MapleApiAtomClient.query("integrations", "hazelStatus", {
+	const statusAtom = retainedQuery("integrations", "hazelStatus", {
 		reactivityKeys: ["hazelIntegrationStatus"],
 	})
 	const statusResult = useAtomValue(statusAtom)

--- a/apps/web/src/components/integrations/integration-catalog.tsx
+++ b/apps/web/src/components/integrations/integration-catalog.tsx
@@ -14,8 +14,8 @@ import {
 import { PLANETSCALE_COLOR } from "@/components/infra/planetscale/metrics"
 import { formatRelativeTime } from "@maple/ui/lib/time-format"
 import { Result, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { scrapeTargetsListAtom } from "@/lib/services/atoms/scrape-target-atoms"
 
 export type IntegrationId =
@@ -173,28 +173,28 @@ const STATUS_UNAVAILABLE: CardStatus = { label: "Status unavailable", variant: "
  */
 export function useIntegrationStatuses(): Partial<Record<IntegrationId, CardStatus | null>> {
 	const cloudflareAccountResult = useAtomValue(
-		MapleApiAtomClient.query("integrations", "cloudflareStatus", {
+		retainedQuery("integrations", "cloudflareStatus", {
 			reactivityKeys: ["cloudflareIntegrationStatus"],
 		}),
 	)
 	const scrapeResult = useAtomValue(scrapeTargetsListAtom)
 	const planetscaleResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "status", {
+		retainedQueryV2("planetscaleIntegration", "status", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)
 	const hazelResult = useAtomValue(
-		MapleApiAtomClient.query("integrations", "hazelStatus", {
+		retainedQuery("integrations", "hazelStatus", {
 			reactivityKeys: ["hazelIntegrationStatus"],
 		}),
 	)
 	const githubResult = useAtomValue(
-		MapleApiAtomClient.query("integrations", "githubStatus", {
+		retainedQuery("integrations", "githubStatus", {
 			reactivityKeys: ["githubIntegrationStatus"],
 		}),
 	)
 	const slackResult = useAtomValue(
-		MapleApiV2AtomClient.query("slackIntegration", "status", {
+		retainedQueryV2("slackIntegration", "status", {
 			reactivityKeys: ["slackIntegration"],
 		}),
 	)
@@ -387,34 +387,34 @@ const maxMs = (values: ReadonlyArray<number | null | undefined>): number | null 
 
 export function useIntegrationOverviews(): Record<IntegrationId, IntegrationOverview> {
 	const cloudflareResult = useAtomValue(
-		MapleApiAtomClient.query("integrations", "cloudflareStatus", {
+		retainedQuery("integrations", "cloudflareStatus", {
 			reactivityKeys: ["cloudflareIntegrationStatus"],
 		}),
 	)
 	const scrapeResult = useAtomValue(scrapeTargetsListAtom)
 	const planetscaleResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "status", {
+		retainedQueryV2("planetscaleIntegration", "status", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)
 	// Poller-inventory read (no warehouse) — feeds the "N databases tracked" stat.
 	const planetscaleDbResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "databases", {
+		retainedQueryV2("planetscaleIntegration", "databases", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)
 	const hazelResult = useAtomValue(
-		MapleApiAtomClient.query("integrations", "hazelStatus", {
+		retainedQuery("integrations", "hazelStatus", {
 			reactivityKeys: ["hazelIntegrationStatus"],
 		}),
 	)
 	const githubResult = useAtomValue(
-		MapleApiAtomClient.query("integrations", "githubStatus", {
+		retainedQuery("integrations", "githubStatus", {
 			reactivityKeys: ["githubIntegrationStatus"],
 		}),
 	)
 	const slackResult = useAtomValue(
-		MapleApiV2AtomClient.query("slackIntegration", "status", {
+		retainedQueryV2("slackIntegration", "status", {
 			reactivityKeys: ["slackIntegration"],
 		}),
 	)

--- a/apps/web/src/components/integrations/integration-connect.tsx
+++ b/apps/web/src/components/integrations/integration-connect.tsx
@@ -10,8 +10,8 @@ import { toastManager } from "@maple/ui/components/ui/toast"
 
 import { trackProduct } from "@/lib/analytics"
 import { useAtomRefresh, useAtomSet } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
+import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { showErrorToast } from "@/lib/error-toast"
 import { useMountEffect } from "@/hooks/use-mount-effect"
 import type { IntegrationId } from "./integration-catalog"
@@ -147,12 +147,12 @@ function useIntegrationMessage(
 
 function CloudflareConnectBoundary({ children }: { children: React.ReactNode }) {
 	const refreshStatus = useAtomRefresh(
-		MapleApiAtomClient.query("integrations", "cloudflareStatus", {
+		retainedQuery("integrations", "cloudflareStatus", {
 			reactivityKeys: ["cloudflareIntegrationStatus"],
 		}),
 	)
 	const refreshUsage = useAtomRefresh(
-		MapleApiAtomClient.query("integrations", "cloudflareUsage", {
+		retainedQuery("integrations", "cloudflareUsage", {
 			reactivityKeys: ["cloudflareIntegrationUsage"],
 		}),
 	)
@@ -190,7 +190,7 @@ function CloudflareConnectBoundary({ children }: { children: React.ReactNode }) 
 
 function HazelConnectBoundary({ children }: { children: React.ReactNode }) {
 	const refreshStatus = useAtomRefresh(
-		MapleApiAtomClient.query("integrations", "hazelStatus", {
+		retainedQuery("integrations", "hazelStatus", {
 			reactivityKeys: ["hazelIntegrationStatus"],
 		}),
 	)
@@ -224,7 +224,7 @@ function HazelConnectBoundary({ children }: { children: React.ReactNode }) {
 
 function GithubConnectBoundary({ children }: { children: React.ReactNode }) {
 	const refreshStatus = useAtomRefresh(
-		MapleApiAtomClient.query("integrations", "githubStatus", {
+		retainedQuery("integrations", "githubStatus", {
 			reactivityKeys: ["githubIntegrationStatus"],
 		}),
 	)
@@ -260,7 +260,7 @@ function GithubConnectBoundary({ children }: { children: React.ReactNode }) {
 
 function PlanetscaleConnectBoundary({ children }: { children: React.ReactNode }) {
 	const refreshStatus = useAtomRefresh(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "status", {
+		retainedQueryV2("planetscaleIntegration", "status", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)

--- a/apps/web/src/components/integrations/planetscale-integration-card.tsx
+++ b/apps/web/src/components/integrations/planetscale-integration-card.tsx
@@ -21,7 +21,7 @@ import { cn } from "@maple/ui/lib/utils"
 import { isExcluded } from "@/components/infra/planetscale/branch-selection"
 import { useIntervalRefresh } from "@/hooks/use-interval-refresh"
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { showErrorToast } from "@/lib/error-toast"
 import { IntegrationIconPlate, catalogEntry } from "./integration-catalog"
 import { useIntegrationConnect } from "./integration-connect"
@@ -55,7 +55,7 @@ const parsePatternList = (value: string): string[] =>
  * as a single status row — the machinery stays out of the UI.
  */
 export function PlanetScaleIntegrationCard() {
-	const statusQuery = MapleApiV2AtomClient.query("planetscaleIntegration", "status", {
+	const statusQuery = retainedQueryV2("planetscaleIntegration", "status", {
 		reactivityKeys: ["planetscaleIntegration"],
 	})
 	const statusResult = useAtomValue(statusQuery)
@@ -429,14 +429,14 @@ function PlanetScaleOrgPicker(props: {
 	cancelLabel: string
 }) {
 	const organizationsResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "organizations", {
+		retainedQueryV2("planetscaleIntegration", "organizations", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)
 	// Powers the live filter preview. Empty before the first inventory poll, which
 	// is exactly the pending-org-selection case — the preview then stays quiet.
 	const inventoryResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "databases", {
+		retainedQueryV2("planetscaleIntegration", "databases", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)
@@ -617,7 +617,7 @@ function PlanetScaleWebhookSetup() {
 
 function PlanetScaleWebhookConfig() {
 	const configResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "webhookConfig", {
+		retainedQueryV2("planetscaleIntegration", "webhookConfig", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)

--- a/apps/web/src/components/integrations/slack-integration-card.tsx
+++ b/apps/web/src/components/integrations/slack-integration-card.tsx
@@ -19,8 +19,8 @@ import { ErrorState } from "@/components/common/error-state"
 import { LoaderIcon, SlackIcon, SlackMonoIcon } from "@/components/icons"
 import { useIsOrgAdmin } from "@/hooks/use-is-org-admin"
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
+import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 import { formatRelativeTime } from "@maple/ui/lib/time-format"
 import { getExitErrorMessage } from "@/lib/alerts/form-utils"
@@ -134,7 +134,7 @@ function LoadingState() {
  * this, so a non-admin only ever sees a disabled affordance.
  */
 export function SlackIntegrationCard() {
-	const statusAtom = MapleApiV2AtomClient.query("slackIntegration", "status", {
+	const statusAtom = retainedQueryV2("slackIntegration", "status", {
 		reactivityKeys: ["slackIntegration"],
 	})
 	const statusResult = useAtomValue(statusAtom)
@@ -146,7 +146,7 @@ export function SlackIntegrationCard() {
 	// `useIsOrgAdmin` reports false until the session lands, so the admin-only copy
 	// would briefly tell an admin they aren't one. The controls still stay disabled
 	// while unknown — only the explanation waits for a settled session.
-	const sessionResult = useAtomValue(MapleApiAtomClient.query("auth", "session", {}))
+	const sessionResult = useAtomValue(retainedQuery("auth", "session", {}))
 	const adminKnown = !isClerkAuthEnabled || !Result.isInitial(sessionResult)
 	const showNotAdmin = adminKnown && !isAdmin
 

--- a/apps/web/src/components/investigations/investigation-meta.tsx
+++ b/apps/web/src/components/investigations/investigation-meta.tsx
@@ -21,7 +21,7 @@ import { cn } from "@maple/ui/lib/utils"
 import { formatNumber } from "@maple/ui/lib/format"
 
 import { Result, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 import { investigationOriginLabel } from "./investigation-status"
 
 export function InvestigationMeta({ investigation }: { investigation: V2Investigation }) {
@@ -126,7 +126,7 @@ function Escalation({
 	issueId: NonNullable<Extract<V2Investigation["subject"], { type: "incident" }>["issue_id"]>
 }) {
 	const result = useAtomValue(
-		MapleApiAtomClient.query("errors", "listIssueEscalations", {
+		retainedQuery("errors", "listIssueEscalations", {
 			params: { issueId },
 			reactivityKeys: [`errorIssue:${issueId}:escalations`],
 		}),

--- a/apps/web/src/components/service-map/service-map-view.tsx
+++ b/apps/web/src/components/service-map/service-map-view.tsx
@@ -21,8 +21,8 @@ import {
 import "@xyflow/react/dist/style.css"
 
 import { Result, useAtom, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { serviceMapLayoutAtomFamily, upsertSnapshot } from "@/atoms/service-map-layout-atoms"
 import { serviceMapViewPrefsAtomFamily } from "@/atoms/service-map-view-prefs-atoms"
 import { Link } from "@tanstack/react-router"
@@ -2483,12 +2483,12 @@ export function ServiceMapView({
 		getServiceMapPlanetScaleResultAtom(cloudflareInput),
 	)
 	const planetscaleInventoryResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "databases", {
+		retainedQueryV2("planetscaleIntegration", "databases", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)
 	const hyperdriveInventoryResult = useAtomValue(
-		MapleApiAtomClient.query("integrations", "cloudflareHyperdrives", {
+		retainedQuery("integrations", "cloudflareHyperdrives", {
 			reactivityKeys: ["cloudflareIntegrationStatus"],
 		}),
 	)

--- a/apps/web/src/components/services/service-errors-panel.tsx
+++ b/apps/web/src/components/services/service-errors-panel.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from "@maple/ui/components/ui/skeleton"
 
 import { SeverityBadge } from "@/components/errors/severity-badge"
 import { Result, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { buildServiceOpenIssuesQuery, errorIssueFromV2 } from "@/lib/services/error-issues"
 import { formatNumber } from "@maple/ui/lib/format"
 import { SectionCard } from "./section-card"
@@ -114,7 +114,7 @@ export function ServiceErrorsPanel({
 		? new Date(Date.parse(effectiveEndTime) - 90 * 24 * 60 * 60 * 1000).toISOString()
 		: effectiveStartTime
 	const result = useAtomValue(
-		MapleApiV2AtomClient.query("errorIssues", "list", {
+		retainedQueryV2("errorIssues", "list", {
 			query: buildServiceOpenIssuesQuery(serviceName, {
 				environment,
 				startTime: detailStartTime,

--- a/apps/web/src/components/settings/ai-triage-settings-section.tsx
+++ b/apps/web/src/components/settings/ai-triage-settings-section.tsx
@@ -10,7 +10,7 @@ import { Input } from "@maple/ui/components/ui/input"
 import { Label } from "@maple/ui/components/ui/label"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { Switch } from "@maple/ui/components/ui/switch"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
 import { AiTriageSettingsUpdateRequest } from "@maple/domain/http"
 
 interface AiTriageSettingsSectionProps {
@@ -73,7 +73,7 @@ function DailyLimitField({
 }
 
 export function AiTriageSettingsSection({ isAdmin, hasEntitlement }: AiTriageSettingsSectionProps) {
-	const settingsQueryAtom = MapleApiAtomClient.query("aiTriage", "getSettings", {
+	const settingsQueryAtom = retainedQuery("aiTriage", "getSettings", {
 		reactivityKeys: SETTINGS_REACTIVITY_KEYS,
 	})
 	const settingsResult = useAtomValue(settingsQueryAtom)

--- a/apps/web/src/components/settings/automation-section.tsx
+++ b/apps/web/src/components/settings/automation-section.tsx
@@ -14,7 +14,7 @@ import { Badge } from "@maple/ui/components/ui/badge"
 import { AiTriageSettingsSection } from "./ai-triage-settings-section"
 import { EscalationPolicySection } from "./escalation-policy-section"
 import { SectionHeader } from "@/components/layout/section-header"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
 import { useAlertDestinationsList } from "@/hooks/use-alerts-list"
 import { formatRelativeTime } from "@maple/ui/lib/time-format"
 
@@ -170,7 +170,7 @@ function SimulatorField({ label, children }: { label: string; children: ReactNod
 
 function RecentDeliveries() {
 	const result = useAtomValue(
-		MapleApiAtomClient.query("errors", "listRecentEscalations", {
+		retainedQuery("errors", "listRecentEscalations", {
 			query: { limit: 20 },
 			reactivityKeys: ["issueEscalations"],
 		}),

--- a/apps/web/src/components/settings/escalation-policy-section.tsx
+++ b/apps/web/src/components/settings/escalation-policy-section.tsx
@@ -6,7 +6,7 @@ import { toastManager } from "@maple/ui/components/ui/toast"
 import { Schema } from "effect"
 
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
 import { useAlertDestinationsList } from "@/hooks/use-alerts-list"
 import {
 	IssueEscalationPolicyRule,
@@ -54,7 +54,7 @@ const emptyDraft = (): DraftRules => ({
  * detection-time alerts keep using the alert rule's own destinations.
  */
 export function EscalationPolicySection({ isAdmin }: { isAdmin: boolean }) {
-	const policyQueryAtom = MapleApiAtomClient.query("errors", "getEscalationPolicy", {
+	const policyQueryAtom = retainedQuery("errors", "getEscalationPolicy", {
 		reactivityKeys: ["issueEscalationPolicy"],
 	})
 	const policyResult = useAtomValue(policyQueryAtom)

--- a/apps/web/src/components/settings/ingestion-section.tsx
+++ b/apps/web/src/components/settings/ingestion-section.tsx
@@ -29,7 +29,7 @@ import { CopyIndicator } from "@maple/ui/components/ui/copy-button"
 import { useCopy } from "@maple/ui/hooks/use-copy"
 import { formatNumber } from "@maple/ui/lib/format"
 import { ingestUrl } from "@/lib/services/common/ingest-url"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { maskKey } from "@maple/ui/components/ui/copyable-field"
 import { ConnectInstructions, FrameworkPicker, useGuidedFramework } from "@/components/ingest/guided-setup"
 import {
@@ -225,7 +225,7 @@ export function IngestionSection() {
 	const [regenerateKeyType, setRegenerateKeyType] = useState<"public" | "private" | null>(null)
 	const [submittingKeyType, setSubmittingKeyType] = useState<"public" | "private" | null>(null)
 
-	const keysQueryAtom = MapleApiV2AtomClient.query("ingestKeys", "retrieve", {})
+	const keysQueryAtom = retainedQueryV2("ingestKeys", "retrieve", {})
 	const keysResult = useAtomValue(keysQueryAtom)
 	const refreshKeys = useAtomRefresh(keysQueryAtom)
 

--- a/apps/web/src/components/settings/notifications-section.tsx
+++ b/apps/web/src/components/settings/notifications-section.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import { Exit } from "effect"
 import { toastManager } from "@maple/ui/components/ui/toast"
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
 import { UpsertDigestSubscriptionRequest } from "@maple/domain/http"
 import { useUser } from "@clerk/clerk-react"
 
@@ -16,7 +16,7 @@ export function NotificationsSection() {
 	const { user } = useUser()
 	const email = user?.primaryEmailAddress?.emailAddress
 
-	const subscriptionQueryAtom = MapleApiAtomClient.query("digest", "getSubscription", {})
+	const subscriptionQueryAtom = retainedQuery("digest", "getSubscription", {})
 	const subscriptionResult = useAtomValue(subscriptionQueryAtom)
 	const refreshSubscription = useAtomRefresh(subscriptionQueryAtom)
 

--- a/apps/web/src/components/settings/org-clickhouse-settings-section.tsx
+++ b/apps/web/src/components/settings/org-clickhouse-settings-section.tsx
@@ -31,7 +31,7 @@ import {
 	CircleXmarkIcon,
 	LoaderIcon,
 } from "@/components/icons"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
 import { OrgClickHouseSettingsUpsertRequest } from "@maple/domain/http"
 import { DataPlatformUsageSection } from "@/components/settings/data-platform-usage-section"
 
@@ -81,15 +81,15 @@ export function OrgClickHouseSettingsSection({ isAdmin, hasEntitlement }: OrgCli
 	const [isDisabling, setIsDisabling] = useState(false)
 	const [expandedDrifts, setExpandedDrifts] = useState<ReadonlySet<string>>(new Set())
 
-	const settingsQueryAtom = MapleApiAtomClient.query("orgClickHouseSettings", "get", {})
+	const settingsQueryAtom = retainedQuery("orgClickHouseSettings", "get", {})
 	const settingsResult = useAtomValue(settingsQueryAtom)
 	const refreshSettings = useAtomRefresh(settingsQueryAtom)
 
-	const diffQueryAtom = MapleApiAtomClient.query("orgClickHouseSettings", "schemaDiff", {})
+	const diffQueryAtom = retainedQuery("orgClickHouseSettings", "schemaDiff", {})
 	const diffResult = useAtomValue(diffQueryAtom)
 	const refreshDiff = useAtomRefresh(diffQueryAtom)
 
-	const statusQueryAtom = MapleApiAtomClient.query("orgClickHouseSettings", "applySchemaStatus", {})
+	const statusQueryAtom = retainedQuery("orgClickHouseSettings", "applySchemaStatus", {})
 	const statusResult = useAtomValue(statusQueryAtom)
 	const refreshStatus = useAtomRefresh(statusQueryAtom)
 

--- a/apps/web/src/components/settings/settings-nav.tsx
+++ b/apps/web/src/components/settings/settings-nav.tsx
@@ -5,7 +5,7 @@ import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 import { hasBringYourOwnCloudAddOn } from "@/lib/billing/plan-gating"
 import { useOrganizationFeatureFlags } from "@/hooks/use-organization-feature-flags"
 import { useIsOrgAdmin } from "@/hooks/use-is-org-admin"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 import {
 	BellIcon,
 	CircleCheckIcon,
@@ -149,7 +149,7 @@ export function useVisibleSettingsSections() {
 	// in the Clerk-auth path below. `isClerkAuthEnabled` is a build-time constant
 	// today, but keeping the hooks above the early return avoids a conditional-hook
 	// hazard if it ever becomes dynamic.
-	const sessionResult = useAtomValue(MapleApiAtomClient.query("auth", "session", {}))
+	const sessionResult = useAtomValue(retainedQuery("auth", "session", {}))
 	const isAdmin = useIsOrgAdmin()
 	const { data: customer, isLoading: isCustomerLoading } = useMapleCustomer()
 	// Shared with the main sidebar and the flagged routes, so a flag can't be read

--- a/apps/web/src/components/vcs/commit-sha-hover-card.tsx
+++ b/apps/web/src/components/vcs/commit-sha-hover-card.tsx
@@ -2,7 +2,7 @@ import { formatRelativeFrom, formatRelativeShortFrom } from "@maple/ui/lib/time-
 import { type ReactNode, type RefObject, useEffect, useRef, useState } from "react"
 import { Link } from "@tanstack/react-router"
 
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 import { Atom, Result, useAtomValue } from "@/lib/effect-atom"
 import type { VcsCommitDetailResponse } from "@maple/domain/http"
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@maple/ui/components/ui/hover-card"
@@ -155,7 +155,7 @@ const COMMIT_DETAIL_TTL_MS = 5 * 60_000
 // the SHA *string* is what actually lets the prefetch subscriber, the popup body,
 // the deploy-marker flags, and the commit-list rows share ONE fetch + cached result.
 export const commitQueryAtom = Atom.family((sha: string) =>
-	MapleApiAtomClient.query("integrations", "vcsCommitDetail", {
+	retainedQuery("integrations", "vcsCommitDetail", {
 		params: { sha },
 		timeToLive: COMMIT_DETAIL_TTL_MS,
 	}),
@@ -169,7 +169,7 @@ export const commitQueryAtom = Atom.family((sha: string) =>
  * reuses the same atom (and its cached result).
  */
 export const commitsQueryAtom = Atom.family((shasKey: string) =>
-	MapleApiAtomClient.query("integrations", "vcsCommitDetails", {
+	retainedQuery("integrations", "vcsCommitDetails", {
 		query: { shas: shasKey },
 		timeToLive: COMMIT_DETAIL_TTL_MS,
 	}),

--- a/apps/web/src/hooks/use-alert-rule-preview.ts
+++ b/apps/web/src/hooks/use-alert-rule-preview.ts
@@ -1,6 +1,6 @@
 import { useDeferredValue, useMemo } from "react"
 import { Atom, Result, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { IsoDateTimeString, isRangeComparator, type AlertRulePreviewResponse } from "@maple/domain/http"
 import type { V2AlertRulePreviewParams } from "@maple/domain/http/v2"
@@ -80,7 +80,7 @@ export function useAlertRulePreview(
 
 	const result = useAtomValue(
 		payload
-			? MapleApiV2AtomClient.query("alertRules", "preview", {
+			? retainedQueryV2("alertRules", "preview", {
 					payload,
 					reactivityKeys: ["alertPreview"],
 					// Idle TTL so abandoned keystroke variants don't accumulate.

--- a/apps/web/src/hooks/use-effective-time-range.ts
+++ b/apps/web/src/hooks/use-effective-time-range.ts
@@ -1,30 +1,47 @@
 import { useMemo } from "react"
 import { useOptionalPageRefreshContext } from "@/components/time-range-picker/page-refresh-context"
-import { relativeToAbsolute } from "@/lib/time-utils"
+import { relativeToAbsolute, snapRangeForCache } from "@/lib/time-utils"
 
 interface TimeRange {
 	startTime: string
 	endTime: string
 }
 
+export interface ResolveEffectiveTimeRangeOptions {
+	/**
+	 * Floor the endpoint to the cache-key grid. Default `true`.
+	 *
+	 * Pass `false` only when the user has explicitly asked for fresh data — see
+	 * the note on refresh below.
+	 */
+	snap?: boolean
+}
+
 /**
  * The hook's resolution, without the hook — so a router `loader` can build the
- * exact same query inputs the component will and prefetch against them. Safe to
- * call from both: atom family keys run through `encodeKey`, which snaps
- * timestamps to a 15s grid, so a loader and a component resolving `now`
- * milliseconds apart land on the same cache entry.
+ * exact same query inputs the component will and prefetch against them.
+ *
+ * A preset range has no absolute endpoint in the URL, so it is re-resolved
+ * against `Date.now()` on every fresh mount. `snapRangeForCache` floors that
+ * endpoint to a grid scaled to the window (15s for 1h, 5m for 12h, 15m for 7d),
+ * which is what makes the atom key hold still between navigations — a loader
+ * and a component resolving `now` milliseconds apart land on the same entry,
+ * and so does the same page revisited a minute later.
+ *
+ * An explicit `startTime`/`endTime` pair is an absolute range the user chose;
+ * it is already stable and is returned untouched.
  */
 export function resolveEffectiveTimeRange(
 	startTime?: string,
 	endTime?: string,
 	defaultRange: string = "12h",
+	options?: ResolveEffectiveTimeRangeOptions,
 ): TimeRange {
 	if (startTime && endTime) {
 		return { startTime, endTime }
 	}
-	const resolved = relativeToAbsolute(defaultRange)
-	if (resolved) return resolved
-	return relativeToAbsolute("12h")!
+	const resolved = relativeToAbsolute(defaultRange) ?? relativeToAbsolute("12h")!
+	return options?.snap === false ? resolved : snapRangeForCache(resolved)
 }
 
 /**
@@ -45,7 +62,12 @@ export function useEffectiveTimeRange(
 	const refreshVersion = pageRefresh?.refreshVersion ?? 0
 
 	return useMemo(
-		() => resolveEffectiveTimeRange(startTime, endTime, defaultRange),
+		// Snap while idle, but not once the user has asked for fresh data. Snapping
+		// a reload would leave the window up to a grid interval in the past, so the
+		// newest rows stay invisible however many times they click it. The bypass
+		// lasts only for this mount — `refreshVersion` is back to 0 on the next
+		// one, so navigation returns to stable, cache-friendly keys.
+		() => resolveEffectiveTimeRange(startTime, endTime, defaultRange, { snap: refreshVersion === 0 }),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[startTime, endTime, defaultRange, refreshVersion],
 	)

--- a/apps/web/src/hooks/use-is-org-admin.ts
+++ b/apps/web/src/hooks/use-is-org-admin.ts
@@ -1,6 +1,6 @@
 import { Result, useAtomValue } from "@/lib/effect-atom"
 import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 
 /**
  * Whether the current user holds an org-admin role — the gate the API applies to
@@ -12,7 +12,7 @@ import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
  * disabled until we know the answer rather than flickering enabled.
  */
 export function useIsOrgAdmin(): boolean {
-	const sessionResult = useAtomValue(MapleApiAtomClient.query("auth", "session", {}))
+	const sessionResult = useAtomValue(retainedQuery("auth", "session", {}))
 
 	if (!isClerkAuthEnabled) return true
 

--- a/apps/web/src/hooks/use-maple-organization.test.tsx
+++ b/apps/web/src/hooks/use-maple-organization.test.tsx
@@ -11,6 +11,7 @@ vi.mock("@/lib/effect-atom", async () => {
 })
 vi.mock("@/lib/services/common/atom-client", () => ({
 	MapleApiAtomClient: { query: () => ({}) },
+	retainedQuery: () => ({}),
 }))
 
 const { Result } = await import("@/lib/effect-atom")

--- a/apps/web/src/hooks/use-maple-organization.ts
+++ b/apps/web/src/hooks/use-maple-organization.ts
@@ -1,5 +1,5 @@
 import { Result, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 
 /**
  * The organization the **API** resolved this session to, or `null` while that is
@@ -18,7 +18,7 @@ import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
  * read this same atom, so this costs no extra request.
  */
 export function useMapleOrganizationId(): string | null {
-	const sessionResult = useAtomValue(MapleApiAtomClient.query("auth", "session", {}))
+	const sessionResult = useAtomValue(retainedQuery("auth", "session", {}))
 
 	return Result.builder(sessionResult)
 		.onSuccess((session) => session.orgId as string)

--- a/apps/web/src/hooks/use-table-refresh-time-range.ts
+++ b/apps/web/src/hooks/use-table-refresh-time-range.ts
@@ -47,6 +47,10 @@ export function useTableRefreshTimeRange({
 	let refreshedRange = refreshState.range
 
 	if (refreshState.source !== source) {
+		// Deliberately unsnapped: this branch only runs on an explicit reload, and
+		// the point of a reload is to advance the window to the real "now". The
+		// snapped, cache-friendly range comes back on the next mount via
+		// `baseRange`.
 		const nextRange =
 			pageRefresh && relativePreset ? (relativeToAbsolute(relativePreset) ?? baseRange) : baseRange
 		refreshedRange = nextRange

--- a/apps/web/src/hooks/use-widget-data.ts
+++ b/apps/web/src/hooks/use-widget-data.ts
@@ -23,7 +23,8 @@ export type WidgetDataSourceLike = {
 import { disabledResultAtom } from "@/lib/services/atoms/disabled-result-atom"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import type { WidgetDataState } from "@/components/dashboard-builder/types"
-import { encodeKey, encodeOrgScopedKey, orgScopedKeyPayload } from "@/lib/cache-key"
+import { encodeKey, encodeOrgScopedKey, identityFromKey, orgScopedKeyPayload } from "@/lib/cache-key"
+import { nextRetentionNamespace, withRetention } from "@/lib/services/atoms/retained-atom"
 import { getActiveOrgId } from "@/lib/services/common/auth-headers"
 import { formatBackendError } from "@/lib/error-messages"
 import { Cause, Option } from "effect"
@@ -341,8 +342,19 @@ const fetchWidgetData = Effect.fnUntraced(
 // with its retry/`peer.service` transforms, tracer, logger — on every fetch *and* every
 // retry. On an N-tile dashboard that was N+ full layer builds per load. The runtime also
 // puts the real tracer in scope, so logs and span annotations here no longer no-op.
+//
+// Namespaced like the warehouse query families. This one family serves every
+// endpoint, but the endpoint is part of the payload and so already part of the
+// identity; the namespace only has to keep it clear of the query atoms.
+const WIDGET_RETENTION_NAMESPACE = nextRetentionNamespace()
+
 const widgetFetchFamily = Atom.family((key: string) =>
-	MapleApiAtomClient.runtime.atom(fetchWidgetData(key)).pipe(Atom.setIdleTTL(120_000)),
+	// Retained so a tile whose dashboard range has rolled onto a new grid cell
+	// re-renders its previous values while the new window loads.
+	withRetention(
+		MapleApiAtomClient.runtime.atom(fetchWidgetData(key)).pipe(Atom.setIdleTTL(120_000)),
+		`${WIDGET_RETENTION_NAMESPACE}:${identityFromKey(key)}`,
+	),
 )
 
 const widgetFetchAtom = (input: { endpoint: string; params: Record<string, unknown> }) =>

--- a/apps/web/src/lib/cache-key.test.ts
+++ b/apps/web/src/lib/cache-key.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+
+import { encodeKey, encodeOrgScopedKey, identityFromKey, orgScopedKeyPayload } from "./cache-key"
+
+/** Mirrors `ORG_KEY_SEPARATOR` in cache-key.ts — NUL cannot occur in JSON or a Clerk org id. */
+const SEP = "\u0000"
+const MALFORMED = `org_1${SEP}not-json`
+const SEPARATED = `org_1${SEP}`
+
+describe("encodeKey", () => {
+	it("is order-insensitive across object keys", () => {
+		expect(encodeKey({ a: 1, b: 2 })).toBe(encodeKey({ b: 2, a: 1 }))
+	})
+
+	it("drops undefined values", () => {
+		expect(encodeKey({ a: 1, b: undefined })).toBe(encodeKey({ a: 1 }))
+	})
+
+	it("snaps timestamps to the 15s grid", () => {
+		expect(encodeKey({ startTime: "2026-03-08 14:30:07" })).toBe(
+			encodeKey({ startTime: "2026-03-08 14:30:00" }),
+		)
+	})
+})
+
+describe("identityFromKey", () => {
+	const key = (orgId: string, input: unknown) => encodeOrgScopedKey(orgId, input)
+
+	it("collapses two keys that differ only in their time window", () => {
+		const a = key("org_1", {
+			serviceName: "api",
+			startTime: "2026-03-08 02:30:00",
+			endTime: "2026-03-08 14:30:00",
+		})
+		const b = key("org_1", {
+			serviceName: "api",
+			startTime: "2026-03-08 02:35:00",
+			endTime: "2026-03-08 14:35:00",
+		})
+
+		expect(a).not.toBe(b)
+		expect(identityFromKey(a)).toBe(identityFromKey(b))
+	})
+
+	it("strips millisecond-precision and T-separated timestamps too", () => {
+		const spaced = key("org_1", { at: "2026-03-08 14:30:00" })
+		const fractional = key("org_1", { at: "2026-03-08 14:30:00.123" })
+		const tSeparated = key("org_1", { at: "2026-03-08T14:30:00" })
+
+		expect(identityFromKey(fractional)).toBe(identityFromKey(spaced))
+		expect(identityFromKey(tSeparated)).toBe(identityFromKey(spaced))
+	})
+
+	it("separates identities across orgs", () => {
+		const input = { serviceName: "api", startTime: "2026-03-08 02:30:00" }
+
+		expect(identityFromKey(key("org_1", input))).not.toBe(identityFromKey(key("org_2", input)))
+	})
+
+	it("separates identities across non-time inputs", () => {
+		const at = { startTime: "2026-03-08 02:30:00" }
+
+		expect(identityFromKey(key("org_1", { ...at, serviceName: "api" }))).not.toBe(
+			identityFromKey(key("org_1", { ...at, serviceName: "web" })),
+		)
+		expect(identityFromKey(key("org_1", { ...at, limit: 50 }))).not.toBe(
+			identityFromKey(key("org_1", { ...at, limit: 100 })),
+		)
+	})
+
+	it("strips timestamps nested in objects and arrays", () => {
+		const a = key("org_1", { windows: [{ from: "2026-03-08 02:30:00" }], name: "api" })
+		const b = key("org_1", { windows: [{ from: "2026-03-08 09:45:15" }], name: "api" })
+
+		expect(identityFromKey(a)).toBe(identityFromKey(b))
+	})
+
+	it("keeps a filter value that merely contains a date distinct", () => {
+		// Only the exact warehouse shape is stripped; a free-text filter that
+		// happens to mention a date is still part of the query.
+		const a = key("org_1", { q: "deploy at 2026-03-08 14:30:00 failed" })
+		const b = key("org_1", { q: "deploy at 2026-03-09 14:30:00 failed" })
+
+		expect(identityFromKey(a)).not.toBe(identityFromKey(b))
+	})
+
+	it("falls back to the key itself when the payload is not JSON", () => {
+		expect(identityFromKey(MALFORMED)).toBe(MALFORMED)
+	})
+
+	it("round-trips the org prefix that orgScopedKeyPayload strips", () => {
+		const identity = identityFromKey(key("org_1", { serviceName: "api" }))
+
+		expect(identity.startsWith(SEPARATED)).toBe(true)
+		expect(JSON.parse(orgScopedKeyPayload(identity))).toEqual({ serviceName: "api" })
+	})
+})

--- a/apps/web/src/lib/cache-key.ts
+++ b/apps/web/src/lib/cache-key.ts
@@ -1,13 +1,24 @@
 import { snapTimestamp } from "@/lib/time-utils"
 
-function normalizeForKey(value: unknown): unknown {
+/** How a leaf string is treated: snapped to the 15s grid, or dropped entirely. */
+type TimestampMode = "snap" | "drop"
+
+/** Matches the warehouse `YYYY-MM-DD HH:MM:SS[.fff]` shape, with or without a `T`. */
+const TIMESTAMP_SHAPE = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?$/
+
+const DROPPED = Symbol("dropped")
+
+function normalize(value: unknown, mode: TimestampMode): unknown {
 	if (value === null || typeof value !== "object") {
-		if (typeof value === "string") return snapTimestamp(value)
+		if (typeof value === "string") {
+			if (mode === "snap") return snapTimestamp(value)
+			return TIMESTAMP_SHAPE.test(value) ? DROPPED : value
+		}
 		return value
 	}
 
 	if (Array.isArray(value)) {
-		return value.map(normalizeForKey)
+		return value.map((entry) => normalize(entry, mode)).filter((entry) => entry !== DROPPED)
 	}
 
 	const entries = Object.entries(value as Record<string, unknown>)
@@ -16,10 +27,15 @@ function normalizeForKey(value: unknown): unknown {
 
 	const normalized: Record<string, unknown> = {}
 	for (const [key, entryValue] of entries) {
-		normalized[key] = normalizeForKey(entryValue)
+		const entry = normalize(entryValue, mode)
+		if (entry !== DROPPED) normalized[key] = entry
 	}
 
 	return normalized
+}
+
+function normalizeForKey(value: unknown): unknown {
+	return normalize(value, "snap")
 }
 
 export function encodeKey(value: unknown): string {
@@ -53,4 +69,39 @@ export function encodeOrgScopedKey(orgId: string | null | undefined, value: unkn
 /** Recover just the encoded input from a key built by `encodeOrgScopedKey`. */
 export function orgScopedKeyPayload(key: string): string {
 	return key.slice(key.indexOf(ORG_KEY_SEPARATOR) + 1)
+}
+
+/**
+ * The *logical* identity of an atom key: the same query, with the time window
+ * removed. Two keys that differ only in their range collapse to one identity.
+ *
+ * This is what lets a remount serve the previous result while the new window
+ * loads. Snapping the range (see `snapRangeForCache`) keeps a key stable for
+ * minutes at a time, but the boundary still has to be crossed eventually, and
+ * on a 1h preset the grid is only 15s — at that point the key is genuinely new
+ * and only an identity that ignores time can find what was there before.
+ *
+ * Derived from the key rather than the input because `Atom.family` factories
+ * only ever see the key.
+ *
+ * The org prefix is preserved deliberately. An identity that spanned orgs would
+ * revive exactly the bug `ORG_KEY_SEPARATOR` above exists to prevent: switching
+ * orgs and being shown the previous org's rows.
+ */
+export function identityFromKey(key: string): string {
+	const separatorIndex = key.indexOf(ORG_KEY_SEPARATOR)
+	const orgPrefix = separatorIndex === -1 ? "" : key.slice(0, separatorIndex)
+	const payload = orgScopedKeyPayload(key)
+
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(payload)
+	} catch {
+		// Not decodable — fall back to the key itself. Identity stays correct
+		// (never over-shares), it just can't match across windows.
+		return key
+	}
+
+	const stripped = normalize(parsed, "drop")
+	return `${orgPrefix}${ORG_KEY_SEPARATOR}${JSON.stringify(stripped === DROPPED ? null : stripped)}`
 }

--- a/apps/web/src/lib/services/atoms/anomaly-atoms.ts
+++ b/apps/web/src/lib/services/atoms/anomaly-atoms.ts
@@ -1,11 +1,11 @@
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 
 /**
  * Shared open-incident read for service health surfaces. A module-level atom
  * ensures the dashboard summary, dashboard list, and services page all observe
  * the same request/cache entry and invalidate together.
  */
-export const openAnomalyIncidentsAtom = MapleApiAtomClient.query("anomalies", "listIncidents", {
+export const openAnomalyIncidentsAtom = retainedQuery("anomalies", "listIncidents", {
 	query: { status: "open", limit: 500 },
 	reactivityKeys: ["anomalyIncidents"],
 })

--- a/apps/web/src/lib/services/atoms/billing-atoms.ts
+++ b/apps/web/src/lib/services/atoms/billing-atoms.ts
@@ -1,4 +1,4 @@
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
 
 // Reactivity keys: a mutation that bumps a key invalidates every query atom
 // registered with it. attach/portal change the customer (and thus per-plan
@@ -13,29 +13,29 @@ export const BILLING_INVOICES_KEY = "billingInvoices"
 // (atom-client.ts scopes a 401 retry to /api/billing/*), and effect-atom
 // refetches on remount + reactivity invalidation — so these can't freeze the
 // way the old autumn-js QueryClient (retry:false) did.
-export const billingCustomerAtom = MapleApiAtomClient.query("billing", "getCustomer", {
+export const billingCustomerAtom = retainedQuery("billing", "getCustomer", {
 	reactivityKeys: [BILLING_CUSTOMER_KEY],
 })
 
-export const billingPlansAtom = MapleApiAtomClient.query("billingPublic", "listPlans", {
+export const billingPlansAtom = retainedQuery("billingPublic", "listPlans", {
 	reactivityKeys: [BILLING_PLANS_KEY],
 })
 
 // The billing page always meters the same four features over one billing cycle,
 // so a single static atom (not a family) is enough.
-export const billingUsageAtom = MapleApiAtomClient.query("billing", "getUsage", {
+export const billingUsageAtom = retainedQuery("billing", "getUsage", {
 	query: { featureId: ["logs", "traces", "metrics", "browser_sessions"], range: "1bc" },
 	reactivityKeys: [BILLING_USAGE_KEY],
 })
 
-export const billingInvoicesAtom = MapleApiAtomClient.query("billing", "listInvoices", {
+export const billingInvoicesAtom = retainedQuery("billing", "listInvoices", {
 	reactivityKeys: [BILLING_INVOICES_KEY],
 })
 
 // Warehouse-backed daily volume behind the spend chart. Shares the customer's
 // reactivity key: the series is scoped to the subscription's cycle, so a plan
 // change re-fetches it.
-export const billingDailySpendAtom = MapleApiAtomClient.query("billing", "getDailySpend", {
+export const billingDailySpendAtom = retainedQuery("billing", "getDailySpend", {
 	reactivityKeys: [BILLING_CUSTOMER_KEY],
 })
 

--- a/apps/web/src/lib/services/atoms/result-retention.test.ts
+++ b/apps/web/src/lib/services/atoms/result-retention.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+	MAX_ENTRIES,
+	MAX_RETAINED_AGE_MS,
+	clearRetainedResults,
+	nextRetentionNamespace,
+	retainResult,
+	retainedResult,
+	retainedResultCount,
+} from "./result-retention"
+
+const T0 = Date.parse("2026-03-08T14:30:00.000Z")
+
+beforeEach(() => {
+	clearRetainedResults()
+})
+
+describe("retainResult / retainedResult", () => {
+	it("returns the retained value with its timestamp", () => {
+		retainResult("q", { rows: 3 }, T0)
+
+		expect(retainedResult("q", T0 + 1000)).toEqual({ value: { rows: 3 }, timestamp: T0 })
+	})
+
+	it("returns undefined for an identity never seen", () => {
+		expect(retainedResult("missing", T0)).toBeUndefined()
+	})
+
+	it("overwrites an earlier value for the same identity", () => {
+		retainResult("q", "old", T0)
+		retainResult("q", "new", T0 + 1000)
+
+		expect(retainedResult("q", T0 + 1000)?.value).toBe("new")
+		expect(retainedResultCount()).toBe(1)
+	})
+})
+
+describe("nextRetentionNamespace", () => {
+	it("hands out a distinct namespace per call", () => {
+		expect(nextRetentionNamespace()).not.toBe(nextRetentionNamespace())
+	})
+
+	// Regression: two queries that take nothing but a time window both reduce to
+	// the identity `{}`. Un-namespaced, one served the other's rows as a fallback
+	// and the consuming component crashed on the unexpected shape.
+	it("keeps same-shaped identities from different families apart", () => {
+		const facets = nextRetentionNamespace()
+		const overview = nextRetentionNamespace()
+		const identity = "org_1:{}"
+
+		retainResult(`${facets}:${identity}`, { environments: ["production"] }, T0)
+		retainResult(`${overview}:${identity}`, { services: 20 }, T0)
+
+		expect(retainedResult(`${facets}:${identity}`, T0)?.value).toEqual({
+			environments: ["production"],
+		})
+		expect(retainedResult(`${overview}:${identity}`, T0)?.value).toEqual({ services: 20 })
+	})
+})
+
+describe("age bound", () => {
+	it("serves a value inside MAX_RETAINED_AGE_MS", () => {
+		retainResult("q", "v", T0)
+
+		expect(retainedResult("q", T0 + MAX_RETAINED_AGE_MS)?.value).toBe("v")
+	})
+
+	it("drops a value past MAX_RETAINED_AGE_MS rather than painting stale data", () => {
+		retainResult("q", "v", T0)
+
+		expect(retainedResult("q", T0 + MAX_RETAINED_AGE_MS + 1)).toBeUndefined()
+	})
+
+	it("evicts the expired entry on read instead of leaving it resident", () => {
+		retainResult("q", "v", T0)
+		retainedResult("q", T0 + MAX_RETAINED_AGE_MS + 1)
+
+		expect(retainedResultCount()).toBe(0)
+	})
+})
+
+describe("LRU bound", () => {
+	it("never exceeds the cap", () => {
+		for (let i = 0; i < MAX_ENTRIES * 2; i++) retainResult(`q${i}`, i, T0)
+
+		expect(retainedResultCount()).toBeLessThanOrEqual(MAX_ENTRIES)
+	})
+
+	it("evicts the least recently used entry first", () => {
+		for (let i = 0; i < MAX_ENTRIES; i++) retainResult(`q${i}`, i, T0)
+
+		// Touch the oldest so it is no longer the eviction candidate.
+		expect(retainedResult("q0", T0)?.value).toBe(0)
+
+		retainResult("overflow", "x", T0)
+
+		expect(retainedResult("q0", T0)?.value).toBe(0)
+		expect(retainedResult("q1", T0)).toBeUndefined()
+	})
+
+	it("keeps what the user keeps coming back to", () => {
+		retainResult("hot", "v", T0)
+
+		for (let i = 0; i < MAX_ENTRIES * 2; i++) {
+			retainResult(`cold${i}`, i, T0)
+			retainedResult("hot", T0)
+		}
+
+		expect(retainedResult("hot", T0)?.value).toBe("v")
+	})
+})

--- a/apps/web/src/lib/services/atoms/result-retention.ts
+++ b/apps/web/src/lib/services/atoms/result-retention.ts
@@ -1,0 +1,107 @@
+/**
+ * Last-successful-result store, keyed by logical query identity.
+ *
+ * Atom idle TTLs keep a result alive only for as long as its *key* exists. A
+ * relative time preset produces a new key every grid interval, so navigating
+ * away and back eventually lands on a key that has never been fetched — the
+ * atom starts `Initial`, and the page paints a skeleton over data that was
+ * correct moments ago.
+ *
+ * This store sits underneath that. It is keyed by `identityFromKey` (the query
+ * minus its time window), so the result from the previous window is still
+ * findable, and `Atom.withFallback` serves it as `waiting: true` while the new
+ * window loads.
+ *
+ * Two bounds keep it honest, because it deliberately outlives the atoms it
+ * mirrors:
+ *
+ *  - `MAX_ENTRIES` — a hard cap with LRU eviction. Without it, a long session
+ *    that visits many filter combinations retains every one of them forever.
+ *  - `MAX_RETAINED_AGE_MS` — reads past this return nothing. Showing data from
+ *    thirty seconds ago while it refreshes is helpful; showing data from an
+ *    hour ago is a lie with a spinner on it.
+ */
+
+export const MAX_ENTRIES = 400
+
+export const MAX_RETAINED_AGE_MS = 30 * 60 * 1000
+
+/**
+ * Namespace for one atom family, so identities never collide across queries.
+ *
+ * Required, not optional. A logical identity is the query input with its time
+ * window stripped, and plenty of distinct queries take nothing *but* a window —
+ * `getServicesFacets` and `getServiceOverview` both reduce to `{}`. Without a
+ * per-family namespace they share an identity, and one query's rows get served
+ * to the other as a fallback, which surfaces as a shape error in whatever
+ * component reads it first.
+ *
+ * A counter is enough: the store is in-memory, so identities only have to be
+ * stable within a session, and module init order is deterministic within one.
+ */
+let familySequence = 0
+
+export function nextRetentionNamespace(): string {
+	familySequence += 1
+	return `f${familySequence}`
+}
+
+interface RetainedEntry {
+	readonly value: unknown
+	/** Epoch ms the value was produced — surfaced as the served result's timestamp. */
+	readonly timestamp: number
+}
+
+/**
+ * Insertion order doubles as recency: a `Map` preserves it, so re-inserting on
+ * read moves an entry to the back and the oldest is always `keys().next()`.
+ */
+const entries = new Map<string, RetainedEntry>()
+
+/**
+ * Record a successful result for later reuse under a different time window.
+ *
+ * `timestamp` should be the moment the value was *produced* (a `Result`'s own
+ * timestamp), not the moment it was recorded. Callers re-record on every read,
+ * so stamping with `Date.now()` here would keep resetting an entry's age and
+ * nothing would ever expire.
+ */
+export function retainResult(identity: string, value: unknown, timestamp: number = Date.now()): void {
+	entries.delete(identity)
+	entries.set(identity, { value, timestamp })
+
+	while (entries.size > MAX_ENTRIES) {
+		const oldest = entries.keys().next()
+		if (oldest.done) break
+		entries.delete(oldest.value)
+	}
+}
+
+/**
+ * The most recent result for this identity, or `undefined` if there is none or
+ * it has aged out. A hit is refreshed to the back of the LRU — what the user
+ * keeps navigating back to is what is worth keeping.
+ */
+export function retainedResult(identity: string, now: number = Date.now()): RetainedEntry | undefined {
+	const entry = entries.get(identity)
+	if (!entry) return undefined
+
+	if (now - entry.timestamp > MAX_RETAINED_AGE_MS) {
+		entries.delete(identity)
+		return undefined
+	}
+
+	entries.delete(identity)
+	entries.set(identity, entry)
+	return entry
+}
+
+/** Test seam. */
+export function clearRetainedResults(): void {
+	entries.clear()
+}
+
+/** Test seam. */
+export function retainedResultCount(): number {
+	return entries.size
+}

--- a/apps/web/src/lib/services/atoms/retained-atom.test.ts
+++ b/apps/web/src/lib/services/atoms/retained-atom.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { Atom, Registry, Result } from "@/lib/effect-atom"
+
+import { clearRetainedResults, nextRetentionNamespace } from "./result-retention"
+import { withRetention } from "./retained-atom"
+
+beforeEach(() => {
+	clearRetainedResults()
+})
+
+/** A cold atom: what a rebuilt query atom looks like before its fetch lands. */
+const pending = <A>() => Atom.make(() => Result.initial<A, never>())
+
+/** A settled atom: what one looks like once its fetch has resolved. */
+const settled = <A>(value: A) => Atom.make(() => Result.success<A, never>(value))
+
+describe("withRetention", () => {
+	it("passes a live result straight through", () => {
+		const registry = Registry.make()
+		const result = registry.get(withRetention(settled("fresh"), "id"))
+
+		expect(Result.isSuccess(result) && result.value).toBe("fresh")
+	})
+
+	// The whole point: the atom that recorded the value is gone (disposed by its
+	// idle TTL, or replaced because the time window rolled), and a brand-new one
+	// under the same logical identity must not paint a skeleton.
+	it("serves a previous result to a rebuilt atom under the same identity", () => {
+		const identity = "shared-identity"
+
+		const first = Registry.make()
+		first.get(withRetention(settled("recorded"), identity))
+
+		const rebuilt = Registry.make()
+		const result = rebuilt.get(withRetention(pending<string>(), identity))
+
+		expect(Result.isSuccess(result) && result.value).toBe("recorded")
+	})
+
+	it("marks a served fallback as waiting, so the UI can show it is refreshing", () => {
+		const identity = "waiting-identity"
+
+		Registry.make().get(withRetention(settled("recorded"), identity))
+		const result = Registry.make().get(withRetention(pending<string>(), identity))
+
+		expect(result.waiting).toBe(true)
+	})
+
+	it("stays Initial when nothing was ever recorded", () => {
+		const result = Registry.make().get(withRetention(pending<string>(), "never-seen"))
+
+		expect(Result.isInitial(result)).toBe(true)
+	})
+
+	// Regression: identities are the query minus its time window, so two queries
+	// that take only a window both reduce to the same string. Namespacing is what
+	// stops one serving the other's rows to a component expecting a different shape.
+	it("does not serve one namespace's value to another", () => {
+		const a = `${nextRetentionNamespace()}:{}`
+		const b = `${nextRetentionNamespace()}:{}`
+
+		Registry.make().get(withRetention(settled({ facets: [] }), a))
+		const result = Registry.make().get(withRetention(pending<{ services: number }>(), b))
+
+		expect(Result.isInitial(result)).toBe(true)
+	})
+
+	it("records when the value was produced, not when it was read", () => {
+		const identity = "aging-identity"
+		// Reading is what triggers recording, so stamping entries with the read
+		// time would let a value that is repeatedly re-read never age out. The
+		// Result's own timestamp is used instead, and it must survive round-trip.
+		const producedAt = Date.now() - 60_000
+		const registry = Registry.make()
+		const atom = withRetention(
+			Atom.make(() => Result.success("v", { timestamp: producedAt })),
+			identity,
+		)
+
+		registry.get(atom)
+		registry.get(atom)
+
+		const served = Registry.make().get(withRetention(pending<string>(), identity))
+		expect(Result.isSuccess(served) && served.timestamp).toBe(producedAt)
+	})
+
+	it("refuses to serve a value older than the age bound", () => {
+		const identity = "stale-identity"
+		Registry.make().get(
+			withRetention(
+				Atom.make(() => Result.success("ancient", { timestamp: Date.now() - 60 * 60 * 1000 })),
+				identity,
+			),
+		)
+
+		const served = Registry.make().get(withRetention(pending<string>(), identity))
+		expect(Result.isInitial(served)).toBe(true)
+	})
+})

--- a/apps/web/src/lib/services/atoms/retained-atom.ts
+++ b/apps/web/src/lib/services/atoms/retained-atom.ts
@@ -1,0 +1,61 @@
+import { Atom, Result } from "@/lib/effect-atom"
+
+import {
+	nextRetentionNamespace,
+	retainResult,
+	retainedResult,
+} from "@/lib/services/atoms/result-retention"
+
+export { nextRetentionNamespace }
+
+/**
+ * Give an atom stale-while-revalidate behaviour across rebuilds.
+ *
+ * An atom's idle TTL is a *gcTime*: once the last subscriber unmounts and the
+ * TTL lapses, the atom is disposed. The next mount therefore starts at
+ * `Initial` and the page paints a skeleton over data that was correct moments
+ * ago. Effect-atom already covers the easier case — refreshing a *live* atom
+ * yields `waitingFrom(previous)`, so the old value stays on screen — but it has
+ * nothing to offer once the atom itself is gone, or when the key changed.
+ *
+ * This closes that gap: successes are recorded against a logical identity, and
+ * a rebuilt atom serves the last recorded value (flagged `waiting`) until the
+ * real fetch lands.
+ *
+ * Wrap the atom rather than the effect inside it, so this works for anything
+ * producing a `Result` — the warehouse query families, dashboard widget fetches
+ * and the plain HTTP query atoms all share one implementation.
+ *
+ * @param identity Stable across time windows but unique per query. Build it
+ * with `nextRetentionNamespace()` plus `identityFromKey`, or from a
+ * group/endpoint pair. Two different queries sharing an identity will serve
+ * each other's rows — see the note in `result-retention.ts`.
+ */
+export function withRetention<A, E>(
+	self: Atom.Atom<Result.Result<A, E>>,
+	identity: string,
+): Atom.Atom<Result.Result<A, E>> {
+	// Recording on read rather than inside the effect keeps this generic. It is
+	// idempotent because the entry is stamped with the Result's own timestamp
+	// (fixed when the value was produced) instead of `Date.now()` — re-reading a
+	// value must not keep resetting its age, or nothing would ever expire.
+	//
+	// `waiting` successes are skipped: those carry the *previous* value during a
+	// refresh, so recording them would write stale data back over itself.
+	const recorded = Atom.map(self, (result) => {
+		if (Result.isSuccess(result) && !result.waiting) {
+			retainResult(identity, result.value, result.timestamp)
+		}
+		return result
+	})
+
+	return Atom.withFallback(
+		recorded,
+		Atom.make(() => {
+			const retained = retainedResult(identity)
+			return retained
+				? Result.success<A, never>(retained.value as A, { timestamp: retained.timestamp })
+				: Result.initial<A, never>()
+		}),
+	)
+}

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
@@ -1,6 +1,7 @@
 import { Atom } from "@/lib/effect-atom"
 import { Effect, Schema } from "effect"
-import { encodeOrgScopedKey, orgScopedKeyPayload } from "@/lib/cache-key"
+import { encodeOrgScopedKey, identityFromKey, orgScopedKeyPayload } from "@/lib/cache-key"
+import { nextRetentionNamespace, withRetention } from "@/lib/services/atoms/retained-atom"
 import { getActiveOrgId } from "@/lib/services/common/auth-headers"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import type { BackendError, WarehouseApiError } from "@/api/warehouse/effect-utils"
@@ -140,8 +141,17 @@ export type QueryAtomFailure = QueryError | QueryAtomError
 
 function makeQueryAtomFamily<Input, Output>(query: QueryEffect<Input, Output>, options?: QueryAtomOptions) {
 	const UnknownFromJson = Schema.fromJsonString(Schema.Unknown)
+	// Namespaces this family's retained results. Without it, two queries taking
+	// only a time window would share a logical identity and hand each other's
+	// rows back as fallbacks.
+	const namespace = nextRetentionNamespace()
 
 	const family = Atom.family((key: string) => {
+		// The same query under a different time window, so a remount onto a
+		// rolled-over key renders the previous window's data immediately rather
+		// than an empty skeleton. See `withRetention`.
+		const identity = `${namespace}:${identityFromKey(key)}`
+
 		// Build on the mounted `MapleApiAtomClient.runtime` (not bare `Atom.make`,
 		// which runs on the default atom runtime). That runtime owns the Maple OTLP
 		// tracer that actually flushes, so the wrapper span each `query` opens — e.g.
@@ -167,7 +177,10 @@ function makeQueryAtomFamily<Input, Output>(query: QueryEffect<Input, Output>, o
 			resultAtom = Atom.setIdleTTL(resultAtom, options.staleTime)
 		}
 
-		return resultAtom
+		// Applied at the atom rather than in a hook so that every consumer gets it
+		// — `useAtomValue`, `useRefreshableAtomValue` and
+		// `useRetainedRefreshableResultValue` alike — with no call-site changes.
+		return withRetention(resultAtom, identity)
 	})
 
 	return (input: Input) => family(encodeOrgScopedKey(getActiveOrgId(), input))

--- a/apps/web/src/lib/services/common/atom-client.ts
+++ b/apps/web/src/lib/services/common/atom-client.ts
@@ -1,6 +1,9 @@
 import { AtomHttpApi } from "@/lib/effect-atom"
 import { MapleApi } from "@maple/domain/http"
+import { encodeOrgScopedKey, identityFromKey } from "@/lib/cache-key"
+import { withRetention } from "@/lib/services/atoms/retained-atom"
 import { apiBaseUrl } from "./api-base-url"
+import { getActiveOrgId } from "./auth-headers"
 import { transformMapleApiClient } from "./api-client-transform"
 import { MapleFetchHttpClientLive } from "./http-client"
 
@@ -19,3 +22,56 @@ export class MapleApiAtomClient extends AtomHttpApi.Service<MapleApiAtomClient>(
 		transformClient: transformMapleApiClient,
 	},
 ) {}
+
+/**
+ * Idle TTL applied to every `retainedQuery` atom.
+ *
+ * `AtomHttpApi.query` applies neither `setIdleTTL` nor `keepAlive` unless a
+ * `timeToLive` is given, so a bare query atom is disposed the moment its last
+ * subscriber unmounts — every revisit is a cold fetch, however quickly the user
+ * comes back. A minute is enough to make back-and-forth navigation free and
+ * short enough that anything not covered by `reactivityKeys` self-heals fast.
+ *
+ * Staleness past the TTL is not a risk: retention only fills the visual gap
+ * while a refetch is in flight, it never suppresses the refetch.
+ */
+export const DEFAULT_QUERY_TTL = "1 minute"
+
+/**
+ * `MapleApiAtomClient.query` with caching that survives unmount.
+ *
+ * Prefer this over calling `.query` directly — the bare version has no TTL and
+ * no retention, which is why settings, integrations and similar panels used to
+ * flash a skeleton on every single visit.
+ *
+ * Pass `timeToLive` in the request to override the default; pass
+ * `reactivityKeys` (as before) so mutations invalidate the atom.
+ */
+// The single cast in this module, and it is confined to the signature rather
+// than the body. `query`'s return type is a conditional resolved from the
+// group/endpoint literals; a forwarder cannot restate that relationship, so TS
+// rejects both the generic arguments going in and the generic atom coming out.
+// The runtime behaviour is a pass-through — `withRetention` wraps the atom
+// without changing its value type — so the borrowed signature stays accurate.
+const queryWithRetention = (
+	group: string,
+	endpoint: string,
+	request: Record<string, unknown> | undefined,
+) => {
+	const atom = MapleApiAtomClient.query(group as never, endpoint as never, {
+		timeToLive: DEFAULT_QUERY_TTL,
+		...request,
+	} as never)
+
+	// Org-scoped, and with any time window stripped, so the identity is stable
+	// across windows but can never serve one org's rows to another. `group` and
+	// `endpoint` namespace it, so two endpoints taking the same request shape
+	// cannot collide.
+	const identity = `${group}:${endpoint}:${identityFromKey(
+		encodeOrgScopedKey(getActiveOrgId(), request ?? {}),
+	)}`
+
+	return withRetention(atom, identity)
+}
+
+export const retainedQuery = queryWithRetention as unknown as typeof MapleApiAtomClient.query

--- a/apps/web/src/lib/services/common/v2-atom-client.ts
+++ b/apps/web/src/lib/services/common/v2-atom-client.ts
@@ -1,6 +1,10 @@
 import { AtomHttpApi } from "@/lib/effect-atom"
 import { MapleApiV2 } from "@maple/domain/http/v2"
+import { encodeOrgScopedKey, identityFromKey } from "@/lib/cache-key"
+import { withRetention } from "@/lib/services/atoms/retained-atom"
+import { DEFAULT_QUERY_TTL } from "./atom-client"
 import { apiBaseUrl } from "./api-base-url"
+import { getActiveOrgId } from "./auth-headers"
 import { transformMapleApiClient } from "./api-client-transform"
 import { MapleFetchHttpClientLive } from "./http-client"
 
@@ -14,3 +18,28 @@ export class MapleApiV2AtomClient extends AtomHttpApi.Service<MapleApiV2AtomClie
 		transformClient: transformMapleApiClient,
 	},
 ) {}
+
+/**
+ * `MapleApiV2AtomClient.query` with caching that survives unmount.
+ *
+ * Same rationale as `retainedQuery` in `atom-client.ts` — see the note there.
+ * Prefer this over calling `.query` directly.
+ */
+export const retainedQueryV2: typeof MapleApiV2AtomClient.query = ((
+	group: string,
+	endpoint: string,
+	request: Record<string, unknown> | undefined,
+) => {
+	const atom = MapleApiV2AtomClient.query(group as never, endpoint as never, {
+		timeToLive: DEFAULT_QUERY_TTL,
+		...request,
+	} as never)
+
+	const identity = `v2:${group}:${endpoint}:${identityFromKey(
+		encodeOrgScopedKey(getActiveOrgId(), request ?? {}),
+	)}`
+
+	return withRetention(atom, identity)
+	// See `retainedQuery`: `query`'s conditional return type cannot be restated
+	// by a forwarder, and the wrapping is a value-preserving pass-through.
+}) as unknown as typeof MapleApiV2AtomClient.query

--- a/apps/web/src/lib/time-utils.ts
+++ b/apps/web/src/lib/time-utils.ts
@@ -3,6 +3,18 @@ import { formatWarehouseDateTime, resolveRelativeRangeToWarehouse } from "@maple
 import { normalizeTimestampInput } from "@/lib/timezone-format"
 
 /**
+ * Floor a resolved range to the cache-key snap grid, scaled to the window
+ * width. Apply this wherever a relative preset is resolved into the range that
+ * feeds a query — without it the key moves with the clock and the atom idle
+ * TTLs never get to fire. See `snapRangeForCache` in `@maple/query-engine`.
+ *
+ * Do *not* apply it where a preset is materialized into an absolute range the
+ * user sees and keeps (the picker writing to the URL) — that should record the
+ * instant they actually chose.
+ */
+export { cacheSnapSecondsForRange, snapRangeForCache } from "@maple/query-engine"
+
+/**
  * Format a Date as the ClickHouse/Tinybird `YYYY-MM-DD HH:mm:ss` shape.
  * Thin Date-taking wrapper over the shared epoch-ms formatter.
  */

--- a/apps/web/src/routes/alerts/$ruleId.tsx
+++ b/apps/web/src/routes/alerts/$ruleId.tsx
@@ -6,7 +6,7 @@ import { Fragment, useCallback, useMemo, useRef, useState } from "react"
 import { toastManager } from "@maple/ui/components/ui/toast"
 
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { useAlertRuleChecks } from "@/hooks/use-alert-rule-checks"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
@@ -152,7 +152,7 @@ function RuleDetailContent() {
 	const ruleStates = useAlertRuleStates(ruleId)
 	const { result: destinationsResult } = useAlertDestinationsList()
 	const deliveryEventsResult = useAtomValue(
-		MapleApiV2AtomClient.query("alertDeliveries", "list", {
+		retainedQueryV2("alertDeliveries", "list", {
 			query: { limit: 100 },
 			reactivityKeys: ["alertDeliveryEvents"],
 		}),

--- a/apps/web/src/routes/alerts/index.tsx
+++ b/apps/web/src/routes/alerts/index.tsx
@@ -6,7 +6,7 @@ import { AlertsSettingsTab, useDestinationManager } from "@/components/alerts/ov
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { PlusIcon } from "@/components/icons"
 import { useAlertDestinationsList } from "@/hooks/use-alerts-list"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 import { BooleanFromStringParam, OptionalStringArrayParam } from "@/lib/search-params"
 import { Result, useAtomValue } from "@/lib/effect-atom"
 import { Button } from "@maple/ui/components/ui/button"
@@ -43,7 +43,7 @@ function AlertsPage() {
 
 	// Session + destinations back the header action only; the tabs own the rest
 	// of their data (the atoms are shared, so this costs no extra requests).
-	const sessionResult = useAtomValue(MapleApiAtomClient.query("auth", "session", {}))
+	const sessionResult = useAtomValue(retainedQuery("auth", "session", {}))
 	const { result: destinationsResult } = useAlertDestinationsList()
 	const isAdmin = Result.builder(sessionResult)
 		.onSuccess((session) => session.roles.some((role) => role === "root" || role === "org:admin"))

--- a/apps/web/src/routes/anomalies/$incidentId.tsx
+++ b/apps/web/src/routes/anomalies/$incidentId.tsx
@@ -22,7 +22,7 @@ import { useAnomalyMutations } from "@/components/anomalies/use-anomaly-mutation
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { SectionHeader } from "@/components/layout/section-header"
 import { useIntervalRefresh } from "@/hooks/use-interval-refresh"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 import { formatRelativeTime } from "@maple/ui/lib/time-format"
 import {
@@ -54,7 +54,7 @@ function AnomalyDetailPage() {
 	const { incidentId: rawIncidentId } = Route.useParams()
 	const incidentId = decodeIncidentId(rawIncidentId)
 
-	const incidentQueryAtom = MapleApiAtomClient.query("anomalies", "getIncident", {
+	const incidentQueryAtom = retainedQuery("anomalies", "getIncident", {
 		params: { incidentId },
 		reactivityKeys: ["anomalyIncidents", `anomalyIncident:${incidentId}`],
 	})
@@ -146,7 +146,7 @@ function AnomalyDetailBody({
 	const isStale = isStaleOpenIncident(incident)
 	const tone = severityToneFor(incident)
 
-	const timeseriesQueryAtom = MapleApiAtomClient.query("anomalies", "getIncidentTimeseries", {
+	const timeseriesQueryAtom = retainedQuery("anomalies", "getIncidentTimeseries", {
 		params: { incidentId },
 		query: {},
 		reactivityKeys: [`anomalyIncident:${incidentId}:timeseries`],

--- a/apps/web/src/routes/anomalies/index.tsx
+++ b/apps/web/src/routes/anomalies/index.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/anomalies/anomaly-group"
 import { AnomalyLiveIndicator } from "@/components/anomalies/anomaly-live-indicator"
 import { ListToolbar } from "@/components/common/list-toolbar"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 import { Button } from "@maple/ui/components/ui/button"
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@maple/ui/components/ui/empty"
 import { ErrorState } from "@/components/common/error-state"
@@ -61,7 +61,7 @@ function AnomaliesPage() {
 	const status: StatusTab = search.status ?? "open"
 	const live = search.live ?? status === "open"
 
-	const incidentsQueryAtom = MapleApiAtomClient.query("anomalies", "listIncidents", {
+	const incidentsQueryAtom = retainedQuery("anomalies", "listIncidents", {
 		query: status === "all" ? { limit: INCIDENTS_PAGE_LIMIT } : { status, limit: INCIDENTS_PAGE_LIMIT },
 		reactivityKeys: ["anomalyIncidents"],
 	})

--- a/apps/web/src/routes/dashboards/templates.tsx
+++ b/apps/web/src/routes/dashboards/templates.tsx
@@ -9,7 +9,7 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "
 import { useMediaQuery } from "@maple/ui/hooks/use-media-query"
 import { LIST_LIMIT_MAX } from "@maple/domain/http/v2"
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { useDashboardMutationSync } from "@/hooks/use-dashboard-store"
 import { formatBackendError } from "@/lib/error-messages"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
@@ -61,7 +61,7 @@ function TemplatesPage() {
 	// so an unbounded request silently drops the tail of the array.
 	const listAtom = useMemo(
 		() =>
-			MapleApiV2AtomClient.query("dashboards", "listTemplates", {
+			retainedQueryV2("dashboards", "listTemplates", {
 				query: { limit: LIST_LIMIT_MAX },
 				reactivityKeys: ["dashboard-templates"],
 			}),

--- a/apps/web/src/routes/errors/index.tsx
+++ b/apps/web/src/routes/errors/index.tsx
@@ -1,7 +1,13 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { warmAtoms } from "@effect-router/core"
 import { Schema } from "effect"
 
 import { BooleanFromStringParam, OptionalStringArrayParam } from "@/lib/search-params"
+import { resolveEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import {
+	getErrorsByTypeResultAtom,
+	getErrorsSummaryResultAtom,
+} from "@/lib/services/atoms/warehouse-query-atoms"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { ErrorsSummaryCards } from "@/components/errors/errors-summary-cards"
 import { ErrorsByTypeTable } from "@/components/errors/errors-by-type-table"
@@ -22,9 +28,43 @@ const errorsSearchSchema = Schema.Struct({
 
 export type ErrorsSearchParams = Schema.Schema.Type<typeof errorsSearchSchema>
 
+/**
+ * Filters shared by the loader and the page, so the atoms warmed on hover are
+ * the exact ones `ErrorsSummaryCards` and `ErrorsByTypeTable` go on to read.
+ * A mismatch here does not fail loudly — it just fetches everything twice.
+ */
+function errorsApiFilters(
+	search: ErrorsSearchParams,
+	range: { startTime: string; endTime: string },
+) {
+	return {
+		startTime: range.startTime,
+		endTime: range.endTime,
+		services: search.services,
+		deploymentEnvs: search.deploymentEnvs,
+		errorTypes: search.errorTypes,
+		showSpam: search.showSpam,
+		rootOnly: search.rootOnly !== false,
+	}
+}
+
 export const Route = createFileRoute("/errors/")({
 	component: ErrorsPage,
 	validateSearch: Schema.toStandardSchemaV1(errorsSearchSchema),
+	loaderDeps: ({ search }) => search,
+	loader: ({ context, deps }) => {
+		// The loader has no refresh context, so it resolves the range directly.
+		// The component goes through `useEffectiveTimeRange`, which additionally
+		// re-resolves against the real clock once the user hits Reload.
+		const filters = errorsApiFilters(
+			deps,
+			resolveEffectiveTimeRange(deps.startTime, deps.endTime, deps.timePreset ?? "12h"),
+		)
+		warmAtoms(context.effectRegistry, [
+			getErrorsSummaryResultAtom({ data: filters }),
+			getErrorsByTypeResultAtom({ data: filters }),
+		])
+	},
 })
 
 function ErrorsPage() {
@@ -39,12 +79,11 @@ function ErrorsPage() {
 function ErrorsContent() {
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
-	const { startTime: effectiveStartTime, endTime: effectiveEndTime } = useEffectiveTimeRange(
+	const effectiveRange = useEffectiveTimeRange(
 		search.startTime,
 		search.endTime,
 		search.timePreset ?? "12h",
 	)
-
 	const handleTimeChange = (
 		range: {
 			startTime?: string
@@ -59,15 +98,9 @@ function ErrorsContent() {
 		})
 	}
 
-	const apiFilters = {
-		startTime: effectiveStartTime,
-		endTime: effectiveEndTime,
-		services: search.services,
-		deploymentEnvs: search.deploymentEnvs,
-		errorTypes: search.errorTypes,
-		showSpam: search.showSpam,
-		rootOnly: search.rootOnly !== false,
-	}
+	// Same builder the loader uses, so hover-warmed atoms and mounted atoms are
+	// the same entries.
+	const apiFilters = errorsApiFilters(search, effectiveRange)
 
 	return (
 		<DashboardLayout.Root>

--- a/apps/web/src/routes/errors/issues/$issueId.tsx
+++ b/apps/web/src/routes/errors/issues/$issueId.tsx
@@ -33,8 +33,8 @@ import { IssueSidebar } from "@/components/errors/issue-sidebar"
 import { IssueTimeline } from "@/components/errors/issue-timeline"
 import { SectionHeader } from "@/components/layout/section-header"
 import { WorkflowBadge } from "@/components/errors/workflow-badge"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
+import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { useAlertDestinationsList } from "@/hooks/use-alerts-list"
 import { errorIssueDetailFromV2 } from "@/lib/services/error-issues"
 import { Badge } from "@maple/ui/components/ui/badge"
@@ -80,7 +80,7 @@ function IssueDetailPage() {
 	const { issueId: rawIssueId } = Route.useParams()
 	const issueId = decodeIssueId(rawIssueId)
 
-	const detailQueryAtom = MapleApiV2AtomClient.query("errorIssues", "retrieve", {
+	const detailQueryAtom = retainedQueryV2("errorIssues", "retrieve", {
 		params: { id: issueId },
 		query: {},
 		reactivityKeys: ["errorIssues", `errorIssue:${issueId}`],
@@ -88,19 +88,19 @@ function IssueDetailPage() {
 	const detailResult = useAtomValue(detailQueryAtom)
 	const refreshDetail = useAtomRefresh(detailQueryAtom)
 
-	const eventsQueryAtom = MapleApiAtomClient.query("errors", "listIssueEvents", {
+	const eventsQueryAtom = retainedQuery("errors", "listIssueEvents", {
 		params: { issueId },
 		query: { limit: 200 },
 		reactivityKeys: ["errorIssues", `errorIssue:${issueId}:events`],
 	})
 	const eventsResult = useAtomValue(eventsQueryAtom)
 	const refreshEvents = useAtomRefresh(eventsQueryAtom)
-	const investigationsQueryAtom = MapleApiV2AtomClient.query("investigations", "list", {
+	const investigationsQueryAtom = retainedQueryV2("investigations", "list", {
 		query: { issue_id: issueId, limit: 10 },
 		reactivityKeys: ["investigations", `errorIssue:${issueId}:investigations`],
 	})
 	const investigationsResult = useAtomValue(investigationsQueryAtom)
-	const escalationQueryAtom = MapleApiAtomClient.query("errors", "listIssueEscalations", {
+	const escalationQueryAtom = retainedQuery("errors", "listIssueEscalations", {
 		params: { issueId },
 		reactivityKeys: [`errorIssue:${issueId}:escalations`],
 	})

--- a/apps/web/src/routes/errors/issues/index.tsx
+++ b/apps/web/src/routes/errors/issues/index.tsx
@@ -21,7 +21,7 @@ import {
 	updateIssueSelection,
 } from "@/lib/models/issue-selection"
 import { Result, useAtomRefresh, useAtomValue } from "@/lib/effect-atom"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { runMapleApiV2 } from "@/lib/collections/api-runner"
 import {
 	appendUniqueErrorIssues,
@@ -185,13 +185,13 @@ function IssuesPage() {
 		kind: kindFilter,
 	})
 	const result = useAtomValue(
-		MapleApiV2AtomClient.query("errorIssues", "list", {
+		retainedQueryV2("errorIssues", "list", {
 			query: listQuery,
 			reactivityKeys: ["errorIssues"],
 		}),
 	)
 	const refresh = useAtomRefresh(
-		MapleApiV2AtomClient.query("errorIssues", "list", {
+		retainedQueryV2("errorIssues", "list", {
 			query: listQuery,
 			reactivityKeys: ["errorIssues"],
 		}),

--- a/apps/web/src/routes/infra/cloudflare/index.tsx
+++ b/apps/web/src/routes/infra/cloudflare/index.tsx
@@ -34,7 +34,7 @@ import {
 	cloudflareZonesResultAtom,
 	cloudflareZoneTimeseriesResultAtom,
 } from "@/lib/services/atoms/warehouse-query-atoms"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { retainedQuery } from "@/lib/services/common/atom-client"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useRetainedRefreshableResultValue } from "@/hooks/use-retained-refreshable-result-value"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
@@ -73,7 +73,7 @@ function CloudflarePage() {
 	// Integration-gated (not infra-agent-gated): the page is useful exactly when
 	// the org has the Cloudflare integration connected with analytics scopes.
 	const statusResult = useAtomValue(
-		MapleApiAtomClient.query("integrations", "cloudflareStatus", {
+		retainedQuery("integrations", "cloudflareStatus", {
 			reactivityKeys: ["cloudflareIntegrationStatus"],
 		}),
 	)

--- a/apps/web/src/routes/infra/planetscale/$dbName.tsx
+++ b/apps/web/src/routes/infra/planetscale/$dbName.tsx
@@ -71,7 +71,7 @@ import {
 	planetscaleEventsResultAtom,
 	planetscaleInfraTimeseriesResultAtom,
 } from "@/lib/services/atoms/warehouse-query-atoms"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
@@ -168,12 +168,12 @@ function PlanetScaleDatabasePage() {
 	}
 
 	const statusResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "status", {
+		retainedQueryV2("planetscaleIntegration", "status", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)
 	const inventoryResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "databases", {
+		retainedQueryV2("planetscaleIntegration", "databases", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)

--- a/apps/web/src/routes/infra/planetscale/index.tsx
+++ b/apps/web/src/routes/infra/planetscale/index.tsx
@@ -37,7 +37,7 @@ import {
 	type SetupStep,
 } from "@/components/integrations/planetscale-setup-steps"
 import { getServiceMapPlanetScaleResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { formatNumber } from "@maple/ui/lib/format"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
@@ -76,7 +76,7 @@ function PlanetScalePage() {
 	// Integration-gated: the page is useful exactly when the org has the
 	// PlanetScale integration connected.
 	const statusResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "status", {
+		retainedQueryV2("planetscaleIntegration", "status", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)
@@ -156,7 +156,7 @@ function PlanetScaleData({
 	lastInventoryError: string | null
 }) {
 	const inventoryResult = useAtomValue(
-		MapleApiV2AtomClient.query("planetscaleIntegration", "databases", {
+		retainedQueryV2("planetscaleIntegration", "databases", {
 			reactivityKeys: ["planetscaleIntegration"],
 		}),
 	)

--- a/apps/web/src/routes/investigations/index.tsx
+++ b/apps/web/src/routes/investigations/index.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/components/investigations/investigation-table"
 import { InvestigateBar } from "@/components/investigations/investigate-bar"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
-import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
+import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 
 type HubView = "active" | "history"
 
@@ -95,7 +95,7 @@ function InvestigationsHub() {
 	const isFiltered = query.trim().length > 0 || search.kind !== undefined
 
 	const [creating, setCreating] = useState(false)
-	const listQuery = MapleApiV2AtomClient.query("investigations", "list", {
+	const listQuery = retainedQueryV2("investigations", "list", {
 		query: { limit: PAGE_SIZE },
 		reactivityKeys: ["investigations"],
 	})

--- a/apps/web/src/routes/logs/$logId.tsx
+++ b/apps/web/src/routes/logs/$logId.tsx
@@ -1,3 +1,4 @@
+import { warmAtoms } from "@effect-router/core"
 import type { ReactNode } from "react"
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import { Result, useAtomValue } from "@/lib/effect-atom"
@@ -40,7 +41,7 @@ export const Route = createFileRoute("/logs/$logId")({
 	component: LogDetailPage,
 	loader: ({ context, params }) => {
 		const key = decodeLogKey(params.logId)
-		if (key) context.effectRegistry.mount(getLogResultAtom({ data: keyToInput(key) }))
+		if (key) warmAtoms(context.effectRegistry, [getLogResultAtom({ data: keyToInput(key) })])
 	},
 })
 

--- a/apps/web/src/routes/replays/$sessionId.tsx
+++ b/apps/web/src/routes/replays/$sessionId.tsx
@@ -1,3 +1,4 @@
+import { warmAtoms } from "@effect-router/core"
 import { useMemo } from "react"
 import { createFileRoute } from "@tanstack/react-router"
 import { Schema } from "effect"
@@ -28,13 +29,15 @@ export const Route = createFileRoute("/replays/$sessionId")({
 	loader: ({ context, params, deps }) => {
 		const window = replayPartitionWindow(typeof deps.t === "string" ? deps.t : undefined)
 		const data = { sessionId: params.sessionId, ...window }
-		context.effectRegistry.mount(getReplayResultAtom({ data }))
-		// The manifest, not the payload: which payload range to fetch depends on
-		// where the first checkpoint is, which the manifest is what tells us. That
-		// costs one extra round-trip on a cold load and saves fetching a session
-		// that can run to hundreds of megabytes.
-		context.effectRegistry.mount(getReplayManifestResultAtom({ data }))
-		context.effectRegistry.mount(getSessionTranscriptResultAtom({ data }))
+		warmAtoms(context.effectRegistry, [
+			getReplayResultAtom({ data }),
+			// The manifest, not the payload: which payload range to fetch depends on
+			// where the first checkpoint is, which the manifest is what tells us. That
+			// costs one extra round-trip on a cold load and saves fetching a session
+			// that can run to hundreds of megabytes.
+			getReplayManifestResultAtom({ data }),
+			getSessionTranscriptResultAtom({ data }),
+		])
 	},
 })
 

--- a/apps/web/src/routes/replays/index.tsx
+++ b/apps/web/src/routes/replays/index.tsx
@@ -1,3 +1,4 @@
+import { warmAtoms } from "@effect-router/core"
 import { useMemo } from "react"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Schema } from "effect"
@@ -59,10 +60,10 @@ export const Route = createFileRoute("/replays/")({
 	// component reads the same entries and renders its skeleton meanwhile.
 	loader: ({ context, deps }) => {
 		const filterInputs = replaysFilterInputs(deps)
-		context.effectRegistry.mount(
+		warmAtoms(context.effectRegistry, [
 			listReplaysResultAtom({ data: { ...filterInputs, limit: REPLAYS_PAGE_SIZE, offset: 0 } }),
-		)
-		context.effectRegistry.mount(replaysFacetsResultAtom({ data: filterInputs }))
+			replaysFacetsResultAtom({ data: filterInputs }),
+		])
 	},
 })
 

--- a/apps/web/src/routes/services/index.tsx
+++ b/apps/web/src/routes/services/index.tsx
@@ -1,7 +1,14 @@
 import { useNavigate, createFileRoute } from "@tanstack/react-router"
+import { warmAtoms } from "@effect-router/core"
 import { Schema } from "effect"
 
 import { OptionalStringArrayParam } from "@/lib/search-params"
+import { resolveEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import {
+	getCustomChartServiceSparklinesResultAtom,
+	getServiceOverviewResultAtom,
+	getServicesFacetsResultAtom,
+} from "@/lib/services/atoms/warehouse-query-atoms"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { ServicesTable } from "@/components/services/services-table"
 import { ServicesFilterSidebar } from "@/components/services/services-filter-sidebar"
@@ -22,9 +29,51 @@ const servicesSearchSchema = Schema.Struct({
 
 export type ServicesSearchParams = Schema.Schema.Type<typeof servicesSearchSchema>
 
+/**
+ * Atoms the page blocks its first paint on, built from search alone.
+ *
+ * Exported so the loader and the components cannot drift: the router warms
+ * exactly what `ServicesFilterSidebar` and `ServicesTable` go on to read. The
+ * inputs must match theirs byte for byte — a mismatch does not fail loudly, it
+ * just fetches everything twice.
+ *
+ * `resolveEffectiveTimeRange` is the same resolver behind `useEffectiveTimeRange`,
+ * and it snaps to the cache grid, so a loader firing on hover and a component
+ * mounting a moment later land on one entry.
+ */
+export function servicesRouteAtoms(search: ServicesSearchParams) {
+	const { startTime, endTime } = resolveEffectiveTimeRange(
+		search.startTime,
+		search.endTime,
+		search.timePreset ?? "12h",
+	)
+	const filters = {
+		startTime,
+		endTime,
+		environments: search.environments,
+		commitShas: search.commitShas,
+	}
+
+	return [
+		getServicesFacetsResultAtom({ data: { startTime, endTime } }),
+		getServiceOverviewResultAtom({ data: filters }),
+		getCustomChartServiceSparklinesResultAtom({ data: filters }),
+	]
+}
+
 export const Route = createFileRoute("/services/")({
 	component: ServicesPage,
 	validateSearch: Schema.toStandardSchemaV1(servicesSearchSchema),
+	loaderDeps: ({ search }) => search,
+	// A plain `loader`, not the `effectRoute` wrapper: TanStack's route
+	// code-splitting extracts `component` by statically matching
+	// `createFileRoute(...)({ ... })`, and it cannot see through a wrapper.
+	//
+	// `defaultPreload: "intent"` fires this on hover, ahead of the route chunk
+	// evaluating and React committing.
+	loader: ({ context, deps }) => {
+		warmAtoms(context.effectRegistry, servicesRouteAtoms(deps))
+	},
 })
 
 function ServicesPage() {

--- a/apps/web/src/routes/traces/$traceId.tsx
+++ b/apps/web/src/routes/traces/$traceId.tsx
@@ -1,3 +1,4 @@
+import { warmAtoms } from "@effect-router/core"
 import * as React from "react"
 import { useNavigate, useRouterState, createFileRoute } from "@tanstack/react-router"
 import { Result, useAtomValue } from "@/lib/effect-atom"
@@ -43,14 +44,14 @@ export const Route = createFileRoute("/traces/$traceId")({
 	validateSearch: Schema.toStandardSchemaV1(TraceDetailSearchSchema),
 	loaderDeps: ({ search }) => ({ t: search.t }),
 	loader: ({ context, params, deps }) => {
-		context.effectRegistry.mount(
+		warmAtoms(context.effectRegistry, [
 			getSpanHierarchyResultAtom({
 				data: {
 					traceId: Schema.decodeSync(TraceId)(params.traceId),
 					timestamp: deps.t,
 				},
 			}),
-		)
+		])
 	},
 })
 

--- a/apps/web/src/routes/traces/index.tsx
+++ b/apps/web/src/routes/traces/index.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { useNavigate, createFileRoute } from "@tanstack/react-router"
+import { warmAtoms } from "@effect-router/core"
 import { Schema } from "effect"
 
 import { BooleanFromStringParam, OptionalStringArrayParam } from "@/lib/search-params"
@@ -9,7 +10,7 @@ import { TracesFilterSidebar } from "@/components/traces/traces-filter-sidebar"
 import { AdvancedFilterDialog } from "@/components/traces/advanced-filter-dialog"
 import { MagnifierIcon, XmarkIcon } from "@/components/icons"
 import { Button } from "@maple/ui/components/ui/button"
-import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { resolveEffectiveTimeRange, useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useAtomValue } from "@/lib/effect-atom"
 import { applyWhereClause } from "@/lib/traces/advanced-filter-sync"
 import { getTracesFacetsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
@@ -66,6 +67,19 @@ export type TracesSearchParams = Schema.Schema.Type<typeof tracesSearchSchema>
 export const Route = createFileRoute("/traces/")({
 	component: TracesPage,
 	validateSearch: Schema.toStandardSchemaV1(tracesSearchSchema),
+	loaderDeps: ({ search }) => search,
+	// Only the facet sidebar is warmed. The trace list is paginated and sorted
+	// from state the route does not own, so rebuilding its input here would risk
+	// warming a different entry than the table reads — two fetches instead of
+	// none.
+	loader: ({ context, deps }) => {
+		const { startTime, endTime } = resolveEffectiveTimeRange(
+			deps.startTime,
+			deps.endTime,
+			deps.timePreset ?? "12h",
+		)
+		warmAtoms(context.effectRegistry, [getTracesFacetsResultAtom({ data: { startTime, endTime } })])
+	},
 })
 
 function TracesPage() {

--- a/lib/effect-router/src/file-route.ts
+++ b/lib/effect-router/src/file-route.ts
@@ -41,6 +41,36 @@ export type PreloadFn = (ctx: PreloadContext) => ReadonlyArray<Atom.Atom<any>>
  * })
  * ```
  */
+/**
+ * How long a preloaded atom is held mounted before it is released back to its
+ * own idle TTL.
+ *
+ * A preload has to hold a subscription or the fetch it just started is
+ * discarded before the component can read it. But holding it *forever* is the
+ * trap: `mount` returns an unmount function, and dropping that pins the atom
+ * for the life of the session. With preload-on-intent every hover runs the
+ * loader, and keys that embed a time window roll over as the clock moves, so
+ * the pinned set grows for as long as the tab is open.
+ *
+ * Releasing after a delay covers the hand-off both ways: if the user navigates,
+ * the component has taken its own subscription long before this fires; if they
+ * only hovered, the atom goes idle and expires normally.
+ */
+const PRELOAD_HOLD_MS = 30_000
+
+/**
+ * Start a fetch for each atom and release it once the hand-off window passes.
+ */
+export function warmAtoms(
+	registry: { readonly mount: <A>(atom: Atom.Atom<A>) => () => void },
+	atoms: ReadonlyArray<Atom.Atom<any>>,
+): void {
+	for (const atom of atoms) {
+		const unmount = registry.mount(atom)
+		setTimeout(unmount, PRELOAD_HOLD_MS)
+	}
+}
+
 export function effectRoute<T extends (...args: any[]) => any>(fileRoute: T, preload?: PreloadFn): T {
 	return ((options?: any) => {
 		if (!options) return (fileRoute as any)()
@@ -57,8 +87,7 @@ function transformOptions(options: Record<string, any>, preload?: PreloadFn): Re
 		result.loader = (ctx: any) => {
 			if (preload) {
 				const { effectRegistry } = getEffectContext(ctx.context)
-				const atoms = preload({ params: ctx.params, search: ctx.search ?? {} })
-				for (const atom of atoms) effectRegistry.mount(atom)
+				warmAtoms(effectRegistry, preload({ params: ctx.params, search: ctx.search ?? {} }))
 			}
 			if (userLoader) return userLoader(ctx)
 		}

--- a/lib/effect-router/src/index.ts
+++ b/lib/effect-router/src/index.ts
@@ -1,4 +1,4 @@
 export { createEffectRouter, type EffectRouterContext, type EffectRouterOptions } from "./router.ts"
-export { effectRoute, type PreloadFn, type PreloadContext } from "./file-route.ts"
+export { effectRoute, warmAtoms, type PreloadFn, type PreloadContext } from "./file-route.ts"
 export { effectLoader, effectBeforeLoad, type EffectLoaderFn, type EffectBeforeLoadFn } from "./route.ts"
 export { routeAtom, routeAtomDerived, type RouteAtomOptions, type RouteAtomFn } from "./atoms.ts"

--- a/packages/query-engine/src/datetime.test.ts
+++ b/packages/query-engine/src/datetime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
 	bucketTimeline,
+	cacheSnapSecondsForRange,
 	computeBucketSeconds,
 	formatWarehouseDateTime,
 	formatWarehouseDateTimeMs,
@@ -8,6 +9,7 @@ import {
 	relativeRangeSeconds,
 	resolveRelativeRange,
 	resolveRelativeRangeToWarehouse,
+	snapRangeForCache,
 	warehouseDateTimeToIso,
 } from "./datetime"
 
@@ -238,5 +240,117 @@ describe("resolveRelativeRangeToWarehouse", () => {
 
 	it("propagates null for invalid shorthand", () => {
 		expect(resolveRelativeRangeToWarehouse("nope")).toBeNull()
+	})
+})
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+describe("cacheSnapSecondsForRange", () => {
+	it("coarsens the grid as the window widens", () => {
+		expect(cacheSnapSecondsForRange(30 * 60 * 1000)).toBe(15)
+		expect(cacheSnapSecondsForRange(HOUR_MS)).toBe(15)
+		expect(cacheSnapSecondsForRange(6 * HOUR_MS)).toBe(60)
+		expect(cacheSnapSecondsForRange(12 * HOUR_MS)).toBe(300)
+		expect(cacheSnapSecondsForRange(DAY_MS)).toBe(300)
+		expect(cacheSnapSecondsForRange(7 * DAY_MS)).toBe(900)
+		expect(cacheSnapSecondsForRange(30 * DAY_MS)).toBe(1800)
+	})
+
+	// Worst case is just above a rung boundary, where the wider grid has just
+	// kicked in but the window has not grown to match. The peak is 1h+ε on the
+	// 1m rung (1.67%); each later boundary is milder (6h+ε 1.39%, 24h+ε 1.04%,
+	// 7d+ε 0.30%).
+	it("keeps drift under 2% of the window at every rung boundary", () => {
+		for (const rangeMs of [
+			HOUR_MS,
+			HOUR_MS + 1,
+			6 * HOUR_MS,
+			6 * HOUR_MS + 1,
+			12 * HOUR_MS,
+			DAY_MS,
+			DAY_MS + 1,
+			7 * DAY_MS,
+			7 * DAY_MS + 1,
+			30 * DAY_MS,
+		]) {
+			expect((cacheSnapSecondsForRange(rangeMs) * 1000) / rangeMs).toBeLessThan(0.02)
+		}
+	})
+
+	it("bounds absolute drift by window class", () => {
+		// The guarantee users actually feel, in wall-clock terms.
+		expect(cacheSnapSecondsForRange(6 * HOUR_MS)).toBeLessThanOrEqual(60)
+		expect(cacheSnapSecondsForRange(DAY_MS)).toBeLessThanOrEqual(300)
+		expect(cacheSnapSecondsForRange(7 * DAY_MS)).toBeLessThanOrEqual(900)
+		expect(cacheSnapSecondsForRange(90 * DAY_MS)).toBeLessThanOrEqual(1800)
+	})
+
+	it("falls back to the finest rung for degenerate widths", () => {
+		expect(cacheSnapSecondsForRange(0)).toBe(15)
+		expect(cacheSnapSecondsForRange(-1)).toBe(15)
+		expect(cacheSnapSecondsForRange(Number.NaN)).toBe(15)
+	})
+})
+
+describe("snapRangeForCache", () => {
+	// The point of the whole exercise: `now` drifting within one grid cell must
+	// produce a byte-identical range, because that range becomes the cache key.
+	it("collapses clock drift inside a grid cell to one key", () => {
+		const at = (iso: string) => resolveRelativeRangeToWarehouse("12h", Date.parse(iso))!
+
+		const early = snapRangeForCache(at("2026-03-08T14:31:02.000Z"))
+		const late = snapRangeForCache(at("2026-03-08T14:34:59.000Z"))
+
+		expect(early).toEqual(late)
+		expect(early.endTime).toBe("2026-03-08 14:30:00")
+		expect(early.startTime).toBe("2026-03-08 02:30:00")
+	})
+
+	it("advances once the next cell is reached", () => {
+		const at = (iso: string) => resolveRelativeRangeToWarehouse("12h", Date.parse(iso))!
+
+		expect(snapRangeForCache(at("2026-03-08T14:34:59.000Z")).endTime).toBe("2026-03-08 14:30:00")
+		expect(snapRangeForCache(at("2026-03-08T14:35:00.000Z")).endTime).toBe("2026-03-08 14:35:00")
+	})
+
+	it("holds the window width exactly constant across the ladder", () => {
+		for (const shorthand of ["30m", "1h", "6h", "12h", "1d", "7d", "30d"]) {
+			// Sweep offsets that straddle grid boundaries — flooring both bounds
+			// independently would make the width oscillate by one grid step here.
+			for (const offsetMs of [0, 1000, 61_000, 299_000, 899_000, 1_799_000]) {
+				const resolved = resolveRelativeRangeToWarehouse(
+					shorthand,
+					Date.parse("2026-03-08T14:30:00.000Z") + offsetMs,
+				)!
+				const before =
+					parseWarehouseDateTime(resolved.endTime) - parseWarehouseDateTime(resolved.startTime)
+
+				const snapped = snapRangeForCache(resolved)
+				const after =
+					parseWarehouseDateTime(snapped.endTime) - parseWarehouseDateTime(snapped.startTime)
+
+				expect(after).toBe(before)
+			}
+		}
+	})
+
+	it("never moves the endpoint forward", () => {
+		const resolved = resolveRelativeRangeToWarehouse("12h", Date.parse("2026-03-08T14:34:59.000Z"))!
+		const snapped = snapRangeForCache(resolved)
+
+		expect(parseWarehouseDateTime(snapped.endTime)).toBeLessThanOrEqual(
+			parseWarehouseDateTime(resolved.endTime),
+		)
+	})
+
+	it("passes unparseable input through untouched", () => {
+		const garbage = { startTime: "not-a-date", endTime: "also-not" }
+		expect(snapRangeForCache(garbage)).toBe(garbage)
+	})
+
+	it("passes an inverted range through untouched", () => {
+		const inverted = { startTime: "2026-03-08 14:30:00", endTime: "2026-03-08 02:30:00" }
+		expect(snapRangeForCache(inverted)).toBe(inverted)
 	})
 })

--- a/packages/query-engine/src/datetime.ts
+++ b/packages/query-engine/src/datetime.ts
@@ -186,6 +186,82 @@ export function resolveRelativeRangeToWarehouse(
 	}
 }
 
+// Cache-key snap grid — single source of truth
+//
+// A relative preset ("12h") has no absolute endpoint in the URL, so every fresh
+// mount re-resolves it against `Date.now()` and produces a slightly different
+// range. Cache keys are built from that range, so the key rolls over as fast as
+// the clock moves — and a client-side idle TTL of 30s never gets to fire,
+// because the key it was keeping alive no longer exists. Navigating away and
+// back re-fetches from cold.
+//
+// The fix is to floor the endpoint to a grid coarse enough that the key holds
+// still between navigations, and fine enough that the data is still current.
+// A flat grid can't do both: 15s is right for "last 1 hour" and pointless for
+// "last 7 days". So the grid scales with the window.
+//
+// Drift is worst just above a rung boundary, where the wider grid has kicked in
+// but the window has not yet grown to match; the peak is 1h+ε on the 1m rung,
+// at 1.7% of the window. In absolute terms it is never more than a minute on a
+// window of 6h or less, 5 minutes on a day, 15 on a week, 30 beyond that.
+// Explicit refresh and auto-refresh re-resolve against the real clock, so this
+// bounds staleness while idle, not staleness overall.
+//
+// This is a *cache-key* concern, not a display one. Callers that materialize a
+// preset into an absolute range the user will see (the time-range picker
+// writing to the URL) should record the true instant and skip this.
+
+const CACHE_SNAP_LADDER: ReadonlyArray<readonly [maxRangeMs: number, snapSeconds: number]> = [
+	[60 * 60 * 1000, 15], // <= 1h  → 15s
+	[6 * 60 * 60 * 1000, 60], // <= 6h  → 1m
+	[24 * 60 * 60 * 1000, 300], // <= 24h → 5m
+	[7 * 24 * 60 * 60 * 1000, 900], // <= 7d  → 15m
+] as const
+
+const CACHE_SNAP_FALLBACK_SECONDS = 1800 // > 7d → 30m
+
+/**
+ * Cache-key snap grid (seconds) for a window of the given width. Wider windows
+ * tolerate a coarser grid because the same absolute drift is a smaller share of
+ * the range. Non-finite or non-positive widths fall back to the finest rung.
+ */
+export function cacheSnapSecondsForRange(rangeMs: number): number {
+	if (!Number.isFinite(rangeMs) || rangeMs <= 0) return CACHE_SNAP_LADDER[0][1]
+	for (const [maxRangeMs, snapSeconds] of CACHE_SNAP_LADDER) {
+		if (rangeMs <= maxRangeMs) return snapSeconds
+	}
+	return CACHE_SNAP_FALLBACK_SECONDS
+}
+
+/**
+ * Floor a resolved range's endpoint to the grid from `cacheSnapSecondsForRange`,
+ * holding the window width exactly constant.
+ *
+ * Width is preserved by deriving the start from the snapped end rather than
+ * flooring both independently — independent floors make the width oscillate by
+ * one grid step as `now` crosses a boundary, which changes the bucket count and
+ * defeats the point of snapping.
+ *
+ * Unparseable input is returned untouched, so a malformed timestamp degrades to
+ * the previous (unsnapped) behaviour instead of throwing on the cache-key path.
+ */
+export function snapRangeForCache(range: { readonly startTime: string; readonly endTime: string }): {
+	startTime: string
+	endTime: string
+} {
+	const startMs = parseWarehouseDateTime(range.startTime)
+	const endMs = parseWarehouseDateTime(range.endTime)
+	if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) return range
+
+	const gridMs = cacheSnapSecondsForRange(endMs - startMs) * 1000
+	const snappedEndMs = Math.floor(endMs / gridMs) * gridMs
+
+	return {
+		startTime: formatWarehouseDateTime(snappedEndMs - (endMs - startMs)),
+		endTime: formatWarehouseDateTime(snappedEndMs),
+	}
+}
+
 // Time-series bucketing — single source of truth
 //
 // Both the web app and the query engine pick an auto bucket size and build


### PR DESCRIPTION
## Why

Navigating back and forth between pages showed a skeleton almost every time, even though every one of the ~95 query atoms already declared a generous idle TTL (30s typical, up to 30min).

Those TTLs were effectively unreachable. `Atom.setIdleTTL` is a **gcTime, not a staleTime**, and the cache *key* rolled over faster than the TTL could ever fire:

1. A preset time range strips `startTime`/`endTime` from the URL, so the range is re-derived from `Date.now()` on every fresh mount.
2. Keys snapped that to a **flat 15-second grid** — the same 15s whether the window was 1 hour or 7 days.

Effective hit window was `min(idleTTL, time-to-next-15s-boundary)` = **0–15 seconds**. Leave a page for 20s, come back, cold fetch.

## What changed

Three changes for three distinct failure modes.

**1. Range-proportional snap grid** — `cacheSnapSecondsForRange` / `snapRangeForCache` in `packages/query-engine/src/datetime.ts`:

| window | grid |
| --- | --- |
| ≤ 1h | 15s |
| ≤ 6h | 1m |
| ≤ 24h | 5m |
| ≤ 7d | 15m |
| > 7d | 30m |

Width is held exactly constant (start derived from the snapped end — flooring both independently makes it oscillate by a grid step and changes the bucket count). Drift peaks at 1.7% of the window at a rung boundary; in wall-clock terms never more than a minute on a window of 6h or less.

Applied only where a preset resolves into query inputs — **not** where the picker materializes an absolute range the user chose — and **skipped once the user hits Reload**, so an explicit refresh still advances to the real "now" rather than sitting in the previous grid cell. An existing test caught that one.

**2. Cross-key stale-while-revalidate** — `withRetention(atom, identity)`: a bounded LRU (400 entries / 30 min) keyed by the query *minus its time window*, served through `Atom.withFallback`. Wired at the atom rather than in a hook, so every consumer benefits with no call-site changes. Entries are stamped with the `Result`'s own timestamp, so repeated reads can't keep a value alive past the age bound.

**3. `retainedQuery` / `retainedQueryV2`** — `AtomHttpApi.query` applies neither `setIdleTTL` nor `keepAlive` unless a `timeToLive` is passed, so a bare query atom is **disposed the instant its last subscriber unmounts**. Settings, integrations, anomalies and similar panels refetched on every single visit — strictly worse than the warehouse atoms were before this PR. The wrappers add a 1-minute TTL plus retention, across both HTTP clients (51 call sites).

Plus **warm-on-hover** loaders for `/services`, `/errors`, `/traces`.

## Reviewer notes

- **`effectRoute` can't be used for loaders.** TanStack extracts `component` by statically matching `createFileRoute(...)({ ... })` and can't see through a wrapper — the `?tsr-split=component` import returns `undefined` and rendering fails. Route tests caught this; it would have hit the production build too. These use a plain `loader:`, like the four pre-existing preload routes.
- **`warmAtoms` fixes a pre-existing leak.** `registry.mount()` returns an unmount function that all four existing loaders were discarding, pinning that atom for the session. With `defaultPreload: "intent"` firing on every hover and time keys rolling, that set grows all session. It now releases after a 30s hand-off window.
- **Two casts**, one per client wrapper. `query`'s return type is a conditional resolved from the group/endpoint literals; a forwarder can't restate it. Confined to the signature, not the body — the wrapping is a value-preserving pass-through.
- **Retention identities need a per-family namespace.** `identityFromKey` strips timestamps, and plenty of queries take *nothing but* a window (`getServicesFacets` and `getServiceOverview` both reduce to `{}`). Un-namespaced they collided and one served the other's rows — this crashed `ServicesFilterSidebar` during development. Regression test included.

## Deliberately not covered

Six module-level `runtime.atom(...)` singletons (scrape targets, setup audit, ingestion mappings ×2, alert-rule checks, scrape-target checks). They carry no org in their key, so adding a TTL would keep the **previous org's** value alive across an org switch. They need converting to org-scoped families first — worth a follow-up.

Also out of scope: cross-reload persistence (nothing survives F5 today).

## Testing

- `bun run --cwd apps/web test` — 172 files, **1496 pass**
- `bun run test --filter=@maple/query-engine -- datetime` — **52 pass**
- `bun run --cwd apps/web typecheck` clean; oxlint clean
- New tests: snap ladder + constant-width invariant, `identityFromKey`, retention LRU/age bounds, and `withRetention` (including the namespace-collision regression)

Verified against the running app:
- `/services` issues **exactly one** request per atom — loader and component land on the same key, no double-fetch
- Revisiting Integrations serves **6 of 7** endpoints from cache; previously all 7 refetched (the 7th is the known singleton gap above)
- Confirmed from the loaded module that a 12h range 20s apart is now byte-identical, where unsnapped it differs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789083251&installation_model_id=427786&pr_number=440&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F440&signature=06b9b4fd14c1036c2e2735eb3929b5774a1f07a267a5060da719bc7360c0a9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->