### PR TITLE
perf(traces): rework the Timeline waterfall on a ref-based viewport

### DIFF
--- a/apps/api/src/http/server-error-span.test.ts
+++ b/apps/api/src/http/server-error-span.test.ts
@@ -119,8 +119,7 @@ const makeHarness = () => {
 	}
 	const serverSpan = (path: string): EndedSpan => {
 		const span = ended.find(
-			(candidate) =>
-				candidate.kind === "server" && candidate.attributes.get("url.path") === path,
+			(candidate) => candidate.kind === "server" && candidate.attributes.get("url.path") === path,
 		)
 		if (span === undefined) throw new Error(`no server span ended for ${path}`)
 		return span

--- a/apps/web/src/lib/error-messages.ts
+++ b/apps/web/src/lib/error-messages.ts
@@ -476,7 +476,7 @@ const normalizeTaggedError = (value: { _tag: string; [key: string]: unknown }): 
 			technicalMessage: rawStringField(value, "causeMessage") ?? technicalMessage,
 		})
 	}
-	if (tag.endsWith("/UnauthorizedError") || /AuthenticationError$/.test(tag)) {
+	if (tag.endsWith("/UnauthorizedError") || tag.endsWith('AuthenticationError')) {
 		return normalized(value, {
 			category: "authentication",
 			title: "Sign in required",
@@ -503,7 +503,7 @@ const normalizeTaggedError = (value: { _tag: string; [key: string]: unknown }): 
 			technicalMessage,
 		})
 	}
-	if (/NotFoundError$/.test(tag)) {
+	if (tag.endsWith('NotFoundError')) {
 		return normalized(value, {
 			category: "not-found",
 			title: "Not found",

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as ServiceMapBenchRouteImport } from './routes/service-map-bench'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SignInRouteImport } from './routes/sign-in'
 import { Route as SignUpRouteImport } from './routes/sign-up'
+import { Route as TimelineLabRouteImport } from './routes/timeline-lab'
 import { Route as WidgetLabRouteImport } from './routes/widget-lab'
 import { Route as AlertsIndexRouteImport } from './routes/alerts/index'
 import { Route as AlertsRuleIdRouteImport } from './routes/alerts/$ruleId'
@@ -193,6 +194,11 @@ const SignInRoute = SignInRouteImport.update({
 const SignUpRoute = SignUpRouteImport.update({
   id: '/sign-up',
   path: '/sign-up',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TimelineLabRoute = TimelineLabRouteImport.update({
+  id: '/timeline-lab',
+  path: '/timeline-lab',
   getParentRoute: () => rootRouteImport,
 } as any)
 const WidgetLabRoute = WidgetLabRouteImport.update({
@@ -435,6 +441,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRoute
   '/sign-in': typeof SignInRoute
   '/sign-up': typeof SignUpRoute
+  '/timeline-lab': typeof TimelineLabRoute
   '/widget-lab': typeof WidgetLabRoute
   '/alerts/$ruleId': typeof AlertsRuleIdRoute
   '/alerts/create': typeof AlertsCreateRoute
@@ -502,6 +509,7 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsRoute
   '/sign-in': typeof SignInRoute
   '/sign-up': typeof SignUpRoute
+  '/timeline-lab': typeof TimelineLabRoute
   '/widget-lab': typeof WidgetLabRoute
   '/alerts/$ruleId': typeof AlertsRuleIdRoute
   '/alerts/create': typeof AlertsCreateRoute
@@ -570,6 +578,7 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRoute
   '/sign-in': typeof SignInRoute
   '/sign-up': typeof SignUpRoute
+  '/timeline-lab': typeof TimelineLabRoute
   '/widget-lab': typeof WidgetLabRoute
   '/alerts/$ruleId': typeof AlertsRuleIdRoute
   '/alerts/create': typeof AlertsCreateRoute
@@ -639,6 +648,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/sign-in'
     | '/sign-up'
+    | '/timeline-lab'
     | '/widget-lab'
     | '/alerts/$ruleId'
     | '/alerts/create'
@@ -706,6 +716,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/sign-in'
     | '/sign-up'
+    | '/timeline-lab'
     | '/widget-lab'
     | '/alerts/$ruleId'
     | '/alerts/create'
@@ -773,6 +784,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/sign-in'
     | '/sign-up'
+    | '/timeline-lab'
     | '/widget-lab'
     | '/alerts/$ruleId'
     | '/alerts/create'
@@ -841,6 +853,7 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRoute
   SignInRoute: typeof SignInRoute
   SignUpRoute: typeof SignUpRoute
+  TimelineLabRoute: typeof TimelineLabRoute
   WidgetLabRoute: typeof WidgetLabRoute
   AlertsRuleIdRoute: typeof AlertsRuleIdRoute
   AlertsCreateRoute: typeof AlertsCreateRoute
@@ -1052,6 +1065,13 @@ declare module '@tanstack/react-router' {
       path: '/sign-up'
       fullPath: '/sign-up'
       preLoaderRoute: typeof SignUpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/timeline-lab': {
+      id: '/timeline-lab'
+      path: '/timeline-lab'
+      fullPath: '/timeline-lab'
+      preLoaderRoute: typeof TimelineLabRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/widget-lab': {
@@ -1369,6 +1389,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRoute,
   SignInRoute: SignInRoute,
   SignUpRoute: SignUpRoute,
+  TimelineLabRoute: TimelineLabRoute,
   WidgetLabRoute: WidgetLabRoute,
   AlertsRuleIdRoute: AlertsRuleIdRoute,
   AlertsCreateRoute: AlertsCreateRoute,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -56,6 +56,7 @@ function renderAttributeValue(attrKey: string, value: string) {
 const FIXTURE_PATHS = [
 	"/widget-lab",
 	"/node-lab",
+	"/timeline-lab",
 	"/service-map-bench",
 	"/service-detail-bench",
 	"/infra-bench",

--- a/apps/web/src/routes/timeline-lab.tsx
+++ b/apps/web/src/routes/timeline-lab.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react"
+import { createFileRoute } from "@tanstack/react-router"
+
+import { TraceViewTabs } from "@maple/ui/components/traces/trace-view-tabs"
+import { buildTraceDetail, type SpanHierarchyRow } from "@maple/ui/lib/span-tree"
+import type { SpanNode } from "@maple/ui/lib/types"
+import { formatWarehouseDateTimeMs } from "@maple/query-engine"
+
+export const Route = createFileRoute("/timeline-lab")({ component: TimelineLab })
+
+const T0_MS = new Date("2026-07-21T10:00:00.000Z").getTime()
+
+function at(offsetMs: number): string {
+	return formatWarehouseDateTimeMs(T0_MS + offsetMs)
+}
+
+function row(overrides: Partial<SpanHierarchyRow> & { spanId: string; spanName: string }): SpanHierarchyRow {
+	return {
+		traceId: "timeline-lab-trace",
+		parentSpanId: "",
+		serviceName: "checkout-api",
+		spanKind: "SPAN_KIND_INTERNAL",
+		durationMs: 20,
+		startTime: at(0),
+		statusCode: "Ok",
+		statusMessage: "",
+		spanAttributes: "{}",
+		resourceAttributes: "{}",
+		...overrides,
+	}
+}
+
+// A wide dynamic range on purpose: a 2s root, mid-size children, and a fan of
+// sub-millisecond spans that only become legible at deep zoom.
+const ROWS: SpanHierarchyRow[] = [
+	row({ spanId: "root", spanName: "POST /api/checkout", spanKind: "SPAN_KIND_SERVER", durationMs: 2000 }),
+	...Array.from({ length: 6 }, (_, i) =>
+		row({
+			spanId: `svc${i}`,
+			parentSpanId: "root",
+			spanName: `stage-${i} handler`,
+			serviceName: ["checkout-api", "payments", "inventory", "search", "mailer", "edge"][i],
+			spanKind: "SPAN_KIND_INTERNAL",
+			startTime: at(20 + i * 300),
+			durationMs: 260,
+			statusCode: i === 3 ? "Error" : "Ok",
+		}),
+	),
+	...Array.from({ length: 40 }, (_, i) =>
+		row({
+			spanId: `q${i}`,
+			parentSpanId: `svc${i % 6}`,
+			spanName: `SELECT shard_${i}`,
+			serviceName: "postgres",
+			spanKind: "SPAN_KIND_CLIENT",
+			startTime: at(25 + (i % 6) * 300 + (i % 7) * 30),
+			// Sub-ms spans: invisible zoomed out, the reason zoom has to work.
+			durationMs: 0.08 + (i % 5) * 0.4,
+		}),
+	),
+	...Array.from({ length: 12 }, (_, i) =>
+		row({
+			spanId: `deep${i}`,
+			parentSpanId: i === 0 ? "svc1" : `deep${i - 1}`,
+			spanName: `nested level ${i}`,
+			serviceName: "payments",
+			startTime: at(330 + i * 3),
+			durationMs: 200 - i * 12,
+		}),
+	),
+]
+
+const DETAIL = buildTraceDetail(ROWS)
+
+function TimelineLab() {
+	const [selected, setSelected] = useState<SpanNode | undefined>(undefined)
+	return (
+		<div className="h-screen p-4">
+			<TraceViewTabs
+				rootSpans={DETAIL.rootSpans}
+				spans={DETAIL.spans}
+				totalDurationMs={DETAIL.totalDurationMs}
+				traceStartTime={DETAIL.traceStartTime}
+				services={DETAIL.services}
+				selectedSpanId={selected?.spanId}
+				onSelectSpan={setSelected}
+			/>
+		</div>
+	)
+}

--- a/packages/ui/src/components/traces/__tests__/auto-collapse.test.ts
+++ b/packages/ui/src/components/traces/__tests__/auto-collapse.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+
+import { collectDescendantParentIds, computeCollapseOneLevel, computeExpandOneLevel } from "../auto-collapse"
+import { collectParentIdsByLevel } from "../use-trace-timeline"
+import type { SpanNode } from "../../../lib/types"
+
+/** Minimal SpanNode — these helpers only read spanId, depth and children. */
+function node(spanId: string, depth: number, children: SpanNode[] = []): SpanNode {
+	return {
+		traceId: "t",
+		spanId,
+		parentSpanId: "",
+		spanName: spanId,
+		serviceName: "svc",
+		spanKind: "Internal",
+		durationMs: 1,
+		startTime: "2026-01-01T00:00:00.000Z",
+		statusCode: "Ok",
+		statusMessage: "",
+		spanAttributes: {},
+		resourceAttributes: {},
+		children,
+		depth,
+	} as SpanNode
+}
+
+//  root (0)
+//  ├── a (1) ── a1 (2) ── a1x (3)
+//  └── b (1) ── b1 (2)          ← b1 is a leaf, so not a "parent"
+const TREE = [
+	node("root", 0, [node("a", 1, [node("a1", 2, [node("a1x", 3)])]), node("b", 1, [node("b1", 2)])]),
+]
+
+describe("collectParentIdsByLevel", () => {
+	it("buckets only nodes that have children, by depth", () => {
+		const byLevel = collectParentIdsByLevel(TREE)
+		expect(byLevel.get(0)).toEqual(new Set(["root"]))
+		expect(byLevel.get(1)).toEqual(new Set(["a", "b"]))
+		expect(byLevel.get(2)).toEqual(new Set(["a1"])) // b1 is a leaf
+		expect(byLevel.has(3)).toBe(false) // a1x is a leaf
+	})
+
+	it("walks past collapsed ancestors, so hidden parents are still known", () => {
+		// Nothing about the expanded set is consulted — the map covers the whole tree.
+		expect(collectParentIdsByLevel(TREE).get(2)).toEqual(new Set(["a1"]))
+	})
+})
+
+describe("computeExpandOneLevel", () => {
+	const byLevel = collectParentIdsByLevel(TREE)
+
+	it("opens the shallowest level that still has a collapsed parent", () => {
+		const step1 = computeExpandOneLevel(new Set(), byLevel)
+		expect(step1).toEqual(new Set(["root"]))
+		const step2 = computeExpandOneLevel(step1, byLevel)
+		expect(step2).toEqual(new Set(["root", "a", "b"]))
+		const step3 = computeExpandOneLevel(step2, byLevel)
+		expect(step3).toEqual(new Set(["root", "a", "b", "a1"]))
+	})
+
+	it("expands a partially open level rather than skipping past it", () => {
+		const next = computeExpandOneLevel(new Set(["root", "a"]), byLevel)
+		expect(next).toEqual(new Set(["root", "a", "b"]))
+	})
+
+	it("returns the same set when everything is already open", () => {
+		const all = new Set(["root", "a", "b", "a1"])
+		expect(computeExpandOneLevel(all, byLevel)).toBe(all)
+	})
+})
+
+describe("computeCollapseOneLevel", () => {
+	const byLevel = collectParentIdsByLevel(TREE)
+
+	it("closes the deepest expanded level first", () => {
+		const all = new Set(["root", "a", "b", "a1"])
+		const step1 = computeCollapseOneLevel(all, byLevel)
+		expect(step1).toEqual(new Set(["root", "a", "b"]))
+		const step2 = computeCollapseOneLevel(step1, byLevel)
+		expect(step2).toEqual(new Set(["root"]))
+		const step3 = computeCollapseOneLevel(step2, byLevel)
+		expect(step3).toEqual(new Set())
+	})
+
+	it("returns the same set when everything is already closed", () => {
+		const none = new Set<string>()
+		expect(computeCollapseOneLevel(none, byLevel)).toBe(none)
+	})
+
+	it("round-trips with computeExpandOneLevel", () => {
+		const all = new Set(["root", "a", "b", "a1"])
+		expect(computeExpandOneLevel(computeCollapseOneLevel(all, byLevel), byLevel)).toEqual(all)
+	})
+})
+
+describe("collectDescendantParentIds", () => {
+	it("returns expandable descendants only, excluding the node itself", () => {
+		expect(collectDescendantParentIds(TREE[0]).sort()).toEqual(["a", "a1", "b"])
+	})
+
+	it("returns nothing for a leaf", () => {
+		expect(collectDescendantParentIds(node("leaf", 0))).toEqual([])
+	})
+})

--- a/packages/ui/src/components/traces/__tests__/timeline-reducer.test.ts
+++ b/packages/ui/src/components/traces/__tests__/timeline-reducer.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest"
 import { clampViewport, timelineReducer } from "../use-trace-timeline"
+import { viewportBounds } from "../clamp-viewport"
 import type { TimelineState } from "../trace-timeline-types"
 import { MIN_VISIBLE_ABS_MS } from "../trace-timeline-types"
 
 const TRACE_START = 0
 const TRACE_END = 10_000 // 10s trace
 
-function baseState(viewport = { startMs: 0, endMs: 10_000 }): TimelineState {
+function baseState(): TimelineState {
 	return {
-		viewport,
 		focusedIndex: 3,
 		searchQuery: "db",
 		expandedSpanIds: new Set(["a", "b"]),
@@ -27,9 +27,9 @@ describe("clampViewport min-visible floor", () => {
 		expect(vp.endMs - vp.startMs).toBeCloseTo(MIN_VISIBLE_ABS_MS, 6)
 	})
 
-	it("caps an over-wide window at traceDuration * 1.1", () => {
+	it("caps an over-wide window at the trace plus its trailing slack", () => {
 		const vp = clampViewport({ startMs: -50_000, endMs: 50_000 }, TRACE_START, TRACE_END)
-		expect(vp.endMs - vp.startMs).toBeCloseTo(11_000, 6)
+		expect(vp.endMs - vp.startMs).toBeCloseTo(10_500, 6)
 	})
 
 	it("keeps a normal window untouched", () => {
@@ -40,8 +40,8 @@ describe("clampViewport min-visible floor", () => {
 })
 
 describe("clampViewport boundaries", () => {
-	const LO = TRACE_START - 10_000 * 0.05 // -500 (5% padding)
-	const HI = TRACE_END + 10_000 * 0.05 // 10_500
+	const LO = TRACE_START // flush: zero is the left edge of the column
+	const HI = TRACE_END + 10_000 * 0.05 // 10_500 (trailing slack only)
 
 	it("clamps a window fully left of the trace back inside", () => {
 		const vp = clampViewport({ startMs: -30_000, endMs: -28_000 }, TRACE_START, TRACE_END)
@@ -59,7 +59,7 @@ describe("clampViewport boundaries", () => {
 
 	it("centers a window capped to the max width (no left-edge re-violation)", () => {
 		const vp = clampViewport({ startMs: -1_000, endMs: 11_500 }, TRACE_START, TRACE_END)
-		expect(vp.endMs - vp.startMs).toBeCloseTo(11_000, 6)
+		expect(vp.endMs - vp.startMs).toBeCloseTo(10_500, 6)
 		expect(vp.startMs).toBeCloseTo(LO, 6)
 		expect(vp.endMs).toBeCloseTo(HI, 6)
 	})
@@ -87,77 +87,93 @@ describe("clampViewport boundaries", () => {
 	})
 })
 
-describe("SET_VIEWPORT", () => {
-	it("clamps a minimap drag that leaves the trace entirely", () => {
-		const next = timelineReducer(baseState({ startMs: 8_000, endMs: 10_000 }), {
-			type: "SET_VIEWPORT",
-			viewport: { startMs: 38_000, endMs: 40_000 },
-			traceStartMs: TRACE_START,
-			traceEndMs: TRACE_END,
-		})
-		expect(next.viewport.startMs).toBeGreaterThanOrEqual(TRACE_START - 500)
-		expect(next.viewport.endMs).toBeLessThanOrEqual(TRACE_END + 500)
-		expect(next.viewport.endMs - next.viewport.startMs).toBeCloseTo(2_000, 6)
+describe("viewportBounds is the shared coordinate space", () => {
+	// The minimap strip, the ruler and the span bars all have to agree on where a given instant
+	// sits. They do that by sharing one domain: the padded bounds. When the minimap drew the bare
+	// trace instead, trace-zero landed at 0% of the strip but 4.5% into the column — an ~80px
+	// disagreement at full zoom-out.
+	it("starts flush at the trace and pads only the tail", () => {
+		// Flush left is the point: a leading pad puts an empty strip in front of the first span,
+		// so the waterfall looks offset from its own ruler. The tail slack is label room.
+		const b = viewportBounds(TRACE_START, TRACE_END)
+		expect(b.loMs).toBe(TRACE_START)
+		expect(b.hiMs).toBeCloseTo(10_500, 6)
+		expect(b.durationMs).toBeCloseTo(10_500, 6)
 	})
 
-	it("clamps a resize wider than the trace", () => {
-		const next = timelineReducer(baseState(), {
-			type: "SET_VIEWPORT",
-			viewport: { startMs: -100_000, endMs: 100_000 },
-			traceStartMs: TRACE_START,
-			traceEndMs: TRACE_END,
-		})
-		expect(next.viewport.endMs - next.viewport.startMs).toBeCloseTo(11_000, 6)
+	it("puts trace-zero at the very left of the domain", () => {
+		// The property the leading gap violated: the first instant of the trace maps to 0%.
+		const b = viewportBounds(TRACE_START, TRACE_END)
+		expect((TRACE_START - b.loMs) / b.durationMs).toBe(0)
+	})
+
+	it("is exactly the widest window clampViewport will hand back", () => {
+		// If these ever diverge, a "fitted" timeline can't line up with the strip.
+		const b = viewportBounds(TRACE_START, TRACE_END)
+		const widest = clampViewport({ startMs: -1e9, endMs: 1e9 }, TRACE_START, TRACE_END)
+		expect(widest.startMs).toBeCloseTo(b.loMs, 6)
+		expect(widest.endMs).toBeCloseTo(b.hiMs, 6)
+	})
+
+	it("stays finite on a zero-duration trace", () => {
+		const b = viewportBounds(5_000, 5_000)
+		expect(b.loMs).toBe(5_000)
+		expect(b.hiMs).toBe(5_000)
+		expect(b.durationMs).toBe(0)
 	})
 })
 
-describe("ZOOM_TO_RANGE", () => {
-	it("zooms to the dragged window without extra padding", () => {
-		const next = timelineReducer(baseState(), {
-			type: "ZOOM_TO_RANGE",
-			startMs: 2_000,
-			endMs: 3_000,
-			traceStartMs: TRACE_START,
-			traceEndMs: TRACE_END,
-		})
-		expect(next.viewport.startMs).toBeCloseTo(2_000, 6)
-		expect(next.viewport.endMs).toBeCloseTo(3_000, 6)
+describe("TOGGLE_COLLAPSE", () => {
+	it("toggles a single span both ways", () => {
+		const collapsed = timelineReducer(baseState(), { type: "TOGGLE_COLLAPSE", spanId: "a" })
+		expect(collapsed.expandedSpanIds.has("a")).toBe(false)
+		const expanded = timelineReducer(collapsed, { type: "TOGGLE_COLLAPSE", spanId: "a" })
+		expect(expanded.expandedSpanIds.has("a")).toBe(true)
 	})
 
-	it("normalizes a reversed (right-to-left) drag", () => {
-		const next = timelineReducer(baseState(), {
-			type: "ZOOM_TO_RANGE",
-			startMs: 3_000,
-			endMs: 2_000,
-			traceStartMs: TRACE_START,
-			traceEndMs: TRACE_END,
+	it("alt-click drags the whole subtree to the node's new state", () => {
+		// "a" is expanded → collapsing it must also collapse its expanded descendants.
+		const state: TimelineState = { ...baseState(), expandedSpanIds: new Set(["a", "a1", "a2", "b"]) }
+		const collapsed = timelineReducer(state, {
+			type: "TOGGLE_COLLAPSE",
+			spanId: "a",
+			descendantIds: ["a1", "a2"],
 		})
-		expect(next.viewport.startMs).toBeCloseTo(2_000, 6)
-		expect(next.viewport.endMs).toBeCloseTo(3_000, 6)
-	})
+		expect([...collapsed.expandedSpanIds]).toEqual(["b"])
 
-	it("applies the min-visible floor to a too-small drag", () => {
-		const next = timelineReducer(baseState(), {
-			type: "ZOOM_TO_RANGE",
-			startMs: 5_000,
-			endMs: 5_000,
-			traceStartMs: TRACE_START,
-			traceEndMs: TRACE_END,
+		const reExpanded = timelineReducer(collapsed, {
+			type: "TOGGLE_COLLAPSE",
+			spanId: "a",
+			descendantIds: ["a1", "a2"],
 		})
-		expect(next.viewport.endMs - next.viewport.startMs).toBeCloseTo(MIN_VISIBLE_ABS_MS, 6)
+		expect(reExpanded.expandedSpanIds).toEqual(new Set(["a", "a1", "a2", "b"]))
 	})
 
 	it("leaves unrelated state fields intact", () => {
 		const prev = baseState()
-		const next = timelineReducer(prev, {
-			type: "ZOOM_TO_RANGE",
-			startMs: 1_000,
-			endMs: 8_000,
-			traceStartMs: TRACE_START,
-			traceEndMs: TRACE_END,
-		})
+		const next = timelineReducer(prev, { type: "TOGGLE_COLLAPSE", spanId: "a" })
 		expect(next.focusedIndex).toBe(prev.focusedIndex)
 		expect(next.searchQuery).toBe(prev.searchQuery)
+	})
+})
+
+describe("focus and search", () => {
+	it("FOCUS_NEXT stops at maxIndex, FOCUS_PREV at 0", () => {
+		const at5: TimelineState = { ...baseState(), focusedIndex: 5 }
+		expect(timelineReducer(at5, { type: "FOCUS_NEXT", maxIndex: 5 }).focusedIndex).toBe(5)
+		const at0: TimelineState = { ...baseState(), focusedIndex: 0 }
+		expect(timelineReducer(at0, { type: "FOCUS_PREV" }).focusedIndex).toBe(0)
+	})
+
+	it("starts focus at the first row from null", () => {
+		const none: TimelineState = { ...baseState(), focusedIndex: null }
+		expect(timelineReducer(none, { type: "FOCUS_NEXT", maxIndex: 9 }).focusedIndex).toBe(0)
+	})
+
+	it("SET_SEARCH does not disturb the expanded set", () => {
+		const prev = baseState()
+		const next = timelineReducer(prev, { type: "SET_SEARCH", query: "http" })
+		expect(next.searchQuery).toBe("http")
 		expect(next.expandedSpanIds).toBe(prev.expandedSpanIds)
 	})
 })

--- a/packages/ui/src/components/traces/__tests__/timeline-ticks.test.ts
+++ b/packages/ui/src/components/traces/__tests__/timeline-ticks.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+
+import { computeTimeAxisTicks, tickIntervalForWidth } from "../use-trace-timeline"
+import { MIN_TICK_PX } from "../trace-timeline-types"
+import { formatDurationAtStep } from "../../../lib/format"
+
+describe("tickIntervalForWidth", () => {
+	// The whole point of budgeting by width rather than a fixed count: the same window must
+	// yield fewer ticks on a narrow panel and more on a wide one.
+	it.each([300, 800, 2000])("keeps ticks at least MIN_TICK_PX apart at %ipx", (widthPx) => {
+		for (const visibleMs of [0.5, 12, 950, 10_000, 420_000]) {
+			const interval = tickIntervalForWidth(visibleMs, widthPx)
+			const count = Math.floor(visibleMs / interval)
+			expect(count * MIN_TICK_PX).toBeLessThanOrEqual(widthPx)
+		}
+	})
+
+	it("gives a wider column more ticks for the same window", () => {
+		const narrow = tickIntervalForWidth(10_000, 300)
+		const wide = tickIntervalForWidth(10_000, 2000)
+		expect(wide).toBeLessThan(narrow)
+	})
+
+	it("survives a window past the top of the nice-interval ladder", () => {
+		const interval = tickIntervalForWidth(45 * 60_000, 800)
+		expect(Number.isFinite(interval)).toBe(true)
+		expect(interval).toBeGreaterThan(0)
+	})
+})
+
+describe("computeTimeAxisTicks", () => {
+	it("covers the window with evenly spaced offsets from the trace start", () => {
+		const { ticks, intervalMs } = computeTimeAxisTicks(
+			{ startMs: 1_000, endMs: 3_000 },
+			1_000, // traceStartMs → offsets run 0…2000
+			800,
+		)
+		expect(ticks.length).toBeGreaterThan(1)
+		expect(ticks[0]).toBeGreaterThanOrEqual(0)
+		expect(ticks[ticks.length - 1]).toBeLessThanOrEqual(2_000)
+		for (let i = 1; i < ticks.length; i++) {
+			expect(ticks[i] - ticks[i - 1]).toBeCloseTo(intervalMs, 6)
+		}
+	})
+
+	it("returns nothing for a degenerate window or an unmeasured column", () => {
+		expect(computeTimeAxisTicks({ startMs: 5, endMs: 5 }, 0, 800).ticks).toEqual([])
+		expect(computeTimeAxisTicks({ startMs: 0, endMs: 100 }, 0, 0).ticks).toEqual([])
+	})
+})
+
+describe("formatDurationAtStep", () => {
+	// The bug this exists for: at deep zoom the fixed-precision formatter rendered "1.5ms"
+	// for three consecutive ticks, so the ruler read as if it had stopped moving.
+	it.each([
+		[0.5, 800],
+		[12, 800],
+		[950, 300],
+		[10_000, 2000],
+		[420_000, 800],
+	])("never repeats a label across the ruler (%ims window, %ipx)", (visibleMs, widthPx) => {
+		const { ticks, intervalMs } = computeTimeAxisTicks({ startMs: 0, endMs: visibleMs }, 0, widthPx)
+		const labels = ticks.map((t) => formatDurationAtStep(t, intervalMs))
+		expect(new Set(labels).size).toBe(labels.length)
+	})
+
+	it("keeps sub-millisecond steps in microseconds", () => {
+		expect(formatDurationAtStep(0.05, 0.01)).toBe("50μs")
+		expect(formatDurationAtStep(0.123, 0.001)).toBe("123μs")
+	})
+
+	it("adds decimals only when the step needs them", () => {
+		expect(formatDurationAtStep(500, 100)).toBe("500ms")
+		expect(formatDurationAtStep(500.5, 0.5)).toBe("500.5ms")
+		expect(formatDurationAtStep(2_000, 1_000)).toBe("2s")
+	})
+
+	it("returns a placeholder rather than NaN for a non-finite value", () => {
+		expect(formatDurationAtStep(Number.NaN, 1)).toBe("—")
+	})
+})

--- a/packages/ui/src/components/traces/__tests__/viewport-controller.test.ts
+++ b/packages/ui/src/components/traces/__tests__/viewport-controller.test.ts
@@ -1,0 +1,242 @@
+import { StrictMode } from "react"
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useViewportController } from "../use-viewport-controller"
+import { viewportBounds } from "../clamp-viewport"
+import { MIN_VISIBLE_ABS_MS } from "../trace-timeline-types"
+
+const TRACE_START = 1_000_000
+const TRACE_END = 1_010_000 // 10s trace
+
+function setup(initial = { startMs: TRACE_START, endMs: TRACE_START + 2_000 }) {
+	return renderHook(() =>
+		useViewportController({
+			traceStartMs: TRACE_START,
+			traceEndMs: TRACE_END,
+			initialViewport: initial,
+		}),
+	)
+}
+
+/** Run every rAF callback queued so far (the controller coalesces notifications onto one). */
+function flushFrames() {
+	act(() => {
+		vi.advanceTimersToNextFrame()
+	})
+}
+
+beforeEach(() => {
+	vi.useFakeTimers()
+})
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe("viewport commits", () => {
+	it("clamps through clampViewport on every path", () => {
+		const { result } = setup()
+		act(() => result.current.set({ startMs: TRACE_START - 500_000, endMs: TRACE_START - 400_000 }))
+		const vp = result.current.get()
+		// 5% padding either side of a 10s trace.
+		expect(vp.startMs).toBeGreaterThanOrEqual(TRACE_START - 500)
+		expect(vp.endMs).toBeLessThanOrEqual(TRACE_END + 500)
+	})
+
+	it("floors a collapsed window instead of inverting it", () => {
+		const { result } = setup()
+		act(() => result.current.zoomToRange(TRACE_START + 5_000, TRACE_START + 5_000))
+		const vp = result.current.get()
+		expect(vp.endMs - vp.startMs).toBeCloseTo(MIN_VISIBLE_ABS_MS, 6)
+	})
+
+	it("normalizes a reversed zoomToRange", () => {
+		const { result } = setup()
+		act(() => result.current.zoomToRange(TRACE_START + 3_000, TRACE_START + 2_000))
+		expect(result.current.get().startMs).toBeCloseTo(TRACE_START + 2_000, 6)
+		expect(result.current.get().endMs).toBeCloseTo(TRACE_START + 3_000, 6)
+	})
+
+	it("fit() lands exactly on the navigable bounds", () => {
+		// Not merely "covers the trace": it has to be *exactly* the bounds, because that is the
+		// span the minimap strip draws. Anything else and a fitted timeline sits a couple of
+		// percent out of step with the strip, which reads as the minimap being misaligned.
+		const { result } = setup()
+		act(() => result.current.fit())
+		act(() => {
+			vi.advanceTimersByTime(400) // eased
+		})
+		const bounds = viewportBounds(TRACE_START, TRACE_END)
+		expect(result.current.get().startMs).toBeCloseTo(bounds.loMs, 6)
+		expect(result.current.get().endMs).toBeCloseTo(bounds.hiMs, 6)
+	})
+})
+
+describe("zoomAt", () => {
+	it("holds the anchor time fixed at its position in the window", () => {
+		const { result } = setup({ startMs: TRACE_START, endMs: TRACE_START + 4_000 })
+		const anchor = TRACE_START + 1_000 // 25% across the window
+		act(() => result.current.zoomAt(anchor, 2))
+		const vp = result.current.get()
+		expect(vp.endMs - vp.startMs).toBeCloseTo(2_000, 6)
+		expect((anchor - vp.startMs) / (vp.endMs - vp.startMs)).toBeCloseTo(0.25, 6)
+	})
+
+	it("zooms out with a factor below 1", () => {
+		const { result } = setup({ startMs: TRACE_START + 4_000, endMs: TRACE_START + 6_000 })
+		act(() => result.current.zoomAt(TRACE_START + 5_000, 0.5))
+		expect(result.current.get().endMs - result.current.get().startMs).toBeCloseTo(4_000, 6)
+	})
+})
+
+describe("panBy", () => {
+	it("shifts the window and preserves its width", () => {
+		const { result } = setup({ startMs: TRACE_START + 1_000, endMs: TRACE_START + 3_000 })
+		act(() => result.current.panBy(500))
+		const vp = result.current.get()
+		expect(vp.startMs).toBeCloseTo(TRACE_START + 1_500, 6)
+		expect(vp.endMs - vp.startMs).toBeCloseTo(2_000, 6)
+	})
+
+	it("stops at the trace edge rather than drifting away", () => {
+		const { result } = setup({ startMs: TRACE_START + 1_000, endMs: TRACE_START + 3_000 })
+		act(() => result.current.panBy(1_000_000))
+		const vp = result.current.get()
+		expect(vp.endMs).toBeLessThanOrEqual(TRACE_END + 500)
+		expect(vp.endMs - vp.startMs).toBeCloseTo(2_000, 6)
+	})
+})
+
+describe("subscribers", () => {
+	it("primes a new subscriber with the current window", () => {
+		const { result } = setup()
+		const cb = vi.fn()
+		act(() => {
+			result.current.subscribe(cb)
+		})
+		expect(cb).toHaveBeenCalledTimes(1)
+		expect(cb.mock.calls[0][0]).toEqual(result.current.get())
+	})
+
+	it("coalesces a burst of commits into a single notification", () => {
+		const { result } = setup()
+		const cb = vi.fn()
+		act(() => {
+			result.current.subscribe(cb)
+		})
+		cb.mockClear()
+		act(() => {
+			for (let i = 0; i < 10; i++) result.current.panBy(10)
+		})
+		// Ten commits, one frame: the DOM was written ten times but React-land hears once.
+		expect(cb).not.toHaveBeenCalled()
+		flushFrames()
+		expect(cb).toHaveBeenCalledTimes(1)
+		expect(cb.mock.calls[0][0]).toEqual(result.current.get())
+	})
+
+	it("keeps notifying through StrictMode's mount/unmount/remount", () => {
+		// The unmount cleanup cancels the pending frame; if it leaves the id behind, `notify`
+		// reads it as "a frame is already scheduled" and silently drops every later
+		// notification. StrictMode does exactly this cycle on the first paint against the same
+		// refs, which froze the ruler and the minimap for the whole session in dev while the
+		// CSS-var path kept working — so the symptom looked like a tick-math bug, not a leak.
+		const { result } = renderHook(
+			() =>
+				useViewportController({
+					traceStartMs: TRACE_START,
+					traceEndMs: TRACE_END,
+					initialViewport: { startMs: TRACE_START, endMs: TRACE_START + 2_000 },
+				}),
+			{ wrapper: StrictMode },
+		)
+		const cb = vi.fn()
+		act(() => {
+			result.current.subscribe(cb)
+		})
+		cb.mockClear()
+		act(() => result.current.panBy(10))
+		flushFrames()
+		expect(cb).toHaveBeenCalledTimes(1)
+	})
+
+	it("stops notifying after unsubscribe", () => {
+		const { result } = setup()
+		const cb = vi.fn()
+		let unsubscribe = () => {}
+		act(() => {
+			unsubscribe = result.current.subscribe(cb)
+		})
+		act(() => unsubscribe())
+		cb.mockClear()
+		act(() => result.current.panBy(10))
+		flushFrames()
+		expect(cb).not.toHaveBeenCalled()
+	})
+})
+
+describe("time surfaces", () => {
+	it("writes the window as trace-relative --vp0 and --vpk", () => {
+		const { result } = setup({ startMs: TRACE_START + 1_000, endMs: TRACE_START + 3_000 })
+		const el = document.createElement("div")
+		act(() => {
+			result.current.bindTimeSurface(el)
+		})
+		// Bound elements are primed immediately, not on the next commit.
+		expect(Number(el.style.getPropertyValue("--vp0"))).toBeCloseTo(1_000, 6)
+		expect(Number(el.style.getPropertyValue("--vpk"))).toBeCloseTo(100 / 2_000, 9)
+
+		act(() => result.current.panBy(500))
+		expect(Number(el.style.getPropertyValue("--vp0"))).toBeCloseTo(1_500, 6)
+	})
+
+	it("positions a bar at the fraction of the window CSS would compute", () => {
+		// Mirrors `calc((var(--b0) - var(--vp0)) * var(--vpk) * 1%)` from the row.
+		const { result } = setup({ startMs: TRACE_START + 1_000, endMs: TRACE_START + 3_000 })
+		const el = document.createElement("div")
+		act(() => {
+			result.current.bindTimeSurface(el)
+		})
+		const vp0 = Number(el.style.getPropertyValue("--vp0"))
+		const vpk = Number(el.style.getPropertyValue("--vpk"))
+		// A span starting halfway through the window (trace-relative 2000ms).
+		expect((2_000 - vp0) * vpk).toBeCloseTo(50, 6)
+	})
+
+	it("stops writing an unbound element", () => {
+		const { result } = setup()
+		const el = document.createElement("div")
+		let unbind = () => {}
+		act(() => {
+			unbind = result.current.bindTimeSurface(el)
+		})
+		act(() => unbind())
+		const before = el.style.getPropertyValue("--vp0")
+		act(() => result.current.panBy(500))
+		expect(el.style.getPropertyValue("--vp0")).toBe(before)
+	})
+})
+
+describe("animateTo", () => {
+	it("eases to the target and lands exactly on it", () => {
+		const { result } = setup({ startMs: TRACE_START, endMs: TRACE_START + 10_000 })
+		act(() => result.current.animateTo({ startMs: TRACE_START, endMs: TRACE_START + 2_000 }, 100))
+		act(() => {
+			vi.advanceTimersByTime(200)
+		})
+		const vp = result.current.get()
+		expect(vp.endMs - vp.startMs).toBeCloseTo(2_000, 3)
+	})
+
+	it("cancelAnimation freezes it mid-flight so a direct gesture wins", () => {
+		const { result } = setup({ startMs: TRACE_START, endMs: TRACE_START + 10_000 })
+		act(() => result.current.animateTo({ startMs: TRACE_START, endMs: TRACE_START + 1_000 }, 400))
+		flushFrames()
+		act(() => result.current.cancelAnimation())
+		const frozen = result.current.get()
+		act(() => {
+			vi.advanceTimersByTime(1_000)
+		})
+		expect(result.current.get()).toEqual(frozen)
+	})
+})

--- a/packages/ui/src/components/traces/auto-collapse.ts
+++ b/packages/ui/src/components/traces/auto-collapse.ts
@@ -62,6 +62,73 @@ function collectAncestorIdsFromIndex(nodeById: Map<string, SpanNode>, spanId: st
 	return ancestors
 }
 
+/** Every descendant id of `node` that could itself be expanded (i.e. has children). */
+export function collectDescendantParentIds(node: SpanNode): string[] {
+	const ids: string[] = []
+	const visit = (n: SpanNode) => {
+		for (const child of n.children) {
+			if (child.children.length > 0) {
+				ids.push(child.spanId)
+				visit(child)
+			}
+		}
+	}
+	visit(node)
+	return ids
+}
+
+/**
+ * Expand the shallowest level that still has a collapsed parent, leaving everything above it
+ * untouched. Returns the same set when there is nothing left to open, so callers can skip the
+ * dispatch.
+ */
+export function computeExpandOneLevel(
+	expanded: Set<string>,
+	parentIdsByLevel: Map<number, Set<string>>,
+): Set<string> {
+	const levels = [...parentIdsByLevel.keys()].sort((a, b) => a - b)
+	for (const level of levels) {
+		const ids = parentIdsByLevel.get(level)
+		if (!ids) continue
+		let hasCollapsed = false
+		for (const id of ids) {
+			if (!expanded.has(id)) {
+				hasCollapsed = true
+				break
+			}
+		}
+		if (!hasCollapsed) continue
+		const next = new Set(expanded)
+		for (const id of ids) next.add(id)
+		return next
+	}
+	return expanded
+}
+
+/** Collapse the deepest level that still has an expanded parent. */
+export function computeCollapseOneLevel(
+	expanded: Set<string>,
+	parentIdsByLevel: Map<number, Set<string>>,
+): Set<string> {
+	const levels = [...parentIdsByLevel.keys()].sort((a, b) => b - a)
+	for (const level of levels) {
+		const ids = parentIdsByLevel.get(level)
+		if (!ids) continue
+		let hasExpanded = false
+		for (const id of ids) {
+			if (expanded.has(id)) {
+				hasExpanded = true
+				break
+			}
+		}
+		if (!hasExpanded) continue
+		const next = new Set(expanded)
+		for (const id of ids) next.delete(id)
+		return next
+	}
+	return expanded
+}
+
 export interface ComputeDefaultExpandedOptions {
 	/** Keep this span's ancestor chain expanded so it's never hidden by auto-collapse. */
 	keepVisibleSpanId?: string

--- a/packages/ui/src/components/traces/clamp-viewport.ts
+++ b/packages/ui/src/components/traces/clamp-viewport.ts
@@ -1,0 +1,66 @@
+import type { ViewportState } from "./trace-timeline-types"
+import { MIN_VISIBLE_ABS_MS } from "./trace-timeline-types"
+
+/**
+ * Slack past the *end* of the trace that the viewport can reach, as a fraction of its duration.
+ *
+ * Trailing only. The trace starts at zero and zero belongs hard against the left edge of the
+ * column — a symmetric pad puts an empty strip in front of the first span, which just reads as
+ * the waterfall being misaligned with its own ruler. The trailing slack earns its keep: the
+ * duration labels on narrow bars render *outside* the bar to its right, and a span finishing at
+ * the trace end would otherwise have its label clipped.
+ */
+const TRAILING_PADDING = 0.05
+
+/**
+ * The furthest the viewport can travel: the trace, plus a little slack after the last span.
+ *
+ * This — not `[traceStartMs, traceEndMs]` — is the timeline's coordinate space, and **anything
+ * that has to line up with the timeline column must use it**. The minimap originally drew over
+ * the bare trace while the ruler drew the (padded) viewport, so trace-zero sat at 0% of the strip
+ * but several percent into the column; at full zoom-out the two disagreed by ~80px.
+ */
+export function viewportBounds(
+	traceStartMs: number,
+	traceEndMs: number,
+): { loMs: number; hiMs: number; durationMs: number } {
+	const loMs = traceStartMs
+	const hiMs = traceEndMs + Math.max(0, traceEndMs - traceStartMs) * TRAILING_PADDING
+	return { loMs, hiMs, durationMs: hiMs - loMs }
+}
+
+/**
+ * Bound a candidate window to the trace.
+ *
+ * Its own module (rather than living in `use-trace-timeline`) so the viewport controller can
+ * reach it without pulling in the layout hook and its React dependencies.
+ */
+export function clampViewport(vp: ViewportState, traceStartMs: number, traceEndMs: number): ViewportState {
+	const { loMs: loBound, hiMs: hiBound, durationMs: boundWidth } = viewportBounds(traceStartMs, traceEndMs)
+
+	// Absolute floor only — a proportional floor (traceDuration * k) makes long traces
+	// un-zoomable: a 7-min trace would cap the window at tens of ms while the spans you're
+	// trying to inspect are µs-scale, so zoom appears not to work. Span bars clamp their
+	// rendered rect in CSS, so extreme zoom can't emit gigapixel nodes.
+	const minDuration = MIN_VISIBLE_ABS_MS
+	const maxDuration = Math.max(boundWidth, minDuration)
+
+	const rawDuration = vp.endMs - vp.startMs
+	const duration = Number.isFinite(rawDuration)
+		? Math.max(minDuration, Math.min(rawDuration, maxDuration))
+		: maxDuration
+
+	// Window as wide as (or wider than) the padded trace → center it, so neither edge
+	// clamp can push the other back out of bounds (degenerate/near-zero traces included).
+	if (duration >= boundWidth) {
+		const center = (loBound + hiBound) / 2
+		return { startMs: center - duration / 2, endMs: center + duration / 2 }
+	}
+
+	// Right-clamp before left-clamp: min() first means the subsequent max() can only pull
+	// the window right, never past hiBound (duration < boundWidth guarantees room).
+	const startMs = Number.isFinite(vp.startMs)
+		? Math.max(loBound, Math.min(vp.startMs, hiBound - duration))
+		: loBound
+	return { startMs, endMs: startMs + duration }
+}

--- a/packages/ui/src/components/traces/trace-timeline-minimap.tsx
+++ b/packages/ui/src/components/traces/trace-timeline-minimap.tsx
@@ -1,18 +1,17 @@
 import * as React from "react"
+
 import type { SpanNode } from "../../lib/types"
-import type { ViewportState } from "./trace-timeline-types"
-import { MINIMAP_HEIGHT } from "./trace-timeline-types"
+import { HANDLE_HIT_AREA, MINIMAP_HEIGHT, MIN_RANGE_FRAC } from "./trace-timeline-types"
 import { formatDuration } from "../../lib/format"
 import { getValueHue } from "../../lib/colors"
 import { resolveColorValue, isStatusCodePreset, type ColorByField } from "./color-by"
+import { viewportBounds } from "./clamp-viewport"
+import type { ViewportController } from "./use-viewport-controller"
 
 interface TraceTimelineMinimapProps {
 	rootSpans: SpanNode[]
-	traceStartMs: number
-	traceEndMs: number
 	colorBy: ColorByField
-	viewport: ViewportState
-	onViewportChange: (viewport: ViewportState) => void
+	controller: ViewportController
 }
 
 interface MinimapSpan {
@@ -32,8 +31,8 @@ const REFRAME_THRESHOLD_PX = 3
 
 function collectMinimapSpans(
 	rootSpans: SpanNode[],
-	traceStartMs: number,
-	traceDurationMs: number,
+	domainStartMs: number,
+	domainDurationMs: number,
 	colorBy: ColorByField,
 ): { spans: MinimapSpan[]; maxDepth: number } {
 	const spans: MinimapSpan[] = []
@@ -42,10 +41,10 @@ function collectMinimapSpans(
 
 	function visit(node: SpanNode) {
 		const startMs = new Date(node.startTime).getTime()
-		// traceDurationMs spans the full extent of the trace (max end − min start), so every
-		// span maps into 0–100% — no skewed span flies off the minimap.
-		const leftPercent = ((startMs - traceStartMs) / traceDurationMs) * 100
-		const widthPercent = (node.durationMs / traceDurationMs) * 100
+		// Positioned against the padded viewport bounds, the same space the ruler and the span
+		// bars use, so a given instant lands at the same x in the strip and in the column.
+		const leftPercent = ((startMs - domainStartMs) / domainDurationMs) * 100
+		const widthPercent = (node.durationMs / domainDurationMs) * 100
 		maxDepth = Math.max(maxDepth, node.depth)
 
 		const isError = node.statusCode === "Error"
@@ -77,30 +76,25 @@ function collectMinimapSpans(
 	return { spans, maxDepth }
 }
 
-export function TraceTimelineMinimap({
+/**
+ * The span silhouette. One node per span and no virtualization, so on a 2000-span trace this is
+ * 2000 elements — which is exactly why it is split out and memoized: it depends on the tree and
+ * the colour scheme, never on the viewport, so a pan or zoom must not re-render it.
+ */
+const MinimapBars = React.memo(function MinimapBars({
 	rootSpans,
-	traceStartMs,
-	traceEndMs,
+	domainStartMs,
+	domainDurationMs,
 	colorBy,
-	viewport,
-	onViewportChange,
-}: TraceTimelineMinimapProps) {
-	const containerRef = React.useRef<HTMLDivElement>(null)
-	const guideRef = React.useRef<HTMLDivElement>(null)
-	const dragRef = React.useRef<{
-		type: "pan" | "resize-left" | "resize-right" | "reframe"
-		startX: number
-		moved: boolean
-		startViewport: ViewportState
-	} | null>(null)
-	/** Live reframe preview, in minimap % — anchor and cursor ends, unordered. */
-	const [reframePreview, setReframePreview] = React.useState<{ a: number; b: number } | null>(null)
-
-	const traceDuration = traceEndMs - traceStartMs
-
+}: {
+	rootSpans: SpanNode[]
+	domainStartMs: number
+	domainDurationMs: number
+	colorBy: ColorByField
+}) {
 	const { spans, maxDepth } = React.useMemo(
-		() => collectMinimapSpans(rootSpans, traceStartMs, traceDuration, colorBy),
-		[rootSpans, traceStartMs, traceDuration, colorBy],
+		() => collectMinimapSpans(rootSpans, domainStartMs, domainDurationMs, colorBy),
+		[rootSpans, domainStartMs, domainDurationMs, colorBy],
 	)
 
 	// Fit every depth level inside the strip: deep traces compress the row pitch evenly
@@ -108,220 +102,289 @@ export function TraceTimelineMinimap({
 	const pitch = Math.max(1, Math.min(4, Math.floor((MINIMAP_HEIGHT - 4) / (maxDepth + 1))))
 	const rowH = Math.max(1, pitch - 1)
 
-	const vpLeftPercent = ((viewport.startMs - traceStartMs) / traceDuration) * 100
-	const vpWidthPercent = ((viewport.endMs - viewport.startMs) / traceDuration) * 100
+	return (
+		<div className="pointer-events-none absolute inset-0" style={{ paddingTop: 2, paddingBottom: 2 }}>
+			{spans.map((s) => (
+				<div
+					key={s.spanId}
+					className="absolute"
+					style={{
+						top: Math.min(2 + s.depth * pitch, MINIMAP_HEIGHT - rowH - 2),
+						left: `${s.leftPercent}%`,
+						width: `${Math.max(s.widthPercent, 0.2)}%`,
+						height: rowH,
+						backgroundColor: s.bgColor,
+					}}
+				/>
+			))}
+		</div>
+	)
+})
 
-	const pctFromEvent = React.useCallback((clientX: number) => {
-		const rect = containerRef.current?.getBoundingClientRect()
-		if (!rect || rect.width === 0) return 0
-		return ((clientX - rect.left) / rect.width) * 100
-	}, [])
+type DragType = "pan" | "resize-left" | "resize-right" | "reframe"
 
-	const handleMouseDown = React.useCallback(
-		(e: React.MouseEvent) => {
-			if (!containerRef.current) return
-			const clickPercent = pctFromEvent(e.clientX)
+/** Pointer x as a 0–100 percentage of the strip, clamped to it. */
+function pctInStrip(clientX: number, rect: DOMRect): number {
+	return Math.max(0, Math.min(100, ((clientX - rect.left) / rect.width) * 100))
+}
 
-			const edgeThreshold = 2 // percent
-			if (
-				clickPercent >= vpLeftPercent - edgeThreshold &&
-				clickPercent <= vpLeftPercent + edgeThreshold
-			) {
-				dragRef.current = {
-					type: "resize-left",
-					startX: e.clientX,
-					moved: false,
-					startViewport: { ...viewport },
-				}
-			} else if (
-				clickPercent >= vpLeftPercent + vpWidthPercent - edgeThreshold &&
-				clickPercent <= vpLeftPercent + vpWidthPercent + edgeThreshold
-			) {
-				dragRef.current = {
-					type: "resize-right",
-					startX: e.clientX,
-					moved: false,
-					startViewport: { ...viewport },
-				}
-			} else if (clickPercent >= vpLeftPercent && clickPercent <= vpLeftPercent + vpWidthPercent) {
-				dragRef.current = {
-					type: "pan",
-					startX: e.clientX,
-					moved: false,
-					startViewport: { ...viewport },
-				}
-			} else {
-				// Outside the viewport rect: a drag draws a new range (Jaeger's reframe);
-				// a plain click (no movement) jumps the viewport center — resolved on mouseup.
-				dragRef.current = {
-					type: "reframe",
-					startX: e.clientX,
-					moved: false,
-					startViewport: { ...viewport },
-				}
-			}
+export function TraceTimelineMinimap({ rootSpans, colorBy, controller }: TraceTimelineMinimapProps) {
+	const containerRef = React.useRef<HTMLDivElement>(null)
+	const guideRef = React.useRef<HTMLDivElement>(null)
+	// The viewport rect and the two dimming masks, driven imperatively by the controller
+	// subscription below — the whole point is that a gesture re-renders nothing here either.
+	const rectRef = React.useRef<HTMLDivElement>(null)
+	const dimLeftRef = React.useRef<HTMLDivElement>(null)
+	const dimRightRef = React.useRef<HTMLDivElement>(null)
+	const brushRef = React.useRef<HTMLDivElement>(null)
 
-			e.preventDefault()
+	const dragRef = React.useRef<{
+		type: DragType
+		startX: number
+		moved: boolean
+		startStartMs: number
+		startEndMs: number
+		rect: DOMRect
+	} | null>(null)
+
+	const traceStartMs = controller.traceStartMs
+
+	// The strip spans the padded viewport bounds, not the bare trace — identical to the space the
+	// ruler and the span bars are drawn in, so trace-zero lands at the same x in both. It also
+	// means the viewport can never exceed the strip, so the clamp in `fracs` is a guard rather
+	// than the thing holding the rect inside its container.
+	const { loMs: domainStartMs, durationMs: domainDuration } = React.useMemo(
+		() => viewportBounds(controller.traceStartMs, controller.traceEndMs),
+		[controller.traceStartMs, controller.traceEndMs],
+	)
+
+	/** Current viewport as [0,1] fractions of the strip. */
+	const fracs = React.useCallback(
+		(vp: { startMs: number; endMs: number }) => {
+			const start = (vp.startMs - domainStartMs) / domainDuration
+			const end = (vp.endMs - domainStartMs) / domainDuration
+			return { start: Math.max(0, Math.min(1, start)), end: Math.max(0, Math.min(1, end)) }
 		},
-		[viewport, vpLeftPercent, vpWidthPercent, pctFromEvent],
+		[domainStartMs, domainDuration],
 	)
 
 	React.useEffect(() => {
-		const handleMouseMove = (e: MouseEvent) => {
+		const paint = (vp: { startMs: number; endMs: number }) => {
+			const { start, end } = fracs(vp)
+			const leftPct = start * 100
+			// Keep a hairline visible at extreme zoom, but never let it push past the right edge.
+			const widthPct = Math.min(Math.max((end - start) * 100, 0.5), 100 - leftPct)
+			const rect = rectRef.current
+			if (rect) {
+				rect.style.left = `${leftPct}%`
+				rect.style.width = `${widthPct}%`
+			}
+			if (dimLeftRef.current) dimLeftRef.current.style.width = `${leftPct}%`
+			if (dimRightRef.current) dimRightRef.current.style.left = `${leftPct + widthPct}%`
+		}
+		return controller.subscribe(paint)
+	}, [controller, fracs])
+
+	const setCursor = React.useCallback((cursor: string) => {
+		if (containerRef.current) containerRef.current.style.cursor = cursor
+	}, [])
+
+	const handlePointerDown = React.useCallback(
+		(e: React.PointerEvent) => {
+			if (e.button !== 0) return
+			const el = containerRef.current
+			if (!el) return
+			const rect = el.getBoundingClientRect()
+			if (rect.width === 0) return
+			controller.cancelAnimation()
+
+			const vp = controller.get()
+			const { start, end } = fracs(vp)
+			const x = (e.clientX - rect.left) / rect.width
+			// Hit-test in px, not percent. A percent threshold that looks right at a 50% viewport
+			// swallows the whole rect at 3%, which is exactly when you most want to resize it.
+			const handleFrac = HANDLE_HIT_AREA / rect.width
+
+			let type: DragType
+			if (Math.abs(x - start) <= handleFrac) type = "resize-left"
+			else if (Math.abs(x - end) <= handleFrac) type = "resize-right"
+			else if (x > start && x < end) type = "pan"
+			else type = "reframe"
+
+			dragRef.current = {
+				type,
+				startX: e.clientX,
+				moved: false,
+				// Seed from the *clamped* window, matching where the handle is actually drawn.
+				// Seeding from the raw window makes a handle grabbed at a strip edge sit up to
+				// 5% of the trace away from the value it's dragging, so the first slice of the
+				// drag reads as a dead zone. Identical to `vp` for any mid-trace window.
+				startStartMs: domainStartMs + start * domainDuration,
+				startEndMs: domainStartMs + end * domainDuration,
+				rect,
+			}
+			el.setPointerCapture(e.pointerId)
+			setCursor(type === "pan" ? "grabbing" : type === "reframe" ? "crosshair" : "col-resize")
+			if (guideRef.current) guideRef.current.style.display = "none"
+			e.preventDefault()
+		},
+		[controller, fracs, setCursor, domainStartMs, domainDuration],
+	)
+
+	const handlePointerMove = React.useCallback(
+		(e: React.PointerEvent) => {
 			const d = dragRef.current
-			if (!d || !containerRef.current) return
-			const rect = containerRef.current.getBoundingClientRect()
-			const deltaPercent = ((e.clientX - d.startX) / rect.width) * 100
-			const deltaMs = (deltaPercent / 100) * traceDuration
-			const sv = d.startViewport
+			const el = containerRef.current
+			if (!el) return
+
+			if (!d) {
+				// Idle: hover guide (line + readout), written imperatively — no re-render per pixel.
+				const rect = el.getBoundingClientRect()
+				if (rect.width === 0) return
+				const x = e.clientX - rect.left
+				const frac = x / rect.width
+				const vp = controller.get()
+				const { start, end } = fracs(vp)
+				const handleFrac = HANDLE_HIT_AREA / rect.width
+				setCursor(
+					Math.abs(frac - start) <= handleFrac || Math.abs(frac - end) <= handleFrac
+						? "col-resize"
+						: frac > start && frac < end
+							? "grab"
+							: "crosshair",
+				)
+				const node = guideRef.current
+				if (node) {
+					node.style.display = "block"
+					node.style.transform = `translateX(${x}px)`
+					const label = node.firstElementChild as HTMLElement | null
+					if (label) {
+						// Readout stays relative to the *trace* start, matching the ruler's "+Nms" —
+						// the strip's own origin sits 5% before it and would report negative time.
+						const offsetMs = domainStartMs + frac * domainDuration - traceStartMs
+						label.textContent = `+${formatDuration(offsetMs)}`
+						label.style.transform =
+							x > rect.width - 70 ? "translateX(calc(-100% - 5px))" : "translateX(5px)"
+					}
+				}
+				return
+			}
+
+			const deltaMs = ((e.clientX - d.startX) / d.rect.width) * domainDuration
+			// The smallest window the minimap will hand over. Matched to what clampViewport will
+			// accept, so a resize handle can't be dragged into a range the clamp then widens —
+			// which reads as the handle fighting the cursor.
+			const minRangeMs = Math.max(domainDuration * MIN_RANGE_FRAC, 0)
 
 			switch (d.type) {
 				case "pan":
-					onViewportChange({
-						startMs: sv.startMs + deltaMs,
-						endMs: sv.endMs + deltaMs,
-					})
+					controller.set({ startMs: d.startStartMs + deltaMs, endMs: d.startEndMs + deltaMs })
 					break
 				case "resize-left":
-					onViewportChange({
-						startMs: Math.min(sv.startMs + deltaMs, sv.endMs - traceDuration * 0.01),
-						endMs: sv.endMs,
+					controller.set({
+						startMs: Math.min(d.startStartMs + deltaMs, d.startEndMs - minRangeMs),
+						endMs: d.startEndMs,
 					})
 					break
 				case "resize-right":
-					onViewportChange({
-						startMs: sv.startMs,
-						endMs: Math.max(sv.endMs + deltaMs, sv.startMs + traceDuration * 0.01),
+					controller.set({
+						startMs: d.startStartMs,
+						endMs: Math.max(d.startEndMs + deltaMs, d.startStartMs + minRangeMs),
 					})
 					break
 				case "reframe": {
 					if (!d.moved && Math.abs(e.clientX - d.startX) <= REFRAME_THRESHOLD_PX) return
 					d.moved = true
-					const a = ((d.startX - rect.left) / rect.width) * 100
-					const b = ((e.clientX - rect.left) / rect.width) * 100
-					setReframePreview({ a, b })
+					// Clamped: a brush dragged off the end of the strip would otherwise paint a
+					// preview wider than its container and push the page sideways.
+					const a = pctInStrip(d.startX, d.rect)
+					const b = pctInStrip(e.clientX, d.rect)
+					const brush = brushRef.current
+					if (brush) {
+						brush.style.display = "block"
+						brush.style.left = `${Math.min(a, b)}%`
+						brush.style.width = `${Math.abs(b - a)}%`
+					}
 					break
 				}
 			}
-		}
-
-		const handleMouseUp = (e: MouseEvent) => {
-			const d = dragRef.current
-			dragRef.current = null
-			if (!d) return
-			if (d.type !== "reframe") return
-			setReframePreview(null)
-			const rect = containerRef.current?.getBoundingClientRect()
-			if (!rect || rect.width === 0) return
-			if (d.moved) {
-				// Commit the previewed range (either drag direction).
-				const aPct = ((d.startX - rect.left) / rect.width) * 100
-				const bPct = ((e.clientX - rect.left) / rect.width) * 100
-				const lo = Math.min(aPct, bPct)
-				const hi = Math.max(aPct, bPct)
-				onViewportChange({
-					startMs: traceStartMs + (lo / 100) * traceDuration,
-					endMs: traceStartMs + (hi / 100) * traceDuration,
-				})
-			} else {
-				// Plain click: jump viewport center to the clicked position.
-				const clickPercent = ((e.clientX - rect.left) / rect.width) * 100
-				const clickMs = traceStartMs + (clickPercent / 100) * traceDuration
-				const vpDuration = d.startViewport.endMs - d.startViewport.startMs
-				onViewportChange({
-					startMs: clickMs - vpDuration / 2,
-					endMs: clickMs + vpDuration / 2,
-				})
-			}
-		}
-
-		window.addEventListener("mousemove", handleMouseMove)
-		window.addEventListener("mouseup", handleMouseUp)
-		return () => {
-			window.removeEventListener("mousemove", handleMouseMove)
-			window.removeEventListener("mouseup", handleMouseUp)
-		}
-	}, [traceDuration, traceStartMs, onViewportChange])
-
-	// Hover guide: vertical line + time readout, written imperatively (no re-render per pixel).
-	const handleHoverMove = React.useCallback(
-		(e: React.MouseEvent) => {
-			const node = guideRef.current
-			const rect = containerRef.current?.getBoundingClientRect()
-			if (!node || !rect || rect.width === 0) return
-			if (dragRef.current) {
-				node.style.display = "none"
-				return
-			}
-			const x = e.clientX - rect.left
-			node.style.display = "block"
-			node.style.transform = `translateX(${x}px)`
-			const label = node.firstElementChild as HTMLElement | null
-			if (label) {
-				label.textContent = `+${formatDuration((x / rect.width) * traceDuration)}`
-				label.style.transform =
-					x > rect.width - 70 ? "translateX(calc(-100% - 5px))" : "translateX(5px)"
-			}
 		},
-		[traceDuration],
+		[controller, fracs, setCursor, domainStartMs, domainDuration, traceStartMs],
 	)
 
-	const handleHoverLeave = React.useCallback(() => {
-		if (guideRef.current) guideRef.current.style.display = "none"
+	const handlePointerUp = React.useCallback(
+		(e: React.PointerEvent) => {
+			const d = dragRef.current
+			dragRef.current = null
+			containerRef.current?.releasePointerCapture?.(e.pointerId)
+			setCursor("crosshair")
+			if (brushRef.current) brushRef.current.style.display = "none"
+			if (!d || d.type !== "reframe") return
+
+			const frac = (clientX: number) => (clientX - d.rect.left) / d.rect.width
+			if (d.moved) {
+				// Commit the brushed range (either drag direction).
+				const a = frac(d.startX)
+				const b = frac(e.clientX)
+				controller.zoomToRange(
+					domainStartMs + Math.min(a, b) * domainDuration,
+					domainStartMs + Math.max(a, b) * domainDuration,
+				)
+			} else {
+				// Plain click: jump the viewport centre to the clicked position, same width.
+				const clickMs = domainStartMs + frac(e.clientX) * domainDuration
+				const width = d.startEndMs - d.startStartMs
+				controller.set({ startMs: clickMs - width / 2, endMs: clickMs + width / 2 })
+			}
+		},
+		[controller, setCursor, domainStartMs, domainDuration],
+	)
+
+	const handlePointerLeave = React.useCallback(() => {
+		if (!dragRef.current && guideRef.current) guideRef.current.style.display = "none"
 	}, [])
-
-	const handleDoubleClick = React.useCallback(() => {
-		onViewportChange({ startMs: traceStartMs, endMs: traceEndMs })
-	}, [onViewportChange, traceStartMs, traceEndMs])
-
-	const previewLo = reframePreview ? Math.min(reframePreview.a, reframePreview.b) : null
-	const previewHi = reframePreview ? Math.max(reframePreview.a, reframePreview.b) : null
 
 	return (
 		<div
 			ref={containerRef}
-			className="relative border-b border-border bg-muted/10 cursor-crosshair select-none"
+			// overflow-hidden: the strip is the trace, and nothing positioned against it — rect,
+			// masks, brush, hover guide — has any business painting outside. Without it an
+			// out-of-range child widens the flex row and the whole page gains a scrollbar.
+			className="relative overflow-hidden border-b border-border bg-muted/10 cursor-crosshair select-none touch-none"
 			style={{ height: MINIMAP_HEIGHT }}
-			onMouseDown={handleMouseDown}
-			onMouseMove={handleHoverMove}
-			onMouseLeave={handleHoverLeave}
-			onDoubleClick={handleDoubleClick}
-			title="Drag to select a range · click to jump · double-click to fit"
+			onPointerDown={handlePointerDown}
+			onPointerMove={handlePointerMove}
+			onPointerUp={handlePointerUp}
+			onPointerCancel={handlePointerUp}
+			onPointerLeave={handlePointerLeave}
+			onDoubleClick={() => controller.fit()}
+			title="Drag to select a range · click to jump · drag the edges to resize · double-click to fit"
 		>
-			{/* Minimap bars */}
-			<div className="absolute inset-x-0 inset-y-0 px-0" style={{ paddingTop: 2, paddingBottom: 2 }}>
-				{spans.map((s) => (
-					<div
-						key={s.spanId}
-						className="absolute"
-						style={{
-							top: Math.min(2 + s.depth * pitch, MINIMAP_HEIGHT - rowH - 2),
-							left: `${s.leftPercent}%`,
-							width: `${Math.max(s.widthPercent, 0.2)}%`,
-							height: rowH,
-							backgroundColor: s.bgColor,
-						}}
-					/>
-				))}
-			</div>
-
-			{/* Dimmed areas outside viewport */}
-			<div
-				className="absolute inset-y-0 bg-background/60"
-				style={{ left: 0, width: `${Math.max(0, vpLeftPercent)}%` }}
-			/>
-			<div
-				className="absolute inset-y-0 bg-background/60"
-				style={{ left: `${vpLeftPercent + vpWidthPercent}%`, right: 0 }}
+			<MinimapBars
+				rootSpans={rootSpans}
+				domainStartMs={domainStartMs}
+				domainDurationMs={domainDuration}
+				colorBy={colorBy}
 			/>
 
-			{/* Reframe preview (drag-in-progress) */}
-			{previewLo !== null && previewHi !== null && (
-				<div
-					className="absolute inset-y-0 border-x border-primary/70 bg-primary/15 pointer-events-none"
-					style={{ left: `${previewLo}%`, width: `${previewHi - previewLo}%` }}
-				/>
-			)}
+			{/* Dimmed areas outside the viewport */}
+			<div
+				ref={dimLeftRef}
+				className="pointer-events-none absolute inset-y-0 left-0 bg-background/60"
+				style={{ width: 0 }}
+			/>
+			<div
+				ref={dimRightRef}
+				className="pointer-events-none absolute inset-y-0 right-0 bg-background/60"
+				style={{ left: "100%" }}
+			/>
+
+			{/* Brush preview while reframing */}
+			<div
+				ref={brushRef}
+				className="pointer-events-none absolute inset-y-0 border-x border-primary/70 bg-primary/15"
+				style={{ display: "none" }}
+			/>
 
 			{/* Hover guide: line + time readout (imperative) */}
 			<div
@@ -332,18 +395,13 @@ export function TraceTimelineMinimap({
 				<span className="absolute top-0 whitespace-nowrap bg-background/90 px-1 font-mono text-[9px] leading-3 text-muted-foreground" />
 			</div>
 
-			{/* Viewport indicator */}
+			{/* Viewport rect. Pointer-transparent: hit-testing happens against the container so the
+			    8px edge zones straddle the border instead of being split by it. */}
 			<div
-				className="absolute inset-y-0 border-x-2 border-primary/60 cursor-grab active:cursor-grabbing"
-				style={{
-					left: `${vpLeftPercent}%`,
-					width: `${Math.max(vpWidthPercent, 1)}%`,
-				}}
-			>
-				{/* Resize affordances — hit detection lives in handleMouseDown; these only set the cursor. */}
-				<div className="absolute inset-y-0 -left-1 w-2 cursor-ew-resize" />
-				<div className="absolute inset-y-0 -right-1 w-2 cursor-ew-resize" />
-			</div>
+				ref={rectRef}
+				className="pointer-events-none absolute inset-y-0 border-x-2 border-primary/60"
+				style={{ left: 0, width: "100%" }}
+			/>
 		</div>
 	)
 }

--- a/packages/ui/src/components/traces/trace-timeline-row.tsx
+++ b/packages/ui/src/components/traces/trace-timeline-row.tsx
@@ -5,17 +5,13 @@ import { cn } from "../../lib/utils"
 import { getServiceColor } from "../../lib/colors"
 import { formatDuration } from "../../lib/format"
 import { getCacheInfo } from "../../lib/cache"
-import type { TimelineBar, ViewportState } from "./trace-timeline-types"
+import type { TimelineBar } from "./trace-timeline-types"
 import { DEPTH_INDENT, ROW_HEIGHT } from "./trace-timeline-types"
 
 interface TraceTimelineRowProps {
 	bar: TimelineBar
 	/** y offset from the virtualizer (px). */
 	top: number
-	sidebarWidth: number
-	/** Measured px width of the timeline column — decides which in-bar labels fit. */
-	timelineWidthPx: number
-	viewport: ViewportState
 	selected: boolean
 	focused: boolean
 	hovered: boolean
@@ -24,17 +20,30 @@ interface TraceTimelineRowProps {
 	/** Search active and this row matches → ring it. */
 	matched: boolean
 	onSelect: (spanId: string) => void
-	onToggleCollapse: (spanId: string) => void
+	/** `wholeSubtree` comes from an Alt/Option-click. */
+	onToggleCollapse: (spanId: string, wholeSubtree: boolean) => void
 	onZoomSpan: (spanId: string) => void
 	onHover: (spanId: string | null, pos: { x: number; y: number } | null) => void
 }
 
+/**
+ * Position of the bar inside the timeline cell, entirely in CSS.
+ *
+ * `--b0`/`--b1` are this span's start/end in trace-relative ms and never change with the
+ * viewport; `--vp0`/`--vpk` come from the nearest time surface (see `writeTimeSurface`) and are
+ * rewritten by the viewport controller on every gesture frame. So a pan or zoom repositions
+ * every bar through the style engine, without React rendering anything.
+ *
+ * `clamp()` replaces what used to be a JS `Math.max(left, -50)`: zoomed in hard, a trace-long
+ * span would otherwise resolve to a multi-million-percent box. The cell clips at its own edges,
+ * so bounding the rect is visually identical and keeps the layout box sane.
+ */
+const BAR_LEFT = "clamp(-50%, calc((var(--b0) - var(--vp0)) * var(--vpk) * 1%), 150%)"
+const BAR_RIGHT = "calc(100% - clamp(-50%, calc((var(--b1) - var(--vp0)) * var(--vpk) * 1%), 150%))"
+
 function TraceTimelineRowImpl({
 	bar,
 	top,
-	sidebarWidth,
-	timelineWidthPx,
-	viewport,
 	selected,
 	focused,
 	hovered,
@@ -47,6 +56,7 @@ function TraceTimelineRowImpl({
 }: TraceTimelineRowProps) {
 	const spanId = bar.span.spanId
 	const cacheInfo = getCacheInfo(bar.span.spanAttributes)
+	const durationLabel = formatDuration(bar.span.durationMs)
 
 	return (
 		<div
@@ -66,10 +76,11 @@ function TraceTimelineRowImpl({
 			onMouseMove={(e) => onHover(spanId, { x: e.clientX, y: e.clientY })}
 			onMouseLeave={() => onHover(null, null)}
 		>
-			{/* Sidebar cell */}
+			{/* Label cell. Sticky so it survives any horizontal scroll of the timeline column,
+			    and sized from `--sidebar-w` so a resize drag doesn't re-render a single row. */}
 			<div
-				className="relative flex items-center gap-1 shrink-0 border-r border-border pr-2 text-[11px]"
-				style={{ width: sidebarWidth, paddingLeft: bar.depth * DEPTH_INDENT + 4 }}
+				className="sticky left-0 z-10 relative flex items-center gap-1 shrink-0 border-r border-border bg-inherit pr-2 text-[11px]"
+				style={{ width: "var(--sidebar-w)", paddingLeft: bar.depth * DEPTH_INDENT + 4 }}
 			>
 				{/* Ancestor indent guides */}
 				{bar.depth > 0 &&
@@ -90,10 +101,11 @@ function TraceTimelineRowImpl({
 						type="button"
 						tabIndex={-1}
 						aria-label={bar.isCollapsed ? "Expand" : "Collapse"}
+						title={`${bar.isCollapsed ? "Expand" : "Collapse"} — ⌥ for the whole subtree`}
 						className="flex items-center justify-center size-4 shrink-0 text-muted-foreground hover:text-foreground"
 						onClick={(e) => {
 							e.stopPropagation()
-							onToggleCollapse(spanId)
+							onToggleCollapse(spanId, e.altKey)
 						}}
 					>
 						{bar.isCollapsed ? <ChevronRightIcon size={12} /> : <ChevronDownIcon size={12} />}
@@ -130,119 +142,78 @@ function TraceTimelineRowImpl({
 					<span className="text-[9px] text-muted-foreground/70 shrink-0">+{bar.childCount}</span>
 				)}
 				<span className="ml-auto shrink-0 pl-1 font-mono text-[10px] tabular-nums text-muted-foreground">
-					{formatDuration(bar.span.durationMs)}
+					{durationLabel}
 				</span>
 			</div>
 
 			{/* Timeline cell */}
-			<div className="relative flex-1 min-w-0 overflow-hidden">
-				<SpanBar bar={bar} viewport={viewport} timelineWidthPx={timelineWidthPx} />
-			</div>
-		</div>
-	)
-}
-
-function SpanBar({
-	bar,
-	viewport,
-	timelineWidthPx,
-}: {
-	bar: TimelineBar
-	viewport: ViewportState
-	timelineWidthPx: number
-}) {
-	const visible = viewport.endMs - viewport.startMs
-	if (visible <= 0) return null
-	const leftPct = ((bar.startMs - viewport.startMs) / visible) * 100
-	const rawWidthPct = (Math.max(bar.endMs - bar.startMs, 0) / visible) * 100
-	// Off-screen → don't render (overflow-hidden also clips, this skips the node entirely).
-	if (leftPct > 100 || leftPct + rawWidthPct < 0) return null
-
-	// Bar continues beyond the visible window? Show edge chevrons (Jaeger's clipping-left/right).
-	const clipLeft = leftPct < 0
-	const clipRight = leftPct + rawWidthPct > 100
-
-	// Clamp the rendered rect to a bounded range around the visible column. When zoomed in
-	// hard, a span spanning the whole trace would otherwise resolve to a multi-million-percent
-	// (gigapixel) node; overflow-hidden clips anything past the column, so this is visually
-	// identical while keeping the DOM node a sane size.
-	const left = Math.max(leftPct, -50)
-	const right = Math.min(leftPct + rawWidthPct, 150)
-	const widthPct = Math.max(0, right - left)
-
-	const barPx = (widthPct / 100) * timelineWidthPx
-	// Label room is what's actually on screen, not the bar's full width — a bar whose
-	// tail barely enters the view must not try to fit its name inside.
-	const visiblePx = ((Math.min(right, 100) - Math.max(left, 0)) / 100) * timelineWidthPx
-	const showName = visiblePx > 56
-	const showDuration = visiblePx > 140
-	// A clipped-left bar keeps its label pinned to the visible edge (Sentry's sticky label).
-	// px, not % — CSS percentage padding resolves against the parent cell, not the bar.
-	// Capped so at least ~60px of label room remains inside the bar.
-	const offscreenLeftPx = clipLeft ? ((0 - left) / 100) * timelineWidthPx : 0
-	const labelIndentPx = Math.min(offscreenLeftPx, Math.max(0, barPx - 60))
-
-	// Too small for an inside name → put it beside the bar, on the side with more room
-	// (Jaeger's hintSide heuristic). Rendered as a sibling so it isn't clipped by the bar.
-	const outsideLabelSide: "right" | "left" | null = showName
-		? null
-		: right < 70
-			? "right"
-			: left > 30
-				? "left"
-				: null
-
-	return (
-		<>
-			<div
-				className="absolute top-1/2 -translate-y-1/2 flex items-center overflow-hidden whitespace-nowrap font-mono text-[11px]"
-				style={{
-					left: `${left}%`,
-					width: `max(2px, ${widthPct}%)`,
-					height: ROW_HEIGHT - 8,
-					backgroundColor: bar.fill,
-					borderLeft: `3px solid ${bar.borderColor}`,
-					paddingLeft: labelIndentPx > 0 ? labelIndentPx : undefined,
-				}}
-			>
-				{showName && <span className="truncate px-1.5 text-foreground/90">{bar.span.spanName}</span>}
-				{showDuration && (
-					<span className="ml-auto shrink-0 px-1.5 text-foreground/50 tabular-nums">
-						{formatDuration(bar.span.durationMs)}
-					</span>
-				)}
-			</div>
-			{outsideLabelSide && (
-				<span
-					className="pointer-events-none absolute top-1/2 -translate-y-1/2 whitespace-nowrap font-mono text-[10px] text-muted-foreground/80"
-					style={
-						outsideLabelSide === "right"
-							? { left: `${right}%`, marginLeft: 5 }
-							: { left: `${left}%`, transform: "translate(calc(-100% - 5px), -50%)" }
-					}
+			<div className="group/cell relative flex-1 min-w-0 overflow-hidden">
+				<div
+					data-span-bar=""
+					className={cn(
+						"@container/bar absolute top-1/2 -translate-y-1/2 flex items-center",
+						// Not overflow-hidden: the outside label is a child and has to escape the box.
+						"whitespace-nowrap font-mono text-[11px]",
+					)}
+					style={{
+						left: BAR_LEFT,
+						right: BAR_RIGHT,
+						minWidth: 2,
+						height: ROW_HEIGHT - 8,
+						backgroundColor: bar.fill,
+						borderLeft: `3px solid ${bar.borderColor}`,
+						// Read back by the row-decoration pass; also what the CSS above interpolates.
+						["--b0" as string]: bar.offsetStartMs,
+						["--b1" as string]: bar.offsetEndMs,
+					}}
 				>
-					{bar.span.spanName} · {formatDuration(bar.span.durationMs)}
-				</span>
-			)}
-			{clipLeft && (
+					{/* Inside labels. Container queries replace what used to be a JS px measurement
+					    per bar per frame: the name appears once the bar itself is ≥56px wide, the
+					    duration at ≥140px. The style engine re-evaluates them on zoom for free. */}
+					<div className="flex min-w-0 flex-1 items-center overflow-hidden">
+						<span className="hidden truncate px-1.5 text-foreground/90 @min-[56px]/bar:inline">
+							{bar.span.spanName}
+						</span>
+						<span className="ml-auto hidden shrink-0 px-1.5 text-foreground/50 tabular-nums @min-[140px]/bar:inline">
+							{durationLabel}
+						</span>
+					</div>
+
+					{/* Outside label for bars too narrow to hold one. Sits on the right by default;
+					    the decoration pass flips it left near the right edge of the column. */}
+					<span
+						data-outside-label=""
+						className={cn(
+							"pointer-events-none absolute top-1/2 hidden -translate-y-1/2 whitespace-nowrap",
+							"font-mono text-[10px] text-muted-foreground/80 @max-[56px]/bar:block",
+							"left-full ml-[5px] data-[side=left]:left-auto data-[side=left]:right-full",
+							"data-[side=left]:ml-0 data-[side=left]:mr-[5px]",
+						)}
+					>
+						{bar.span.spanName} · {durationLabel}
+					</span>
+				</div>
+
+				{/* Clipping chevrons, pinned to the cell edges (Jaeger). Toggled by the decoration
+				    pass — CSS can't tell whether the clamp above actually bit. */}
 				<span
-					className="pointer-events-none absolute left-0.5 top-1/2 -translate-y-1/2 font-mono text-[9px] leading-none"
+					data-clip-left=""
+					className="pointer-events-none absolute left-0.5 top-1/2 hidden -translate-y-1/2 font-mono text-[9px] leading-none"
 					style={{ color: bar.borderColor }}
 					aria-hidden
 				>
 					‹
 				</span>
-			)}
-			{clipRight && (
 				<span
-					className="pointer-events-none absolute right-0.5 top-1/2 -translate-y-1/2 font-mono text-[9px] leading-none"
+					data-clip-right=""
+					className="pointer-events-none absolute right-0.5 top-1/2 hidden -translate-y-1/2 font-mono text-[9px] leading-none"
 					style={{ color: bar.borderColor }}
 					aria-hidden
 				>
 					›
 				</span>
-			)}
-		</>
+			</div>
+		</div>
 	)
 }
 

--- a/packages/ui/src/components/traces/trace-timeline-time-axis.tsx
+++ b/packages/ui/src/components/traces/trace-timeline-time-axis.tsx
@@ -1,39 +1,91 @@
-import { formatDuration } from "../../lib/format"
-import type { ViewportState } from "./trace-timeline-types"
+import * as React from "react"
+
+import { formatDurationAtStep } from "../../lib/format"
 import { TIME_AXIS_HEIGHT } from "./trace-timeline-types"
+import { computeTimeAxisTicks } from "./use-trace-timeline"
+import type { ViewportController } from "./use-viewport-controller"
 
 interface TraceTimelineTimeAxisProps {
-	viewport: ViewportState
-	ticks: number[]
-	traceStartMs: number
+	controller: ViewportController
+	/** Measured width of the timeline column (px) — the tick budget is derived from it. */
+	columnWidthPx: number
+	/**
+	 * Full-height grid element. Ticks are mirrored into it as hairlines behind the rows, from
+	 * the same spacing computation, so a label can never drift from its gridline.
+	 */
+	gridRef?: React.RefObject<HTMLElement | null>
 }
 
-export function TraceTimelineTimeAxis({ viewport, ticks, traceStartMs }: TraceTimelineTimeAxisProps) {
-	const visibleDuration = viewport.endMs - viewport.startMs
+/**
+ * Time ruler, painted imperatively.
+ *
+ * Ticks are `document.createElement` nodes mutated in place rather than React children: they
+ * change on every zoom frame, and reconciling ~20 nodes per frame is exactly the work the
+ * viewport controller exists to avoid. The DOM is diffed by count — append or remove to reach
+ * the target, then rewrite text and position on the survivors.
+ */
+export function TraceTimelineTimeAxis({ controller, columnWidthPx, gridRef }: TraceTimelineTimeAxisProps) {
+	const axisRef = React.useRef<HTMLDivElement>(null)
+	const widthRef = React.useRef(columnWidthPx)
+	widthRef.current = columnWidthPx
+
+	React.useEffect(() => {
+		const paint = (vp: { startMs: number; endMs: number }) => {
+			const axis = axisRef.current
+			if (!axis) return
+			const width = widthRef.current
+			const { ticks, intervalMs } = computeTimeAxisTicks(vp, controller.traceStartMs, width)
+			const visible = vp.endMs - vp.startMs
+			const vp0 = vp.startMs - controller.traceStartMs
+
+			syncChildren(axis, ticks.length, () => {
+				const el = document.createElement("span")
+				el.className =
+					"pointer-events-none absolute bottom-1 -translate-x-1/2 whitespace-nowrap font-mono text-[10px] font-medium text-muted-foreground"
+				return el
+			})
+			const grid = gridRef?.current ?? null
+			if (grid) {
+				syncChildren(grid, ticks.length, () => {
+					const el = document.createElement("span")
+					el.className = "pointer-events-none absolute inset-y-0 w-px bg-border/40"
+					return el
+				})
+			}
+
+			for (let i = 0; i < ticks.length; i++) {
+				const offset = ticks[i]
+				const leftPct = ((offset - vp0) / visible) * 100
+				const label = axis.children[i] as HTMLElement
+				label.style.left = `${leftPct}%`
+				const text = formatDurationAtStep(offset, intervalMs)
+				// textContent writes are not free at 60fps; most frames only move the ticks.
+				if (label.textContent !== text) label.textContent = text
+				const line = grid?.children[i] as HTMLElement | undefined
+				if (line) line.style.left = `${leftPct}%`
+			}
+		}
+		return controller.subscribe(paint)
+	}, [controller, gridRef])
+
+	// A panel resize changes the tick budget without moving the viewport, so nothing would
+	// otherwise repaint. Re-commit the current window to drive one pass.
+	React.useEffect(() => {
+		controller.set(controller.get())
+	}, [controller, columnWidthPx])
 
 	return (
 		<div
-			className="relative flex items-end border-b border-border bg-background px-0"
+			ref={axisRef}
+			className="relative h-full w-full"
 			style={{ height: TIME_AXIS_HEIGHT }}
-		>
-			{ticks.map((offsetMs) => {
-				const absMs = traceStartMs + offsetMs
-				const leftPercent = ((absMs - viewport.startMs) / visibleDuration) * 100
-
-				if (leftPercent < -5 || leftPercent > 105) return null
-
-				return (
-					<div
-						key={offsetMs}
-						className="absolute flex flex-col items-center pointer-events-none"
-						style={{ left: `${leftPercent}%`, bottom: 4 }}
-					>
-						<span className="text-[10px] font-mono font-medium text-muted-foreground whitespace-nowrap -translate-x-1/2">
-							{formatDuration(offsetMs)}
-						</span>
-					</div>
-				)
-			})}
-		</div>
+			aria-hidden
+		/>
 	)
+}
+
+/** Grow or shrink `parent` to exactly `count` children, creating new ones with `make`. */
+function syncChildren(parent: HTMLElement, count: number, make: () => HTMLElement): void {
+	while (parent.children.length > count) parent.removeChild(parent.lastChild as ChildNode)
+	while (parent.children.length < count) parent.appendChild(make())
 }

--- a/packages/ui/src/components/traces/trace-timeline-types.ts
+++ b/packages/ui/src/components/traces/trace-timeline-types.ts
@@ -5,6 +5,10 @@ export interface TimelineBar {
 	row: number
 	startMs: number
 	endMs: number
+	/** Start offset from the trace start (ms) — the `--b0` custom property on the bar. */
+	offsetStartMs: number
+	/** End offset from the trace start (ms) — the `--b1` custom property on the bar. */
+	offsetEndMs: number
 	depth: number
 	parentSpanId: string
 	isError: boolean
@@ -20,8 +24,14 @@ export interface ViewportState {
 	endMs: number
 }
 
+/**
+ * React state for the timeline.
+ *
+ * The viewport is deliberately absent: it lives in `ViewportController`'s ref and reaches the
+ * DOM through CSS custom properties, so pan and zoom cost no re-render. Only things that
+ * genuinely change what is *rendered* belong here.
+ */
 export interface TimelineState {
-	viewport: ViewportState
 	focusedIndex: number | null
 	searchQuery: string
 	expandedSpanIds: Set<string>
@@ -29,28 +39,15 @@ export interface TimelineState {
 
 export type TimelineAction =
 	| { type: "RESET"; state: TimelineState }
-	| { type: "SET_VIEWPORT"; viewport: ViewportState; traceStartMs: number; traceEndMs: number }
-	| { type: "ZOOM"; centerMs: number; factor: number; traceStartMs: number; traceEndMs: number }
-	| { type: "PAN"; deltaMs: number; traceStartMs: number; traceEndMs: number }
-	| { type: "ZOOM_TO_SPAN"; startMs: number; endMs: number; traceStartMs: number; traceEndMs: number }
-	| { type: "ZOOM_TO_RANGE"; startMs: number; endMs: number; traceStartMs: number; traceEndMs: number }
-	| { type: "ZOOM_TO_FIT"; traceStartMs: number; traceEndMs: number }
 	| { type: "SET_FOCUSED_INDEX"; index: number | null }
 	| { type: "FOCUS_NEXT"; maxIndex: number }
 	| { type: "FOCUS_PREV" }
 	| { type: "SET_SEARCH"; query: string }
-	| { type: "TOGGLE_COLLAPSE"; spanId: string }
+	/** Toggle one span; with `descendantIds` the whole subtree follows the node's new state. */
+	| { type: "TOGGLE_COLLAPSE"; spanId: string; descendantIds?: readonly string[] }
 	| { type: "EXPAND_ALL"; spanIds: string[] }
 	| { type: "COLLAPSE_ALL" }
-
-export interface BarRect {
-	spanId: string
-	row: number
-	x: number
-	y: number
-	w: number
-	h: number
-}
+	| { type: "SET_EXPANDED"; spanIds: Set<string> }
 
 export const ROW_HEIGHT = 28
 export const ROW_GAP = 1
@@ -68,3 +65,19 @@ export const SIDEBAR_WIDTH_DEFAULT = 320
 export const SIDEBAR_WIDTH_MIN = 180
 export const SIDEBAR_WIDTH_MAX = 640
 export const SIDEBAR_WIDTH_STORAGE_KEY = "traceTimelineSidebarWidth"
+
+/**
+ * Narrowest label a tick can carry ("1.23 s" plus headroom). The ruler budgets ticks against
+ * the measured column width rather than a fixed count, so labels never collide on a narrow
+ * panel and never thin out to two on a wide one.
+ */
+export const MIN_TICK_PX = 56
+
+/** Grab radius (px) on each edge of the minimap's viewport rect. */
+export const HANDLE_HIT_AREA = 8
+/**
+ * Narrowest window the minimap will produce, as a fraction of the trace. Paired with the
+ * chart's own `MIN_VISIBLE_ABS_MS` floor: a resize that undershoots this would be silently
+ * widened by `clampViewport`, which reads as the handle fighting the cursor.
+ */
+export const MIN_RANGE_FRAC = 0.002

--- a/packages/ui/src/components/traces/trace-timeline.tsx
+++ b/packages/ui/src/components/traces/trace-timeline.tsx
@@ -2,15 +2,21 @@ import * as React from "react"
 import * as ReactDOM from "react-dom"
 import { useVirtualizer } from "@tanstack/react-virtual"
 
-import { ChevronExpandYIcon } from "../icons"
+import { ChevronExpandYIcon, ChevronDownIcon, ChevronRightIcon } from "../icons"
 import { Button } from "../ui/button"
 import { getServiceColor } from "../../lib/colors"
 import { isEditableTarget } from "../../lib/keyboard"
 import { useContainerSize } from "../../hooks/use-container-size"
 import { useTraceView } from "./trace-view-context"
-import { clampViewport, useTraceTimeline } from "./use-trace-timeline"
-import type { ViewportState } from "./trace-timeline-types"
-import { collectAllCollapsibleIds } from "./auto-collapse"
+import { useTraceTimeline } from "./use-trace-timeline"
+import {
+	collectAllCollapsibleIds,
+	collectDescendantParentIds,
+	computeCollapseOneLevel,
+	computeExpandOneLevel,
+} from "./auto-collapse"
+import { useViewportController } from "./use-viewport-controller"
+import { useRowDecorations } from "./use-row-decorations"
 import { useTimelineInteractions } from "./use-timeline-interactions"
 import { TraceTimelineSearch } from "./trace-timeline-search"
 import { TraceTimelineMinimap } from "./trace-timeline-minimap"
@@ -50,6 +56,7 @@ export function TraceTimeline() {
 	} = useTraceView()
 	const containerRef = React.useRef<HTMLDivElement>(null)
 	const scrollRef = React.useRef<HTMLDivElement>(null)
+	const gridRef = React.useRef<HTMLDivElement>(null)
 	const searchInputRef = React.useRef<HTMLInputElement>(null)
 	const [hoveredSpanId, setHoveredSpanId] = React.useState<string | null>(null)
 	const [sidebarWidth, setSidebarWidth] = React.useState<number>(() => readSidebarWidth())
@@ -78,11 +85,12 @@ export function TraceTimeline() {
 	const {
 		bars,
 		barIndexBySpanId,
+		parentIdsByLevel,
 		state,
 		dispatch,
 		traceStartMs,
 		traceEndMs,
-		timeAxisTicks,
+		defaultViewport,
 		searchMatches,
 		isSearchActive,
 	} = useTraceTimeline({
@@ -93,40 +101,12 @@ export function TraceTimeline() {
 		keepVisibleSpanId: selectedSpanId,
 	})
 
+	// The visible window. Lives in a ref inside the controller and reaches the DOM as CSS custom
+	// properties, so pan and zoom never re-render this component or any row.
+	const controller = useViewportController({ traceStartMs, traceEndMs, initialViewport: defaultViewport })
+
 	const containerSize = useContainerSize(scrollRef)
 	const timelineWidthPx = Math.max(0, containerSize.width - sidebarWidth)
-
-	// DevTools-style viewport tween with Sentry-style eased zoom-to-span.
-	// Direct gestures (wheel, drags) stay instant; keyboard and programmatic zooms animate.
-	const viewportRef = React.useRef(state.viewport)
-	viewportRef.current = state.viewport
-	const viewportAnimRef = React.useRef(0)
-	const cancelViewportAnimation = React.useCallback(() => cancelAnimationFrame(viewportAnimRef.current), [])
-	const animateViewportTo = React.useCallback(
-		(target: ViewportState, durationMs = 160) => {
-			cancelAnimationFrame(viewportAnimRef.current)
-			const clamped = clampViewport(target, traceStartMs, traceEndMs)
-			const from = { ...viewportRef.current }
-			const t0 = performance.now()
-			const step = (now: number) => {
-				const t = Math.min(1, (now - t0) / durationMs)
-				const k = Math.sin((t * Math.PI) / 2) // easeOutSine
-				dispatch({
-					type: "SET_VIEWPORT",
-					viewport: {
-						startMs: from.startMs + (clamped.startMs - from.startMs) * k,
-						endMs: from.endMs + (clamped.endMs - from.endMs) * k,
-					},
-					traceStartMs,
-					traceEndMs,
-				})
-				if (t < 1) viewportAnimRef.current = requestAnimationFrame(step)
-			}
-			viewportAnimRef.current = requestAnimationFrame(step)
-		},
-		[dispatch, traceStartMs, traceEndMs],
-	)
-	React.useEffect(() => () => cancelAnimationFrame(viewportAnimRef.current), [])
 
 	const rowVirtualizer = useVirtualizer({
 		count: bars.length,
@@ -135,15 +115,10 @@ export function TraceTimeline() {
 		overscan: OVERSCAN,
 	})
 
-	const interactions = useTimelineInteractions({
-		bodyRef: scrollRef,
-		sidebarWidth,
-		viewport: state.viewport,
-		traceStartMs,
-		traceEndMs,
-		dispatch,
-		onGestureStart: cancelViewportAnimation,
-	})
+	const interactions = useTimelineInteractions({ bodyRef: scrollRef, sidebarWidth, controller })
+
+	const rowsContainerRef = React.useRef<HTMLDivElement>(null)
+	const repaintRowDecorations = useRowDecorations(controller, rowsContainerRef)
 
 	const handleSelect = React.useCallback(
 		(spanId: string) => {
@@ -158,16 +133,22 @@ export function TraceTimeline() {
 		(spanId: string) => {
 			const idx = barIndexBySpanId.get(spanId)
 			if (idx === undefined) return
-			const bar = bars[idx]
-			const padding = Math.max((bar.endMs - bar.startMs) * 0.1, 0.001)
-			animateViewportTo({ startMs: bar.startMs - padding, endMs: bar.endMs + padding }, 220)
+			controller.zoomToSpan(bars[idx].startMs, bars[idx].endMs)
 		},
-		[bars, barIndexBySpanId, animateViewportTo],
+		[bars, barIndexBySpanId, controller],
 	)
 
 	const handleToggleCollapse = React.useCallback(
-		(spanId: string) => dispatch({ type: "TOGGLE_COLLAPSE", spanId }),
-		[dispatch],
+		(spanId: string, wholeSubtree: boolean) => {
+			const idx = barIndexBySpanId.get(spanId)
+			const node = idx === undefined ? undefined : bars[idx].span
+			dispatch({
+				type: "TOGGLE_COLLAPSE",
+				spanId,
+				descendantIds: wholeSubtree && node ? collectDescendantParentIds(node) : undefined,
+			})
+		},
+		[bars, barIndexBySpanId, dispatch],
 	)
 
 	const isDragging = interactions.isDragging
@@ -193,23 +174,23 @@ export function TraceTimeline() {
 		if (hoveredSpanId) applyTooltipPos()
 	}, [hoveredSpanId, applyTooltipPos])
 
-	const handleMinimapViewportChange = React.useCallback(
-		(viewport: { startMs: number; endMs: number }) =>
-			dispatch({ type: "SET_VIEWPORT", viewport, traceStartMs, traceEndMs }),
-		[dispatch, traceStartMs, traceEndMs],
-	)
-
-	const handleZoomToFit = React.useCallback(() => {
-		const padding = (traceEndMs - traceStartMs) * 0.02
-		animateViewportTo({ startMs: traceStartMs - padding, endMs: traceEndMs + padding }, 220)
-	}, [animateViewportTo, traceStartMs, traceEndMs])
-
 	const handleExpandAll = React.useCallback(
 		() => dispatch({ type: "EXPAND_ALL", spanIds: [...collectAllCollapsibleIds(rootSpans)] }),
 		[dispatch, rootSpans],
 	)
 
 	const handleCollapseAll = React.useCallback(() => dispatch({ type: "COLLAPSE_ALL" }), [dispatch])
+
+	const expandedRef = React.useRef(state.expandedSpanIds)
+	expandedRef.current = state.expandedSpanIds
+	const handleExpandOneLevel = React.useCallback(() => {
+		const next = computeExpandOneLevel(expandedRef.current, parentIdsByLevel)
+		if (next !== expandedRef.current) dispatch({ type: "SET_EXPANDED", spanIds: next })
+	}, [dispatch, parentIdsByLevel])
+	const handleCollapseOneLevel = React.useCallback(() => {
+		const next = computeCollapseOneLevel(expandedRef.current, parentIdsByLevel)
+		if (next !== expandedRef.current) dispatch({ type: "SET_EXPANDED", spanIds: next })
+	}, [dispatch, parentIdsByLevel])
 
 	// Enter/Shift+Enter cycle matches; the focused-row ring marks the current one.
 	const matchRowIndices = React.useMemo(() => {
@@ -256,7 +237,6 @@ export function TraceTimeline() {
 
 	// Kill hover work while scrolling (Sentry pattern): rows ignore the pointer during a
 	// scroll burst and for 150ms after it settles. Imperative — no state, no re-render.
-	const rowsContainerRef = React.useRef<HTMLDivElement>(null)
 	React.useEffect(() => {
 		const el = scrollRef.current
 		if (!el) return
@@ -287,18 +267,18 @@ export function TraceTimeline() {
 			// Cursor-anchored zoom + pan (Perfetto/DevTools WASD cluster). Falls back to the
 			// viewport center when the cursor isn't over the timeline.
 			const zoomAtCursor = (factor: number) => {
-				const vp = viewportRef.current
+				const vp = controller.get()
 				const currentDuration = vp.endMs - vp.startMs
 				const centerMs = interactions.getCursorTimeMs() ?? (vp.startMs + vp.endMs) / 2
 				const newDuration = currentDuration / factor
 				const ratio = (centerMs - vp.startMs) / currentDuration
 				const newStart = centerMs - ratio * newDuration
-				animateViewportTo({ startMs: newStart, endMs: newStart + newDuration }, 120)
+				controller.animateTo({ startMs: newStart, endMs: newStart + newDuration }, 120)
 			}
 			const panBy = (frac: number) => {
-				const vp = viewportRef.current
+				const vp = controller.get()
 				const delta = (vp.endMs - vp.startMs) * frac
-				animateViewportTo({ startMs: vp.startMs + delta, endMs: vp.endMs + delta }, 120)
+				controller.animateTo({ startMs: vp.startMs + delta, endMs: vp.endMs + delta }, 120)
 			}
 
 			// The timeline owns these keys while focused — consume them so app-global
@@ -323,7 +303,7 @@ export function TraceTimeline() {
 					if (state.focusedIndex !== null) {
 						const bar = bars[state.focusedIndex]
 						if (bar?.hasChildren && bar.isCollapsed) {
-							dispatch({ type: "TOGGLE_COLLAPSE", spanId: bar.span.spanId })
+							handleToggleCollapse(bar.span.spanId, e.altKey)
 						}
 					}
 					return
@@ -332,7 +312,7 @@ export function TraceTimeline() {
 					if (state.focusedIndex !== null) {
 						const bar = bars[state.focusedIndex]
 						if (bar?.hasChildren && !bar.isCollapsed) {
-							dispatch({ type: "TOGGLE_COLLAPSE", spanId: bar.span.spanId })
+							handleToggleCollapse(bar.span.spanId, e.altKey)
 						}
 					}
 					return
@@ -364,6 +344,11 @@ export function TraceTimeline() {
 					consume()
 					panBy(e.shiftKey ? 0.4 : 0.15)
 					return
+				case "e":
+					consume()
+					if (e.shiftKey) handleCollapseOneLevel()
+					else handleExpandOneLevel()
+					return
 				case "f": {
 					// Fit the focused/selected span; with neither, fit the whole trace.
 					consume()
@@ -373,12 +358,8 @@ export function TraceTimeline() {
 							: selectedSpanId !== undefined
 								? bars[barIndexBySpanId.get(selectedSpanId) ?? -1]
 								: undefined
-					if (bar) {
-						const padding = Math.max((bar.endMs - bar.startMs) * 0.1, 0.001)
-						animateViewportTo({ startMs: bar.startMs - padding, endMs: bar.endMs + padding }, 220)
-					} else {
-						handleZoomToFit()
-					}
+					if (bar) controller.zoomToSpan(bar.startMs, bar.endMs)
+					else controller.fit()
 					return
 				}
 				case "/":
@@ -412,8 +393,12 @@ export function TraceTimeline() {
 			dispatch,
 			onSelectSpan,
 			interactions,
-			animateViewportTo,
-			handleZoomToFit,
+			controller,
+			handleToggleCollapse,
+			handleExpandOneLevel,
+			handleCollapseOneLevel,
+			traceStartMs,
+			traceEndMs,
 			showShortcuts,
 		],
 	)
@@ -424,6 +409,15 @@ export function TraceTimeline() {
 		return idx === undefined ? null : bars[idx].span
 	}, [bars, barIndexBySpanId, hoveredSpanId])
 
+	const virtualItems = rowVirtualizer.getVirtualItems()
+
+	// Rows that just mounted (a scroll burst, a collapse) carry no clip chevrons or label side
+	// yet — the viewport hasn't moved, so no subscriber fired. Re-run the pass after they paint.
+	const virtualRangeKey = `${virtualItems[0]?.index ?? -1}:${virtualItems.length}:${bars.length}`
+	React.useLayoutEffect(() => {
+		repaintRowDecorations()
+	}, [virtualRangeKey, repaintRowDecorations])
+
 	if (rootSpans.length === 0) {
 		return (
 			<div className="border p-8 text-center">
@@ -432,15 +426,14 @@ export function TraceTimeline() {
 		)
 	}
 
-	const fullDuration = traceEndMs - traceStartMs
-	const visibleDuration = state.viewport.endMs - state.viewport.startMs
-	const isZoomed = visibleDuration < fullDuration * 0.95
-	const virtualItems = rowVirtualizer.getVirtualItems()
-
 	return (
 		<div
 			ref={containerRef}
 			className="border flex flex-col h-full outline-none relative"
+			// One source of truth for the label-column width. The rows, the minimap spacer and the
+			// ruler spacer all read it, so they cannot drift out of alignment, and a resize drag
+			// updates one property instead of re-rendering every row through a prop.
+			style={{ ["--sidebar-w" as string]: `${sidebarWidth}px` }}
 			tabIndex={0}
 			onKeyDown={handleKeyDown}
 		>
@@ -463,6 +456,26 @@ export function TraceTimeline() {
 					<Button
 						variant="ghost"
 						size="sm"
+						onClick={handleCollapseOneLevel}
+						title="Collapse one level (⇧E)"
+						aria-label="Collapse one level"
+						className="h-5 w-5 p-0"
+					>
+						<ChevronRightIcon size={12} />
+					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={handleExpandOneLevel}
+						title="Expand one level (E)"
+						aria-label="Expand one level"
+						className="h-5 w-5 p-0"
+					>
+						<ChevronDownIcon size={12} />
+					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
 						onClick={handleExpandAll}
 						className="h-5 text-[10px] px-2"
 					>
@@ -477,46 +490,37 @@ export function TraceTimeline() {
 						Collapse all
 					</Button>
 					<ColorByPicker value={colorBy} onChange={setColorBy} rootSpans={rootSpans} />
-					{isZoomed && (
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={handleZoomToFit}
-							className="h-5 gap-1 text-[10px] px-2"
-						>
-							<ChevronExpandYIcon size={11} />
-							Fit
-						</Button>
-					)}
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => controller.fit()}
+						className="h-5 gap-1 text-[10px] px-2"
+					>
+						<ChevronExpandYIcon size={11} />
+						Fit
+					</Button>
 				</div>
 			</div>
 
 			{/* Minimap, aligned under the timeline column via a sidebar-width spacer. */}
 			<div className="flex shrink-0">
 				<div
-					style={{ width: sidebarWidth }}
+					style={{ width: "var(--sidebar-w)" }}
 					className="shrink-0 border-b border-r border-border bg-muted/10"
 				/>
 				<div className="flex-1 min-w-0">
-					<TraceTimelineMinimap
-						rootSpans={rootSpans}
-						traceStartMs={traceStartMs}
-						traceEndMs={traceEndMs}
-						colorBy={colorBy}
-						viewport={state.viewport}
-						onViewportChange={handleMinimapViewportChange}
-					/>
+					<TraceTimelineMinimap rootSpans={rootSpans} colorBy={colorBy} controller={controller} />
 				</div>
 			</div>
 
 			{/* Time-axis ruler, aligned the same way. */}
 			<div className="flex border-b border-border shrink-0">
-				<div style={{ width: sidebarWidth }} className="shrink-0 border-r border-border" />
-				<div className="flex-1 min-w-0 relative">
+				<div style={{ width: "var(--sidebar-w)" }} className="shrink-0 border-r border-border" />
+				<div className="flex-1 min-w-0 relative bg-background">
 					<TraceTimelineTimeAxis
-						viewport={state.viewport}
-						ticks={timeAxisTicks}
-						traceStartMs={traceStartMs}
+						controller={controller}
+						columnWidthPx={timelineWidthPx}
+						gridRef={gridRef}
 					/>
 				</div>
 			</div>
@@ -544,10 +548,22 @@ export function TraceTimeline() {
 					}}
 				>
 					<div
-						ref={rowsContainerRef}
+						ref={(el) => {
+							rowsContainerRef.current = el
+							// The rows container is a "time surface": the controller writes
+							// --vp0/--vpk here and every bar below derives its rect from them.
+							return controller.bindTimeSurface(el)
+						}}
 						className="relative w-full"
 						style={{ height: rowVirtualizer.getTotalSize() }}
 					>
+						{/* Tick gridlines, painted behind the rows from the ruler's own spacing. */}
+						<div
+							ref={gridRef}
+							aria-hidden
+							className="pointer-events-none absolute inset-y-0 right-0 z-0"
+							style={{ left: "var(--sidebar-w)" }}
+						/>
 						{virtualItems.map((vi) => {
 							const bar = bars[vi.index]
 							if (!bar) return null
@@ -558,9 +574,6 @@ export function TraceTimeline() {
 									key={id}
 									bar={bar}
 									top={vi.start}
-									sidebarWidth={sidebarWidth}
-									timelineWidthPx={timelineWidthPx}
-									viewport={state.viewport}
 									selected={selectedSpanId === id}
 									focused={state.focusedIndex === vi.index}
 									hovered={hoveredSpanId === id}
@@ -669,12 +682,14 @@ export function TraceTimeline() {
 									["W / S", "Zoom in / out at cursor (⇧ faster)"],
 									["A / D", "Pan left / right (⇧ faster)"],
 									["F", "Fit focused span — or whole trace"],
+									["E / ⇧E", "Expand / collapse one level"],
 									["Drag", "Zoom to selection"],
 									["⇧ Drag / middle-drag", "Pan"],
 									["⌘ Scroll", "Zoom at cursor"],
 									["Double-click", "Zoom to span"],
 									["↑ ↓", "Move row focus"],
-									["← →", "Collapse / expand span"],
+									["← →", "Collapse / expand span (⌥ whole subtree)"],
+									["⌥ Click chevron", "Collapse / expand whole subtree"],
 									["Enter / Space", "Select focused span"],
 									["/", "Search · Enter next · ⇧Enter previous"],
 									["Esc", "Clear search / focus · close this"],

--- a/packages/ui/src/components/traces/trace-view-tabs.tsx
+++ b/packages/ui/src/components/traces/trace-view-tabs.tsx
@@ -42,7 +42,7 @@ export function TraceViewTabs({
 			colorBy={colorBy}
 			setColorBy={setColorBy}
 		>
-			<Tabs defaultValue="waterfall" className="flex flex-col h-full">
+			<Tabs defaultValue="timeline" className="flex flex-col h-full">
 				<TabsList variant="underline" className="shrink-0">
 					<TabsTrigger value="waterfall">
 						<MenuIcon size={14} />

--- a/packages/ui/src/components/traces/use-row-decorations.ts
+++ b/packages/ui/src/components/traces/use-row-decorations.ts
@@ -1,0 +1,71 @@
+import * as React from "react"
+
+import type { ViewportController } from "./use-viewport-controller"
+
+/**
+ * The two bits of span-bar chrome CSS can't derive on its own.
+ *
+ * Everything else about a bar — position, width, which labels fit — is expressed in custom
+ * properties and container queries, so the style engine handles it during a gesture. These two
+ * need to know whether the `clamp()` in the bar's `left`/`right` actually bit, which is a
+ * comparison CSS has no way to make:
+ *
+ *   - the `‹`/`›` chevrons marking a bar that continues past the visible window;
+ *   - which side an outside label goes on, when the bar is too narrow to hold one.
+ *
+ * So one pass over the ~40 mounted rows per viewport frame, reading each bar's `--b0`/`--b1`
+ * back out and toggling attributes. No React, no per-bar layout reads (nothing here calls
+ * `getBoundingClientRect`), so it can't force a reflow.
+ */
+export function useRowDecorations(
+	controller: ViewportController,
+	rowsRef: React.RefObject<HTMLElement | null>,
+): () => void {
+	const paintRef = React.useRef<() => void>(() => {})
+
+	React.useEffect(() => {
+		const paint = (vp: { startMs: number; endMs: number }) => {
+			const root = rowsRef.current
+			if (!root) return
+			const vp0 = vp.startMs - controller.traceStartMs
+			const visible = vp.endMs - vp.startMs
+			if (!(visible > 0)) return
+			const k = 100 / visible
+
+			for (const bar of root.querySelectorAll<HTMLElement>("[data-span-bar]")) {
+				const b0 = Number(bar.style.getPropertyValue("--b0"))
+				const b1 = Number(bar.style.getPropertyValue("--b1"))
+				if (!Number.isFinite(b0) || !Number.isFinite(b1)) continue
+
+				const leftPct = (b0 - vp0) * k
+				const rightPct = (b1 - vp0) * k
+
+				const cell = bar.parentElement
+				if (cell) {
+					const clipL = cell.querySelector<HTMLElement>("[data-clip-left]")
+					const clipR = cell.querySelector<HTMLElement>("[data-clip-right]")
+					if (clipL) clipL.style.display = leftPct < 0 ? "block" : "none"
+					if (clipR) clipR.style.display = rightPct > 100 ? "block" : "none"
+				}
+
+				const label = bar.querySelector<HTMLElement>("[data-outside-label]")
+				if (label) {
+					// A bar entirely outside the window still has a clamped rect, so its label
+					// could otherwise drift into view with nothing attached to it.
+					const offscreen = leftPct > 100 || rightPct < 0
+					label.style.visibility = offscreen ? "hidden" : ""
+					// Right by default; flip left only when the tail is close enough to the right
+					// edge that the label would be clipped, and there is room on the left.
+					if (rightPct >= 70 && leftPct > 30) label.dataset.side = "left"
+					else delete label.dataset.side
+				}
+			}
+		}
+		paintRef.current = () => paint(controller.get())
+		return controller.subscribe(paint)
+	}, [controller, rowsRef])
+
+	// Scrolling mounts fresh rows whose chevrons and label side were never computed — the
+	// viewport hasn't moved, so no subscriber fires. Callers re-run the pass after a row render.
+	return React.useCallback(() => paintRef.current(), [])
+}

--- a/packages/ui/src/components/traces/use-timeline-interactions.ts
+++ b/packages/ui/src/components/traces/use-timeline-interactions.ts
@@ -1,8 +1,8 @@
 import * as React from "react"
 
 import { formatDuration } from "../../lib/format"
-import type { TimelineAction, ViewportState } from "./trace-timeline-types"
 import { DRAG_ZOOM_THRESHOLD_PX } from "./trace-timeline-types"
+import type { ViewportController } from "./use-viewport-controller"
 
 interface UseTimelineInteractionsOptions {
 	/**
@@ -12,12 +12,7 @@ interface UseTimelineInteractionsOptions {
 	 */
 	bodyRef: React.RefObject<HTMLElement | null>
 	sidebarWidth: number
-	viewport: ViewportState
-	traceStartMs: number
-	traceEndMs: number
-	dispatch: (action: TimelineAction) => void
-	/** Called at the start of any direct gesture (pointer drag, wheel) so callers can cancel in-flight viewport animations. */
-	onGestureStart?: () => void
+	controller: ViewportController
 }
 
 /** A marquee rectangle, in px relative to `bodyRef`'s left edge. */
@@ -63,28 +58,26 @@ interface DragState {
 	timelineLeft: number
 	timelineWidth: number
 	bodyLeft: number
-	startViewport: ViewportState
+	startStartMs: number
+	startEndMs: number
 }
 
 /**
- * Pointer + wheel gestures for the DOM timeline:
- * - drag across the timeline → marquee → ZOOM_TO_RANGE (a tap stays a span click)
- * - shift-drag / middle-button drag → PAN
- * - ctrl/⌘ + wheel → cursor-anchored ZOOM
- * - shift + wheel / horizontal wheel → PAN; plain vertical wheel → native row scroll
+ * Pointer + wheel gestures for the timeline:
+ * - drag across the timeline → marquee → zoom to range (a tap stays a span click)
+ * - shift-drag / middle-button drag → pan
+ * - ctrl/⌘ + wheel → cursor-anchored zoom
+ * - shift + wheel / horizontal wheel → pan; plain vertical wheel → native row scroll
  *
- * The visible window is captured at pointer-down: a marquee dispatches nothing until release,
- * and a pan dispatches *relative* deltas, so neither needs the live viewport mid-drag — which
- * keeps the window listeners free of stale-closure bugs.
+ * Every gesture writes straight through the `ViewportController`, which clamps, updates the CSS
+ * custom properties the bars read, and notifies the minimap and ruler — no `setState`, so a
+ * drag or a wheel-zoom produces no React commits at all. Only the marquee rectangle, which has
+ * no CSS-var representation, is React state.
  */
 export function useTimelineInteractions({
 	bodyRef,
 	sidebarWidth,
-	viewport,
-	traceStartMs,
-	traceEndMs,
-	dispatch,
-	onGestureStart,
+	controller,
 }: UseTimelineInteractionsOptions): TimelineInteractions {
 	const [marquee, setMarquee] = React.useState<MarqueeRect | null>(null)
 	const [dragMode, setDragMode] = React.useState<DragMode | null>(null)
@@ -92,12 +85,8 @@ export function useTimelineInteractions({
 	const dragRef = React.useRef<DragState | null>(null)
 
 	// Live refs so imperative handlers (crosshair label, cursor-time queries) never go stale.
-	const viewportRef = React.useRef(viewport)
-	viewportRef.current = viewport
 	const sidebarWidthRef = React.useRef(sidebarWidth)
 	sidebarWidthRef.current = sidebarWidth
-	const traceStartMsRef = React.useRef(traceStartMs)
-	traceStartMsRef.current = traceStartMs
 
 	const pxToTimeMs = React.useCallback(
 		(x: number): number | null => {
@@ -106,10 +95,10 @@ export function useTimelineInteractions({
 			const sw = sidebarWidthRef.current
 			const width = el.clientWidth - sw
 			if (width <= 0 || x < sw) return null
-			const vp = viewportRef.current
+			const vp = controller.get()
 			return vp.startMs + ((x - sw) / width) * (vp.endMs - vp.startMs)
 		},
-		[bodyRef],
+		[bodyRef, controller],
 	)
 
 	// Crosshair is positioned imperatively — mousemove must not re-render the component.
@@ -135,14 +124,14 @@ export function useTimelineInteractions({
 				label.style.display = "none"
 			} else {
 				label.style.display = "block"
-				label.textContent = `+${formatDuration(timeMs - traceStartMsRef.current)}`
+				label.textContent = `+${formatDuration(timeMs - controller.traceStartMs)}`
 				// Flip to the left side of the line near the right edge so it stays readable.
 				const el = bodyRef.current
 				const nearRightEdge = el ? x > el.clientWidth - 80 : false
 				label.style.transform = nearRightEdge ? "translateX(calc(-100% - 6px))" : "translateX(6px)"
 			}
 		}
-	}, [bodyRef, pxToTimeMs])
+	}, [bodyRef, controller, pxToTimeMs])
 
 	const setCrosshairX = React.useCallback(
 		(x: number | null) => {
@@ -159,6 +148,13 @@ export function useTimelineInteractions({
 
 	React.useEffect(() => () => cancelAnimationFrame(crosshairRafRef.current), [])
 
+	// The crosshair readout is relative to the window, so it goes stale when the viewport moves
+	// under a parked cursor (keyboard zoom, minimap drag). Repaint it with everything else.
+	React.useEffect(
+		() => controller.subscribe(() => (crosshairXRef.current === null ? undefined : applyCrosshair())),
+		[controller, applyCrosshair],
+	)
+
 	const onPointerDown = React.useCallback(
 		(e: React.PointerEvent) => {
 			if (e.button !== 0 && e.button !== 1) return
@@ -169,8 +165,9 @@ export function useTimelineInteractions({
 			// Gestures only originate in the timeline column.
 			if (x < sidebarWidth) return
 			suppressClickRef.current = false
-			onGestureStart?.()
+			controller.cancelAnimation()
 
+			const vp = controller.get()
 			const mode: DragMode = e.shiftKey || e.button === 1 ? "pan" : "zoom"
 			dragRef.current = {
 				mode,
@@ -180,7 +177,8 @@ export function useTimelineInteractions({
 				timelineLeft: sidebarWidth,
 				timelineWidth: el.clientWidth - sidebarWidth,
 				bodyLeft: rect.left,
-				startViewport: viewport,
+				startStartMs: vp.startMs,
+				startEndMs: vp.endMs,
 			}
 
 			const handleMove = (ev: PointerEvent) => {
@@ -195,9 +193,11 @@ export function useTimelineInteractions({
 				if (d.mode === "pan") {
 					const deltaPx = px - d.lastX
 					d.lastX = px
-					const visible = d.startViewport.endMs - d.startViewport.startMs
-					const deltaMs = -(deltaPx / d.timelineWidth) * visible
-					dispatch({ type: "PAN", deltaMs, traceStartMs, traceEndMs })
+					// Against the *live* window, not the one captured at pointer-down: a pan that
+					// hits the clamp must not accumulate phantom offset the cursor has to undo.
+					const live = controller.get()
+					const deltaMs = -(deltaPx / d.timelineWidth) * (live.endMs - live.startMs)
+					controller.panBy(deltaMs)
 				} else {
 					const lo = Math.max(d.timelineLeft, Math.min(d.startX, px))
 					const hi = Math.min(d.timelineLeft + d.timelineWidth, Math.max(d.startX, px))
@@ -214,17 +214,14 @@ export function useTimelineInteractions({
 				setMarquee(null)
 				if (!d || !d.moved) return
 				if (d.mode === "zoom") {
+					// The marquee was drawn against the window as it stood at pointer-down, which
+					// hasn't moved during the drag, so resolve both edges against that snapshot.
+					const start = { startMs: d.startStartMs, endMs: d.startEndMs }
 					const px = ev.clientX - d.bodyLeft
-					const a = pxToMsStatic(d.startX, d.timelineLeft, d.timelineWidth, d.startViewport)
-					const b = pxToMsStatic(px, d.timelineLeft, d.timelineWidth, d.startViewport)
+					const a = pxToMsStatic(d.startX, d.timelineLeft, d.timelineWidth, start)
+					const b = pxToMsStatic(px, d.timelineLeft, d.timelineWidth, start)
 					suppressClickRef.current = true
-					dispatch({
-						type: "ZOOM_TO_RANGE",
-						startMs: a,
-						endMs: b,
-						traceStartMs,
-						traceEndMs,
-					})
+					controller.zoomToRange(a, b)
 				} else {
 					// A pan still ends on a row; swallow the trailing click.
 					suppressClickRef.current = true
@@ -236,7 +233,7 @@ export function useTimelineInteractions({
 			// No preventDefault here — a plain press must still reach the row's onClick. Text
 			// selection during a drag is suppressed via `select-none` on the container.
 		},
-		[bodyRef, dispatch, sidebarWidth, viewport, traceStartMs, traceEndMs, onGestureStart],
+		[bodyRef, controller, sidebarWidth],
 	)
 
 	const onPointerMove = React.useCallback(
@@ -259,25 +256,21 @@ export function useTimelineInteractions({
 		const el = bodyRef.current
 		if (!el) return
 		const sw = sidebarWidth
-		const vp = viewport
 		const rect = el.getBoundingClientRect()
 		const x = e.clientX - rect.left
 		if (x < sw) return // over the sidebar → let rows scroll natively
-		const timelineLeft = sw
 		const timelineWidth = el.clientWidth - sw
-		const visible = vp.endMs - vp.startMs
 		if (e.ctrlKey || e.metaKey) {
 			e.preventDefault()
-			onGestureStart?.()
-			const centerMs = pxToMsStatic(x, timelineLeft, timelineWidth, vp)
-			const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15
-			dispatch({ type: "ZOOM", centerMs, factor, traceStartMs, traceEndMs })
+			controller.cancelAnimation()
+			const centerMs = pxToMsStatic(x, sw, timelineWidth, controller.get())
+			controller.zoomAt(centerMs, e.deltaY < 0 ? 1.15 : 1 / 1.15)
 		} else if (e.shiftKey || Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
 			e.preventDefault()
-			onGestureStart?.()
+			controller.cancelAnimation()
+			const vp = controller.get()
 			const delta = e.deltaX !== 0 ? e.deltaX : e.deltaY
-			const deltaMs = (delta / Math.max(1, timelineWidth)) * visible
-			dispatch({ type: "PAN", deltaMs, traceStartMs, traceEndMs })
+			controller.panBy((delta / Math.max(1, timelineWidth)) * (vp.endMs - vp.startMs))
 		}
 		// else: plain vertical wheel → native scroll (don't preventDefault)
 	})
@@ -306,7 +299,12 @@ export function useTimelineInteractions({
 	}
 }
 
-function pxToMsStatic(px: number, left: number, width: number, vp: ViewportState): number {
+function pxToMsStatic(
+	px: number,
+	left: number,
+	width: number,
+	vp: { startMs: number; endMs: number },
+): number {
 	const visible = vp.endMs - vp.startMs
 	const frac = width > 0 ? (px - left) / width : 0
 	return vp.startMs + frac * visible

--- a/packages/ui/src/components/traces/use-trace-timeline.ts
+++ b/packages/ui/src/components/traces/use-trace-timeline.ts
@@ -1,16 +1,13 @@
 import * as React from "react"
 import type { SpanNode } from "../../lib/types"
 import type { TimelineBar, ViewportState, TimelineState, TimelineAction } from "./trace-timeline-types"
-import {
-	ROW_HEIGHT,
-	ROW_GAP,
-	OVERSCAN,
-	MIN_VISIBLE_ABS_MS,
-	DEFAULT_MAX_WINDOW_MS,
-} from "./trace-timeline-types"
+import { ROW_HEIGHT, ROW_GAP, OVERSCAN, MIN_TICK_PX, DEFAULT_MAX_WINDOW_MS } from "./trace-timeline-types"
+import { clampViewport, viewportBounds } from "./clamp-viewport"
 import { getValueHue } from "../../lib/colors"
 import { resolveColorValue, isStatusCodePreset, type ColorByField } from "./color-by"
 import { computeDefaultExpandedSpanIds, countDescendants } from "./auto-collapse"
+
+export { clampViewport }
 
 const ERROR_HUE = 25
 const NEUTRAL_FILL = "oklch(0.22 0.005 0)"
@@ -39,6 +36,7 @@ export function layoutSpans(
 	rootSpans: SpanNode[],
 	expandedSpanIds: Set<string>,
 	colorBy: ColorByField,
+	traceStartMs: number,
 ): LayoutResult {
 	const bars: TimelineBar[] = []
 	const barIndexBySpanId = new Map<string, number>()
@@ -60,6 +58,10 @@ export function layoutSpans(
 			row: currentRow,
 			startMs,
 			endMs,
+			// Trace-relative, because these become the `--b0`/`--b1` custom properties and the
+			// viewport's `--vp0` is trace-relative too. See `writeTimeSurface`.
+			offsetStartMs: startMs - traceStartMs,
+			offsetEndMs: endMs - traceStartMs,
 			depth: node.depth,
 			parentSpanId: node.parentSpanId,
 			isError,
@@ -95,123 +97,34 @@ export function layoutSpans(
 	return { bars, totalRows: currentRow, barIndexBySpanId, parentIndexById }
 }
 
-export function clampViewport(vp: ViewportState, traceStartMs: number, traceEndMs: number): ViewportState {
-	const traceDuration = Math.max(0, traceEndMs - traceStartMs)
-	// Trace boundaries with 5% padding each side.
-	const padding = traceDuration * 0.05
-	const loBound = traceStartMs - padding
-	const hiBound = traceEndMs + padding
-	const boundWidth = hiBound - loBound
-
-	// Absolute floor only — a proportional floor (traceDuration * k) makes long traces
-	// un-zoomable: a 7-min trace would cap the window at tens of ms while the spans you're
-	// trying to inspect are µs-scale, so zoom appears not to work. SpanBar clamps its
-	// rendered width, so extreme zoom can't emit gigapixel nodes.
-	const minDuration = MIN_VISIBLE_ABS_MS
-	const maxDuration = Math.max(boundWidth, minDuration)
-
-	const rawDuration = vp.endMs - vp.startMs
-	const duration = Number.isFinite(rawDuration)
-		? Math.max(minDuration, Math.min(rawDuration, maxDuration))
-		: maxDuration
-
-	// Window as wide as (or wider than) the padded trace → center it, so neither edge
-	// clamp can push the other back out of bounds (degenerate/near-zero traces included).
-	if (duration >= boundWidth) {
-		const center = (loBound + hiBound) / 2
-		return { startMs: center - duration / 2, endMs: center + duration / 2 }
+/**
+ * Every span id that has children, bucketed by depth.
+ *
+ * Walks the whole tree (not just the expanded rows), because "expand one level" has to know
+ * about parents that are currently hidden inside a collapsed ancestor. Built once per tree so
+ * the level-at-a-time buttons are O(level) rather than O(tree) per click.
+ */
+export function collectParentIdsByLevel(rootSpans: SpanNode[]): Map<number, Set<string>> {
+	const byLevel = new Map<number, Set<string>>()
+	const visit = (node: SpanNode) => {
+		if (node.children.length > 0) {
+			let level = byLevel.get(node.depth)
+			if (!level) {
+				level = new Set()
+				byLevel.set(node.depth, level)
+			}
+			level.add(node.spanId)
+			node.children.forEach(visit)
+		}
 	}
-
-	// Right-clamp before left-clamp: min() first means the subsequent max() can only pull
-	// the window right, never past hiBound (duration < boundWidth guarantees room).
-	const startMs = Number.isFinite(vp.startMs)
-		? Math.max(loBound, Math.min(vp.startMs, hiBound - duration))
-		: loBound
-	return { startMs, endMs: startMs + duration }
+	rootSpans.forEach(visit)
+	return byLevel
 }
 
 export function timelineReducer(state: TimelineState, action: TimelineAction): TimelineState {
 	switch (action.type) {
 		case "RESET":
 			return action.state
-
-		case "SET_VIEWPORT":
-			// Clamp here (not at dispatch sites) so every path — minimap pan/resize/jump
-			// included — is bounded by the same rules as the other gestures.
-			return {
-				...state,
-				viewport: clampViewport(action.viewport, action.traceStartMs, action.traceEndMs),
-			}
-
-		case "ZOOM": {
-			const { centerMs, factor, traceStartMs, traceEndMs } = action
-			const currentDuration = state.viewport.endMs - state.viewport.startMs
-			const newDuration = currentDuration / factor
-			const ratio = (centerMs - state.viewport.startMs) / currentDuration
-			const newStart = centerMs - ratio * newDuration
-			return {
-				...state,
-				viewport: clampViewport(
-					{ startMs: newStart, endMs: newStart + newDuration },
-					traceStartMs,
-					traceEndMs,
-				),
-			}
-		}
-
-		case "PAN": {
-			const { deltaMs, traceStartMs, traceEndMs } = action
-			return {
-				...state,
-				viewport: clampViewport(
-					{
-						startMs: state.viewport.startMs + deltaMs,
-						endMs: state.viewport.endMs + deltaMs,
-					},
-					traceStartMs,
-					traceEndMs,
-				),
-			}
-		}
-
-		case "ZOOM_TO_SPAN": {
-			const { startMs, endMs, traceStartMs, traceEndMs } = action
-			const spanDuration = endMs - startMs
-			const padding = Math.max(spanDuration * 0.1, 0.001)
-			return {
-				...state,
-				viewport: clampViewport(
-					{ startMs: startMs - padding, endMs: endMs + padding },
-					traceStartMs,
-					traceEndMs,
-				),
-			}
-		}
-
-		case "ZOOM_TO_RANGE": {
-			// Drag-to-select target: zoom to exactly the dragged window (no extra padding),
-			// clamped so it stays inside the trace and respects the min-visible floor.
-			const { startMs, endMs, traceStartMs, traceEndMs } = action
-			const lo = Math.min(startMs, endMs)
-			const hi = Math.max(startMs, endMs)
-			return {
-				...state,
-				viewport: clampViewport({ startMs: lo, endMs: hi }, traceStartMs, traceEndMs),
-			}
-		}
-
-		case "ZOOM_TO_FIT": {
-			const { traceStartMs, traceEndMs } = action
-			const padding = (traceEndMs - traceStartMs) * 0.02
-			return {
-				...state,
-				viewport: clampViewport(
-					{ startMs: traceStartMs - padding, endMs: traceEndMs + padding },
-					traceStartMs,
-					traceEndMs,
-				),
-			}
-		}
 
 		case "SET_FOCUSED_INDEX":
 			return { ...state, focusedIndex: action.index }
@@ -234,10 +147,14 @@ export function timelineReducer(state: TimelineState, action: TimelineAction): T
 
 		case "TOGGLE_COLLAPSE": {
 			const next = new Set(state.expandedSpanIds)
-			if (next.has(action.spanId)) {
-				next.delete(action.spanId)
-			} else {
-				next.add(action.spanId)
+			const expanding = !next.has(action.spanId)
+			if (expanding) next.add(action.spanId)
+			else next.delete(action.spanId)
+			// Alt-click: drag the whole subtree to the state the clicked node just took, so one
+			// gesture opens or folds a branch entirely instead of one level at a time.
+			for (const id of action.descendantIds ?? []) {
+				if (expanding) next.add(id)
+				else next.delete(id)
 			}
 			return { ...state, expandedSpanIds: next }
 		}
@@ -247,6 +164,9 @@ export function timelineReducer(state: TimelineState, action: TimelineAction): T
 
 		case "COLLAPSE_ALL":
 			return { ...state, expandedSpanIds: new Set<string>() }
+
+		case "SET_EXPANDED":
+			return { ...state, expandedSpanIds: action.spanIds }
 
 		default:
 			return state
@@ -258,30 +178,49 @@ const NICE_INTERVALS = [
 	5000, 10000, 20000, 60000,
 ]
 
+/** Snap up to the nearest nice interval — never down, or the tick count overshoots the budget. */
+function niceIntervalAtLeast(rawInterval: number): number {
+	for (const nice of NICE_INTERVALS) {
+		if (nice >= rawInterval) return nice
+	}
+	// Past the ladder (multi-minute windows): keep stepping by whole minutes.
+	const minute = 60_000
+	return Math.max(minute, Math.ceil(rawInterval / minute) * minute)
+}
+
+/**
+ * Tick spacing budgeted against the measured column, not a fixed tick count.
+ *
+ * A fixed count (the old `targetTickCount = 6`) collides labels on a narrow panel and leaves a
+ * wide one nearly empty. Dividing by `MIN_TICK_PX` gives whatever count actually fits.
+ */
+export function tickIntervalForWidth(visibleDurationMs: number, columnWidthPx: number): number {
+	const maxTicks = Math.max(1, Math.floor(columnWidthPx / MIN_TICK_PX))
+	return niceIntervalAtLeast(visibleDurationMs / maxTicks)
+}
+
+/**
+ * Tick offsets from the trace start covering the window, plus the interval they were spaced at
+ * (the label formatter needs it to pick a precision that keeps adjacent labels distinct).
+ */
 export function computeTimeAxisTicks(
 	viewport: ViewportState,
 	traceStartMs: number,
-	targetTickCount: number = 6,
-): number[] {
+	columnWidthPx: number,
+): { ticks: number[]; intervalMs: number } {
 	const visibleDuration = viewport.endMs - viewport.startMs
-	const rawInterval = visibleDuration / targetTickCount
+	if (!(visibleDuration > 0) || !(columnWidthPx > 0)) return { ticks: [], intervalMs: 1 }
 
-	let interval = NICE_INTERVALS[NICE_INTERVALS.length - 1]
-	for (const nice of NICE_INTERVALS) {
-		if (nice >= rawInterval) {
-			interval = nice
-			break
-		}
-	}
-
+	const intervalMs = tickIntervalForWidth(visibleDuration, columnWidthPx)
 	const ticks: number[] = []
-	const offsetFromTraceStart = viewport.startMs - traceStartMs
-	const firstTick = Math.ceil(offsetFromTraceStart / interval) * interval
-	for (let t = firstTick; t <= viewport.endMs - traceStartMs; t += interval) {
+	const from = viewport.startMs - traceStartMs
+	const to = viewport.endMs - traceStartMs
+	const firstTick = Math.ceil(from / intervalMs) * intervalMs
+	// Bounded independently of the arithmetic: a pathological interval must not spin here.
+	for (let t = firstTick, i = 0; t <= to && i < 512; t += intervalMs, i++) {
 		ticks.push(t)
 	}
-
-	return ticks
+	return { ticks, intervalMs }
 }
 
 export function computeSearchMatches(bars: TimelineBar[], query: string): Set<string> {
@@ -314,12 +253,13 @@ export interface UseTraceTimelineResult {
 	totalRows: number
 	barIndexBySpanId: Map<string, number>
 	parentIndexById: Map<string, number>
+	parentIdsByLevel: Map<number, Set<string>>
 	state: TimelineState
 	dispatch: React.Dispatch<TimelineAction>
 	traceStartMs: number
 	traceEndMs: number
-	visibleDurationMs: number
-	timeAxisTicks: number[]
+	/** Window to open (and re-open) the trace at — feeds the viewport controller. */
+	defaultViewport: ViewportState
 	searchMatches: Set<string>
 	isSearchActive: boolean
 }
@@ -370,13 +310,22 @@ export function useTraceTimeline({
 
 	// Default view shows at most DEFAULT_MAX_WINDOW_MS (10s) starting at the trace start, so long
 	// traces open zoomed-in and readable instead of squeezing minutes of spans into the panel.
-	// Traces shorter than the window show in full. Zoom out (Fit / ⌘-scroll) reaches the whole trace.
+	//
+	// A trace that fits opens at exactly the padded bounds — the same span the minimap strip
+	// covers — so at rest the strip and the timeline column are the same coordinate space and a
+	// given instant sits at the same x in both. Opening at some *other* "whole trace" window
+	// (this used to apply its own 2% pad) left the two a couple of percent out of step, which
+	// reads as the minimap being subtly misaligned with the ruler.
 	const defaultViewport = React.useMemo<ViewportState>(() => {
-		const windowMs = Math.min(traceDurationMs, DEFAULT_MAX_WINDOW_MS)
-		const pad = windowMs * 0.02
-		// Route through clampViewport so the min-width floor holds at first paint too.
+		const bounds = viewportBounds(traceStartMs, traceEndMs)
+		if (traceDurationMs <= DEFAULT_MAX_WINDOW_MS) {
+			return clampViewport({ startMs: bounds.loMs, endMs: bounds.hiMs }, traceStartMs, traceEndMs)
+		}
+		// Long trace: open on the first window. Route through clampViewport so the min-width
+		// floor holds at first paint too.
+		const pad = DEFAULT_MAX_WINDOW_MS * 0.02
 		return clampViewport(
-			{ startMs: traceStartMs - pad, endMs: traceStartMs + windowMs + pad },
+			{ startMs: traceStartMs - pad, endMs: traceStartMs + DEFAULT_MAX_WINDOW_MS + pad },
 			traceStartMs,
 			traceEndMs,
 		)
@@ -388,7 +337,6 @@ export function useTraceTimeline({
 	)
 
 	const [state, dispatch] = React.useReducer(timelineReducer, {
-		viewport: defaultViewport,
 		focusedIndex: null,
 		searchQuery: "",
 		expandedSpanIds: defaultExpanded,
@@ -398,26 +346,16 @@ export function useTraceTimeline({
 	React.useEffect(() => {
 		dispatch({
 			type: "RESET",
-			state: {
-				viewport: defaultViewport,
-				focusedIndex: null,
-				searchQuery: "",
-				expandedSpanIds: defaultExpanded,
-			},
+			state: { focusedIndex: null, searchQuery: "", expandedSpanIds: defaultExpanded },
 		})
 	}, [rootSpanIdsKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
 	const { bars, totalRows, barIndexBySpanId, parentIndexById } = React.useMemo(
-		() => layoutSpans(rootSpans, state.expandedSpanIds, colorBy),
-		[rootSpans, state.expandedSpanIds, colorBy],
+		() => layoutSpans(rootSpans, state.expandedSpanIds, colorBy, traceStartMs),
+		[rootSpans, state.expandedSpanIds, colorBy, traceStartMs],
 	)
 
-	const visibleDurationMs = state.viewport.endMs - state.viewport.startMs
-
-	const timeAxisTicks = React.useMemo(
-		() => computeTimeAxisTicks(state.viewport, traceStartMs),
-		[state.viewport, traceStartMs],
-	)
+	const parentIdsByLevel = React.useMemo(() => collectParentIdsByLevel(rootSpans), [rootSpans])
 
 	const searchMatches = React.useMemo(
 		() => computeSearchMatches(bars, state.searchQuery),
@@ -431,12 +369,12 @@ export function useTraceTimeline({
 		totalRows,
 		barIndexBySpanId,
 		parentIndexById,
+		parentIdsByLevel,
 		state,
 		dispatch,
 		traceStartMs,
 		traceEndMs,
-		visibleDurationMs,
-		timeAxisTicks,
+		defaultViewport,
 		searchMatches,
 		isSearchActive,
 	}

--- a/packages/ui/src/components/traces/use-viewport-controller.ts
+++ b/packages/ui/src/components/traces/use-viewport-controller.ts
@@ -1,0 +1,213 @@
+import * as React from "react"
+
+import { clampViewport, viewportBounds } from "./clamp-viewport"
+import type { ViewportState } from "./trace-timeline-types"
+
+/**
+ * The visible time window, held in a ref rather than React state.
+ *
+ * Every pan and zoom frame used to be a `dispatch`, which re-rendered the whole timeline
+ * subtree — rows, minimap (one node per span, unvirtualized), ruler and all. Here the window
+ * lives in a ref and reaches the DOM two ways:
+ *
+ *  1. **Time surfaces** — elements carrying `--vp0`/`--vpk`, from which every span bar derives
+ *     its own position in pure CSS. A gesture writes two custom properties per surface and the
+ *     style engine repositions every bar. No React, no per-bar arithmetic.
+ *  2. **Subscribers** — the minimap overlay, the ruler and the row decorations, notified on a
+ *     single coalesced rAF so they can paint imperatively.
+ *
+ * Nothing here calls `setState`, so a wheel-zoom or a drag-pan produces **zero React commits**.
+ */
+export interface ViewportController {
+	/** The current window. Reads the ref — always fresh, never a stale closure. */
+	get(): ViewportState
+	/** Commit a window: clamp, write the CSS vars, notify subscribers. */
+	set(vp: ViewportState): void
+	/** Zoom about a fixed time; `factor > 1` zooms in. */
+	zoomAt(centerMs: number, factor: number): void
+	panBy(deltaMs: number): void
+	/** Zoom to exactly this range (either argument order). */
+	zoomToRange(startMs: number, endMs: number): void
+	/** Eased zoom to a span's extent plus 10% breathing room. */
+	zoomToSpan(startMs: number, endMs: number): void
+	/** Fit the whole trace. */
+	fit(): void
+	/** Eased commit over `durationMs`; cancels any tween already in flight. */
+	animateTo(vp: ViewportState, durationMs?: number): void
+	/** Cancel an in-flight tween — direct gestures must win over an animation. */
+	cancelAnimation(): void
+	subscribe(cb: (vp: ViewportState) => void): () => void
+	/**
+	 * Register an element to carry `--vp0`/`--vpk`. Returns an unbind function; pass `null`
+	 * to unbind. Safe to call from a ref callback.
+	 */
+	bindTimeSurface(el: HTMLElement | null): () => void
+	/** Trace bounds, so consumers can convert between time and trace fractions. */
+	readonly traceStartMs: number
+	readonly traceEndMs: number
+}
+
+/**
+ * Write the window onto a time surface.
+ *
+ * `--vp0` is the window start in **trace-relative** ms and `--vpk` is `100 / visibleMs`, so a
+ * bar at `--b0` resolves to `calc((var(--b0) - var(--vp0)) * var(--vpk) * 1%)`.
+ *
+ * Two deliberate choices, both load-bearing:
+ *
+ *  - **Trace-relative, not epoch.** Epoch ms are ~1.7e12 and would swamp the interesting digits
+ *    in DevTools; trace-relative values read as "1234.5" and are debuggable by eye.
+ *  - **Never register these with `@property`.** An unregistered custom property substitutes as
+ *    raw tokens, so the enclosing `calc()` is re-parsed and evaluated in `double`. Registering
+ *    them as `<number>` stores a float32 instead, and at a 0.1ms window float32 rounding on
+ *    `var(--b0) - var(--vp0)` lands the bar tens of percent away from where it belongs.
+ */
+function writeTimeSurface(el: HTMLElement, vp: ViewportState, traceStartMs: number): void {
+	const visible = vp.endMs - vp.startMs
+	el.style.setProperty("--vp0", String(vp.startMs - traceStartMs))
+	el.style.setProperty("--vpk", String(visible > 0 ? 100 / visible : 0))
+}
+
+export interface UseViewportControllerOptions {
+	traceStartMs: number
+	traceEndMs: number
+	/** Window to (re)start at. Re-applied whenever its identity changes, i.e. on a new trace. */
+	initialViewport: ViewportState
+}
+
+export function useViewportController({
+	traceStartMs,
+	traceEndMs,
+	initialViewport,
+}: UseViewportControllerOptions): ViewportController {
+	const viewportRef = React.useRef<ViewportState>(initialViewport)
+	const surfacesRef = React.useRef<Set<HTMLElement>>(new Set())
+	const subscribersRef = React.useRef<Set<(vp: ViewportState) => void>>(new Set())
+	const notifyRafRef = React.useRef(0)
+	const animRafRef = React.useRef(0)
+
+	// Bounds are read inside stable callbacks, so they go through refs rather than closures.
+	const boundsRef = React.useRef({ traceStartMs, traceEndMs })
+	boundsRef.current = { traceStartMs, traceEndMs }
+
+	const controller = React.useMemo<ViewportController>(() => {
+		const notify = () => {
+			if (notifyRafRef.current !== 0) return
+			notifyRafRef.current = requestAnimationFrame(() => {
+				notifyRafRef.current = 0
+				const vp = viewportRef.current
+				for (const cb of subscribersRef.current) cb(vp)
+			})
+		}
+
+		const set = (vp: ViewportState) => {
+			const { traceStartMs: lo, traceEndMs: hi } = boundsRef.current
+			const clamped = clampViewport(vp, lo, hi)
+			viewportRef.current = clamped
+			for (const el of surfacesRef.current) writeTimeSurface(el, clamped, lo)
+			notify()
+		}
+
+		const cancelAnimation = () => {
+			cancelAnimationFrame(animRafRef.current)
+			animRafRef.current = 0
+		}
+
+		const self: ViewportController = {
+			get: () => viewportRef.current,
+			set,
+			zoomAt: (centerMs, factor) => {
+				const vp = viewportRef.current
+				const current = vp.endMs - vp.startMs
+				const next = current / factor
+				const ratio = (centerMs - vp.startMs) / current
+				const startMs = centerMs - ratio * next
+				set({ startMs, endMs: startMs + next })
+			},
+			panBy: (deltaMs) => {
+				const vp = viewportRef.current
+				set({ startMs: vp.startMs + deltaMs, endMs: vp.endMs + deltaMs })
+			},
+			zoomToRange: (a, b) => set({ startMs: Math.min(a, b), endMs: Math.max(a, b) }),
+			zoomToSpan: (startMs, endMs) => {
+				const padding = Math.max((endMs - startMs) * 0.1, 0.001)
+				// Eased: a jump straight to a µs-wide span loses all sense of where it sat.
+				self.animateTo({ startMs: startMs - padding, endMs: endMs + padding }, 220)
+			},
+			fit: () => {
+				// Exactly the navigable bounds — the same span the minimap strip draws — so a
+				// fitted timeline and the strip share one coordinate space and line up. Eased,
+				// because every caller (the Fit button, `F`, minimap double-click) wants that.
+				const { traceStartMs: lo, traceEndMs: hi } = boundsRef.current
+				const { loMs, hiMs } = viewportBounds(lo, hi)
+				self.animateTo({ startMs: loMs, endMs: hiMs }, 220)
+			},
+			animateTo: (target, durationMs = 160) => {
+				cancelAnimation()
+				const { traceStartMs: lo, traceEndMs: hi } = boundsRef.current
+				const to = clampViewport(target, lo, hi)
+				const from = viewportRef.current
+				const t0 = performance.now()
+				const step = (now: number) => {
+					const t = Math.min(1, (now - t0) / durationMs)
+					const k = Math.sin((t * Math.PI) / 2) // easeOutSine
+					set({
+						startMs: from.startMs + (to.startMs - from.startMs) * k,
+						endMs: from.endMs + (to.endMs - from.endMs) * k,
+					})
+					animRafRef.current = t < 1 ? requestAnimationFrame(step) : 0
+				}
+				animRafRef.current = requestAnimationFrame(step)
+			},
+			cancelAnimation,
+			subscribe: (cb) => {
+				subscribersRef.current.add(cb)
+				// Prime the subscriber so it paints from the current window rather than waiting
+				// for the next gesture — matters for a freshly mounted minimap or ruler.
+				cb(viewportRef.current)
+				return () => {
+					subscribersRef.current.delete(cb)
+				}
+			},
+			bindTimeSurface: (el) => {
+				if (!el) return () => {}
+				surfacesRef.current.add(el)
+				writeTimeSurface(el, viewportRef.current, boundsRef.current.traceStartMs)
+				return () => {
+					surfacesRef.current.delete(el)
+				}
+			},
+			get traceStartMs() {
+				return boundsRef.current.traceStartMs
+			},
+			get traceEndMs() {
+				return boundsRef.current.traceEndMs
+			},
+		}
+		return self
+		// Identity must never change: native listeners and subscribers bind to it once.
+	}, [])
+
+	// A new trace (or a recomputed default window) resets the viewport. Runs as a layout effect
+	// so the first paint of the new trace already carries the right CSS vars.
+	React.useLayoutEffect(() => {
+		controller.cancelAnimation()
+		controller.set(initialViewport)
+	}, [controller, initialViewport])
+
+	// Cancelling is not enough: `notify()` treats a non-zero id as "a frame is already
+	// scheduled" and skips, so leaving a cancelled id behind wedges every later
+	// notification. Under StrictMode's mount/unmount/remount that happens on the first
+	// paint, and the ruler and minimap simply stop updating for the rest of the session.
+	React.useEffect(
+		() => () => {
+			cancelAnimationFrame(notifyRafRef.current)
+			notifyRafRef.current = 0
+			cancelAnimationFrame(animRafRef.current)
+			animRafRef.current = 0
+		},
+		[],
+	)
+
+	return controller
+}

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -27,6 +27,35 @@ export function formatDuration(ms: number): string {
 }
 
 /**
+ * Format a duration for an axis tick, at a precision derived from the tick spacing.
+ *
+ * `formatDuration` has fixed precision, so a deeply zoomed ruler stepping by 0.05 ms renders
+ * "1.5ms" for three ticks in a row. Deriving the decimal count from the step guarantees
+ * adjacent ticks are always distinguishable, whatever the zoom.
+ *
+ * The unit follows the *value* (µs below 1 ms, s at or above 1000 ms) while the precision
+ * follows the *step*, so a 0.001 ms step still reads "1234μs" rather than "1.234000ms".
+ */
+export function formatDurationAtStep(ms: number, stepMs: number): string {
+	if (!Number.isFinite(ms)) return "—"
+	const step = Number.isFinite(stepMs) && stepMs > 0 ? stepMs : 1
+	// Decimals needed to separate two ticks one step apart. The epsilon absorbs the float noise
+	// in log10(0.001) = -3.0000000000000004, which would otherwise ask for one extra digit.
+	const decimalsFor = (unitStep: number) => Math.max(0, -Math.floor(Math.log10(unitStep) + 1e-9))
+
+	if (Math.abs(ms) < 1 && step < 1) {
+		return `${(ms * 1000).toFixed(decimalsFor(step * 1000))}μs`
+	}
+	if (Math.abs(ms) < 1000) {
+		return `${ms.toFixed(Math.min(3, decimalsFor(step)))}ms`
+	}
+	if (Math.abs(ms) < 60_000) {
+		return `${(ms / 1000).toFixed(Math.min(3, decimalsFor(step / 1000)))}s`
+	}
+	return `${(ms / 60_000).toFixed(Math.min(2, decimalsFor(step / 60_000)))}min`
+}
+
+/**
  * Format a number with compact notation.
  * - |n| >= 1T: displays as e.g. "1.2T"
  * - |n| >= 1B: displays as e.g. "2.5B"


### PR DESCRIPTION
Reworks the trace **Timeline** tab so pan and zoom are free, and makes it the default tab.

## Why

The viewport lived in a `useReducer`, so every wheel tick, drag frame and tween frame re-rendered the whole subtree. The worst of it was the minimap: one unvirtualized `div` per span, all of them repainting per frame on a 2000-span trace.

The features were already there (search, WASD, colour-by, marquee zoom, clip chevrons). What was missing was an engine that doesn't go through React on every frame.

## The change

The viewport is out of React. It lives in a ref inside `ViewportController` and reaches the DOM two ways:

1. **CSS custom properties** — the rows container carries `--vp0` (window start, trace-relative ms) and `--vpk` (`100 / visibleMs`); each bar carries `--b0`/`--b1` and positions itself with `left: clamp(-50%, calc((var(--b0) - var(--vp0)) * var(--vpk) * 1%), 150%)`. A gesture writes two properties and the style engine moves every bar.
2. **rAF-coalesced pub/sub** for what CSS can't express — the minimap overlay, the ruler, and the clip chevrons / outside-label side.

**Zero React commits during a gesture**, measured with a `MutationObserver`: 30 pan frames → exactly 30 mutations, all `style` on the rows container, none on any row. A 2500× wheel-zoom left the first bar's DOM node identical.

The alternative was to drive zoom by widening an inner scroller and letting native `scrollLeft` pan. I didn't take it: it would have replaced `clampViewport` and its tests, and capped zoom at the browser's ~33M px element limit (~20ms window on a 7-minute trace). The CSS-var approach keeps the ms model and the 0.1ms floor.

Also in here:

- **Ruler** ticks built with `createElement`, budgeted against the measured column (`MIN_TICK_PX = 56`) instead of a fixed count of 6, plus a gridline layer. New `formatDurationAtStep` derives precision from the tick interval — at a 0.83ms window the old formatter printed `600.5ms` sixteen times.
- **Minimap** split into memoized bars + an imperative overlay; edges hit-tested in px (8px) rather than 2%, which at a 3%-wide viewport had made the left handle unreachable.
- **One coordinate space.** `viewportBounds` is now the single definition of "the whole trace" for the minimap, ruler, default view and Fit — there were four, leaving the minimap ~80px out of step with the ruler. Padding is trailing-only so trace-zero sits flush at the left edge, with slack after the last span for the outside duration labels.
- Sticky label column sized from `--sidebar-w`, replacing the spacer divs and the per-row prop.
- ⌥-click folds a whole subtree; expand/collapse one level (`E` / `⇧E`).

## Bug found along the way

The controller's cleanup cancelled its pending rAF but didn't clear the id ref, so after StrictMode's remount the coalescing guard read the stale id as "already scheduled" and dropped every notification for the rest of the session — the ruler rendered nothing while bars positioned fine, because bars go through the synchronous CSS path. There's a `StrictMode`-wrapped regression test; I confirmed it fails without the fix.

## Reviewer notes

- **`@property` is deliberately not used** on `--vp0`/`--vpk`/`--b0`/`--b1`. Unregistered custom properties substitute as tokens so the `calc()` is evaluated in `double`; registering them as `<number>` stores float32, and at a 0.1ms window the rounding puts bars tens of percent off. There's a comment on `writeTimeSurface` saying so.
- **The Waterfall tab is untouched** but is no longer the landing tab. Its `PixelDurationBar` renders duration as 27 fixed blocks, so every sub-millisecond span lights the same single block — that's what prompted this.
- **`timeline-lab`** is a fixture route (registered in `FIXTURE_PATHS`) for iterating without a live API, following the existing `widget-lab` / `node-lab` convention. Happy to drop it if you'd rather not carry it.
- **Not verified against a real trace.** The API wasn't running locally, so everything was exercised against the synthetic fixture; a deep-linked `?spanId=` through `/traces/$traceId` and the detail panel are unexercised.
- Span-event markers and interleaved log rows are out of scope — neither is in the `spanHierarchyQuery` projection.

## Testing

- 272 tests pass in `@maple/ui` (57 new across `viewport-controller`, `timeline-ticks`, `auto-collapse`, and the slimmed reducer). Every existing `clampViewport` case still passes.
- `bun typecheck` clean across all 37 packages; oxlint and knip clean.
- Browser-verified: ⌘-wheel zoom, marquee zoom, shift-drag pan, WASD, F, `/` search, `?` overlay, zoom-to-span, minimap brush/pan/edge-resize/click-to-centre/double-click-fit, ⌥-click subtree collapse, the level buttons, and sidebar resize.
