### PR TITLE
fix(ci): repair knip config for the Maizzle email package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -681,7 +681,8 @@ jobs:
             - name: Install pinned DuckDB CLI
               if: matrix.duckdb
               run: |
-                  curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.5.3/duckdb_cli-linux-amd64.gz \
+                  curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
+                    https://github.com/duckdb/duckdb/releases/download/v1.5.3/duckdb_cli-linux-amd64.gz \
                     -o "$RUNNER_TEMP/duckdb.gz"
                   echo "f05f3b448a9a1bc6e7ac27ff14dfe67bf5761b153c2002723365a456618ef35b  $RUNNER_TEMP/duckdb.gz" \
                     | sha256sum --check --strict

--- a/knip.json
+++ b/knip.json
@@ -50,7 +50,8 @@
 			"ignoreBinaries": ["pscale"]
 		},
 		"packages/email": {
-			"entry": ["src/render-preview.tsx"]
+			"entry": ["scripts/**/*.ts"],
+			"ignoreDependencies": ["tailwindcss"]
 		},
 		"lib/effect-cloudflare": {
 			"ignoreDependencies": ["cloudflare"]


### PR DESCRIPTION
CI has been red on `main` since #428.

## knip (the real failure)

The react-email → Maizzle refactor deleted `packages/email/src/render-preview.tsx` and moved Tailwind into a Vue SFC `<style>` block (`@import "tailwindcss/theme.css"` in `components/MapleTailwind.vue`). knip cannot see a CSS `@import` inside an SFC, so `tailwindcss` looked unused and tripped the `devDependencies: "error"` rule — `bun knip` exited 1.

- entry pattern → `scripts/**/*.ts` (the build/preview scripts that actually exist)
- `ignoreDependencies: ["tailwindcss"]` — genuinely used, just invisible to knip

`bunx knip` now exits 0; the remaining findings are all `warn`-level (unused exports/types).

## DuckDB download

Both `Local archive native` jobs died on the same step: `curl` got a 503 from the GitHub release CDN with no retry. Added `--retry 5 --retry-delay 5 --retry-all-errors`. The sha256 check is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789167921&installation_model_id=427786&pr_number=449&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F449&signature=e0f194a1c46c48c98d8d5b01d5f1d8502e551f516d05561cbcff534f5aa71965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->