### PR TITLE
feat(replays): close the v2 search gap and move dashboard helpers internal

### DIFF
--- a/apps/api/src/routes/internal/session-replays.http.ts
+++ b/apps/api/src/routes/internal/session-replays.http.ts
@@ -1,0 +1,115 @@
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import {
+	CurrentTenant,
+	MapleInternalApi,
+	ReplaysFacetsResponse,
+	SessionTraceSummariesResponse,
+	TraceId,
+} from "@maple/domain/http"
+import { Effect, Schema } from "effect"
+import { CH } from "@maple/query-engine"
+import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
+
+const decodeTraceId = Schema.decodeSync(TraceId)
+
+/**
+ * Dashboard-only session-replay helpers.
+ *
+ * Facet counts feed the replays filter sidebar and trace summaries feed a
+ * session's timeline — both are shaped by what those views render, so they stay
+ * off the public API (`docs/http-api-migration.md` marks them "do not lift").
+ */
+export const HttpSessionReplaysInternalLive = HttpApiBuilder.group(
+	MapleInternalApi,
+	"sessionReplaysInternal",
+	(handlers) =>
+		Effect.gen(function* () {
+			const warehouse = yield* WarehouseQueryService
+
+			return handlers
+				.handle("facets", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
+						const compiled = CH.compileUnion(
+							CH.sessionReplaysFacetsQuery({
+								serviceName: payload.serviceName,
+								browser: payload.browser,
+								country: payload.country,
+								deviceType: payload.deviceType,
+								userId: payload.userId,
+								userSearch: payload.userSearch,
+								groupName: payload.groupName,
+								hasErrors: payload.hasErrors,
+								search: payload.search,
+							}),
+							{ orgId: tenant.orgId, startTime: payload.startTime, endTime: payload.endTime },
+						)
+						const rows = yield* warehouse.compiledQuery(tenant, compiled, {
+							profile: "list",
+							context: "replaysFacets",
+						})
+						// ClickHouse serializes integer aggregates (`uniq(...)`) as JSON strings,
+						// while the Tinybird path returns numbers; this query declares no row
+						// schema, so coerce at the edge before the Schema.Number response validates.
+						const pick = (facetType: string) =>
+							rows
+								.filter((row) => row.facetType === facetType)
+								.map((row) => ({ name: row.name, count: Number(row.count) }))
+						// The percentile branches ride the same {name, count} shape as the
+						// facets, with the quantile in `count` — read them back by label.
+						const stat = (name: string) =>
+							Number(
+								rows.find((row) => row.facetType === "durationStat" && row.name === name)
+									?.count ?? 0,
+							)
+						return new ReplaysFacetsResponse({
+							services: pick("service"),
+							browsers: pick("browser"),
+							countries: pick("country"),
+							devices: pick("device"),
+							groups: pick("group"),
+							errorCount: Number(rows.find((row) => row.facetType === "error")?.count ?? 0),
+							durationBuckets: pick("durationBucket"),
+							durationP50: stat("p50"),
+							durationP95: stat("p95"),
+						})
+					}),
+				)
+				.handle("traceSummaries", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						yield* Effect.annotateCurrentSpan({
+							orgId: tenant.orgId,
+							"maple.trace.count": payload.traceIds.length,
+						})
+						// `TraceId IN ()` is invalid SQL; a session with no correlated traces
+						// short-circuits to an empty result without touching the warehouse.
+						if (payload.traceIds.length === 0) {
+							return new SessionTraceSummariesResponse({ data: [] })
+						}
+						const compiled = CH.compile(
+							CH.sessionTraceSummariesQuery({
+								traceIds: payload.traceIds,
+								startTime: payload.windowStart,
+								endTime: payload.windowEnd,
+							}),
+							{ orgId: tenant.orgId },
+						)
+						const rows = yield* warehouse.compiledQuery(tenant, compiled, {
+							profile: "list",
+							context: "sessionTraceSummaries",
+						})
+						return new SessionTraceSummariesResponse({
+							data: rows.map((row) => ({
+								...row,
+								traceId: decodeTraceId(row.traceId),
+								// `count()` is UInt64 — same ClickHouse JSON-string coercion as
+								// listReplays' traceCount; coerce before Schema.Number validates.
+								spanCount: Number(row.spanCount),
+							})),
+						})
+					}),
+				)
+		}),
+)

--- a/apps/api/src/routes/v1/session-replay.http.ts
+++ b/apps/api/src/routes/v1/session-replay.http.ts
@@ -3,11 +3,9 @@ import {
 	CurrentTenant,
 	GetReplayResponse,
 	ListReplaysResponse,
-	ReplaysFacetsResponse,
 	MapleApi,
 	ReplaysForTraceResponse,
 	SessionTranscriptResponse,
-	SessionTraceSummariesResponse,
 	SessionId,
 	TraceId,
 	UserId,
@@ -65,55 +63,6 @@ export const HttpSessionReplaysLive = HttpApiBuilder.group(MapleApi, "sessionRep
 							// Schema.Number validates the response (see the facets handler).
 							traceCount: Number(row.traceCount),
 						})),
-					})
-				}),
-			)
-			.handle("facets", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
-					const compiled = CH.compileUnion(
-						CH.sessionReplaysFacetsQuery({
-							serviceName: payload.serviceName,
-							browser: payload.browser,
-							country: payload.country,
-							deviceType: payload.deviceType,
-							userId: payload.userId,
-							userSearch: payload.userSearch,
-							groupName: payload.groupName,
-							hasErrors: payload.hasErrors,
-							search: payload.search,
-						}),
-						{ orgId: tenant.orgId, startTime: payload.startTime, endTime: payload.endTime },
-					)
-					const rows = yield* warehouse.compiledQuery(tenant, compiled, {
-						profile: "list",
-						context: "replaysFacets",
-					})
-					// ClickHouse serializes integer aggregates (`uniq(...)`) as JSON strings,
-					// while the Tinybird path returns numbers; this query declares no row
-					// schema, so coerce at the edge before the Schema.Number response validates.
-					const pick = (facetType: string) =>
-						rows
-							.filter((row) => row.facetType === facetType)
-							.map((row) => ({ name: row.name, count: Number(row.count) }))
-					// The percentile branches ride the same {name, count} shape as the
-					// facets, with the quantile in `count` — read them back by label.
-					const stat = (name: string) =>
-						Number(
-							rows.find((row) => row.facetType === "durationStat" && row.name === name)
-								?.count ?? 0,
-						)
-					return new ReplaysFacetsResponse({
-						services: pick("service"),
-						browsers: pick("browser"),
-						countries: pick("country"),
-						devices: pick("device"),
-						groups: pick("group"),
-						errorCount: Number(rows.find((row) => row.facetType === "error")?.count ?? 0),
-						durationBuckets: pick("durationBucket"),
-						durationP50: stat("p50"),
-						durationP95: stat("p95"),
 					})
 				}),
 			)
@@ -206,41 +155,6 @@ export const HttpSessionReplaysLive = HttpApiBuilder.group(MapleApi, "sessionRep
 						data: rows.map((row) => ({
 							...row,
 							sessionId: decodeSessionId(row.sessionId),
-						})),
-					})
-				}),
-			)
-			.handle("traceSummaries", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					yield* Effect.annotateCurrentSpan({
-						orgId: tenant.orgId,
-						"maple.trace.count": payload.traceIds.length,
-					})
-					// `TraceId IN ()` is invalid SQL; a session with no correlated traces
-					// short-circuits to an empty result without touching the warehouse.
-					if (payload.traceIds.length === 0) {
-						return new SessionTraceSummariesResponse({ data: [] })
-					}
-					const compiled = CH.compile(
-						CH.sessionTraceSummariesQuery({
-							traceIds: payload.traceIds,
-							startTime: payload.windowStart,
-							endTime: payload.windowEnd,
-						}),
-						{ orgId: tenant.orgId },
-					)
-					const rows = yield* warehouse.compiledQuery(tenant, compiled, {
-						profile: "list",
-						context: "sessionTraceSummaries",
-					})
-					return new SessionTraceSummariesResponse({
-						data: rows.map((row) => ({
-							...row,
-							traceId: decodeTraceId(row.traceId),
-							// `count()` is UInt64 — same ClickHouse JSON-string coercion as
-							// listReplays' traceCount; coerce before Schema.Number validates.
-							spanCount: Number(row.spanCount),
 						})),
 					})
 				}),

--- a/apps/api/src/routes/v2/session-replays.http.ts
+++ b/apps/api/src/routes/v2/session-replays.http.ts
@@ -121,6 +121,9 @@ const HttpV2SessionReplaysGroup = HttpApiBuilder.group(MapleApiV2, "sessionRepla
 								...(payload.group_name !== undefined
 									? { groupName: payload.group_name }
 									: {}),
+								...(payload.visitor_id !== undefined
+									? { visitorId: payload.visitor_id }
+									: {}),
 								...(payload.has_errors !== undefined
 									? { hasErrors: payload.has_errors }
 									: {}),

--- a/apps/api/src/runtime/http-graph.ts
+++ b/apps/api/src/runtime/http-graph.ts
@@ -26,6 +26,7 @@ import { HttpOrganizationsLive } from "@/routes/v1/organizations.http"
 import { PlanetScaleWebhookRouter } from "@/routes/v1/planetscale-webhook.http"
 import { PrometheusScrapeProxyRouter } from "@/routes/v1/prometheus-scrape-proxy.http"
 import { HttpQueryEngineLive } from "@/routes/internal/query-engine.http"
+import { HttpSessionReplaysInternalLive } from "@/routes/internal/session-replays.http"
 import { ScraperInternalRouter } from "@/routes/v1/scraper-internal.http"
 import { HttpSessionReplaysLive } from "@/routes/v1/session-replay.http"
 import { SlackCallbackRouter, SlackInternalRouter } from "@/routes/v1/slack-integration.http"
@@ -104,7 +105,7 @@ const ApiRoutes = HttpApiBuilder.layer(MapleApi).pipe(
  * which is generated from `MapleApi`.
  */
 const ApiInternalRoutes = HttpApiBuilder.layer(MapleInternalApi).pipe(
-	Layer.provide(HttpQueryEngineLive),
+	Layer.provide(Layer.mergeAll(HttpQueryEngineLive, HttpSessionReplaysInternalLive)),
 	Layer.provide(V1ErrorBoundaryLive),
 )
 

--- a/apps/web/src/api/warehouse/replays.ts
+++ b/apps/web/src/api/warehouse/replays.ts
@@ -10,6 +10,7 @@ import {
 	TraceId,
 } from "@maple/domain/http"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleInternalAtomClient } from "@/lib/services/common/internal-atom-client"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 import {
 	WarehouseDateTimeString,
@@ -119,8 +120,8 @@ export const getReplaysFacets = Effect.fn("SessionReplays.facets")(function* ({
 	const fallback = defaultTimeRange(yield* Clock.currentTimeMillis)
 	const result = yield* runWarehouseQuery("replaysFacets", () =>
 		Effect.gen(function* () {
-			const client = yield* MapleApiAtomClient
-			return yield* client.sessionReplays.facets({
+			const client = yield* MapleInternalAtomClient
+			return yield* client.sessionReplaysInternal.facets({
 				payload: new ReplaysFacetsRequest({
 					startTime: input.startTime ?? fallback.startTime,
 					endTime: input.endTime ?? fallback.endTime,
@@ -352,8 +353,8 @@ export const getSessionTraceSummaries = Effect.fn("SessionReplays.traceSummaries
 	const input = yield* decodeInput(SessionTraceSummariesInput, data ?? { traceIds: [] }, "traceSummaries")
 	const result = yield* runWarehouseQuery("traceSummaries", () =>
 		Effect.gen(function* () {
-			const client = yield* MapleApiAtomClient
-			return yield* client.sessionReplays.traceSummaries({
+			const client = yield* MapleInternalAtomClient
+			return yield* client.sessionReplaysInternal.traceSummaries({
 				payload: new SessionTraceSummariesRequest({
 					traceIds: input.traceIds,
 					windowStart: input.windowStart,

--- a/packages/domain/src/http/internal-api.ts
+++ b/packages/domain/src/http/internal-api.ts
@@ -1,5 +1,6 @@
 import { HttpApi, OpenApi } from "effect/unstable/httpapi"
 import { QueryEngineApiGroup } from "./query-engine"
+import { SessionReplaysInternalApiGroup } from "./session-replay"
 import { V1SchemaErrors, V1UnexpectedErrors } from "./v1-boundary"
 
 /**
@@ -22,6 +23,7 @@ import { V1SchemaErrors, V1UnexpectedErrors } from "./v1-boundary"
  */
 export class MapleInternalApi extends HttpApi.make("MapleInternalApi")
 	.add(QueryEngineApiGroup)
+	.add(SessionReplaysInternalApiGroup)
 	.middleware(V1SchemaErrors)
 	.middleware(V1UnexpectedErrors)
 	.annotateMerge(

--- a/packages/domain/src/http/session-replay.ts
+++ b/packages/domain/src/http/session-replay.ts
@@ -2,7 +2,7 @@ import { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
 import { Schema } from "effect"
 import { SessionId, TraceId, UserId } from "../primitives"
 import { TinybirdDateTime } from "../query-engine"
-import { Authorization } from "./current-tenant"
+import { Authorization, SessionAuthorization } from "./current-tenant"
 import { QueryEngineExecutionError, QueryEngineTimeoutError } from "./query-engine"
 import { warehouseHttpErrors } from "./warehouse"
 
@@ -295,13 +295,6 @@ export class SessionReplaysApiGroup extends HttpApiGroup.make("sessionReplays")
 		}),
 	)
 	.add(
-		HttpApiEndpoint.post("facets", "/facets", {
-			payload: ReplaysFacetsRequest,
-			success: ReplaysFacetsResponse,
-			error: sessionReplayEndpointErrors,
-		}),
-	)
-	.add(
 		HttpApiEndpoint.post("getReplay", "/get", {
 			payload: GetReplayRequest,
 			success: GetReplayResponse,
@@ -321,13 +314,6 @@ export class SessionReplaysApiGroup extends HttpApiGroup.make("sessionReplays")
 		}),
 	)
 	.add(
-		HttpApiEndpoint.post("traceSummaries", "/trace-summaries", {
-			payload: SessionTraceSummariesRequest,
-			success: SessionTraceSummariesResponse,
-			error: sessionReplayEndpointErrors,
-		}),
-	)
-	.add(
 		HttpApiEndpoint.post("sessionTranscript", "/transcript", {
 			payload: SessionTranscriptRequest,
 			success: SessionTranscriptResponse,
@@ -336,3 +322,29 @@ export class SessionReplaysApiGroup extends HttpApiGroup.make("sessionReplays")
 	)
 	.prefix("/api/session-replays")
 	.middleware(Authorization) {}
+
+/**
+ * Session-replay helpers that exist for the dashboard and are not public API.
+ *
+ * Facet exploration and per-session trace summaries are shapes the replay UI
+ * drives — a filter sidebar's bucket counts and a timeline's span rollups — so
+ * `docs/http-api-migration.md` marks them "do not lift" to `/v2`. They live in
+ * the internal tier instead, where their shape can follow the UI.
+ */
+export class SessionReplaysInternalApiGroup extends HttpApiGroup.make("sessionReplaysInternal")
+	.add(
+		HttpApiEndpoint.post("facets", "/facets", {
+			payload: ReplaysFacetsRequest,
+			success: ReplaysFacetsResponse,
+			error: sessionReplayEndpointErrors,
+		}),
+	)
+	.add(
+		HttpApiEndpoint.post("traceSummaries", "/trace-summaries", {
+			payload: SessionTraceSummariesRequest,
+			success: SessionTraceSummariesResponse,
+			error: sessionReplayEndpointErrors,
+		}),
+	)
+	.prefix("/internal/session-replays")
+	.middleware(SessionAuthorization) {}

--- a/packages/domain/src/http/v2/session-replays.ts
+++ b/packages/domain/src/http/v2/session-replays.ts
@@ -293,6 +293,12 @@ export const V2SessionReplaySearchParams = Schema.Struct({
 	group_name: Schema.optionalKey(
 		Schema.String.annotate({ description: "Filter by identified group (company / team) name." }),
 	),
+	visitor_id: Schema.optionalKey(
+		Schema.String.annotate({
+			description:
+				"Filter by browser visitor. Unlike `user_id` this survives sign-in, so it walks from an anonymous session to the identified sessions of the same browser.",
+		}),
+	),
 	has_errors: Schema.optionalKey(
 		Schema.Boolean.annotate({ description: "Only sessions with (or without) errors." }),
 	),

--- a/packages/query-engine/src/ch/queries/session-replays.test.ts
+++ b/packages/query-engine/src/ch/queries/session-replays.test.ts
@@ -161,6 +161,32 @@ describe("sessionReplaysListQuery userId filter", () => {
 	})
 })
 
+// VisitorId is the cross-subdomain browser identity: unlike UserId it survives
+// sign-in, which is what lets the UI walk from an anonymous marketing session to
+// the identified product sessions of the same browser. It is exposed on both the
+// v1 list and the v2 search contract, so it needs coverage of its own rather than
+// riding along on the UserId cases above.
+describe("sessionReplaysListQuery visitorId filter", () => {
+	it("adds an exact VisitorId predicate when provided", () => {
+		const q = sessionReplaysListQuery({ visitorId: "vis_abc" })
+		const { sql } = compileCH(q, { ...baseParams, ...WINDOW })
+		expect(sql).toContain("VisitorId = 'vis_abc'")
+	})
+
+	it("omits the VisitorId predicate when absent", () => {
+		const q = sessionReplaysListQuery({})
+		const { sql } = compileCH(q, { ...baseParams, ...WINDOW })
+		expect(sql).not.toContain("VisitorId =")
+	})
+
+	it("combines with UserId rather than replacing it", () => {
+		const q = sessionReplaysListQuery({ userId: "user_123", visitorId: "vis_abc" })
+		const { sql } = compileCH(q, { ...baseParams, ...WINDOW })
+		expect(sql).toContain("UserId = 'user_123'")
+		expect(sql).toContain("VisitorId = 'vis_abc'")
+	})
+})
+
 // The list marks metadata-only sessions ("No recording") from the SDK's
 // `maple.session.recorded` resource attribute. It must survive every branch —
 // the fast path and all three subquery-wrapping ones — or the badge silently


### PR DESCRIPTION
> **Stacked on #461** — targets `refactor/query-engine-internal-tier`, because `MapleInternalApi` and `SessionAuthorization` only exist there. Review/merge #461 first; this rebases onto `main` once it lands.

## What

Groundwork for retiring the v1 `sessionReplays` group. Two prerequisites for migrating the remaining adapters onto v2:

1. Adds `visitor_id` to the v2 session-replay search contract.
2. Moves `facets` and `traceSummaries` to the internal tier.

## Why

**The v2 search gap.** v1 `ListReplaysRequest` can filter by visitor; `V2SessionReplaySearchParams` could not. That's the cross-subdomain walk from an anonymous marketing session to the identified product sessions of the same browser — the "Sessions from visitor" link off a session detail. Without it there was nothing to migrate `listReplays` onto.

It turned out to be **contract-only**. `SessionReplaysListOpts.visitorId` and its `WHERE` clause already exist in `sessionReplaysListQuery`, and v1 and v2 are two thin HTTP wrappers over that one query — the v2 handler simply never spread the field in. No SQL changed.

**The two helpers.** Facet counts shape the replays filter sidebar; trace summaries shape a session's timeline. Both follow what those views render, which is why `docs/http-api-migration.md` marks them "do not lift" to `/v2`. They now serve from `MapleInternalApi` at `/internal/session-replays` — session-only, absent from `/docs` — alongside the query-engine group from #461. Both are self-contained (`sessionReplaysFacetsQuery`, `sessionTraceSummariesQuery`, no coupling to the search path), so this is a lift rather than a rewrite.

## Test coverage

The `visitorId` filter was previously covered only incidentally, inside a `userId`-named describe block. This adds three explicit cases: predicate present when supplied, absent when not, and combining with `userId` rather than replacing it.

## Verification

| Check | Result |
|---|---|
| `bun typecheck` | 40/40 pass |
| `apps/api` tests | 1757 passed |
| `apps/web` tests | 1537 passed |
| `packages/domain` tests | 489 passed |
| `packages/query-engine` tests | 1106 passed (incl. 3 new) |
| `bun run knip` | exit 0 |
| Route introspection | `/internal/session-replays/{facets,trace-summaries}`; v1 retains `{list,get,for-trace,transcript}`; `/v2/session_replays/search` present |

## What's next, and the risk to know about

The v1 group keeps `list`, `get`, `for-trace` and `transcript`. Those move to v2 in the follow-up, and the group goes away with them.

Worth flagging now: **four of the v2 endpoints that follow-up depends on have never served a production request.** Over six months `/v2/session_replays` shows traffic only for `events` (28) and `manifest` (18); `search`, `retrieve`, `transcript` and `for_trace` are all at zero while their v1 counterparts are live. So that PR is the first real exercise of those handlers, their public-ID codecs and their envelopes.

One concrete consequence already identified: v1 `transcript` returns the whole transcript in one response and the events panel assumes that, while v2's is cursor-paginated — so that adapter needs a fetch-until-`has_more`-is-false loop, not a field rename.

## Not verified

No browser pass. `/internal/session-replays/*` returning 200 for a session and the typed 403 for an API key is still unproven at runtime, as is the filter sidebar rendering off the new prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789294601&installation_model_id=427786&pr_number=463&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F463&signature=7c45ab00dd50267c5a0cbe5ee4b30f40322f50aa366d04e9dac6ebd309349cf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->