### PR TITLE
refactor(web): move the anomalies views onto the v2 API

### DIFF
--- a/apps/web/src/components/anomalies/anomaly-link-issue-dialog.tsx
+++ b/apps/web/src/components/anomalies/anomaly-link-issue-dialog.tsx
@@ -17,7 +17,8 @@ import { Spinner } from "@maple/ui/components/ui/spinner"
 import { shortIssueId } from "@/components/errors/issue-id"
 import { WorkflowRingIcon } from "@/components/icons"
 import { formatRelativeTime } from "@maple/ui/lib/time-format"
-import { retainedQuery } from "@/lib/services/common/atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
+import { errorIssueFromV2 } from "@/lib/services/error-issues"
 
 export function AnomalyLinkIssueDialog({
 	incident,
@@ -49,14 +50,14 @@ function DialogContent({
 	const [query, setQuery] = useState("")
 	const [allServices, setAllServices] = useState(false)
 
-	const issuesQueryAtom = retainedQuery("errors", "listIssues", {
-		query: allServices ? { limit: 100 } : { service: incident.serviceName, limit: 100 },
+	const issuesQueryAtom = retainedQueryV2("errorIssues", "list", {
+		query: allServices ? { limit: 100 } : { service_name: incident.serviceName, limit: 100 },
 		reactivityKeys: ["errorIssues"],
 	})
 	const issuesResult = useAtomValue(issuesQueryAtom)
 
 	const issues = Result.builder(issuesResult)
-		.onSuccess((value) => value.issues)
+		.onSuccess((value) => value.data.map(errorIssueFromV2))
 		.orElse(() => [] as ReadonlyArray<ErrorIssueDocument>)
 
 	const filtered = useMemo(() => {

--- a/apps/web/src/components/anomalies/anomaly-linked-issue-card.tsx
+++ b/apps/web/src/components/anomalies/anomaly-linked-issue-card.tsx
@@ -10,7 +10,8 @@ import { shortIssueId } from "@/components/errors/issue-id"
 import { WorkflowBadge } from "@/components/errors/workflow-badge"
 import { ArrowRightIcon, LinkIcon, XmarkIcon } from "@/components/icons"
 import { formatNumber } from "@maple/ui/lib/format"
-import { retainedQuery } from "@/lib/services/common/atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
+import { errorIssueFromV2 } from "@/lib/services/error-issues"
 import { ServiceDot } from "@maple/ui/components/service-dot"
 
 export function AnomalyLinkedIssueCard({
@@ -71,8 +72,8 @@ function LinkedIssueBody({
 	onUnlink: () => void
 	busy: boolean
 }) {
-	const issueQueryAtom = retainedQuery("errors", "getIssue", {
-		params: { issueId },
+	const issueQueryAtom = retainedQueryV2("errorIssues", "retrieve", {
+		params: { id: issueId },
 		query: {},
 		reactivityKeys: ["errorIssues", `errorIssue:${issueId}`],
 	})
@@ -98,45 +99,53 @@ function LinkedIssueBody({
 							/>
 						</div>
 					))
-					.onSuccess(({ issue }) => (
-						<div className="flex flex-wrap items-start justify-between gap-3">
-							<div className="min-w-0 space-y-2">
-								<div className="flex flex-wrap items-center gap-2">
-									<WorkflowBadge state={issue.workflowState} />
-									<code className="font-mono text-xs tabular-nums text-muted-foreground">
-										{shortIssueId(issue.id)}
-									</code>
-									<span className="inline-flex h-5 items-center gap-1.5 rounded-full border border-border/70 bg-background px-2 text-[11px] text-muted-foreground">
-										<ServiceDot serviceName={issue.serviceName} className="size-1.5" />
-										<span className="max-w-[140px] truncate">{issue.serviceName}</span>
-									</span>
-								</div>
-								<p className="min-w-0 truncate font-medium text-foreground">
-									{issue.exceptionType || "Unknown error"}
-									{issue.exceptionMessage ? (
-										<span className="ml-2 font-normal text-muted-foreground">
-											{issue.exceptionMessage}
+					.onSuccess((detail) => {
+						const issue = errorIssueFromV2(detail)
+						return (
+							<div className="flex flex-wrap items-start justify-between gap-3">
+								<div className="min-w-0 space-y-2">
+									<div className="flex flex-wrap items-center gap-2">
+										<WorkflowBadge state={issue.workflowState} />
+										<code className="font-mono text-xs tabular-nums text-muted-foreground">
+											{shortIssueId(issue.id)}
+										</code>
+										<span className="inline-flex h-5 items-center gap-1.5 rounded-full border border-border/70 bg-background px-2 text-[11px] text-muted-foreground">
+											<ServiceDot
+												serviceName={issue.serviceName}
+												className="size-1.5"
+											/>
+											<span className="max-w-[140px] truncate">
+												{issue.serviceName}
+											</span>
 										</span>
-									) : null}
-								</p>
-								<div className="flex items-center gap-3 text-xs text-muted-foreground">
-									<span className="tabular-nums">
-										{formatNumber(issue.occurrenceCount)} events
-									</span>
-									<span className="flex items-center gap-1.5">
-										<ActorAvatar actor={issue.leaseHolder ?? issue.assignedActor} />
-										{issue.leaseHolder || issue.assignedActor ? null : "Unclaimed"}
-									</span>
+									</div>
+									<p className="min-w-0 truncate font-medium text-foreground">
+										{issue.exceptionType || "Unknown error"}
+										{issue.exceptionMessage ? (
+											<span className="ml-2 font-normal text-muted-foreground">
+												{issue.exceptionMessage}
+											</span>
+										) : null}
+									</p>
+									<div className="flex items-center gap-3 text-xs text-muted-foreground">
+										<span className="tabular-nums">
+											{formatNumber(issue.occurrenceCount)} events
+										</span>
+										<span className="flex items-center gap-1.5">
+											<ActorAvatar actor={issue.leaseHolder ?? issue.assignedActor} />
+											{issue.leaseHolder || issue.assignedActor ? null : "Unclaimed"}
+										</span>
+									</div>
 								</div>
+								<IssueCardActions
+									issueId={issueId}
+									onOpenLinkDialog={onOpenLinkDialog}
+									onUnlink={onUnlink}
+									busy={busy}
+								/>
 							</div>
-							<IssueCardActions
-								issueId={issueId}
-								onOpenLinkDialog={onOpenLinkDialog}
-								onUnlink={onUnlink}
-								busy={busy}
-							/>
-						</div>
-					))
+						)
+					})
 					.render()}
 			</CardContent>
 		</Card>

--- a/apps/web/src/components/anomalies/related-anomalies-section.tsx
+++ b/apps/web/src/components/anomalies/related-anomalies-section.tsx
@@ -4,13 +4,14 @@ import { Badge } from "@maple/ui/components/ui/badge"
 import { cn } from "@maple/ui/lib/utils"
 
 import { SectionHeader } from "@/components/layout/section-header"
-import { retainedQuery } from "@/lib/services/common/atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
+import { anomalyIncidentFromV2 } from "@/lib/services/anomalies"
 import { AnomalyRow } from "./anomaly-row"
 import { SEVERITY_TONE } from "./anomaly-format"
 
 function useRelatedAnomalies(issueId: ErrorIssueId) {
-	const incidentsQueryAtom = retainedQuery("anomalies", "listIncidents", {
-		query: { errorIssueId: issueId, limit: 50 },
+	const incidentsQueryAtom = retainedQueryV2("anomalies", "listIncidents", {
+		query: { error_issue_id: issueId, limit: 50 },
 		reactivityKeys: ["anomalyIncidents", `errorIssue:${issueId}:anomalies`],
 	})
 	return useAtomValue(incidentsQueryAtom)
@@ -23,7 +24,7 @@ function useRelatedAnomalies(issueId: ErrorIssueId) {
 export function RelatedAnomaliesSection({ issueId }: { issueId: ErrorIssueId }) {
 	const result = useRelatedAnomalies(issueId)
 	const incidents = Result.builder(result)
-		.onSuccess((value) => value.incidents)
+		.onSuccess((value) => value.data.map(anomalyIncidentFromV2))
 		.orElse(() => [])
 
 	if (incidents.length === 0) return null
@@ -52,7 +53,7 @@ export function RelatedAnomaliesSection({ issueId }: { issueId: ErrorIssueId }) 
 export function OpenAnomalyBadge({ issueId }: { issueId: ErrorIssueId }) {
 	const result = useRelatedAnomalies(issueId)
 	const openIncidents = Result.builder(result)
-		.onSuccess((value) => value.incidents.filter((incident) => incident.status === "open"))
+		.onSuccess((value) => value.data.filter((incident) => incident.status === "open"))
 		.orElse(() => [])
 
 	if (openIncidents.length === 0) return null

--- a/apps/web/src/components/anomalies/use-anomaly-mutations.ts
+++ b/apps/web/src/components/anomalies/use-anomaly-mutations.ts
@@ -1,25 +1,21 @@
 import { Exit } from "effect"
 import { toastManager } from "@maple/ui/components/ui/toast"
 import { useAtomSet } from "@/lib/effect-atom"
-import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
+import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 import { showErrorToast } from "@/lib/error-toast"
-import {
-	AnomalyIncidentLinkIssueRequest,
-	type AnomalyIncidentId,
-	type ErrorIssueId,
-} from "@maple/domain/http"
+import type { AnomalyIncidentId, ErrorIssueId } from "@maple/domain/http"
 
 export function useAnomalyMutations() {
-	const resolve = useAtomSet(MapleApiAtomClient.mutation("anomalies", "resolveIncident"), {
+	const resolve = useAtomSet(MapleApiV2AtomClient.mutation("anomalies", "resolveIncident"), {
 		mode: "promiseExit",
 	})
-	const setIssue = useAtomSet(MapleApiAtomClient.mutation("anomalies", "setIncidentIssue"), {
+	const setIssue = useAtomSet(MapleApiV2AtomClient.mutation("anomalies", "setIncidentIssue"), {
 		mode: "promiseExit",
 	})
 
 	const resolveIncident = async (incidentId: AnomalyIncidentId) => {
 		const result = await resolve({
-			params: { incidentId },
+			params: { id: incidentId },
 			reactivityKeys: ["anomalyIncidents", `anomalyIncident:${incidentId}`],
 		})
 		if (Exit.isSuccess(result)) {
@@ -43,8 +39,8 @@ export function useAnomalyMutations() {
 			.filter((id): id is ErrorIssueId => id != null)
 			.flatMap((id) => [`errorIssue:${id}`, `errorIssue:${id}:anomalies`, `errorIssue:${id}:events`])
 		const result = await setIssue({
-			params: { incidentId },
-			payload: new AnomalyIncidentLinkIssueRequest({ issueId }),
+			params: { id: incidentId },
+			payload: { issue_id: issueId },
 			reactivityKeys: ["anomalyIncidents", `anomalyIncident:${incidentId}`, ...issueKeys],
 		})
 		if (Exit.isSuccess(result)) {

--- a/apps/web/src/components/dashboard/service-health-section.tsx
+++ b/apps/web/src/components/dashboard/service-health-section.tsx
@@ -4,7 +4,8 @@ import { Link } from "@tanstack/react-router"
 import { Result } from "@/lib/effect-atom"
 import { useRetainedRefreshableResultValue } from "@/hooks/use-retained-refreshable-result-value"
 import { getServiceHealthSnapshotResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
-import { openAnomalyIncidentsAtom } from "@/lib/services/atoms/anomaly-atoms"
+import { openAnomalyServiceCountsAtom } from "@/lib/services/atoms/anomaly-atoms"
+import { anomalyServiceCountFromV2, type AnomalyServiceCount } from "@/lib/services/anomalies"
 import { disabledResultAtom } from "@/lib/services/atoms/disabled-result-atom"
 import { useAlertIncidentsList, useAlertRulesList } from "@/hooks/use-alerts-list"
 import { QueryErrorState } from "@/components/common/query-error-state"
@@ -13,7 +14,7 @@ import { anomalyAffectsServiceHealth } from "@/components/anomalies/anomaly-form
 import { StatRail, StatRailItem, StatRailLoading } from "@/components/infra/primitives/stat-rail"
 import { ArrowRightIcon, ArrowTrendDownIcon, ArrowTrendUpIcon } from "@/components/icons"
 import type { ServiceHealthSnapshot } from "@/api/warehouse/services"
-import type { AlertIncidentDocument, AnomalyIncidentDocument, AnomalySignalType } from "@maple/domain/http"
+import type { AlertIncidentDocument, AnomalySignalType } from "@maple/domain/http"
 
 import { Card } from "@maple/ui/components/ui/card"
 import { Badge } from "@maple/ui/components/ui/badge"
@@ -111,7 +112,7 @@ function useServiceHealthData({ startTime, endTime, environments, canFetch }: Se
 			: disabledResultAtom<{ data: ServiceHealthSnapshot[] }, unknown>(),
 	)
 
-	const anomaliesResult = useRetainedRefreshableResultValue(openAnomalyIncidentsAtom)
+	const anomaliesResult = useRetainedRefreshableResultValue(openAnomalyServiceCountsAtom)
 
 	const { result: alertIncidentsResult } = useAlertIncidentsList()
 	const { result: rulesResult } = useAlertRulesList()
@@ -138,7 +139,7 @@ function useServiceHealthData({ startTime, endTime, environments, canFetch }: Se
 function enrichServices(
 	services: readonly ServiceHealthSnapshot[],
 	openIncidents: ReadonlyArray<AlertIncidentDocument>,
-	openAnomalies: ReadonlyArray<AnomalyIncidentDocument>,
+	openAnomalies: ReadonlyArray<AnomalyServiceCount>,
 ): EnrichedService[] {
 	return services
 		.map((service) => {
@@ -231,7 +232,11 @@ export function ServiceHealthOverview(props: ServiceHealthProps) {
 		.onSuccess(([snapshotResponse, anomaliesResponse, alertsResponse], result) => {
 			const activeAlerts = alertsResponse.incidents.filter((incident) => incident.status === "open")
 			const counts = countByHealth(
-				enrichServices(snapshotResponse.data, activeAlerts, anomaliesResponse.incidents),
+				enrichServices(
+					snapshotResponse.data,
+					activeAlerts,
+					anomaliesResponse.data.map(anomalyServiceCountFromV2),
+				),
 			)
 			return (
 				<section className={cn("mb-4 space-y-3", result.waiting && "opacity-60 transition-opacity")}>
@@ -323,7 +328,7 @@ export function ServiceHealthList(props: ServiceHealthProps) {
 			const rows = enrichServices(
 				snapshotResponse.data,
 				activeAlerts,
-				anomaliesResponse.incidents,
+				anomaliesResponse.data.map(anomalyServiceCountFromV2),
 			).slice(0, MAX_ROWS)
 			return (
 				<section className={cn("mt-4 space-y-3", result.waiting && "opacity-60 transition-opacity")}>

--- a/apps/web/src/components/services/services-table.tsx
+++ b/apps/web/src/components/services/services-table.tsx
@@ -42,7 +42,7 @@ import {
 	getServiceHealthBaselineResultAtom,
 	getServiceOverviewResultAtom,
 } from "@/lib/services/atoms/warehouse-query-atoms"
-import { openAnomalyIncidentsAtom } from "@/lib/services/atoms/anomaly-atoms"
+import { openAnomalyServiceCountsAtom } from "@/lib/services/atoms/anomaly-atoms"
 import type { ServicesSearchParams } from "@/routes/services/index"
 import { ServiceDot } from "@maple/ui/components/service-dot"
 import { LatencyValue } from "@maple/ui/components/latency-value"
@@ -586,7 +586,7 @@ export function ServicesTable({ filters }: ServicesTableProps) {
 	// from "healthy" to "unhealthy" after first paint; the derivation itself
 	// lives in useServiceHealthSummary (shared with the filter sidebar).
 	const { result: incidentsResult } = useAlertIncidentsList()
-	const anomaliesResult = useAtomValue(openAnomalyIncidentsAtom)
+	const anomaliesResult = useAtomValue(openAnomalyServiceCountsAtom)
 	const healthSummary = useServiceHealthSummary({
 		startTime: effectiveStartTime,
 		endTime: effectiveEndTime,

--- a/apps/web/src/components/services/use-service-health-summary.ts
+++ b/apps/web/src/components/services/use-service-health-summary.ts
@@ -1,7 +1,8 @@
 import React from "react"
 import { Result, useAtomValue } from "@/lib/effect-atom"
 import { useAlertIncidentsList } from "@/hooks/use-alerts-list"
-import { openAnomalyIncidentsAtom } from "@/lib/services/atoms/anomaly-atoms"
+import { openAnomalyServiceCountsAtom } from "@/lib/services/atoms/anomaly-atoms"
+import { anomalyServiceCountFromV2 } from "@/lib/services/anomalies"
 import { getServiceOverviewResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { anomalyAffectsServiceHealth } from "@/components/anomalies/anomaly-format"
 import {
@@ -39,7 +40,7 @@ export const isServiceHealth = (value: string): value is ServiceHealth =>
 export function useServiceHealthSummary(input: GetServiceOverviewInput): ServiceHealthSummary | undefined {
 	const overviewResult = useAtomValue(getServiceOverviewResultAtom({ data: input }))
 	const { result: incidentsResult } = useAlertIncidentsList()
-	const anomaliesResult = useAtomValue(openAnomalyIncidentsAtom)
+	const anomaliesResult = useAtomValue(openAnomalyServiceCountsAtom)
 
 	const overview = Result.isSuccess(overviewResult) ? overviewResult.value : undefined
 	const incidents = Result.isSuccess(incidentsResult) ? incidentsResult.value : undefined
@@ -58,11 +59,11 @@ export function useServiceHealthSummary(input: GetServiceOverviewInput): Service
 		}
 
 		const anomalyCausesByRow = new Map<string, ServiceHealthCause[]>()
-		for (const incident of anomalies.incidents) {
-			if (!anomalyAffectsServiceHealth(incident)) continue
-			const key = serviceHealthRowKey(incident.serviceName, incident.deploymentEnv)
+		for (const row of anomalies.data.map(anomalyServiceCountFromV2)) {
+			if (!anomalyAffectsServiceHealth(row)) continue
+			const key = serviceHealthRowKey(row.serviceName, row.deploymentEnv)
 			const causes = anomalyCausesByRow.get(key)
-			const cause: ServiceHealthCause = { severity: incident.severity, label: "Anomaly" }
+			const cause: ServiceHealthCause = { severity: row.severity, label: "Anomaly" }
 			if (causes) causes.push(cause)
 			else anomalyCausesByRow.set(key, [cause])
 		}

--- a/apps/web/src/lib/services/anomalies.ts
+++ b/apps/web/src/lib/services/anomalies.ts
@@ -1,0 +1,112 @@
+import {
+	AnomalyIncidentDocument,
+	AnomalyIncidentFingerprint,
+	AnomalyIncidentTimeseriesResponse,
+	AnomalyTimeseriesBucket,
+	IsoDateTimeString,
+} from "@maple/domain/http"
+import type {
+	V2AnomalyIncident,
+	V2AnomalyIncidentTimeseries,
+	V2AnomalyServiceCount,
+} from "@maple/domain/http/v2"
+import { Schema } from "effect"
+
+/**
+ * v2 wire → the domain documents the anomaly components are typed on.
+ *
+ * Mirrors `error-issues.ts`. Keeping the rename in one module is what lets the
+ * ~12 components that consume `AnomalyIncidentDocument` stay untouched by the
+ * v1 → v2 migration; their tests double as its regression oracle.
+ *
+ * Both wires are already ISO-8601, so this is a field rename, not a format
+ * conversion — `asIso` only re-applies the domain brand.
+ */
+const asIso = Schema.decodeUnknownSync(IsoDateTimeString)
+const asIsoOrNull = (value: string | null) => (value === null ? null : asIso(value))
+
+export const anomalyIncidentFromV2 = (incident: V2AnomalyIncident): AnomalyIncidentDocument =>
+	new AnomalyIncidentDocument({
+		id: incident.id,
+		detectorKey: incident.detector_key,
+		signalType: incident.signal_type,
+		serviceName: incident.service_name,
+		deploymentEnv: incident.deployment_env,
+		fingerprintHash: incident.fingerprint_hash,
+		errorIssueId: incident.error_issue_id,
+		status: incident.status,
+		severity: incident.severity,
+		openedValue: incident.opened_value,
+		baselineMedian: incident.baseline_median,
+		baselineSigma: incident.baseline_sigma,
+		thresholdValue: incident.threshold_value,
+		lastObservedValue: incident.last_observed_value,
+		lastSampleCount: incident.last_sample_count,
+		firstTriggeredAt: asIso(incident.first_triggered_at),
+		lastTriggeredAt: asIso(incident.last_triggered_at),
+		resolvedAt: asIsoOrNull(incident.resolved_at),
+		resolveReason: incident.resolve_reason,
+		triageStatus: incident.triage_status,
+		fingerprints: incident.fingerprints.map(
+			(fingerprint) =>
+				new AnomalyIncidentFingerprint({
+					fingerprintHash: fingerprint.fingerprint_hash,
+					errorIssueId: fingerprint.error_issue_id,
+					openedValue: fingerprint.opened_value,
+					lastValue: fingerprint.last_value,
+					severity: fingerprint.severity,
+					attachedAt: asIso(fingerprint.attached_at),
+					resolvedAt: asIsoOrNull(fingerprint.resolved_at),
+				}),
+		),
+		reopenCount: incident.reopen_count,
+		lastReopenedAt: asIsoOrNull(incident.last_reopened_at),
+	})
+
+export const anomalyTimeseriesFromV2 = (
+	timeseries: V2AnomalyIncidentTimeseries,
+): AnomalyIncidentTimeseriesResponse =>
+	new AnomalyIncidentTimeseriesResponse({
+		signalType: timeseries.signal_type,
+		unit: timeseries.unit,
+		bucketSeconds: timeseries.bucket_seconds,
+		buckets: timeseries.buckets.map(
+			(bucket) =>
+				new AnomalyTimeseriesBucket({
+					bucket: asIso(bucket.bucket),
+					value: bucket.value,
+					sampleCount: bucket.sample_count,
+				}),
+		),
+		baselineMedian: timeseries.baseline_median,
+		thresholdValue: timeseries.threshold_value,
+	})
+
+/**
+ * One (service, environment, signal) group from `/v2/anomalies/incidents/service_counts`.
+ *
+ * Deliberately not an `AnomalyIncidentDocument`: the fleet-health surfaces only
+ * ever shaded rows from these five fields, and pretending a group is an incident
+ * would invent an id that identifies nothing.
+ */
+export interface AnomalyServiceCount {
+	readonly serviceName: string
+	readonly deploymentEnv: string
+	readonly signalType: AnomalyIncidentDocument["signalType"]
+	readonly severity: AnomalyIncidentDocument["severity"]
+	readonly incidentCount: number
+	readonly lastTriggeredAt: string
+	readonly status: AnomalyIncidentDocument["status"]
+}
+
+export const anomalyServiceCountFromV2 = (row: V2AnomalyServiceCount): AnomalyServiceCount => ({
+	serviceName: row.service_name,
+	deploymentEnv: row.deployment_env,
+	signalType: row.signal_type,
+	severity: row.severity,
+	incidentCount: row.incident_count,
+	lastTriggeredAt: row.last_triggered_at,
+	// The endpoint aggregates open incidents; carrying the status keeps
+	// `anomalyAffectsServiceHealth`'s predicate readable at the call site.
+	status: "open",
+})

--- a/apps/web/src/lib/services/atoms/anomaly-atoms.ts
+++ b/apps/web/src/lib/services/atoms/anomaly-atoms.ts
@@ -1,11 +1,15 @@
-import { retainedQuery } from "@/lib/services/common/atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 
 /**
- * Shared open-incident read for service health surfaces. A module-level atom
+ * Shared open-incident rollup for service health surfaces. A module-level atom
  * ensures the dashboard summary, dashboard list, and services page all observe
  * the same request/cache entry and invalidate together.
+ *
+ * This is the `service_counts` aggregate rather than a list: the readers only
+ * ever shaded per-(service, environment) rows, and v2 lists cap at 100 while
+ * the old v1 call took 500 in one shot.
  */
-export const openAnomalyIncidentsAtom = retainedQuery("anomalies", "listIncidents", {
-	query: { status: "open", limit: 500 },
+export const openAnomalyServiceCountsAtom = retainedQueryV2("anomalies", "serviceCounts", {
+	query: { status: "open" },
 	reactivityKeys: ["anomalyIncidents"],
 })

--- a/apps/web/src/routes/anomalies/$incidentId.tsx
+++ b/apps/web/src/routes/anomalies/$incidentId.tsx
@@ -22,7 +22,8 @@ import { useAnomalyMutations } from "@/components/anomalies/use-anomaly-mutation
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { SectionHeader } from "@/components/layout/section-header"
 import { useIntervalRefresh } from "@/hooks/use-interval-refresh"
-import { retainedQuery } from "@/lib/services/common/atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
+import { anomalyIncidentFromV2, anomalyTimeseriesFromV2 } from "@/lib/services/anomalies"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 import { formatRelativeTime } from "@maple/ui/lib/time-format"
 import {
@@ -43,6 +44,14 @@ import { cn } from "@maple/ui/lib/utils"
 import { AnomalyIncidentId, type AnomalyIncidentDocument, type ErrorIssueId } from "@maple/domain/http"
 
 const decodeIncidentId = Schema.decodeSync(AnomalyIncidentId)
+
+/**
+ * The v2 envelope nests the failure under `error`, so the tag has to come from
+ * `displayError` rather than a direct `_tag` read — the literal itself is
+ * preserved end to end.
+ */
+const isIncidentNotFound = (error: unknown) =>
+	displayError(error)._tag === "@maple/http/anomalies/AnomalyIncidentNotFoundError"
 const LIVE_REFRESH_INTERVAL_MS = 15_000
 const ANOMALY_LOADING_BREADCRUMBS = [{ label: "Anomalies", href: "/anomalies" }, { label: "…" }] as const
 
@@ -54,8 +63,8 @@ function AnomalyDetailPage() {
 	const { incidentId: rawIncidentId } = Route.useParams()
 	const incidentId = decodeIncidentId(rawIncidentId)
 
-	const incidentQueryAtom = retainedQuery("anomalies", "getIncident", {
-		params: { incidentId },
+	const incidentQueryAtom = retainedQueryV2("anomalies", "getIncident", {
+		params: { id: incidentId },
 		reactivityKeys: ["anomalyIncidents", `anomalyIncident:${incidentId}`],
 	})
 	const incidentResult = useAtomValue(incidentQueryAtom)
@@ -103,14 +112,15 @@ function AnomalyDetailPage() {
 							<Empty>
 								<EmptyHeader>
 									<EmptyTitle>
-										{error._tag === "@maple/http/anomalies/AnomalyIncidentNotFoundError"
+										{isIncidentNotFound(error)
 											? "Anomaly not found"
 											: "Failed to load anomaly"}
 									</EmptyTitle>
 									<EmptyDescription>
-										{error._tag === "@maple/http/anomalies/AnomalyIncidentNotFoundError"
+										{isIncidentNotFound(error)
 											? "It may have been pruned, or the link is stale."
-											: (error.message ?? "Try refreshing or check API logs.")}
+											: (displayError(error).message ??
+												"Try refreshing or check API logs.")}
 									</EmptyDescription>
 								</EmptyHeader>
 								<Button variant="outline" size="sm" render={<Link to="/anomalies" />}>
@@ -122,7 +132,9 @@ function AnomalyDetailPage() {
 				</DashboardLayout.Body>
 			</DashboardLayout.Root>
 		))
-		.onSuccess((incident) => <AnomalyDetailBody incident={incident} incidentId={incidentId} />)
+		.onSuccess((incident) => (
+			<AnomalyDetailBody incident={anomalyIncidentFromV2(incident)} incidentId={incidentId} />
+		))
 		.render()
 }
 
@@ -146,8 +158,8 @@ function AnomalyDetailBody({
 	const isStale = isStaleOpenIncident(incident)
 	const tone = severityToneFor(incident)
 
-	const timeseriesQueryAtom = retainedQuery("anomalies", "getIncidentTimeseries", {
-		params: { incidentId },
+	const timeseriesQueryAtom = retainedQueryV2("anomalies", "getIncidentTimeseries", {
+		params: { id: incidentId },
 		query: {},
 		reactivityKeys: [`anomalyIncident:${incidentId}:timeseries`],
 	})
@@ -309,7 +321,10 @@ function AnomalyDetailBody({
 										</div>
 									))
 									.onSuccess((timeseries) => (
-										<AnomalyTimeseriesChart incident={incident} timeseries={timeseries} />
+										<AnomalyTimeseriesChart
+											incident={incident}
+											timeseries={anomalyTimeseriesFromV2(timeseries)}
+										/>
 									))
 									.render()}
 							</section>

--- a/apps/web/src/routes/anomalies/index.tsx
+++ b/apps/web/src/routes/anomalies/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Result, useAtomRefresh } from "@/lib/effect-atom"
 import { Schema } from "effect"
@@ -16,7 +16,10 @@ import {
 } from "@/components/anomalies/anomaly-group"
 import { AnomalyLiveIndicator } from "@/components/anomalies/anomaly-live-indicator"
 import { ListToolbar } from "@/components/common/list-toolbar"
-import { retainedQuery } from "@/lib/services/common/atom-client"
+import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
+import { runMapleApiV2 } from "@/lib/collections/api-runner"
+import { anomalyIncidentFromV2 } from "@/lib/services/anomalies"
+import { toastManager } from "@maple/ui/components/ui/toast"
 import { Button } from "@maple/ui/components/ui/button"
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@maple/ui/components/ui/empty"
 import { ErrorState } from "@/components/common/error-state"
@@ -24,9 +27,16 @@ import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import type { AnomalyIncidentDocument, AnomalyIncidentId } from "@maple/domain/http"
 
 const LIVE_REFRESH_INTERVAL_MS = 15_000
-const INCIDENTS_PAGE_LIMIT = 500
+// v2 lists cap at 100; further pages arrive through the explicit "Load more".
+const INCIDENTS_PAGE_LIMIT = 100
 
 type StatusTab = "open" | "resolved" | "all"
+
+interface LoadedPages {
+	readonly key: StatusTab
+	readonly rows: ReadonlyArray<AnomalyIncidentDocument>
+	readonly nextCursor: string | null
+}
 
 const TOOLBAR_TABS: ReadonlyArray<{ value: StatusTab; label: string }> = [
 	{ value: "open", label: "Open" },
@@ -61,14 +71,37 @@ function AnomaliesPage() {
 	const status: StatusTab = search.status ?? "open"
 	const live = search.live ?? status === "open"
 
-	const incidentsQueryAtom = retainedQuery("anomalies", "listIncidents", {
-		query: status === "all" ? { limit: INCIDENTS_PAGE_LIMIT } : { status, limit: INCIDENTS_PAGE_LIMIT },
-		reactivityKeys: ["anomalyIncidents"],
-	})
+	const listQuery = useMemo(
+		() => (status === "all" ? { limit: INCIDENTS_PAGE_LIMIT } : { status, limit: INCIDENTS_PAGE_LIMIT }),
+		[status],
+	)
+	// Memoized because `useRetainedRefreshableResultValue` updates state during
+	// render when the Result identity changes: a fresh atom per render would
+	// feed it a fresh Result every time and never converge.
+	const incidentsQueryAtom = useMemo(
+		() =>
+			retainedQueryV2("anomalies", "listIncidents", {
+				query: listQuery,
+				reactivityKeys: ["anomalyIncidents"],
+			}),
+		[listQuery],
+	)
 	// Retain the previous list across tab switches so the page never collapses
 	// back to skeletons; live refresh ticks keep the same atom and never dim.
 	const incidentsResult = useRetainedRefreshableResultValue(incidentsQueryAtom)
-	const refreshIncidents = useAtomRefresh(incidentsQueryAtom)
+	const refreshFirstPage = useAtomRefresh(incidentsQueryAtom)
+
+	// Pages loaded past the first. Keyed by the tab they were fetched for, so a
+	// tab switch discards them without an effect; a refresh clears them outright,
+	// otherwise the live tick would leave stale rows below fresh ones.
+	const [loadedPages, setLoadedPages] = useState<LoadedPages | null>(null)
+	const [loadingMore, setLoadingMore] = useState(false)
+	const pages = loadedPages?.key === status ? loadedPages : null
+
+	const refreshIncidents = useCallback(() => {
+		setLoadedPages(null)
+		refreshFirstPage()
+	}, [refreshFirstPage])
 
 	useIntervalRefresh(refreshIncidents, {
 		intervalMs: LIVE_REFRESH_INTERVAL_MS,
@@ -101,7 +134,36 @@ function AnomaliesPage() {
 		})
 	}, [navigate])
 
-	const allIncidents = Result.isSuccess(incidentsResult) ? incidentsResult.value.incidents : []
+	const firstPage = Result.isSuccess(incidentsResult) ? incidentsResult.value : undefined
+	const allIncidents = useMemo(() => {
+		const firstPageIncidents = firstPage?.data.map(anomalyIncidentFromV2) ?? []
+		if (pages === null) return firstPageIncidents
+		const byId = new Map(firstPageIncidents.map((incident) => [incident.id, incident]))
+		for (const incident of pages.rows) if (!byId.has(incident.id)) byId.set(incident.id, incident)
+		return [...byId.values()]
+	}, [firstPage, pages])
+
+	const nextCursor = pages === null ? (firstPage?.next_cursor ?? null) : pages.nextCursor
+
+	const loadMore = useCallback(async () => {
+		if (nextCursor === null || loadingMore) return
+		setLoadingMore(true)
+		try {
+			const page = await runMapleApiV2((client) =>
+				client.anomalies.listIncidents({ query: { ...listQuery, cursor: nextCursor } }),
+			)
+			const rows = page.data.map(anomalyIncidentFromV2)
+			setLoadedPages((current) => ({
+				key: status,
+				rows: [...(current?.key === status ? current.rows : []), ...rows],
+				nextCursor: page.next_cursor,
+			}))
+		} catch {
+			toastManager.add({ title: "More anomalies could not be loaded", type: "error" })
+		} finally {
+			setLoadingMore(false)
+		}
+	}, [listQuery, loadingMore, nextCursor, status])
 
 	const filtered = useMemo(
 		() =>
@@ -210,6 +272,9 @@ function AnomaliesPage() {
 				onClearFilters={clearFilters}
 				toolbar={toolbar}
 				Shell={AnomaliesShell}
+				hasMore={nextCursor !== null}
+				loadingMore={loadingMore}
+				onLoadMore={loadMore}
 			/>
 		))
 		.render()
@@ -222,6 +287,9 @@ function AnomaliesPageBody({
 	onClearFilters,
 	toolbar,
 	Shell,
+	hasMore,
+	loadingMore,
+	onLoadMore,
 }: {
 	incidents: ReadonlyArray<AnomalyIncidentDocument>
 	status: StatusTab
@@ -229,6 +297,9 @@ function AnomaliesPageBody({
 	onClearFilters: () => void
 	toolbar: React.ReactNode
 	Shell: (props: { children: React.ReactNode }) => React.ReactElement
+	hasMore: boolean
+	loadingMore: boolean
+	onLoadMore: () => void
 }) {
 	const navigate = useNavigate({ from: Route.fullPath })
 
@@ -328,6 +399,18 @@ function AnomaliesPageBody({
 								onFocus={setFocusedId}
 							/>
 						))}
+						{hasMore ? (
+							<div className="flex justify-center p-4">
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={onLoadMore}
+									disabled={loadingMore}
+								>
+									{loadingMore ? "Loading…" : "Load more"}
+								</Button>
+							</div>
+						) : null}
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
Second of two stacked PRs for step 3 of `docs/http-api-migration.md`.

**Stacked on #468** (the `service_counts` aggregate). Base is
`feat/anomalies-v2-aggregate`, so this diff is web-only — review #468 first, and
merge it first.

## What

Every `apps/web` caller of the v1 `anomalies` group now uses v2, which is what
starts the retirement clock on the group. The two `errors` calls inside the
anomalies feature move at the same time (they have live v2 equivalents already
used by the issues routes); the `errors` group itself keeps plenty of other v1
callers and is untouched.

No v1 group is deleted here. That needs the retirement gate's traffic evidence,
and the clock starts when this deploys.

## What reviewers should look at

**The renames live in one adapter**, `lib/services/anomalies.ts`, mirroring the
existing `error-issues.ts`. Everything downstream stays typed on
`AnomalyIncidentDocument`, so the ~12 anomaly components are untouched and their
tests pass unchanged — that is the oracle for the adapter being correct. Both
wires are already ISO-8601, so there is no timestamp conversion and the
timeseries chart is unchanged.

**Nothing about identity or caching changes.** The public-ID codec runs in the
client's param encoder, so `/anomalies/$incidentId` still takes a raw UUID —
existing links and bookmarks keep working — and reactivity keys keep their exact
strings, so v1 and v2 readers of the same entity still invalidate together.

**One accepted behaviour change.** The list takes 100 rows and pages with an
explicit "Load more" (the issues-index pattern) instead of grabbing 500. Sidebar
facet counts now reflect loaded rows rather than a 500-row snapshot.

**Three quiet failure modes, all fixed here.**

- `$incidentId` compared `error._tag` directly, which is `undefined` under the
  v2 envelope — the not-found branch degraded to a generic message. It goes
  through `displayError` now; the tag literal is preserved end to end.
- Accumulated pages are keyed by tab and dropped on refresh, so the 15s live
  tick cannot leave stale rows below fresh ones.
- The list atom is memoized. `useRetainedRefreshableResultValue` updates state
  during render when the Result identity changes, so a fresh atom per render
  never converges — it rendered as "Too many re-renders". The issues index uses
  plain `useAtomValue` and so never hit this.

## Verification

- 33 web component tests pass **unchanged** — `anomaly-format` and
  `anomalies-filter-sidebar` build fixtures from `AnomalyIncidentDocument`.
- `turbo typecheck --force` across web, api and domain (a warm cache hides
  exactly this class of cross-package break).
- In the browser on the v2 endpoints: the list, the detail page with its
  timeseries chart, the linked-issue card, and a bogus id for the not-found
  branch. Confirmed the request goes out as `anom_…` with a raw UUID in the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
