### PR TITLE
refactor(alerts): name what a rule measures, and put delivery behind a transport registry

### DIFF
--- a/apps/api/src/services/alerts/AlertDeliveryDispatch.providers.test.ts
+++ b/apps/api/src/services/alerts/AlertDeliveryDispatch.providers.test.ts
@@ -1,0 +1,364 @@
+import type { AlertDestinationRow } from "@maple/db"
+import { AlertDeliveryError, AlertDestinationId } from "@maple/domain/http"
+import { assert, describe, it } from "@effect/vitest"
+import { createHmac } from "node:crypto"
+import { Effect, Schema } from "effect"
+import type { DispatchContext } from "./AlertDeliveryDispatch"
+import { dispatchDelivery, type DispatchDeps } from "./delivery/dispatch"
+
+/**
+ * Characterization tests: they pin what each provider ACTUALLY sends today,
+ * before the delivery layer is restructured onto a transport registry.
+ *
+ * `discord`, `pagerduty`, `webhook` and `hazel-oauth` had no direct dispatch
+ * coverage at all — every dispatch test targeted slack-bot or email — so a
+ * refactor had nothing to refactor against. These are deliberately literal
+ * (exact URL, exact headers, exact parsed body) rather than
+ * behaviour-describing: their job is to make any change to the wire show up as
+ * a reviewable diff.
+ *
+ * Where today's behaviour is a known defect, the assertion pins the DEFECT and
+ * says so. Normalizing those is a later, explicit stage.
+ */
+
+const DESTINATION_ID = Schema.decodeUnknownSync(AlertDestinationId)("7c6b5a49-3821-4e0f-9d8c-7b6a59483726")
+
+const SENT_AT_MS = Date.parse("2026-06-02T00:00:00.000Z")
+const LINK = "https://web.localhost/alerts"
+const CHAT = "https://web.localhost/chat?mode=alert"
+
+const destinationRow = (overrides: Partial<AlertDestinationRow> = {}): AlertDestinationRow => ({
+	id: DESTINATION_ID,
+	orgId: "org_1" as AlertDestinationRow["orgId"],
+	name: "Destination",
+	type: "webhook",
+	enabled: true,
+	configJson: {},
+	secretCiphertext: "",
+	secretIv: "",
+	secretTag: "",
+	lastTestedAt: null,
+	lastTestError: null,
+	createdAt: new Date(0),
+	updatedAt: new Date(0),
+	createdBy: "user_1",
+	updatedBy: "user_1",
+	...overrides,
+})
+
+/** A breaching error-rate alert — the shape every provider renders from. */
+const contextFor = (secretConfig: DispatchContext["secretConfig"]): DispatchContext => ({
+	deliveryKey: "org_1:dest_1:delivery",
+	destination: destinationRow({ type: secretConfig.type }),
+	publicConfig: { summary: "Checkout error rate", channelLabel: null },
+	secretConfig,
+	ruleId: "rule_1",
+	ruleName: "Checkout error rate",
+	groupKey: "checkout",
+	signalType: "error_rate",
+	severity: "critical",
+	comparator: "gt",
+	threshold: 0.05,
+	thresholdUpper: null,
+	eventType: "trigger",
+	incidentId: "inc_1",
+	incidentStatus: "open",
+	dedupeKey: "org_1:rule_1:checkout",
+	windowMinutes: 5,
+	value: 0.08,
+	sampleCount: 1200,
+	template: null,
+	sentAtMs: SENT_AT_MS,
+})
+
+/** Neither dep may be invoked by these four providers. */
+const noDeps: DispatchDeps = {
+	sendEmail: () =>
+		Effect.fail(new AlertDeliveryError({ message: "unexpected sendEmail", destinationType: "email" })),
+	resolveSlackBotToken: () =>
+		Effect.fail(
+			new AlertDeliveryError({
+				message: "unexpected resolveSlackBotToken",
+				destinationType: "slack-bot",
+			}),
+		),
+}
+
+interface RecordedCall {
+	readonly url: string
+	readonly method: string
+	readonly headers: Headers
+	readonly body: string
+}
+
+/** Captures the outbound request and replies with `response`. */
+const recorder = (response: () => Response) => {
+	const calls: Array<RecordedCall> = []
+	const fetchFn: typeof fetch = async (input, init) => {
+		calls.push({
+			url: String(input),
+			method: init?.method ?? "GET",
+			headers: new Headers(init?.headers),
+			body: String(init?.body ?? ""),
+		})
+		return response()
+	}
+	return { calls, fetchFn }
+}
+
+const ok = () => new Response("", { status: 200 })
+
+const dispatch = (context: DispatchContext, fetchFn: typeof fetch, payloadJson = "{}") =>
+	dispatchDelivery(context, payloadJson, fetchFn, 5_000, LINK, CHAT, noDeps)
+
+/* -------------------------------------------------------------------------- */
+
+describe("dispatchDelivery: pagerduty", () => {
+	const context = contextFor({ type: "pagerduty", integrationKey: "R0UT1NGK3Y" })
+
+	it.effect("posts an Events v2 trigger envelope to the fixed vendor host", () =>
+		Effect.gen(function* () {
+			const { calls, fetchFn } = recorder(ok)
+			const result = yield* dispatch(context, fetchFn)
+
+			assert.lengthOf(calls, 1)
+			const call = calls[0]!
+			assert.strictEqual(call.url, "https://events.pagerduty.com/v2/enqueue")
+			assert.strictEqual(call.method, "POST")
+			assert.strictEqual(call.headers.get("content-type"), "application/json")
+
+			const body = JSON.parse(call.body)
+			assert.strictEqual(body.routing_key, "R0UT1NGK3Y")
+			assert.strictEqual(body.event_action, "trigger")
+			assert.strictEqual(body.dedup_key, "org_1:rule_1:checkout")
+			assert.strictEqual(body.payload.summary, "Checkout error rate trigger")
+			assert.strictEqual(body.payload.source, "checkout")
+			assert.strictEqual(body.payload.severity, "critical")
+			assert.deepStrictEqual(body.links, [
+				{ href: LINK, text: "Open in Maple" },
+				{ href: CHAT, text: "Ask Maple AI" },
+			])
+			// custom_details carries RAW numbers, not the formatted strings the chat
+			// providers render — a PagerDuty payload is machine-facing.
+			assert.strictEqual(body.payload.custom_details.value, 0.08)
+			assert.strictEqual(body.payload.custom_details.threshold, 0.05)
+			assert.strictEqual(body.payload.custom_details.signalType, "error_rate")
+
+			assert.deepStrictEqual(result, {
+				providerMessage: "Delivered to PagerDuty",
+				providerReference: "org_1:rule_1:checkout",
+				responseCode: 200,
+			})
+		}),
+	)
+
+	it.effect("maps a resolve event to event_action resolve on the same dedup key", () =>
+		Effect.gen(function* () {
+			const { calls, fetchFn } = recorder(ok)
+			yield* dispatch({ ...context, eventType: "resolve" }, fetchFn)
+
+			const body = JSON.parse(calls[0]!.body)
+			assert.strictEqual(body.event_action, "resolve")
+			assert.strictEqual(body.dedup_key, "org_1:rule_1:checkout")
+		}),
+	)
+
+	it.effect("collapses a warning severity to PagerDuty's warning level", () =>
+		Effect.gen(function* () {
+			const { calls, fetchFn } = recorder(ok)
+			yield* dispatch({ ...context, severity: "warning" }, fetchFn)
+
+			assert.strictEqual(JSON.parse(calls[0]!.body).payload.severity, "warning")
+		}),
+	)
+})
+
+describe("dispatchDelivery: webhook", () => {
+	const url = "https://hooks.example.test/maple"
+
+	it.effect("ships the caller's payload verbatim with the maple headers", () =>
+		Effect.gen(function* () {
+			const { calls, fetchFn } = recorder(ok)
+			const payloadJson = '{"eventType":"trigger","rule":{"id":"rule_1"}}'
+			const result = yield* dispatch(
+				contextFor({ type: "webhook", url, signingSecret: null }),
+				fetchFn,
+				payloadJson,
+			)
+
+			assert.lengthOf(calls, 1)
+			const call = calls[0]!
+			assert.strictEqual(call.url, url)
+			assert.strictEqual(call.method, "POST")
+			// Byte-identical: the webhook body IS the caller's payload string.
+			assert.strictEqual(call.body, payloadJson)
+			assert.strictEqual(call.headers.get("content-type"), "application/json")
+			assert.strictEqual(call.headers.get("x-maple-event-type"), "trigger")
+			assert.strictEqual(call.headers.get("x-maple-delivery-key"), "org_1:dest_1:delivery")
+			assert.isNull(call.headers.get("x-maple-signature"))
+
+			assert.deepStrictEqual(result, {
+				providerMessage: "Delivered to webhook",
+				providerReference: "org_1:rule_1:checkout",
+				responseCode: 200,
+			})
+		}),
+	)
+
+	it.effect("signs the exact payload bytes with HMAC-SHA256 when a secret is set", () =>
+		Effect.gen(function* () {
+			const { calls, fetchFn } = recorder(ok)
+			const payloadJson = '{"eventType":"trigger"}'
+			yield* dispatch(
+				contextFor({ type: "webhook", url, signingSecret: "s3cr3t" }),
+				fetchFn,
+				payloadJson,
+			)
+
+			const signature = calls[0]!.headers.get("x-maple-signature")
+			assert.isNotNull(signature)
+			// Pinned: consumers verify against this exact construction.
+			assert.strictEqual(signature, createHmac("sha256", "s3cr3t").update(payloadJson).digest("hex"))
+		}),
+	)
+
+	it.effect("surfaces the upstream status and body on failure", () =>
+		Effect.gen(function* () {
+			const { fetchFn } = recorder(() => new Response("upstream exploded", { status: 500 }))
+			const error = yield* Effect.flip(
+				dispatch(contextFor({ type: "webhook", url, signingSecret: null }), fetchFn),
+			)
+
+			assert.strictEqual(error.destinationType, "webhook")
+			assert.include(error.message, "Webhook delivery failed with 500")
+			assert.include(error.message, "upstream exploded")
+		}),
+	)
+})
+
+describe("dispatchDelivery: discord", () => {
+	const webhookUrl = "https://discord.com/api/webhooks/1234567890/tok3n-in-the-path"
+	const context = contextFor({ type: "discord", webhookUrl })
+
+	it.effect("posts a username + content line + one embed to the configured webhook", () =>
+		Effect.gen(function* () {
+			const { calls, fetchFn } = recorder(ok)
+			const result = yield* dispatch(context, fetchFn)
+
+			assert.lengthOf(calls, 1)
+			const call = calls[0]!
+			assert.strictEqual(call.url, webhookUrl)
+			assert.strictEqual(call.method, "POST")
+			assert.strictEqual(call.headers.get("content-type"), "application/json")
+
+			const body = JSON.parse(call.body)
+			assert.strictEqual(body.username, "Maple Alerts")
+			assert.strictEqual(body.content, "**Checkout error rate**: Triggered")
+			assert.lengthOf(body.embeds, 1)
+			const embed = body.embeds[0]
+			assert.strictEqual(embed.url, LINK)
+			assert.strictEqual(embed.color, 0xe01e5a)
+			const fieldNames = embed.fields.map((f: { name: string }) => f.name)
+			assert.deepStrictEqual(fieldNames, ["Severity", "Signal", "Group", "Observed", "Window", "Links"])
+
+			// NORMALIZED: Discord used to be the only provider returning no
+			// provider reference, so its delivery rows had nothing to correlate
+			// against. Discord's plain webhook POST returns an empty body, so there
+			// is no message id to quote — it now reports the dedupe key, the same
+			// correlation handle pagerduty/webhook/hazel use.
+			assert.deepStrictEqual(result, {
+				providerMessage: "Delivered to Discord",
+				providerReference: "org_1:rule_1:checkout",
+				responseCode: 200,
+			})
+		}),
+	)
+
+	it.effect("does not read the caller's payload json", () =>
+		Effect.gen(function* () {
+			const { calls, fetchFn } = recorder(ok)
+			yield* dispatch(context, fetchFn, '{"totally":"ignored"}')
+
+			assert.notInclude(calls[0]!.body, "totally")
+		}),
+	)
+})
+
+describe("dispatchDelivery: hazel-oauth", () => {
+	const config = {
+		type: "hazel-oauth" as const,
+		hazelOrganizationId: "org_hz",
+		hazelOrganizationName: "Acme",
+		hazelChannelId: "chan_hz",
+		hazelChannelName: "incidents",
+		webhookId: "wh_1",
+		webhookUrl: "https://hazel.test/api/webhooks/wh_1/tok3n-in-the-path",
+		webhookToken: "tok3n-in-the-path",
+	}
+	const context = contextFor(config)
+
+	it.effect("appends /maple to the stored webhook url", () =>
+		Effect.gen(function* () {
+			const { calls, fetchFn } = recorder(ok)
+			const result = yield* dispatch(context, fetchFn)
+
+			assert.strictEqual(calls[0]!.url, `${config.webhookUrl}/maple`)
+			assert.strictEqual(calls[0]!.headers.get("x-maple-event-type"), "trigger")
+			assert.strictEqual(calls[0]!.headers.get("x-maple-delivery-key"), "org_1:dest_1:delivery")
+			assert.deepStrictEqual(result, {
+				providerMessage: "Delivered to Hazel #incidents",
+				providerReference: "org_1:rule_1:checkout",
+				responseCode: 200,
+			})
+		}),
+	)
+
+	it.effect("tolerates a trailing slash on the stored url", () =>
+		Effect.gen(function* () {
+			const { calls, fetchFn } = recorder(ok)
+			yield* dispatch(contextFor({ ...config, webhookUrl: `${config.webhookUrl}/` }), fetchFn)
+
+			assert.strictEqual(calls[0]!.url, `${config.webhookUrl}/maple`)
+		}),
+	)
+
+	/**
+	 * NORMALIZED. Hazel used to build its own near-copy of the wire payload, and
+	 * it had drifted: `thresholdUpper` was dropped entirely and `incidentStatus`
+	 * was recomputed from `eventType` rather than carried. It now ships the
+	 * canonical payload, exactly like the webhook destination, so there is only
+	 * one wire contract to keep correct.
+	 */
+	it.effect("ships the canonical wire payload rather than a hand-built copy", () =>
+		Effect.gen(function* () {
+			const { calls, fetchFn } = recorder(ok)
+			const payloadJson = '{"canonical":"payload","incidentStatus":"acknowledged"}'
+			yield* dispatch(
+				{ ...context, incidentStatus: "acknowledged", thresholdUpper: 0.5 },
+				fetchFn,
+				payloadJson,
+			)
+
+			assert.strictEqual(calls[0]!.body, payloadJson)
+		}),
+	)
+
+	it.effect("maps 401/403 to an actionable reconfigure message", () =>
+		Effect.gen(function* () {
+			for (const status of [401, 403]) {
+				const { fetchFn } = recorder(() => new Response("", { status }))
+				const error = yield* Effect.flip(dispatch(context, fetchFn))
+				assert.strictEqual(error.destinationType, "hazel-oauth")
+				assert.include(error.message, "reconfigure the channel")
+			}
+		}),
+	)
+
+	it.effect("maps 404 to a pick-a-different-channel message", () =>
+		Effect.gen(function* () {
+			const { fetchFn } = recorder(() => new Response("", { status: 404 }))
+			const error = yield* Effect.flip(dispatch(context, fetchFn))
+			assert.include(error.message, "no longer exists")
+		}),
+	)
+})

--- a/apps/api/src/services/alerts/AlertDeliveryDispatch.test.ts
+++ b/apps/api/src/services/alerts/AlertDeliveryDispatch.test.ts
@@ -10,11 +10,11 @@ import {
 	buildSlackBlocksFromTemplate,
 	buildSlackFallbackText,
 	buildTemplateContext,
-	dispatchDelivery,
 	type DispatchContext,
-	type DispatchDeps,
 } from "./AlertDeliveryDispatch"
+import { dispatchDelivery, type DispatchDeps } from "./delivery/dispatch"
 import type { TemplateRenderContext } from "./alert-formatting"
+import { resolveSignalDisplay } from "./alert-signal-display"
 import { renderTemplate } from "./alert-templating/renderer"
 import { DEFAULT_BODY_TEMPLATE, DEFAULT_TITLE_TEMPLATE } from "./alert-templating/defaultTemplates"
 
@@ -196,6 +196,55 @@ describe("buildSlackBlocks (default format)", () => {
 			CHAT,
 		)[1] as SectionBlock
 		assert.include(resolved.text.text, "back within its threshold (between 1% and 5%)")
+	})
+
+	/**
+	 * Regression: a query-driven rule used to render its query-kind enum as the
+	 * metric name and its value as a bare unpunctuated integer —
+	 * "*builder_query* is *1041923*".
+	 */
+	it("names what a builder_query rule measures instead of its query kind", () => {
+		const section = buildSlackBlocks(
+			{
+				...baseContext,
+				ruleName: "Slow DB queries",
+				signalType: "builder_query",
+				signalDisplay: { label: "p95(duration)", unit: "ms" },
+				threshold: 500000,
+				value: 1041923,
+			},
+			LINK,
+			CHAT,
+		)[1] as SectionBlock
+		assert.include(section.text.text, "*p95(duration)* is *1,041,923ms*")
+		assert.include(section.text.text, "above the 500,000ms threshold")
+		assert.notInclude(section.text.text, "builder_query")
+	})
+
+	it("resolves a metrics rule's name from its stored draft, end to end", () => {
+		const section = buildSlackBlocks(
+			{
+				...baseContext,
+				ruleName: "DB duration",
+				signalType: "builder_query",
+				signalDisplay: resolveSignalDisplay({
+					signalType: "builder_query",
+					queryBuilderDraft: {
+						id: "q1",
+						name: "Query A",
+						dataSource: "metrics",
+						aggregation: "sum",
+						metricName: "db.query.duration",
+					},
+				}),
+				threshold: 500000,
+				value: 1041923,
+			},
+			LINK,
+			CHAT,
+		)[1] as SectionBlock
+		assert.include(section.text.text, "*sum(db.query.duration)* is *1,041,923*")
+		assert.include(section.text.text, "above the 500,000 threshold")
 	})
 
 	it("styles buttons per Slack guidance — no danger style on navigation links", () => {

--- a/apps/api/src/services/alerts/AlertDeliveryDispatch.test.ts
+++ b/apps/api/src/services/alerts/AlertDeliveryDispatch.test.ts
@@ -1,5 +1,10 @@
 import type { AlertDestinationRow } from "@maple/db"
-import { AlertDeliveryError, AlertDestinationId } from "@maple/domain/http"
+import {
+	AlertDeliveryError,
+	AlertDeliveryRejectedError,
+	AlertDeliveryTargetMissingError,
+	AlertDestinationId,
+} from "@maple/domain/http"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Fiber, Schema } from "effect"
 import { TestClock } from "effect/testing"
@@ -408,8 +413,12 @@ describe("dispatchDelivery", () => {
 				dispatchDelivery(pagerdutyContext, "{}", fetchFn, 5_000, LINK, CHAT, noEmailDeps),
 			)
 
-			assert.instanceOf(error, AlertDeliveryError)
+			// A 400 is the provider refusing this payload — retrying re-sends the
+			// same rejected request, so it classifies as terminal.
+			assert.instanceOf(error, AlertDeliveryRejectedError)
+			assert.isFalse(error.error.retryable)
 			assert.strictEqual(error.destinationType, "pagerduty")
+			assert.strictEqual(error.providerStatus, 400)
 			assert.include(error.message, "PagerDuty delivery failed with 400")
 			// The PagerDuty rejection reason is now surfaced instead of swallowed.
 			assert.include(error.message, "routing_key is invalid")
@@ -484,8 +493,12 @@ describe("dispatchDelivery", () => {
 				dispatchDelivery(slackBotContext, "{}", fetchFn, 5_000, LINK, CHAT, slackTokenDeps()),
 			)
 
-			assert.instanceOf(error, AlertDeliveryError)
+			// Slack reports this as HTTP 200 + `ok:false`, so only the transport can
+			// classify it. Someone has to re-invite the bot; retrying cannot.
+			assert.instanceOf(error, AlertDeliveryTargetMissingError)
+			assert.isFalse(error.error.retryable)
 			assert.strictEqual(error.destinationType, "slack-bot")
+			assert.strictEqual(error.providerErrorCode, "not_in_channel")
 			assert.include(error.message, "not_in_channel")
 			assert.include(error.message, "invite the Maple bot")
 		}),

--- a/apps/api/src/services/alerts/AlertDeliveryDispatch.ts
+++ b/apps/api/src/services/alerts/AlertDeliveryDispatch.ts
@@ -1,18 +1,20 @@
-import { createHmac } from "node:crypto"
-import {
-	AlertDeliveryError,
-	type AlertComparator,
-	type AlertDestinationType,
-	type AlertEventType,
-	type OrgId,
-	type AlertSignalType,
-	type AlertSeverity,
+/**
+ * Message RENDERING for the chat-style providers, plus the "Ask Maple AI"
+ * deep-link and the template resolver.
+ *
+ * Transport — which provider gets which request, how it is sent, how failures
+ * are classified — lives in `./delivery`. This module is pure: everything here
+ * is a value in, a value out, which is what makes the Slack/Discord block
+ * output assertable without any HTTP stub.
+ */
+import type {
+	AlertComparator,
+	AlertDestinationType,
+	AlertEventType,
+	AlertSignalType,
+	AlertSeverity,
 } from "@maple/domain/http"
-import type { AlertDestinationRow } from "@maple/db"
-import { Clock, Duration, Effect, Match, Schema } from "effect"
-import type { EnrichedDestinationSecretConfig } from "./AlertDestinationHydration"
-import { safeFetch } from "@/http/url-validator"
-import { buildAlertEmailContent } from "./alert-email"
+import type { DispatchContext } from "./delivery/context"
 import {
 	comparatorBreachPhrase,
 	discordEmbedColor,
@@ -26,7 +28,8 @@ import {
 	formatThresholdSummary,
 	formatWindow,
 	severityEmoji,
-	slackAttachmentColor,
+	signalDisplayOf,
+	truncate,
 	type TemplateRenderContext,
 } from "./alert-formatting"
 import { DEFAULT_BODY_TEMPLATE, DEFAULT_TITLE_TEMPLATE } from "./alert-templating/defaultTemplates"
@@ -34,54 +37,8 @@ import {
 	hasCustomTemplate,
 	renderTemplate,
 	resolveTemplate,
-	type NotificationTemplateConfig,
 	type TemplateContext,
 } from "./alert-templating/renderer"
-
-/* -------------------------------------------------------------------------- */
-/*  Types                                                                     */
-/* -------------------------------------------------------------------------- */
-
-interface DestinationPublicConfig {
-	readonly summary: string
-	readonly channelLabel: string | null
-}
-
-export interface DispatchContext {
-	readonly deliveryKey: string
-	readonly destination: AlertDestinationRow
-	readonly publicConfig: DestinationPublicConfig
-	readonly secretConfig: EnrichedDestinationSecretConfig
-	readonly ruleId: string
-	readonly ruleName: string
-	readonly groupKey: string | null
-	readonly signalType: AlertSignalType
-	readonly severity: AlertSeverity
-	readonly comparator: AlertComparator
-	readonly threshold: number
-	readonly thresholdUpper: number | null
-	readonly eventType: AlertEventType
-	readonly incidentId: string | null
-	readonly incidentStatus: string
-	readonly dedupeKey: string
-	readonly windowMinutes: number
-	readonly value: number | null
-	readonly sampleCount: number | null
-	/**
-	 * User-customized notification template (title + Markdown body, optional
-	 * per-destination overrides). `null`/absent → the built-in hardcoded format.
-	 * Snapshotted at enqueue time so retries and post-fire edits stay stable.
-	 */
-	readonly template?: NotificationTemplateConfig | null
-	/** Epoch ms the notification was sent — exposed to templates as `sentAt`. */
-	readonly sentAtMs?: number
-}
-
-export interface DispatchResult {
-	readonly providerMessage: string | null
-	readonly providerReference: string | null
-	readonly responseCode: number | null
-}
 
 /* -------------------------------------------------------------------------- */
 /*  Chat deep-link helper                                                     */
@@ -142,50 +99,6 @@ export const buildAlertChatUrl = (baseUrl: string, context: ChatUrlContext): str
 	return `${baseUrl}/chat?${params.toString()}`
 }
 
-/* -------------------------------------------------------------------------- */
-/*  Dispatch                                                                  */
-/* -------------------------------------------------------------------------- */
-
-const makeDeliveryError = (message: string, destinationType?: AlertDestinationType, cause?: unknown) =>
-	new AlertDeliveryError({ message, destinationType, ...(cause === undefined ? {} : { cause }) })
-
-/**
- * Slack Web API `chat.postMessage` response envelope. Slack returns HTTP 200
- * with `{ ok: false, error }` on logical failures, so the body is the source
- * of truth.
- */
-const SlackPostMessageResponseSchema = Schema.Struct({
-	ok: Schema.optionalKey(Schema.Boolean),
-	error: Schema.optionalKey(Schema.String),
-	ts: Schema.optionalKey(Schema.String),
-})
-const decodeSlackPostMessageResponse = Schema.decodeUnknownEffect(SlackPostMessageResponseSchema)
-
-const runTimedFetch = <A>(
-	destinationType: AlertDestinationType,
-	label: string,
-	fetchFn: typeof fetch,
-	timeoutMs: number,
-	request: () => Promise<A>,
-) =>
-	Effect.tryPromise({
-		try: () => request(),
-		catch: (error) =>
-			makeDeliveryError(
-				error instanceof Error ? error.message : `${label} delivery failed`,
-				destinationType,
-				error,
-			),
-	}).pipe(
-		Effect.timeoutOrElse({
-			duration: Duration.millis(timeoutMs),
-			orElse: () =>
-				Effect.fail(
-					makeDeliveryError(`${label} delivery timed out after ${timeoutMs}ms`, destinationType),
-				),
-		}),
-	)
-
 /**
  * Escape Slack mrkdwn control characters in dynamic text (Slack parses `<...>`
  * as link/mention syntax). Required by https://docs.slack.dev/messaging/formatting-message-text
@@ -202,11 +115,18 @@ const escapeSlackMrkdwn = (value: string): string =>
 const buildSlackSummaryLine = (
 	context: Pick<
 		DispatchContext,
-		"eventType" | "signalType" | "comparator" | "threshold" | "thresholdUpper" | "value" | "windowMinutes"
+		| "eventType"
+		| "signalType"
+		| "signalDisplay"
+		| "comparator"
+		| "threshold"
+		| "thresholdUpper"
+		| "value"
+		| "windowMinutes"
 	>,
 ): string => {
-	const signal = formatSignalLabel(context.signalType)
-	const observed = formatSignalMetric(context.value, context.signalType)
+	const signal = formatSignalLabel(context)
+	const observed = formatSignalMetric(context.value, signalDisplayOf(context))
 	const window = formatWindow(context.windowMinutes)
 	if (context.eventType === "test") {
 		return `This is a test notification. Live alerts fire when *${signal}* is ${comparatorBreachPhrase(context)} over a ${window} window.`
@@ -284,16 +204,16 @@ export const buildSlackBlocks = (context: TemplateRenderContext, linkUrl: string
  * summary, since push/desktop previews render only this string.
  */
 export const buildSlackFallbackText = (context: TemplateRenderContext): string =>
-	`${eventTypeEmoji(context.eventType)} ${escapeSlackMrkdwn(context.ruleName)} — ${formatEventTypeLabel(context.eventType)} · ${formatSignalLabel(context.signalType)} ${formatObservedSummary(context)}`
+	`${eventTypeEmoji(context.eventType)} ${escapeSlackMrkdwn(context.ruleName)} — ${formatEventTypeLabel(context.eventType)} · ${formatSignalLabel(context)} ${formatObservedSummary(context)}`
 
-const buildDiscordEmbeds = (context: DispatchContext, linkUrl: string, chatUrl: string) => [
+export const buildDiscordEmbeds = (context: DispatchContext, linkUrl: string, chatUrl: string) => [
 	{
 		title: `${eventTypeEmoji(context.eventType)} ${context.ruleName} — ${formatEventTypeLabel(context.eventType)}`,
 		url: linkUrl,
 		color: discordEmbedColor(context.eventType, context.severity),
 		fields: [
 			{ name: "Severity", value: context.severity, inline: true },
-			{ name: "Signal", value: formatSignalLabel(context.signalType), inline: true },
+			{ name: "Signal", value: formatSignalLabel(context), inline: true },
 			{ name: "Group", value: context.groupKey ?? "all", inline: true },
 			{ name: "Observed", value: formatObservedSummary(context), inline: true },
 			{ name: "Window", value: formatWindow(context.windowMinutes), inline: true },
@@ -325,34 +245,39 @@ export const buildTemplateContext = (
 	context: TemplateRenderContext,
 	linkUrl: string,
 	chatUrl: string,
-): TemplateContext => ({
-	"rule.name": context.ruleName,
-	"rule.id": context.ruleId,
-	"event.type": context.eventType,
-	"event.label": formatEventTypeLabel(context.eventType),
-	"event.emoji": eventTypeEmoji(context.eventType),
-	severity: context.severity,
-	signal: context.signalType,
-	"signal.label": formatSignalLabel(context.signalType),
-	"comparator.label": formatComparator(context.comparator),
-	threshold: formatSignalMetric(context.threshold, context.signalType),
-	thresholdUpper:
-		context.thresholdUpper != null ? formatSignalMetric(context.thresholdUpper, context.signalType) : "",
-	value: formatSignalMetric(context.value, context.signalType),
-	observed: formatSignalMetric(context.value, context.signalType),
-	"observed.summary": formatObservedSummary(context),
-	sampleCount: context.sampleCount != null ? String(context.sampleCount) : "",
-	group: context.groupKey ?? "all",
-	window: formatWindow(context.windowMinutes),
-	incidentId: context.incidentId ?? "",
-	incidentStatus: context.incidentStatus,
-	dedupeKey: context.dedupeKey,
-	"links.app": linkUrl,
-	linkUrl,
-	"links.chat": chatUrl,
-	chatUrl,
-	sentAt: context.sentAtMs != null ? new Date(context.sentAtMs).toISOString() : "",
-})
+): TemplateContext => {
+	const display = signalDisplayOf(context)
+	return {
+		"rule.name": context.ruleName,
+		"rule.id": context.ruleId,
+		"event.type": context.eventType,
+		"event.label": formatEventTypeLabel(context.eventType),
+		"event.emoji": eventTypeEmoji(context.eventType),
+		severity: context.severity,
+		// Stays the raw query-kind enum for template back-compat; `signal.label`
+		// is the human-readable name of what the rule measures.
+		signal: context.signalType,
+		"signal.label": display.label,
+		"comparator.label": formatComparator(context.comparator),
+		threshold: formatSignalMetric(context.threshold, display),
+		thresholdUpper:
+			context.thresholdUpper != null ? formatSignalMetric(context.thresholdUpper, display) : "",
+		value: formatSignalMetric(context.value, display),
+		observed: formatSignalMetric(context.value, display),
+		"observed.summary": formatObservedSummary(context),
+		sampleCount: context.sampleCount != null ? String(context.sampleCount) : "",
+		group: context.groupKey ?? "all",
+		window: formatWindow(context.windowMinutes),
+		incidentId: context.incidentId ?? "",
+		incidentStatus: context.incidentStatus,
+		dedupeKey: context.dedupeKey,
+		"links.app": linkUrl,
+		linkUrl,
+		"links.chat": chatUrl,
+		chatUrl,
+		sentAt: context.sentAtMs != null ? new Date(context.sentAtMs).toISOString() : "",
+	}
+}
 
 /**
  * Minimal Markdown → Slack mrkdwn transform: `**b**`→`*b*`, `[t](url)`→`<url|t>`.
@@ -375,77 +300,13 @@ const markdownToSlackMrkdwn = (markdown: string): string =>
 			(_match, text: string, url: string) => `<${url.replaceAll("|", "%7C")}|${text}>`,
 		)
 
-const truncate = (value: string, max: number): string =>
-	value.length > max ? `${value.slice(0, max - 1)}…` : value
-
-// Best-effort read of a provider's error response body for diagnostics. Only runs
-// on the failure path; the body is unread in every `!response.ok` branch today.
-const readErrorBody = (response: Response): Effect.Effect<string> =>
-	Effect.promise(() => response.text().catch(() => "")).pipe(
-		Effect.map((body) => truncate(body.trim().replace(/\s+/g, " "), 500)),
-	)
-
-/**
- * A PagerDuty Events API v2 integration ("routing") key is exactly 32
- * alphanumeric characters. A REST API token — the usual wrong paste — is shorter
- * and may contain `+`/`_`/`-`, so the length+charset check alone rejects it.
- */
-export const PAGERDUTY_ROUTING_KEY_PATTERN = /^[A-Za-z0-9]{32}$/
-
-export type PagerDutyKeyVerification =
-	| { status: "valid" }
-	| { status: "invalid"; reason: string }
-	/** Network error / timeout / 429 / 5xx — can't conclude; caller should fail open. */
-	| { status: "unknown" }
-
-/**
- * Verify a PagerDuty routing key actually works by enqueuing a no-op `resolve`
- * event. PagerDuty validates the routing key before the action, so a valid key
- * returns 2xx (resolving an unknown dedup_key creates no incident and pages no
- * one) and an invalid key returns 400 "Invalid routing key". Never fails — any
- * transport/ambiguous response collapses to `unknown` so the caller owns policy.
- */
-export const verifyPagerDutyRoutingKey = (
-	integrationKey: string,
-	fetchFn: typeof fetch,
-	timeoutMs: number,
-	dedupKey: string,
-): Effect.Effect<PagerDutyKeyVerification> =>
-	runTimedFetch("pagerduty", "PagerDuty", fetchFn, timeoutMs, () =>
-		fetchFn("https://events.pagerduty.com/v2/enqueue", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				routing_key: integrationKey,
-				event_action: "resolve",
-				dedup_key: dedupKey,
-			}),
-		}),
-	).pipe(
-		Effect.flatMap((response) => {
-			if (response.ok) return Effect.succeed<PagerDutyKeyVerification>({ status: "valid" })
-			if (response.status === 400) {
-				return readErrorBody(response).pipe(
-					Effect.map(
-						(reason): PagerDutyKeyVerification => ({
-							status: "invalid",
-							reason: reason || "Invalid routing key",
-						}),
-					),
-				)
-			}
-			return Effect.succeed<PagerDutyKeyVerification>({ status: "unknown" })
-		}),
-		Effect.orElseSucceed(() => ({ status: "unknown" as const })),
-	)
-
 /**
  * Resolve + render the effective title/body for a destination. Returns `null`
  * when the rule has no custom template (caller falls back to the hardcoded
  * formatter) or when rendering fails for any reason — templating must never
  * block delivery.
  */
-const renderTitleBody = (
+export const renderTitleBody = (
 	context: TemplateRenderContext,
 	destinationType: AlertDestinationType,
 	linkUrl: string,
@@ -507,370 +368,9 @@ export const buildDiscordEmbedsFromTemplate = (
 	},
 ]
 
-export interface DispatchDeps {
-	/**
-	 * Sends one email via the platform email channel (Cloudflare `EMAIL`
-	 * binding). Injected like `fetchFn` so this module stays dependency-free.
-	 */
-	readonly sendEmail: (to: string, subject: string, html: string) => Effect.Effect<void, AlertDeliveryError>
-	/**
-	 * Resolves the decrypted Slack bot token for an org from its
-	 * `slack_workspaces` row. Injected like `sendEmail` so this module stays
-	 * dependency-free — only the `slack-bot` destination arm invokes it. Fails
-	 * (AlertDeliveryError) when the org has no active Slack installation.
-	 */
-	readonly resolveSlackBotToken: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryError>
-}
-
-export const dispatchDelivery = (
-	context: DispatchContext,
-	payloadJson: string,
-	fetchFn: typeof fetch,
-	timeoutMs: number,
-	linkUrl: string,
-	chatUrl: string,
-	deps: DispatchDeps,
-): Effect.Effect<DispatchResult, AlertDeliveryError> =>
-	Match.value(context.secretConfig).pipe(
-		Match.discriminatorsExhaustive("type")({
-			"slack-bot": (config) =>
-				Effect.gen(function* () {
-					const botToken = yield* deps.resolveSlackBotToken(context.destination.orgId)
-					const templated = renderTitleBody(context, "slack-bot", linkUrl, chatUrl)
-					const blocks = templated
-						? buildSlackBlocksFromTemplate(
-								templated.title,
-								templated.body,
-								context,
-								linkUrl,
-								chatUrl,
-							)
-						: buildSlackBlocks(context, linkUrl, chatUrl)
-					const response = yield* runTimedFetch("slack-bot", "Slack", fetchFn, timeoutMs, () =>
-						fetchFn("https://slack.com/api/chat.postMessage", {
-							method: "POST",
-							headers: {
-								"content-type": "application/json; charset=utf-8",
-								authorization: `Bearer ${botToken}`,
-							},
-							body: JSON.stringify({
-								channel: config.channelId,
-								// Blocks ride inside a colored attachment so the message
-								// carries the severity color bar — same as the webhook
-								// destination (the bar has no Block Kit equivalent). No
-								// top-level `text`: alongside attachments Slack renders it
-								// as a duplicate line above the bar; `fallback` carries
-								// the notification-preview one-liner instead.
-								attachments: [
-									{
-										color: slackAttachmentColor(context.eventType, context.severity),
-										fallback: templated?.title ?? buildSlackFallbackText(context),
-										blocks,
-									},
-								],
-							}),
-						}),
-					)
-					if (!response.ok) {
-						const detail = yield* readErrorBody(response)
-						return yield* Effect.fail(
-							makeDeliveryError(
-								`Slack delivery failed with ${response.status}${detail ? `: ${detail}` : ""}`,
-								"slack-bot",
-							),
-						)
-					}
-					// Slack Web API returns HTTP 200 with `{ ok: false, error }` on
-					// logical failures, so the JSON body — not the status — is the
-					// source of truth.
-					const rawPayload = yield* Effect.tryPromise({
-						try: () => response.json(),
-						catch: (error) =>
-							makeDeliveryError("Slack returned a non-JSON response", "slack-bot", error),
-					})
-					const payload = yield* decodeSlackPostMessageResponse(rawPayload).pipe(
-						Effect.mapError((error) =>
-							makeDeliveryError(
-								`Slack returned an unexpected response payload: ${error.message}`,
-								"slack-bot",
-							),
-						),
-					)
-					if (!payload.ok) {
-						const error = payload.error ?? "unknown_error"
-						// HTTP 200 + `ok:false` is the dominant operational failure here
-						// (`not_in_channel` after a rename/kick). NotificationDispatcher
-						// only records outcome "failed", so annotate the Slack error code
-						// on the span to make it aggregatable.
-						yield* Effect.annotateCurrentSpan({
-							"maple.delivery.destination_type": "slack-bot",
-							"maple.delivery.provider_error": error,
-						})
-						const message =
-							error === "not_in_channel" || error === "channel_not_found"
-								? `Slack rejected the message (${error}) — invite the Maple bot to the channel and try again`
-								: `Slack rejected the message: ${error}`
-						return yield* Effect.fail(makeDeliveryError(message, "slack-bot"))
-					}
-					return {
-						providerMessage: `Delivered to Slack #${config.channelName ?? config.channelId}`,
-						providerReference: payload.ts ?? null,
-						responseCode: response.status,
-					} as DispatchResult
-				}),
-			pagerduty: (config) =>
-				Effect.gen(function* () {
-					const templated = renderTitleBody(context, "pagerduty", linkUrl, chatUrl)
-					const body = {
-						routing_key: config.integrationKey,
-						event_action: context.eventType === "resolve" ? "resolve" : "trigger",
-						dedup_key: context.dedupeKey,
-						payload: {
-							summary: truncate(
-								templated?.title ?? `${context.ruleName} ${context.eventType}`,
-								1024,
-							),
-							source: context.groupKey ?? "maple-alerts",
-							severity: context.severity === "critical" ? "critical" : "warning",
-							custom_details: {
-								...(templated ? { message: templated.body } : {}),
-								ruleName: context.ruleName,
-								signalType: context.signalType,
-								value: context.value,
-								threshold: context.threshold,
-								thresholdUpper: context.thresholdUpper,
-								comparator: context.comparator,
-								groupKey: context.groupKey,
-								linkUrl,
-								chatUrl,
-							},
-						},
-						links: [
-							{ href: linkUrl, text: "Open in Maple" },
-							{ href: chatUrl, text: "Ask Maple AI" },
-						],
-					}
-					const response = yield* runTimedFetch("pagerduty", "PagerDuty", fetchFn, timeoutMs, () =>
-						fetchFn("https://events.pagerduty.com/v2/enqueue", {
-							method: "POST",
-							headers: { "content-type": "application/json" },
-							body: JSON.stringify(body),
-						}),
-					)
-					if (!response.ok) {
-						const detail = yield* readErrorBody(response)
-						return yield* Effect.fail(
-							makeDeliveryError(
-								`PagerDuty delivery failed with ${response.status}${detail ? `: ${detail}` : ""}`,
-								"pagerduty",
-							),
-						)
-					}
-					return {
-						providerMessage: "Delivered to PagerDuty",
-						providerReference: context.dedupeKey,
-						responseCode: response.status,
-					} as DispatchResult
-				}),
-			webhook: (config) =>
-				Effect.gen(function* () {
-					const headers: Record<string, string> = {
-						"content-type": "application/json",
-						"x-maple-event-type": context.eventType,
-						"x-maple-delivery-key": context.deliveryKey,
-					}
-					if (config.signingSecret) {
-						headers["x-maple-signature"] = createHmac("sha256", config.signingSecret)
-							.update(payloadJson)
-							.digest("hex")
-					}
-					const response = yield* runTimedFetch("webhook", "Webhook", fetchFn, timeoutMs, () =>
-						safeFetch(config.url, { method: "POST", headers, body: payloadJson, fetchFn }),
-					)
-					if (!response.ok) {
-						const detail = yield* readErrorBody(response)
-						return yield* Effect.fail(
-							makeDeliveryError(
-								`Webhook delivery failed with ${response.status}${detail ? `: ${detail}` : ""}`,
-								"webhook",
-							),
-						)
-					}
-					return {
-						providerMessage: "Delivered to webhook",
-						providerReference: context.dedupeKey,
-						responseCode: response.status,
-					} as DispatchResult
-				}),
-			"hazel-oauth": (config) =>
-				Effect.gen(function* () {
-					// Hazel exposes per-integration sibling endpoints under the same
-					// `:webhookId/:token` prefix (see hazel
-					// packages/domain/src/http/incoming-webhooks.ts). The stored
-					// webhookUrl is the base; we append `/maple` to hit the
-					// `executeMaple` handler — without it, the payload routes to the
-					// Discord-style `execute` endpoint and is rejected.
-					const hazelUrl = `${config.webhookUrl.replace(/\/$/, "")}/maple`
-					const incidentStatus = context.eventType === "resolve" ? "resolved" : "open"
-					const body = JSON.stringify({
-						eventType: context.eventType,
-						incidentId: context.incidentId,
-						incidentStatus,
-						dedupeKey: context.dedupeKey,
-						rule: {
-							id: context.ruleId,
-							name: context.ruleName,
-							signalType: context.signalType,
-							severity: context.severity,
-							groupKey: context.groupKey,
-							comparator: context.comparator,
-							threshold: context.threshold,
-							windowMinutes: context.windowMinutes,
-						},
-						observed: {
-							value: context.value,
-							sampleCount: context.sampleCount,
-						},
-						template: context.template ?? null,
-						linkUrl,
-						chatUrl,
-						sentAt: new Date(yield* Clock.currentTimeMillis).toISOString(),
-					})
-					const response = yield* runTimedFetch("hazel-oauth", "Hazel", fetchFn, timeoutMs, () =>
-						safeFetch(hazelUrl, {
-							method: "POST",
-							headers: {
-								"content-type": "application/json",
-								"x-maple-event-type": context.eventType,
-								"x-maple-delivery-key": context.deliveryKey,
-							},
-							body,
-							fetchFn,
-						}),
-					)
-					if (response.status === 401 || response.status === 403) {
-						return yield* Effect.fail(
-							makeDeliveryError(
-								"Hazel rejected the webhook token — reconfigure the channel",
-								"hazel-oauth",
-							),
-						)
-					}
-					if (response.status === 404) {
-						return yield* Effect.fail(
-							makeDeliveryError(
-								"Hazel webhook no longer exists — pick a different channel",
-								"hazel-oauth",
-							),
-						)
-					}
-					if (!response.ok) {
-						const detail = yield* readErrorBody(response)
-						return yield* Effect.fail(
-							makeDeliveryError(
-								`Hazel delivery failed with ${response.status}${detail ? `: ${detail}` : ""}`,
-								"hazel-oauth",
-							),
-						)
-					}
-					return {
-						providerMessage: `Delivered to Hazel #${config.hazelChannelName}`,
-						providerReference: context.dedupeKey,
-						responseCode: response.status,
-					} as DispatchResult
-				}),
-			discord: (config) =>
-				Effect.gen(function* () {
-					const templated = renderTitleBody(context, "discord", linkUrl, chatUrl)
-					const embeds = templated
-						? buildDiscordEmbedsFromTemplate(
-								templated.title,
-								templated.body,
-								context,
-								linkUrl,
-								chatUrl,
-							)
-						: buildDiscordEmbeds(context, linkUrl, chatUrl)
-					const response = yield* runTimedFetch("discord", "Discord", fetchFn, timeoutMs, () =>
-						safeFetch(config.webhookUrl, {
-							method: "POST",
-							headers: { "content-type": "application/json" },
-							body: JSON.stringify({
-								username: "Maple Alerts",
-								content:
-									templated?.title ??
-									`**${context.ruleName}**: ${formatEventTypeLabel(context.eventType)}`,
-								embeds,
-							}),
-							fetchFn,
-						}),
-					)
-					if (!response.ok) {
-						const detail = yield* readErrorBody(response)
-						return yield* Effect.fail(
-							makeDeliveryError(
-								`Discord delivery failed with ${response.status}${detail ? `: ${detail}` : ""}`,
-								"discord",
-							),
-						)
-					}
-					return {
-						providerMessage: "Delivered to Discord",
-						providerReference: null,
-						responseCode: response.status,
-					} as DispatchResult
-				}),
-			email: (config) =>
-				Effect.gen(function* () {
-					const { subject, html } = yield* buildAlertEmailContent(context, linkUrl, chatUrl)
-					const outcomes = yield* Effect.forEach(config.members, (member) =>
-						deps.sendEmail(member.email, subject, html).pipe(
-							Effect.match({
-								onSuccess: () => ({ member, error: null as string | null }),
-								onFailure: (error) => ({ member, error: error.message }),
-							}),
-						),
-					)
-					const failures = outcomes.filter((o) => o.error != null)
-					const count = config.members.length
-
-					if (failures.length === count && count > 0) {
-						// Nobody received the email — safe to fail retryable; the retry
-						// re-sends to members who all got nothing. Keep the first failure
-						// message verbatim so timeout classification survives aggregation.
-						return yield* Effect.fail(
-							makeDeliveryError(
-								`Email delivery failed for all ${count} member${count === 1 ? "" : "s"}: ${failures[0]!.error}`,
-								"email",
-							),
-						)
-					}
-
-					if (failures.length > 0) {
-						// Partial success is terminal: there is no per-member attempt
-						// state, so retrying the event would re-email the members who
-						// already received it. Report success and surface the failures.
-						yield* Effect.logWarning("Alert email delivered to a subset of members").pipe(
-							Effect.annotateLogs({
-								failedCount: failures.length,
-								memberCount: count,
-								firstError: failures[0]!.error,
-							}),
-						)
-						return {
-							providerMessage: `Emailed ${count - failures.length} of ${count} members; failed: ${failures
-								.map((f) => `${f.member.email} (${f.error})`)
-								.join(", ")}`,
-							providerReference: null,
-							responseCode: null,
-						} as DispatchResult
-					}
-
-					return {
-						providerMessage: `Emailed ${count} member${count === 1 ? "" : "s"}`,
-						providerReference: null,
-						responseCode: null,
-					} as DispatchResult
-				}),
-		}),
-	)
+/**
+ * Re-exported for the many call sites that still import the dispatch value
+ * types from here. They now live in `./delivery/context`; the collapse onto one
+ * canonical notification value is a later stage.
+ */
+export type { DispatchContext, DispatchResult } from "./delivery/context"

--- a/apps/api/src/services/alerts/AlertDestinationDelivery.ts
+++ b/apps/api/src/services/alerts/AlertDestinationDelivery.ts
@@ -1,5 +1,6 @@
 import {
 	AlertDeliveryError,
+	type AlertDeliveryFailure,
 	AlertDestinationDecryptionError,
 	AlertDestinationStoredConfigInvalidError,
 	AlertValidationError,
@@ -117,7 +118,7 @@ export const makeAlertDestinationDelivery = (options: {
 	const dispatchDelivery = (
 		context: AlertDispatchContext,
 		payloadJson: string,
-	): Effect.Effect<DispatchResult, AlertDeliveryError> =>
+	): Effect.Effect<DispatchResult, AlertDeliveryFailure> =>
 		dispatchDeliveryImpl(
 			context,
 			payloadJson,

--- a/apps/api/src/services/alerts/AlertDestinationDelivery.ts
+++ b/apps/api/src/services/alerts/AlertDestinationDelivery.ts
@@ -12,12 +12,9 @@ import { Effect } from "effect"
 import { parseBase64Aes256GcmKey } from "@/platform/Crypto"
 import type { EmailServiceShape } from "@/platform/EmailService"
 import type { SlackBotTokenResolverShape } from "@/services/integrations/slack-bot-token"
-import {
-	buildAlertChatUrl,
-	dispatchDelivery as dispatchDeliveryImpl,
-	type DispatchContext as DeliveryDispatchContext,
-	type DispatchResult,
-} from "./AlertDeliveryDispatch"
+import { buildAlertChatUrl, type DispatchContext as DeliveryDispatchContext } from "./AlertDeliveryDispatch"
+import { dispatchDelivery as dispatchDeliveryImpl } from "./delivery/dispatch"
+import type { DispatchResult } from "./delivery/context"
 import {
 	hydrateDestinationRow,
 	type DestinationSecretConfig,

--- a/apps/api/src/services/alerts/AlertDestinationsService.ts
+++ b/apps/api/src/services/alerts/AlertDestinationsService.ts
@@ -39,7 +39,7 @@ import {
 	type OrgMembersServiceShape,
 } from "@/services/org/OrgMembersService"
 import { SlackBotTokenResolver } from "@/services/integrations/slack-bot-token"
-import { PAGERDUTY_ROUTING_KEY_PATTERN, verifyPagerDutyRoutingKey } from "./AlertDeliveryDispatch"
+import { PAGERDUTY_ROUTING_KEY_PATTERN, verifyPagerDutyRoutingKey } from "./delivery/transports/pagerduty"
 import {
 	DestinationPublicConfigSchema,
 	type DestinationPublicConfig,

--- a/apps/api/src/services/alerts/AlertDestinationsService.ts
+++ b/apps/api/src/services/alerts/AlertDestinationsService.ts
@@ -1,5 +1,6 @@
 import {
 	AlertDeliveryError,
+	type AlertDeliveryFailure,
 	AlertDestinationDecryptionError,
 	AlertDestinationDeleteResponse,
 	AlertDestinationDocument,
@@ -270,7 +271,7 @@ export interface AlertDestinationsServiceShape {
 		| AlertForbiddenError
 		| AlertPersistenceError
 		| AlertDestinationNotFoundError
-		| AlertDeliveryError
+		| AlertDeliveryFailure
 		| AlertDestinationDecryptionError
 		| AlertDestinationStoredConfigInvalidError
 	>

--- a/apps/api/src/services/alerts/AlertsService.test.ts
+++ b/apps/api/src/services/alerts/AlertsService.test.ts
@@ -1562,6 +1562,107 @@ describe("AlertsService", () => {
 		}).pipe(Effect.provide(layer))
 	})
 
+	/**
+	 * The delivery queue decides whether to re-enqueue from `error.error.retryable`,
+	 * which comes from the failure class's policy. Every delivery failure used to
+	 * be one `AlertDeliveryError` carrying `retry: "backoff"`, so a destination
+	 * whose credentials had been revoked was retried the full
+	 * `MAX_DELIVERY_ATTEMPTS` against a provider that would never accept it.
+	 * These two cases are the guard on that split.
+	 */
+	const deliveryRetryCase = (
+		label: string,
+		status: number,
+		expectRetry: boolean,
+		expectedMessage: string,
+	) =>
+		it.effect(label, () => {
+			const fixedTime = 1_710_000_400_000
+			const testDb = createTestDb(trackedDbs)
+			const respond = (async () => new Response("nope", { status })) as unknown as typeof fetch
+
+			return Effect.gen(function* () {
+				const alerts = yield* AlertsService
+				const orgId = asOrgId(`org_retry_${status}`)
+				const userId = asUserId(`user_retry_${status}`)
+				const destination = yield* createWebhookDestination(alerts, orgId, userId)
+				const rule = yield* createErrorRateRule(alerts, orgId, userId, destination.id)
+				const deliveryKey = `retry-${status}-key`
+
+				yield* Effect.promise(() =>
+					insertDeliveryEventRow(testDb, {
+						id: `00000000-0000-4000-8000-${String(status).padStart(12, "0")}`,
+						orgId,
+						incidentId: null,
+						ruleId: rule.id,
+						destinationId: destination.id,
+						deliveryKey,
+						eventType: "test",
+						attemptNumber: 1,
+						status: "queued",
+						scheduledAt: fixedTime - 1,
+						payloadJson: JSON.stringify({
+							eventType: "test",
+							incidentId: null,
+							incidentStatus: "resolved",
+							dedupeKey: `retry-${status}-dedupe`,
+							rule: {
+								id: rule.id,
+								name: rule.name,
+								signalType: rule.signalType,
+								severity: rule.severity,
+								groupKey: null,
+								comparator: rule.comparator,
+								threshold: rule.threshold,
+								windowMinutes: rule.windowMinutes,
+							},
+							observed: { value: 0, sampleCount: 0 },
+							linkUrl: "http://127.0.0.1:3471/alerts",
+							sentAt: new Date(fixedTime).toISOString(),
+						}),
+					}),
+				)
+
+				const tick = yield* alerts.runSchedulerTick()
+				const events = yield* alerts.listDeliveryEvents(orgId)
+
+				assert.strictEqual(tick.deliveryFailureCount, 1)
+				const firstAttempt = events.events.find(
+					(event) => event.deliveryKey === deliveryKey && event.attemptNumber === 1,
+				)
+				const retryAttempt = events.events.find(
+					(event) => event.deliveryKey === deliveryKey && event.attemptNumber === 2,
+				)
+				assert.strictEqual(firstAttempt?.status, "failed")
+				assert.include(firstAttempt?.errorMessage ?? "", expectedMessage)
+				if (expectRetry) {
+					assert.strictEqual(retryAttempt?.status, "queued", "a transient failure must retry")
+				} else {
+					assert.isUndefined(retryAttempt, "a terminal failure must not enqueue another attempt")
+				}
+			}).pipe(
+				Effect.provide(
+					makeLayer(testDb, makeWarehouseStub({ tracesAggregateRows: emptyWarehouseRows }), {
+						now: Effect.succeed(fixedTime),
+						fetch: respond,
+					}),
+				),
+			)
+		})
+
+	deliveryRetryCase(
+		"does not retry a destination that rejected our credentials",
+		401,
+		false,
+		"Webhook delivery failed with 401",
+	)
+	deliveryRetryCase(
+		"retries a destination that is temporarily unavailable",
+		503,
+		true,
+		"Webhook delivery failed with 503",
+	)
+
 	it.live("times out stuck deliveries and enqueues a retry attempt", () => {
 		const fixedTime = 1_710_000_300_000
 		const testDb = createTestDb(trackedDbs)

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -108,6 +108,7 @@ import {
 	planEvaluateSource,
 	type NormalizedRule,
 } from "./AlertRuleModel"
+import { resolveSignalDisplay } from "./alert-signal-display"
 
 export { AlertRuntime, type AlertRuntimeShape } from "./AlertRuntime"
 
@@ -886,6 +887,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 								ruleName: normalized.name,
 								groupKey: null,
 								signalType: normalized.signalType,
+								signalDisplay: resolveSignalDisplay(normalized),
 								severity: normalized.severity,
 								comparator: normalized.comparator,
 								threshold: normalized.threshold,
@@ -1336,6 +1338,9 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					const payloadRule = payload.rule
 					const storedRule = ruleRow ? yield* decodeStoredAlertRuleMetadata(ruleRow) : null
 					const groupKey = incidentRow?.groupKey ?? payloadRule?.groupKey ?? null
+					const signalType = decodeAlertSignalTypeSync(
+						incidentRow?.signalType ?? payloadRule?.signalType ?? "throughput",
+					)
 
 					const enrichedSecret = yield* enrichSecretForDispatch(hydrated.row, hydrated.secretConfig)
 					const deliveryStart = yield* now
@@ -1348,9 +1353,14 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 							ruleId: decodeAlertRuleIdSync(row.ruleId),
 							ruleName: ruleRow?.name ?? String(payloadRule?.name ?? "Alert"),
 							groupKey,
-							signalType: decodeAlertSignalTypeSync(
-								incidentRow?.signalType ?? payloadRule?.signalType ?? "throughput",
-							),
+							signalType,
+							// The rule row is the only place the measured quantity is
+							// named — the delivery payload carries just the query kind.
+							signalDisplay: resolveSignalDisplay({
+								signalType,
+								queryBuilderDraft: storedRule?.queryBuilderDraft ?? null,
+								rawQueryReducer: ruleRow?.reducer ?? null,
+							}),
 							severity: decodeAlertSeveritySync(
 								incidentRow?.severity ?? payloadRule?.severity ?? "warning",
 							),

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -2,6 +2,7 @@ import { formatWarehouseDateTime } from "@maple/query-engine"
 import {
 	AlertComparator as AlertComparatorSchema,
 	AlertDeliveryError,
+	type AlertDeliveryFailure,
 	AlertDestinationDecryptionError,
 	AlertDeliveryEventDocument,
 	AlertDestinationDocument,
@@ -309,7 +310,7 @@ export interface AlertsServiceShape
 		| AlertValidationError
 		| AlertPersistenceError
 		| AlertRuleDestinationNotFoundError
-		| AlertDeliveryError
+		| AlertDeliveryFailure
 		| AlertDestinationStorageError
 		| QueryEngineValidationError
 		| QueryEngineTimeoutError
@@ -340,7 +341,7 @@ export interface AlertsServiceShape
 			readonly deliveryFailureCount: number
 		},
 		| AlertPersistenceError
-		| AlertDeliveryError
+		| AlertDeliveryFailure
 		| AlertValidationError
 		| AlertRuleNotFoundError
 		| AlertDestinationNotFoundError
@@ -649,7 +650,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 			const toDeliveryAttemptFailure = (
 				error:
 					| AlertValidationError
-					| AlertDeliveryError
+					| AlertDeliveryFailure
 					| AlertPersistenceError
 					| AlertDestinationStorageError
 					| AlertRuleStoredConfigInvalidError,
@@ -1432,7 +1433,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					row: AlertDeliveryEventRow,
 					error:
 						| AlertValidationError
-						| AlertDeliveryError
+						| AlertDeliveryFailure
 						| AlertPersistenceError
 						| AlertDestinationStorageError
 						| AlertRuleStoredConfigInvalidError,
@@ -2641,7 +2642,7 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceS
 					row: AlertRuleRow,
 					error:
 						| AlertValidationError
-						| AlertDeliveryError
+						| AlertDeliveryFailure
 						| AlertPersistenceError
 						| AlertRuleStoredConfigInvalidError
 						| QueryEngineValidationError

--- a/apps/api/src/services/alerts/NotificationDispatcher.ts
+++ b/apps/api/src/services/alerts/NotificationDispatcher.ts
@@ -80,6 +80,18 @@ export interface NotificationDispatcherShape {
 	}>
 }
 
+/** Every failure this path can catch collapses to the same per-destination row. */
+const failedResult = (
+	row: AlertDestinationRow,
+	error: { readonly message: string },
+): Effect.Effect<NotificationDestinationResult> =>
+	Effect.succeed({
+		destinationId: row.id,
+		destinationName: row.name,
+		status: "failed",
+		error: error.message,
+	})
+
 export interface NotificationDestinationResult {
 	readonly destinationId: AlertDestinationId
 	readonly destinationName: string | null
@@ -283,19 +295,16 @@ const make: Effect.Effect<
 						),
 						Effect.catchTags({
 							"@maple/api/services/NotificationDispatchError": (error) =>
-								Effect.succeed<NotificationDestinationResult>({
-									destinationId: row.id,
-									destinationName: row.name,
-									status: "failed",
-									error: error.message,
-								}),
-							"@maple/http/errors/AlertDeliveryError": (error) =>
-								Effect.succeed<NotificationDestinationResult>({
-									destinationId: row.id,
-									destinationName: row.name,
-									status: "failed",
-									error: error.message,
-								}),
+								failedResult(row, error),
+							// Every delivery failure class reports the same way here. The
+							// distinction between them exists to drive the delivery
+							// queue's retry decision, which this path does not run.
+							"@maple/http/errors/AlertDeliveryError": (error) => failedResult(row, error),
+							"@maple/http/errors/AlertDeliveryAuthError": (error) => failedResult(row, error),
+							"@maple/http/errors/AlertDeliveryTargetMissingError": (error) =>
+								failedResult(row, error),
+							"@maple/http/errors/AlertDeliveryRejectedError": (error) =>
+								failedResult(row, error),
 						}),
 					)
 				},

--- a/apps/api/src/services/alerts/NotificationDispatcher.ts
+++ b/apps/api/src/services/alerts/NotificationDispatcher.ts
@@ -11,11 +11,9 @@ import {
 } from "@maple/domain/http"
 import { and, eq, inArray } from "drizzle-orm"
 import { Clock, Context, Effect, Layer, Redacted, Schema } from "effect"
-import {
-	buildAlertChatUrl,
-	dispatchDelivery as dispatchDeliveryImpl,
-	type DispatchContext,
-} from "./AlertDeliveryDispatch"
+import { buildAlertChatUrl } from "./AlertDeliveryDispatch"
+import { dispatchDelivery as dispatchDeliveryImpl } from "./delivery/dispatch"
+import type { DispatchContext } from "./delivery/context"
 import {
 	hydrateDestinationRow,
 	type DestinationSecretConfig,

--- a/apps/api/src/services/alerts/alert-email.ts
+++ b/apps/api/src/services/alerts/alert-email.ts
@@ -37,7 +37,7 @@ export const buildAlertEmailContent = (
 				eventLabel,
 				eventEmoji: emoji,
 				severity: context.severity,
-				signalLabel: formatSignalLabel(context.signalType),
+				signalLabel: formatSignalLabel(context),
 				group: context.groupKey ?? "all",
 				observedSummary: formatObservedSummary(context),
 				window: formatWindow(context.windowMinutes),

--- a/apps/api/src/services/alerts/alert-formatting.ts
+++ b/apps/api/src/services/alerts/alert-formatting.ts
@@ -1,5 +1,6 @@
 import type { AlertComparator, AlertEventType, AlertSeverity, AlertSignalType } from "@maple/domain/http"
 import { Match, Option } from "effect"
+import { resolveSignalDisplay, type SignalDisplay } from "./alert-signal-display"
 import type { NotificationTemplateConfig } from "./alert-templating/renderer"
 
 export interface TemplateRenderContext {
@@ -8,6 +9,12 @@ export interface TemplateRenderContext {
 	readonly eventType: AlertEventType
 	readonly severity: AlertSeverity
 	readonly signalType: AlertSignalType
+	/**
+	 * How this rule's measured quantity is named and unit-formatted. Optional
+	 * because the escalation/error-notification paths dispatch without an alert
+	 * rule; those fall back to what `signalType` alone can say.
+	 */
+	readonly signalDisplay?: SignalDisplay | null
 	readonly comparator: AlertComparator
 	readonly threshold: number
 	readonly thresholdUpper: number | null
@@ -26,6 +33,20 @@ const round = (value: number, decimals = 2): string => {
 	const factor = 10 ** decimals
 	return (Math.round(value * factor) / factor).toString()
 }
+
+/** Clamp to a provider's field limit, marking the cut with an ellipsis. */
+export const truncate = (value: string, max: number): string =>
+	value.length > max ? `${value.slice(0, max - 1)}…` : value
+
+/** Thousands separators — an unpunctuated `1041923` is unreadable at a glance. */
+const grouped = (value: number): string =>
+	new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(value)
+
+/** The fields every signal-aware formatter needs. */
+type SignalContext = Pick<TemplateRenderContext, "signalType" | "signalDisplay">
+
+export const signalDisplayOf = (context: SignalContext): SignalDisplay =>
+	context.signalDisplay ?? resolveSignalDisplay({ signalType: context.signalType })
 
 export const formatComparator = (
 	value: AlertComparator,
@@ -51,17 +72,7 @@ export const formatComparator = (
 	return `${operator} ${threshold}`
 }
 
-export const formatSignalLabel = (signal: string) => {
-	const labels: Record<string, string> = {
-		error_rate: "Error Rate",
-		p95_latency: "P95 Latency",
-		p99_latency: "P99 Latency",
-		apdex: "Apdex",
-		throughput: "Throughput",
-		metric: "Metric",
-	}
-	return labels[signal] ?? signal
-}
+export const formatSignalLabel = (context: SignalContext): string => signalDisplayOf(context).label
 
 export const eventTypeEmoji = (type: string) => {
 	const map: Record<string, string> = {
@@ -83,16 +94,21 @@ export const formatEventTypeLabel = (type: string) => {
 	return map[type] ?? type
 }
 
-export const formatSignalMetric = (value: number | null, signalType: string): string =>
+/**
+ * Formats by the signal's UNIT, not by its query kind — a `builder_query` over
+ * `p95(duration)` is milliseconds just as much as the `p95_latency` preset is.
+ */
+export const formatSignalMetric = (value: number | null, display: SignalDisplay): string =>
 	Option.match(Option.fromNullishOr(value), {
 		onNone: () => "n/a",
 		onSome: (metric) =>
-			Match.value(signalType).pipe(
-				Match.when("error_rate", () => `${round(metric * 100, 1)}%`),
-				Match.whenOr("p95_latency", "p99_latency", () => `${round(metric)}ms`),
+			Match.value(display.unit).pipe(
+				Match.when("ratio", () => `${round(metric * 100, 1)}%`),
+				Match.when("ms", () => `${grouped(metric)}ms`),
 				Match.when("apdex", () => `${round(metric, 3)}`),
-				Match.when("throughput", () => `${round(metric)} rpm`),
-				Match.orElse(() => `${round(metric)}`),
+				Match.when("rpm", () => `${grouped(metric)} rpm`),
+				Match.whenOr("count", "plain", () => grouped(metric)),
+				Match.exhaustive,
 			),
 	})
 
@@ -130,23 +146,24 @@ export const discordEmbedColor = (eventType: string, severity: string): number =
 	return 0xecb22e
 }
 
-type ObservedContext = Pick<
-	TemplateRenderContext,
-	"value" | "signalType" | "comparator" | "threshold" | "thresholdUpper"
->
+type ObservedContext = SignalContext &
+	Pick<TemplateRenderContext, "value" | "comparator" | "threshold" | "thresholdUpper">
 type ThresholdContext = Omit<ObservedContext, "value">
 
-export const formatThresholdSummary = (context: ThresholdContext): string =>
-	context.comparator === "between" || context.comparator === "not_between"
-		? `${formatComparator(context.comparator)} ${formatSignalMetric(context.threshold, context.signalType)} and ${formatSignalMetric(context.thresholdUpper ?? context.threshold, context.signalType)}`
-		: `${formatComparator(context.comparator)} ${formatSignalMetric(context.threshold, context.signalType)}`
+export const formatThresholdSummary = (context: ThresholdContext): string => {
+	const display = signalDisplayOf(context)
+	return context.comparator === "between" || context.comparator === "not_between"
+		? `${formatComparator(context.comparator)} ${formatSignalMetric(context.threshold, display)} and ${formatSignalMetric(context.thresholdUpper ?? context.threshold, display)}`
+		: `${formatComparator(context.comparator)} ${formatSignalMetric(context.threshold, display)}`
+}
 
 export const formatObservedSummary = (context: ObservedContext): string =>
-	`${formatSignalMetric(context.value, context.signalType)} ${formatThresholdSummary(context)}`
+	`${formatSignalMetric(context.value, signalDisplayOf(context))} ${formatThresholdSummary(context)}`
 
 export const comparatorBreachPhrase = (context: ThresholdContext): string => {
-	const threshold = formatSignalMetric(context.threshold, context.signalType)
-	const upper = formatSignalMetric(context.thresholdUpper ?? context.threshold, context.signalType)
+	const display = signalDisplayOf(context)
+	const threshold = formatSignalMetric(context.threshold, display)
+	const upper = formatSignalMetric(context.thresholdUpper ?? context.threshold, display)
 	return Match.value(context.comparator).pipe(
 		Match.whenOr("gt", "gte", () => `above the ${threshold} threshold`),
 		Match.whenOr("lt", "lte", () => `below the ${threshold} threshold`),

--- a/apps/api/src/services/alerts/alert-signal-display.test.ts
+++ b/apps/api/src/services/alerts/alert-signal-display.test.ts
@@ -1,0 +1,149 @@
+import type { QueryBuilderQueryDraftPayload } from "@maple/domain/http"
+import { assert, describe, it } from "@effect/vitest"
+import { resolveSignalDisplay } from "./alert-signal-display"
+
+type TracesDraft = Extract<QueryBuilderQueryDraftPayload, { dataSource: "traces" }>
+type LogsDraft = Extract<QueryBuilderQueryDraftPayload, { dataSource: "logs" }>
+type MetricsDraft = Extract<QueryBuilderQueryDraftPayload, { dataSource: "metrics" }>
+
+const base = { id: "q1", name: "Query A" }
+
+const tracesDraft = (fields: Omit<TracesDraft, "id" | "name" | "dataSource">): TracesDraft => ({
+	...base,
+	dataSource: "traces",
+	...fields,
+})
+
+const logsDraft = (fields: Omit<LogsDraft, "id" | "name" | "dataSource">): LogsDraft => ({
+	...base,
+	dataSource: "logs",
+	...fields,
+})
+
+const metricsDraft = (fields: Omit<MetricsDraft, "id" | "name" | "dataSource">): MetricsDraft => ({
+	...base,
+	dataSource: "metrics",
+	...fields,
+})
+
+describe("resolveSignalDisplay", () => {
+	describe("preset signals", () => {
+		it("keeps their established labels and attaches their units", () => {
+			assert.deepStrictEqual(resolveSignalDisplay({ signalType: "error_rate" }), {
+				label: "Error Rate",
+				unit: "ratio",
+			})
+			assert.deepStrictEqual(resolveSignalDisplay({ signalType: "p95_latency" }), {
+				label: "P95 Latency",
+				unit: "ms",
+			})
+			assert.deepStrictEqual(resolveSignalDisplay({ signalType: "throughput" }), {
+				label: "Throughput",
+				unit: "rpm",
+			})
+			assert.deepStrictEqual(resolveSignalDisplay({ signalType: "apdex" }), {
+				label: "Apdex",
+				unit: "apdex",
+			})
+		})
+	})
+
+	describe("builder_query", () => {
+		it("names a metrics query as aggregation(metricName), unit unknown", () => {
+			assert.deepStrictEqual(
+				resolveSignalDisplay({
+					signalType: "builder_query",
+					queryBuilderDraft: metricsDraft({
+						aggregation: "sum",
+						metricName: "db.query.duration",
+					}),
+				}),
+				{ label: "sum(db.query.duration)", unit: "plain" },
+			)
+		})
+
+		it("drops the parens when the metrics draft has no metric name", () => {
+			assert.strictEqual(
+				resolveSignalDisplay({
+					signalType: "builder_query",
+					queryBuilderDraft: metricsDraft({ aggregation: "avg" }),
+				}).label,
+				"avg",
+			)
+		})
+
+		it("reuses the query builder's own aggregation labels for traces", () => {
+			assert.deepStrictEqual(
+				resolveSignalDisplay({
+					signalType: "builder_query",
+					queryBuilderDraft: tracesDraft({ aggregation: "p95_duration" }),
+				}),
+				{ label: "p95(duration)", unit: "ms" },
+			)
+		})
+
+		it("carries the ratio unit for a traces error_rate query", () => {
+			assert.deepStrictEqual(
+				resolveSignalDisplay({
+					signalType: "builder_query",
+					queryBuilderDraft: tracesDraft({ aggregation: "error_rate" }),
+				}),
+				{ label: "error_rate", unit: "ratio" },
+			)
+		})
+
+		it("names the span attribute when the traces query aggregates a valueField", () => {
+			assert.deepStrictEqual(
+				resolveSignalDisplay({
+					signalType: "builder_query",
+					queryBuilderDraft: tracesDraft({
+						aggregation: "sum",
+						valueField: "attr.result.rowCount",
+					}),
+				}),
+				{ label: "sum(attr.result.rowCount)", unit: "plain" },
+			)
+		})
+
+		it("names a logs count query", () => {
+			assert.deepStrictEqual(
+				resolveSignalDisplay({
+					signalType: "builder_query",
+					queryBuilderDraft: logsDraft({ aggregation: "count" }),
+				}),
+				{ label: "Log count", unit: "count" },
+			)
+		})
+
+		it("falls back to the humanized enum when the rule row is gone", () => {
+			assert.deepStrictEqual(resolveSignalDisplay({ signalType: "builder_query" }), {
+				label: "Builder query",
+				unit: "plain",
+			})
+		})
+	})
+
+	describe("raw_query", () => {
+		it("names the reducer when one is applied", () => {
+			assert.deepStrictEqual(
+				resolveSignalDisplay({ signalType: "raw_query", rawQueryReducer: "sum" }),
+				{ label: "SQL result (sum)", unit: "plain" },
+			)
+		})
+
+		it("omits the reducer for identity and for a missing reducer", () => {
+			assert.strictEqual(
+				resolveSignalDisplay({ signalType: "raw_query", rawQueryReducer: "identity" }).label,
+				"SQL result",
+			)
+			assert.strictEqual(resolveSignalDisplay({ signalType: "raw_query" }).label, "SQL result")
+		})
+	})
+
+	it("never returns a raw snake_case enum for an unmapped signal type", () => {
+		assert.strictEqual(
+			resolveSignalDisplay({ signalType: "some_future_signal" }).label,
+			"Some future signal",
+		)
+	})
+})

--- a/apps/api/src/services/alerts/alert-signal-display.ts
+++ b/apps/api/src/services/alerts/alert-signal-display.ts
@@ -1,0 +1,112 @@
+/**
+ * How an alert rule's measured quantity is named and unit-formatted in outbound
+ * notifications.
+ *
+ * `signalType` alone is NOT that name. It is the rule's *query kind*, and two of
+ * its members — `builder_query` and `raw_query` — say only "this rule runs a
+ * query", not what the query measures. Printing the enum verbatim produced Slack
+ * messages reading "builder_query is 1041923". The measured quantity for those
+ * two lives in the rule's `queryBuilderDraft` / `rawQueryReducer`, which is why
+ * this resolves from the rule rather than from the enum.
+ *
+ * The unit travels with the label because the two are decided by the same facts:
+ * a traces `p95_duration` query is milliseconds, `error_rate` is a ratio, and a
+ * metrics query is an unknown unit that must render as a plain number. Deriving
+ * them separately is how the observed value and its threshold drift apart.
+ */
+import type { AlertSignalType, QueryBuilderQueryDraftPayload } from "@maple/domain/http"
+import { AGGREGATIONS_BY_SOURCE } from "@maple/query-engine/query-builder"
+
+export type SignalUnit = "ratio" | "ms" | "rpm" | "apdex" | "count" | "plain"
+
+export interface SignalDisplay {
+	/** Human-readable name of the measured quantity, e.g. `sum(db.query.duration)`. */
+	readonly label: string
+	readonly unit: SignalUnit
+}
+
+export interface SignalDisplayInput {
+	readonly signalType: AlertSignalType | string
+	readonly queryBuilderDraft?: QueryBuilderQueryDraftPayload | null
+	/**
+	 * Widened to `string` so the undecoded `alert_rules.reducer` column can be
+	 * passed straight through: this only compares it, and a delivery must not
+	 * fail on an unrecognized reducer spelling.
+	 */
+	readonly rawQueryReducer?: string | null
+}
+
+const PRESET_SIGNALS: Record<string, SignalDisplay> = {
+	error_rate: { label: "Error Rate", unit: "ratio" },
+	p95_latency: { label: "P95 Latency", unit: "ms" },
+	p99_latency: { label: "P99 Latency", unit: "ms" },
+	apdex: { label: "Apdex", unit: "apdex" },
+	throughput: { label: "Throughput", unit: "rpm" },
+}
+
+/**
+ * `p95_duration` → `p95(duration)`. Reuses the query builder's own option labels
+ * so the notification names the aggregation exactly as the rule author picked it
+ * in the UI.
+ */
+const TRACES_AGGREGATION_LABELS = new Map(
+	AGGREGATIONS_BY_SOURCE.traces.map((option) => [option.value, option.label]),
+)
+
+const tracesAggregationUnit = (aggregation: string): SignalUnit => {
+	if (aggregation.endsWith("_duration")) return "ms"
+	if (aggregation === "error_rate") return "ratio"
+	if (aggregation === "count") return "count"
+	return "plain"
+}
+
+/** `builder_query` → `Builder query`, so an unmapped enum never leaks verbatim. */
+const humanize = (value: string): string => {
+	const words = value.replace(/[_-]+/g, " ").trim()
+	if (words.length === 0) return "Signal"
+	return words.charAt(0).toUpperCase() + words.slice(1)
+}
+
+const call = (fn: string, arg: string | undefined): string =>
+	arg != null && arg.trim().length > 0 ? `${fn}(${arg.trim()})` : fn
+
+const builderQueryDisplay = (draft: QueryBuilderQueryDraftPayload): SignalDisplay => {
+	const aggregation = draft.aggregation.trim()
+	const named = (label: string, unit: SignalUnit): SignalDisplay =>
+		label.length > 0 ? { label, unit } : { label: draft.name.trim() || "Query", unit }
+
+	if (draft.dataSource === "metrics") {
+		// The metric's unit is not carried on the draft, so the value stays plain.
+		return named(call(aggregation, draft.metricName), "plain")
+	}
+	if (draft.dataSource === "logs") {
+		return named(aggregation === "count" ? "Log count" : aggregation, "count")
+	}
+	// Traces. A non-empty `valueField` switches the query into numeric-attribute
+	// aggregation, so the attribute — not "duration" — is what is being measured.
+	if (draft.valueField != null && draft.valueField.trim().length > 0) {
+		return named(call(aggregation, draft.valueField), "plain")
+	}
+	return named(
+		TRACES_AGGREGATION_LABELS.get(aggregation) ?? aggregation,
+		tracesAggregationUnit(aggregation),
+	)
+}
+
+const rawQueryDisplay = (reducer: string | null | undefined): SignalDisplay => ({
+	// `identity` means "the bucket value as-is" — naming it would add noise.
+	label: reducer != null && reducer !== "identity" ? `SQL result (${reducer})` : "SQL result",
+	unit: "plain",
+})
+
+export const resolveSignalDisplay = (input: SignalDisplayInput): SignalDisplay => {
+	const preset = PRESET_SIGNALS[input.signalType]
+	if (preset) return preset
+	if (input.signalType === "builder_query" && input.queryBuilderDraft != null) {
+		return builderQueryDisplay(input.queryBuilderDraft)
+	}
+	if (input.signalType === "raw_query") return rawQueryDisplay(input.rawQueryReducer)
+	// A query-driven rule whose definition could not be loaded (deleted rule row),
+	// or a signal type added to the domain without an entry here.
+	return { label: humanize(input.signalType), unit: "plain" }
+}

--- a/apps/api/src/services/alerts/delivery/Transport.ts
+++ b/apps/api/src/services/alerts/delivery/Transport.ts
@@ -1,0 +1,141 @@
+/**
+ * The provider → message seam.
+ *
+ * Before this existed, the six providers were inline arms of one `Match` inside
+ * `dispatchDelivery`, each re-deriving the same boilerplate: build a body,
+ * time the fetch, check `!response.ok`, read the body, hand-concatenate
+ * `"<Provider> delivery failed with <status>: <detail>"`. That sentence was
+ * written out five separate times, and no arm had a span, so the outbound calls
+ * to Slack/PagerDuty/Discord/Hazel were invisible.
+ *
+ * Here each provider declares only what is genuinely provider-specific, and
+ * `runHttpTransport` owns everything shared: the spans, the timeout, the SSRF
+ * guard, the error construction and the metrics.
+ *
+ * `render` is deliberately PURE — no Effect, no fetch, no Clock. That is what
+ * makes a provider assertable as `render(input) → HttpRequestSpec` with no stub
+ * of any kind, which is why the four unverified providers were expensive to
+ * cover before and are cheap now.
+ */
+import type { AlertDeliveryError, AlertDestinationType } from "@maple/domain/http"
+import type { Effect, Result } from "effect"
+import type { DestinationSecretConfig } from "../AlertDestinationHydration"
+import type { DispatchContext, DispatchResult } from "./context"
+
+/** Everything a transport is given. Assembled once by the runner. */
+export interface RenderInput<Config> {
+	/** Narrowed secret config — a transport never re-discriminates on `type`. */
+	readonly config: Config
+	readonly context: DispatchContext
+	readonly linkUrl: string
+	readonly chatUrl: string
+	/**
+	 * The canonical wire payload. `webhook` ships it verbatim and HMAC-signs it,
+	 * so it is a customer-facing contract, not an internal detail.
+	 */
+	readonly payloadJson: string
+	/**
+	 * The rule's custom template resolved for THIS destination type, or null
+	 * when it has none (the transport then uses its hardcoded format). Resolved
+	 * once by the runner instead of by six separate per-arm calls.
+	 */
+	readonly templated: ResolvedTitleBody | null
+}
+
+export interface ResolvedTitleBody {
+	readonly title: string
+	readonly body: string
+}
+
+/** What a transport wants sent. Pure data. */
+export interface HttpRequestSpec {
+	readonly url: string
+	readonly headers: Readonly<Record<string, string>>
+	readonly body: string
+	/**
+	 * `true` → route through `safeFetch` (the SSRF guard), because the host came
+	 * from user configuration. `false` → call `fetch` directly, because the host
+	 * is a compile-time vendor constant and there is nothing to validate.
+	 */
+	readonly guarded: boolean
+	/**
+	 * `true` when the URL path itself carries a credential — Discord and Hazel
+	 * webhook URLs embed their delivery token in the path. The runner then
+	 * annotates `server.address` only, never `url.path`.
+	 *
+	 * Declared rather than inferred from `guarded`: the two coincide today and
+	 * a future provider could easily break that.
+	 */
+	readonly sensitivePath: boolean
+}
+
+/** What the provider said on success. */
+export interface ProviderAck {
+	readonly providerMessage: string
+	readonly providerReference: string | null
+}
+
+/**
+ * @typeParam Prepared - value produced by the optional effectful `prepare` step
+ * and handed to `render`. `void` for every provider except `slack-bot`, which
+ * resolves the org's bot token. The parameter is closed at the call site in
+ * `dispatchDelivery`, so it never needs an existential in a union type.
+ */
+export interface HttpTransport<Config, Prepared = void> {
+	readonly kind: "http"
+	readonly type: AlertDestinationType
+	/** Span `peer.service` — this is what draws the provider on the service map. */
+	readonly peerService: string
+	/** The noun in generated error messages: "Slack delivery failed with 500". */
+	readonly providerLabel: string
+	/**
+	 * The only effectful step, and the only place a secret is fetched. Omitted
+	 * by every provider whose credentials are already in the secret config.
+	 */
+	readonly prepare?: (input: RenderInput<Config>) => Effect.Effect<Prepared, AlertDeliveryError>
+	/** PURE. The unit-testable heart of each provider. */
+	readonly render: (input: RenderInput<Config>, prepared: Prepared) => HttpRequestSpec
+	/**
+	 * PURE. Give a non-2xx a better message than the generic one. Return null to
+	 * fall through to the runner's default. Only `hazel-oauth` implements this.
+	 */
+	readonly describeStatus?: (status: number) => string | null
+	/**
+	 * PURE. For a provider that answers 200 and reports failure in the body.
+	 * Only `slack-bot` implements this — Slack returns `{ ok: false, error }`
+	 * with HTTP 200, so the body is the source of truth, not the status.
+	 */
+	readonly interpret?: (
+		input: RenderInput<Config>,
+		rawBody: string,
+	) => Result.Result<ProviderAck, AlertDeliveryError>
+	/** PURE. The success shape when `interpret` is absent. */
+	readonly ack: (input: RenderInput<Config>) => ProviderAck
+}
+
+/**
+ * A provider that is not an HTTP request at all. Only `email`: it fans out over
+ * workspace members through the platform email channel, and its partial-success
+ * case is a *success* with a degraded message — there is no per-member attempt
+ * state, so retrying would re-mail the members who already received it.
+ */
+export interface EffectTransport<Config> {
+	readonly kind: "effect"
+	readonly type: AlertDestinationType
+	readonly peerService: string
+	readonly providerLabel: string
+	readonly send: (
+		input: RenderInput<Config>,
+		deps: EffectTransportDeps,
+	) => Effect.Effect<DispatchResult, AlertDeliveryError>
+}
+
+export interface EffectTransportDeps {
+	readonly sendEmail: (to: string, subject: string, html: string) => Effect.Effect<void, AlertDeliveryError>
+}
+
+/** Narrows the secret-config union to the member a given destination type carries. */
+export type SecretConfigOf<T extends DestinationSecretConfig["type"]> = Extract<
+	DestinationSecretConfig,
+	{ type: T }
+>

--- a/apps/api/src/services/alerts/delivery/Transport.ts
+++ b/apps/api/src/services/alerts/delivery/Transport.ts
@@ -17,7 +17,7 @@
  * of any kind, which is why the four unverified providers were expensive to
  * cover before and are cheap now.
  */
-import type { AlertDeliveryError, AlertDestinationType } from "@maple/domain/http"
+import type { AlertDeliveryFailure, AlertDestinationType } from "@maple/domain/http"
 import type { Effect, Result } from "effect"
 import type { DestinationSecretConfig } from "../AlertDestinationHydration"
 import type { DispatchContext, DispatchResult } from "./context"
@@ -92,7 +92,7 @@ export interface HttpTransport<Config, Prepared = void> {
 	 * The only effectful step, and the only place a secret is fetched. Omitted
 	 * by every provider whose credentials are already in the secret config.
 	 */
-	readonly prepare?: (input: RenderInput<Config>) => Effect.Effect<Prepared, AlertDeliveryError>
+	readonly prepare?: (input: RenderInput<Config>) => Effect.Effect<Prepared, AlertDeliveryFailure>
 	/** PURE. The unit-testable heart of each provider. */
 	readonly render: (input: RenderInput<Config>, prepared: Prepared) => HttpRequestSpec
 	/**
@@ -108,7 +108,7 @@ export interface HttpTransport<Config, Prepared = void> {
 	readonly interpret?: (
 		input: RenderInput<Config>,
 		rawBody: string,
-	) => Result.Result<ProviderAck, AlertDeliveryError>
+	) => Result.Result<ProviderAck, AlertDeliveryFailure>
 	/** PURE. The success shape when `interpret` is absent. */
 	readonly ack: (input: RenderInput<Config>) => ProviderAck
 }
@@ -127,11 +127,15 @@ export interface EffectTransport<Config> {
 	readonly send: (
 		input: RenderInput<Config>,
 		deps: EffectTransportDeps,
-	) => Effect.Effect<DispatchResult, AlertDeliveryError>
+	) => Effect.Effect<DispatchResult, AlertDeliveryFailure>
 }
 
 export interface EffectTransportDeps {
-	readonly sendEmail: (to: string, subject: string, html: string) => Effect.Effect<void, AlertDeliveryError>
+	readonly sendEmail: (
+		to: string,
+		subject: string,
+		html: string,
+	) => Effect.Effect<void, AlertDeliveryFailure>
 }
 
 /** Narrows the secret-config union to the member a given destination type carries. */

--- a/apps/api/src/services/alerts/delivery/context.ts
+++ b/apps/api/src/services/alerts/delivery/context.ts
@@ -1,0 +1,62 @@
+/**
+ * The dispatch value types, extracted from `AlertDeliveryDispatch` so the
+ * transports can depend on them without importing the module that composes the
+ * transports (a runtime import cycle).
+ *
+ * `DispatchContext` is still the pre-refactor 22-field flat shape; collapsing
+ * it and its five near-duplicates onto one canonical notification is a later
+ * stage. It is moved here unchanged so that stage is a rename, not a move.
+ */
+import type { AlertComparator, AlertEventType, AlertSeverity, AlertSignalType } from "@maple/domain/http"
+import type { AlertDestinationRow } from "@maple/db"
+import type { EnrichedDestinationSecretConfig } from "../AlertDestinationHydration"
+import type { SignalDisplay } from "../alert-signal-display"
+import type { NotificationTemplateConfig } from "../alert-templating/renderer"
+
+interface DestinationPublicConfig {
+	readonly summary: string
+	readonly channelLabel: string | null
+}
+
+export interface DispatchContext {
+	readonly deliveryKey: string
+	readonly destination: AlertDestinationRow
+	readonly publicConfig: DestinationPublicConfig
+	readonly secretConfig: EnrichedDestinationSecretConfig
+	readonly ruleId: string
+	readonly ruleName: string
+	readonly groupKey: string | null
+	readonly signalType: AlertSignalType
+	/**
+	 * How this rule's measured quantity is named and unit-formatted. Resolved
+	 * from the rule at dispatch time, because `signalType` alone is the query
+	 * kind and cannot name what a `builder_query`/`raw_query` rule measures.
+	 * Optional: the escalation/error paths dispatch without an alert rule.
+	 */
+	readonly signalDisplay?: SignalDisplay | null
+	readonly severity: AlertSeverity
+	readonly comparator: AlertComparator
+	readonly threshold: number
+	readonly thresholdUpper: number | null
+	readonly eventType: AlertEventType
+	readonly incidentId: string | null
+	readonly incidentStatus: string
+	readonly dedupeKey: string
+	readonly windowMinutes: number
+	readonly value: number | null
+	readonly sampleCount: number | null
+	/**
+	 * User-customized notification template (title + Markdown body, optional
+	 * per-destination overrides). `null`/absent → the built-in hardcoded format.
+	 * Snapshotted at enqueue time so retries and post-fire edits stay stable.
+	 */
+	readonly template?: NotificationTemplateConfig | null
+	/** Epoch ms the notification was sent — exposed to templates as `sentAt`. */
+	readonly sentAtMs?: number
+}
+
+export interface DispatchResult {
+	readonly providerMessage: string
+	readonly providerReference: string | null
+	readonly responseCode: number | null
+}

--- a/apps/api/src/services/alerts/delivery/delivery-spans.test.ts
+++ b/apps/api/src/services/alerts/delivery/delivery-spans.test.ts
@@ -1,0 +1,236 @@
+import type { AlertDestinationRow } from "@maple/db"
+import { AlertDeliveryError, AlertDestinationId } from "@maple/domain/http"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import { makeRecordingTracer, spansNamed } from "@/testing/recording-tracer"
+import { dispatchDelivery, type DispatchDeps } from "./dispatch"
+import type { DispatchContext } from "./context"
+
+/**
+ * The outbound provider call must be a **Client-kind span carrying
+ * `peer.service`** — that pair is what draws Slack/PagerDuty/Discord/Hazel as
+ * nodes on the service map and makes their latency and status attributable.
+ * Before the transport registry existed, `dispatchDelivery` had no span at all
+ * and no provider arm had one, so every provider dependency was invisible.
+ * These assertions are the regression guard for that (same reasoning as
+ * `GithubAppClient.span.test.ts`).
+ *
+ * They also guard the secret-leak rule: Discord and Hazel webhook URLs embed
+ * their delivery token in the PATH, so those transports must annotate
+ * `server.address` only — never `url.path`, and never `url.full`.
+ */
+
+const DESTINATION_ID = Schema.decodeUnknownSync(AlertDestinationId)("7c6b5a49-3821-4e0f-9d8c-7b6a59483726")
+
+const HTTP_SPAN = "AlertDelivery.http"
+
+const destinationRow: AlertDestinationRow = {
+	id: DESTINATION_ID,
+	orgId: "org_1" as AlertDestinationRow["orgId"],
+	name: "Destination",
+	type: "webhook",
+	enabled: true,
+	configJson: {},
+	secretCiphertext: "",
+	secretIv: "",
+	secretTag: "",
+	lastTestedAt: null,
+	lastTestError: null,
+	createdAt: new Date(0),
+	updatedAt: new Date(0),
+	createdBy: "user_1",
+	updatedBy: "user_1",
+}
+
+const contextFor = (secretConfig: DispatchContext["secretConfig"]): DispatchContext => ({
+	deliveryKey: "org_1:dest_1:delivery",
+	destination: { ...destinationRow, type: secretConfig.type },
+	publicConfig: { summary: "Checkout error rate", channelLabel: null },
+	secretConfig,
+	ruleId: "rule_1",
+	ruleName: "Checkout error rate",
+	groupKey: null,
+	signalType: "error_rate",
+	severity: "critical",
+	comparator: "gt",
+	threshold: 0.05,
+	thresholdUpper: null,
+	eventType: "trigger",
+	incidentId: "inc_1",
+	incidentStatus: "open",
+	dedupeKey: "org_1:rule_1:checkout",
+	windowMinutes: 5,
+	value: 0.08,
+	sampleCount: 1200,
+	template: null,
+	sentAtMs: Date.parse("2026-06-02T00:00:00.000Z"),
+})
+
+const deps = (token = "xoxb-token"): DispatchDeps => ({
+	sendEmail: () =>
+		Effect.fail(new AlertDeliveryError({ message: "unexpected sendEmail", destinationType: "email" })),
+	resolveSlackBotToken: () => Effect.succeed(token),
+})
+
+const respondWith =
+	(make: () => Response): typeof fetch =>
+	async () =>
+		make()
+
+const dispatch = (context: DispatchContext, fetchFn: typeof fetch) =>
+	dispatchDelivery(
+		context,
+		"{}",
+		fetchFn,
+		5_000,
+		"https://web.localhost/alerts",
+		"https://web.localhost/chat",
+		deps(),
+	)
+
+describe("AlertDelivery.http span", () => {
+	const cases = [
+		{
+			name: "slack-bot",
+			config: { type: "slack-bot", channelId: "C1", channelName: "incidents" } as const,
+			peerService: "slack",
+			host: "slack.com",
+			expectPath: "/api/chat.postMessage",
+			respond: () => new Response(JSON.stringify({ ok: true, ts: "1.2" }), { status: 200 }),
+		},
+		{
+			name: "pagerduty",
+			config: { type: "pagerduty", integrationKey: "k" } as const,
+			peerService: "pagerduty",
+			host: "events.pagerduty.com",
+			expectPath: "/v2/enqueue",
+			respond: () => new Response("", { status: 202 }),
+		},
+		{
+			name: "webhook",
+			config: {
+				type: "webhook",
+				url: "https://hooks.example.test/maple",
+				signingSecret: null,
+			} as const,
+			peerService: "webhook",
+			host: "hooks.example.test",
+			expectPath: "/maple",
+			respond: () => new Response("", { status: 200 }),
+		},
+		{
+			name: "discord",
+			config: {
+				type: "discord",
+				webhookUrl: "https://discord.com/api/webhooks/1/s3cr3t-token",
+			} as const,
+			peerService: "discord",
+			host: "discord.com",
+			// The webhook token is a path segment — the path must NOT be recorded.
+			expectPath: null,
+			// Discord answers a plain webhook POST with 204 and no body.
+			respond: () => new Response(null, { status: 204 }),
+		},
+		{
+			name: "hazel-oauth",
+			config: {
+				type: "hazel-oauth",
+				hazelOrganizationId: "o",
+				hazelOrganizationName: "Acme",
+				hazelChannelId: "c",
+				hazelChannelName: "incidents",
+				webhookId: "wh_1",
+				webhookUrl: "https://hazel.test/api/webhooks/wh_1/s3cr3t-token",
+				webhookToken: "s3cr3t-token",
+			} as const,
+			peerService: "hazel",
+			host: "hazel.test",
+			expectPath: null,
+			respond: () => new Response("", { status: 200 }),
+		},
+	]
+
+	for (const testCase of cases) {
+		it.effect(`${testCase.name}: is a client span with peer.service and no leaked secret`, () =>
+			Effect.gen(function* () {
+				const { spans, tracer } = makeRecordingTracer()
+
+				yield* dispatch(contextFor(testCase.config), respondWith(testCase.respond)).pipe(
+					Effect.withTracer(tracer),
+				)
+
+				const [span, ...rest] = spansNamed(spans, HTTP_SPAN)
+				assert.isDefined(span, `${testCase.name} must emit an ${HTTP_SPAN} span`)
+				// Guards against reintroducing an `Effect.withSpan` alongside the
+				// `Effect.fn` — that emits two spans that disagree on timeout.
+				assert.deepStrictEqual(rest, [], "exactly one provider span per delivery")
+
+				assert.strictEqual(span!.kind, "client")
+				assert.strictEqual(span!.attributes.get("peer.service"), testCase.peerService)
+				assert.strictEqual(span!.attributes.get("server.address"), testCase.host)
+				assert.strictEqual(span!.attributes.get("http.request.method"), "POST")
+				assert.isUndefined(span!.attributes.get("url.full"))
+
+				if (testCase.expectPath === null) {
+					assert.isUndefined(
+						span!.attributes.get("url.path"),
+						"the webhook token is a path segment — the path must stay off the span",
+					)
+				} else {
+					assert.strictEqual(span!.attributes.get("url.path"), testCase.expectPath)
+				}
+
+				for (const value of span!.attributes.values()) {
+					assert.notInclude(String(value), "s3cr3t")
+					assert.notInclude(String(value), "xoxb-token")
+				}
+			}),
+		)
+	}
+
+	it.effect("records the upstream status even when the delivery fails", () =>
+		Effect.gen(function* () {
+			const { spans, tracer } = makeRecordingTracer()
+			const context = contextFor({
+				type: "webhook",
+				url: "https://hooks.example.test/maple",
+				signingSecret: null,
+			})
+
+			const exit = yield* dispatch(
+				context,
+				respondWith(() => new Response("nope", { status: 503 })),
+			).pipe(Effect.withTracer(tracer), Effect.exit)
+			assert.strictEqual(exit._tag, "Failure")
+
+			// The status lands on the span even though the call failed, so an
+			// upstream 5xx is attributable without parsing the error message.
+			const [span] = spansNamed(spans, HTTP_SPAN)
+			assert.isDefined(span)
+			assert.strictEqual(span!.attributes.get("http.response.status_code"), 503)
+			assert.strictEqual(span!.attributes.get("peer.service"), "webhook")
+		}),
+	)
+
+	it.effect("emits no provider span for the non-HTTP email transport", () =>
+		Effect.gen(function* () {
+			const { spans, tracer } = makeRecordingTracer()
+			const context = contextFor({
+				type: "email",
+				members: [{ userId: "u1", email: "on-call@example.test" }],
+			})
+
+			yield* dispatchDelivery(
+				context,
+				"{}",
+				respondWith(() => new Response("", { status: 200 })),
+				5_000,
+				"https://web.localhost/alerts",
+				"https://web.localhost/chat",
+				{ ...deps(), sendEmail: () => Effect.void },
+			).pipe(Effect.withTracer(tracer))
+
+			assert.deepStrictEqual(spansNamed(spans, HTTP_SPAN), [])
+		}),
+	)
+})

--- a/apps/api/src/services/alerts/delivery/dispatch.ts
+++ b/apps/api/src/services/alerts/delivery/dispatch.ts
@@ -1,0 +1,67 @@
+/**
+ * The delivery entry point: pick the transport for the destination, hand it the
+ * shared render input, run it under the uniform wrapper.
+ *
+ * The `Match` is what makes the registry exhaustive — adding a member to
+ * `DestinationSecretConfig` fails to compile here until it has a transport.
+ * It also narrows the config to the exact member each transport declares, which
+ * is why no transport re-discriminates on `type` and no `any` is needed to hold
+ * the transports in one collection.
+ */
+import type { AlertDeliveryError, OrgId } from "@maple/domain/http"
+import { Effect, Match } from "effect"
+import { renderTitleBody } from "../AlertDeliveryDispatch"
+import { discordTransport } from "./transports/discord"
+import { emailTransport } from "./transports/email"
+import { hazelTransport } from "./transports/hazel"
+import { pagerDutyTransport } from "./transports/pagerduty"
+import { makeSlackTransport } from "./transports/slack"
+import { webhookTransport } from "./transports/webhook"
+import { runEffectTransport, runHttpTransport, type TransportRuntime } from "./runTransport"
+import type { RenderInput } from "./Transport"
+import type { DispatchContext, DispatchResult } from "./context"
+
+export interface DispatchDeps {
+	/**
+	 * Sends one email via the platform email channel (Cloudflare `EMAIL`
+	 * binding). Injected so this module stays dependency-free.
+	 */
+	readonly sendEmail: (to: string, subject: string, html: string) => Effect.Effect<void, AlertDeliveryError>
+	/**
+	 * Resolves the decrypted Slack bot token for an org from its
+	 * `slack_workspaces` row. Only the `slack-bot` transport invokes it. Fails
+	 * when the org has no active Slack installation.
+	 */
+	readonly resolveSlackBotToken: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryError>
+}
+
+export const dispatchDelivery = (
+	context: DispatchContext,
+	payloadJson: string,
+	fetchFn: typeof fetch,
+	timeoutMs: number,
+	linkUrl: string,
+	chatUrl: string,
+	deps: DispatchDeps,
+): Effect.Effect<DispatchResult, AlertDeliveryError> => {
+	const runtime: TransportRuntime = { fetchFn, timeoutMs }
+	/**
+	 * Resolved once here rather than by each provider: the template is a
+	 * property of the rule and the destination TYPE, not of the transport's
+	 * wire format.
+	 */
+	const templated = renderTitleBody(context, context.secretConfig.type, linkUrl, chatUrl)
+	const shared = { context, linkUrl, chatUrl, payloadJson, templated }
+	const input = <Config>(config: Config): RenderInput<Config> => ({ config, ...shared })
+
+	return Match.value(context.secretConfig).pipe(
+		Match.discriminatorsExhaustive("type")({
+			"slack-bot": (config) => runHttpTransport(makeSlackTransport(deps), input(config), runtime),
+			pagerduty: (config) => runHttpTransport(pagerDutyTransport, input(config), runtime),
+			webhook: (config) => runHttpTransport(webhookTransport, input(config), runtime),
+			"hazel-oauth": (config) => runHttpTransport(hazelTransport, input(config), runtime),
+			discord: (config) => runHttpTransport(discordTransport, input(config), runtime),
+			email: (config) => runEffectTransport(emailTransport, input(config), deps),
+		}),
+	)
+}

--- a/apps/api/src/services/alerts/delivery/dispatch.ts
+++ b/apps/api/src/services/alerts/delivery/dispatch.ts
@@ -8,7 +8,7 @@
  * is why no transport re-discriminates on `type` and no `any` is needed to hold
  * the transports in one collection.
  */
-import type { AlertDeliveryError, OrgId } from "@maple/domain/http"
+import type { AlertDeliveryFailure, OrgId } from "@maple/domain/http"
 import { Effect, Match } from "effect"
 import { renderTitleBody } from "../AlertDeliveryDispatch"
 import { discordTransport } from "./transports/discord"
@@ -26,13 +26,17 @@ export interface DispatchDeps {
 	 * Sends one email via the platform email channel (Cloudflare `EMAIL`
 	 * binding). Injected so this module stays dependency-free.
 	 */
-	readonly sendEmail: (to: string, subject: string, html: string) => Effect.Effect<void, AlertDeliveryError>
+	readonly sendEmail: (
+		to: string,
+		subject: string,
+		html: string,
+	) => Effect.Effect<void, AlertDeliveryFailure>
 	/**
 	 * Resolves the decrypted Slack bot token for an org from its
 	 * `slack_workspaces` row. Only the `slack-bot` transport invokes it. Fails
 	 * when the org has no active Slack installation.
 	 */
-	readonly resolveSlackBotToken: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryError>
+	readonly resolveSlackBotToken: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryFailure>
 }
 
 export const dispatchDelivery = (
@@ -43,7 +47,7 @@ export const dispatchDelivery = (
 	linkUrl: string,
 	chatUrl: string,
 	deps: DispatchDeps,
-): Effect.Effect<DispatchResult, AlertDeliveryError> => {
+): Effect.Effect<DispatchResult, AlertDeliveryFailure> => {
 	const runtime: TransportRuntime = { fetchFn, timeoutMs }
 	/**
 	 * Resolved once here rather than by each provider: the template is a

--- a/apps/api/src/services/alerts/delivery/runTransport.ts
+++ b/apps/api/src/services/alerts/delivery/runTransport.ts
@@ -2,7 +2,14 @@
  * The uniform half of every delivery: spans, timeout, SSRF guard, error
  * construction. A transport contributes only what is provider-specific.
  */
-import { AlertDeliveryError, type AlertDestinationType } from "@maple/domain/http"
+import {
+	AlertDeliveryAuthError,
+	AlertDeliveryError,
+	AlertDeliveryRejectedError,
+	AlertDeliveryTargetMissingError,
+	type AlertDeliveryFailure,
+	type AlertDestinationType,
+} from "@maple/domain/http"
 import { Duration, Effect, Option, Result } from "effect"
 import { safeFetch } from "@/http/url-validator"
 import type {
@@ -39,6 +46,31 @@ const readErrorBody = (response: Response) =>
  */
 const statusFailureMessage = (providerLabel: string, status: number, detail: string) =>
 	`${providerLabel} delivery failed with ${status}${detail ? `: ${detail}` : ""}`
+
+/**
+ * Provider HTTP status → the failure class whose policy says whether the queue
+ * should retry. This is the single place that decision is made; the classes
+ * themselves carry `retry`/`recovery`, and `AlertsService` reads
+ * `error.error.retryable` off whichever one it gets.
+ *
+ * A transport overrides this only when its provider disagrees with the HTTP
+ * convention — see `slack-bot`, which reports channel failures as 200 + a body.
+ */
+export const failureForStatus = (
+	status: number,
+	fields: {
+		readonly message: string
+		readonly destinationType: AlertDestinationType
+		readonly providerStatus: number
+	},
+): AlertDeliveryFailure => {
+	if (status === 401 || status === 403) return new AlertDeliveryAuthError(fields)
+	if (status === 404 || status === 410) return new AlertDeliveryTargetMissingError(fields)
+	// 408/429 are the provider asking us to come back, not a rejection.
+	if (status === 408 || status === 429 || status >= 500) return new AlertDeliveryError(fields)
+	if (status >= 400) return new AlertDeliveryRejectedError(fields)
+	return new AlertDeliveryError(fields)
+}
 
 const hostOf = (url: string) => Option.liftThrowable(() => new URL(url))()
 
@@ -115,7 +147,7 @@ export const runHttpTransport = <Config, Prepared>(
 	transport: HttpTransport<Config, Prepared>,
 	input: RenderInput<Config>,
 	runtime: TransportRuntime,
-): Effect.Effect<DispatchResult, AlertDeliveryError> =>
+): Effect.Effect<DispatchResult, AlertDeliveryFailure> =>
 	Effect.gen(function* () {
 		const prepared = transport.prepare
 			? yield* transport.prepare(input)
@@ -126,13 +158,19 @@ export const runHttpTransport = <Config, Prepared>(
 
 		if (!response.ok) {
 			const detail = yield* readErrorBody(response)
+			// A transport may supply a better sentence for a status it knows well;
+			// it does not get to change whether the failure is retryable.
 			const described = transport.describeStatus?.(response.status) ?? null
-			return yield* Effect.fail(
-				makeDeliveryError(
-					described ?? statusFailureMessage(transport.providerLabel, response.status, detail),
-					transport.type,
-				),
-			)
+			const failure = failureForStatus(response.status, {
+				message: described ?? statusFailureMessage(transport.providerLabel, response.status, detail),
+				destinationType: transport.type,
+				providerStatus: response.status,
+			})
+			yield* Effect.annotateCurrentSpan({
+				"maple.delivery.failure_tag": failure._tag,
+				"maple.delivery.retryable": failure.error.retryable,
+			})
+			return yield* Effect.fail(failure)
 		}
 
 		// A 2xx is not proof of delivery for every provider — Slack answers 200
@@ -161,4 +199,4 @@ export const runEffectTransport = <Config>(
 	transport: EffectTransport<Config>,
 	input: RenderInput<Config>,
 	deps: EffectTransportDeps,
-): Effect.Effect<DispatchResult, AlertDeliveryError> => transport.send(input, deps)
+): Effect.Effect<DispatchResult, AlertDeliveryFailure> => transport.send(input, deps)

--- a/apps/api/src/services/alerts/delivery/runTransport.ts
+++ b/apps/api/src/services/alerts/delivery/runTransport.ts
@@ -1,0 +1,164 @@
+/**
+ * The uniform half of every delivery: spans, timeout, SSRF guard, error
+ * construction. A transport contributes only what is provider-specific.
+ */
+import { AlertDeliveryError, type AlertDestinationType } from "@maple/domain/http"
+import { Duration, Effect, Option, Result } from "effect"
+import { safeFetch } from "@/http/url-validator"
+import type {
+	EffectTransport,
+	EffectTransportDeps,
+	HttpRequestSpec,
+	HttpTransport,
+	RenderInput,
+} from "./Transport"
+import type { DispatchResult } from "./context"
+
+export interface TransportRuntime {
+	readonly fetchFn: typeof fetch
+	readonly timeoutMs: number
+}
+
+export const makeDeliveryError = (message: string, destinationType?: AlertDestinationType, cause?: unknown) =>
+	new AlertDeliveryError({ message, destinationType, ...(cause === undefined ? {} : { cause }) })
+
+/**
+ * Best-effort read of a failure body for the error message. Truncated and
+ * whitespace-collapsed: this ends up in a delivery row and a log line, and some
+ * providers answer with an HTML error page.
+ */
+const readErrorBody = (response: Response) =>
+	Effect.tryPromise({ try: () => response.text(), catch: () => null }).pipe(
+		Effect.map((text) => (text ?? "").replace(/\s+/g, " ").trim().slice(0, 500)),
+		Effect.orElseSucceed(() => ""),
+	)
+
+/**
+ * The one copy of the sentence that used to be hand-concatenated in five
+ * separate provider arms.
+ */
+const statusFailureMessage = (providerLabel: string, status: number, detail: string) =>
+	`${providerLabel} delivery failed with ${status}${detail ? `: ${detail}` : ""}`
+
+const hostOf = (url: string) => Option.liftThrowable(() => new URL(url))()
+
+/**
+ * The outbound provider call, as a Client-kind span.
+ *
+ * `kind: "client"` + `peer.service` is what draws the provider as a node on the
+ * service map and makes its latency and status attributable — without it the
+ * dependency is invisible, which is what it was before this existed. Same
+ * reasoning as `GithubAppClient.request`.
+ *
+ * `Effect.fn` already opens the span, so the body must NOT be wrapped in
+ * `Effect.withSpan` too — that emits two spans that disagree on timeout (the
+ * inner closes Ok+interrupted while the outer records Error). The timeout stays
+ * INSIDE the span so the elapsed time is attributed to the call that hung.
+ */
+const sendHttp = Effect.fn("AlertDelivery.http", { kind: "client" })(function* (
+	spec: HttpRequestSpec,
+	transport: {
+		readonly peerService: string
+		readonly providerLabel: string
+		readonly type: AlertDestinationType
+	},
+	runtime: TransportRuntime,
+) {
+	const parsed = hostOf(spec.url)
+	yield* Effect.annotateCurrentSpan({
+		"peer.service": transport.peerService,
+		"http.request.method": "POST",
+		...(Option.isSome(parsed) ? { "server.address": parsed.value.host } : {}),
+		// Never `url.full`, and `url.path` only when the path carries no secret:
+		// Discord and Hazel webhook URLs embed their delivery token in the path.
+		...(Option.isSome(parsed) && !spec.sensitivePath ? { "url.path": parsed.value.pathname } : {}),
+	})
+
+	const response = yield* Effect.tryPromise({
+		try: () =>
+			spec.guarded
+				? safeFetch(spec.url, {
+						method: "POST",
+						headers: { ...spec.headers },
+						body: spec.body,
+						fetchFn: runtime.fetchFn,
+					})
+				: runtime.fetchFn(spec.url, {
+						method: "POST",
+						headers: { ...spec.headers },
+						body: spec.body,
+					}),
+		catch: (error) =>
+			makeDeliveryError(
+				error instanceof Error ? error.message : `${transport.providerLabel} delivery failed`,
+				transport.type,
+				error,
+			),
+	}).pipe(
+		Effect.timeoutOrElse({
+			duration: Duration.millis(runtime.timeoutMs),
+			orElse: () =>
+				Effect.fail(
+					makeDeliveryError(
+						`${transport.providerLabel} delivery timed out after ${runtime.timeoutMs}ms`,
+						transport.type,
+					),
+				),
+		}),
+	)
+
+	yield* Effect.annotateCurrentSpan({ "http.response.status_code": response.status })
+	return response
+})
+
+export const runHttpTransport = <Config, Prepared>(
+	transport: HttpTransport<Config, Prepared>,
+	input: RenderInput<Config>,
+	runtime: TransportRuntime,
+): Effect.Effect<DispatchResult, AlertDeliveryError> =>
+	Effect.gen(function* () {
+		const prepared = transport.prepare
+			? yield* transport.prepare(input)
+			: // `void` for every transport that declares no prepare step.
+				(undefined as Prepared)
+		const spec = transport.render(input, prepared)
+		const response = yield* sendHttp(spec, transport, runtime)
+
+		if (!response.ok) {
+			const detail = yield* readErrorBody(response)
+			const described = transport.describeStatus?.(response.status) ?? null
+			return yield* Effect.fail(
+				makeDeliveryError(
+					described ?? statusFailureMessage(transport.providerLabel, response.status, detail),
+					transport.type,
+				),
+			)
+		}
+
+		// A 2xx is not proof of delivery for every provider — Slack answers 200
+		// with `{ ok: false, error }` — so a transport may claim the body.
+		if (transport.interpret) {
+			const rawBody = yield* Effect.tryPromise({
+				try: () => response.text(),
+				catch: (error) =>
+					makeDeliveryError(
+						`${transport.providerLabel} returned an unreadable response`,
+						transport.type,
+						error,
+					),
+			})
+			const ack = yield* Result.match(transport.interpret(input, rawBody), {
+				onSuccess: (value) => Effect.succeed(value),
+				onFailure: (error) => Effect.fail(error),
+			})
+			return { ...ack, responseCode: response.status }
+		}
+
+		return { ...transport.ack(input), responseCode: response.status }
+	})
+
+export const runEffectTransport = <Config>(
+	transport: EffectTransport<Config>,
+	input: RenderInput<Config>,
+	deps: EffectTransportDeps,
+): Effect.Effect<DispatchResult, AlertDeliveryError> => transport.send(input, deps)

--- a/apps/api/src/services/alerts/delivery/transports/discord.ts
+++ b/apps/api/src/services/alerts/delivery/transports/discord.ts
@@ -1,0 +1,39 @@
+import { buildDiscordEmbeds, buildDiscordEmbedsFromTemplate } from "../../AlertDeliveryDispatch"
+import { formatEventTypeLabel } from "../../alert-formatting"
+import type { HttpTransport, RenderInput, SecretConfigOf } from "../Transport"
+
+type Config = SecretConfigOf<"discord">
+
+export const discordTransport: HttpTransport<Config> = {
+	kind: "http",
+	type: "discord",
+	peerService: "discord",
+	providerLabel: "Discord",
+	render: (input: RenderInput<Config>) => {
+		const { context, templated, linkUrl, chatUrl } = input
+		const embeds = templated
+			? buildDiscordEmbedsFromTemplate(templated.title, templated.body, context, linkUrl, chatUrl)
+			: buildDiscordEmbeds(context, linkUrl, chatUrl)
+		return {
+			url: input.config.webhookUrl,
+			headers: { "content-type": "application/json" },
+			// User-configured URL, and the webhook token lives IN the path — so it
+			// is both SSRF-guarded and excluded from the span's url attributes.
+			guarded: true,
+			sensitivePath: true,
+			body: JSON.stringify({
+				username: "Maple Alerts",
+				content:
+					templated?.title ?? `**${context.ruleName}**: ${formatEventTypeLabel(context.eventType)}`,
+				embeds,
+			}),
+		}
+	},
+	ack: (input) => ({
+		providerMessage: "Delivered to Discord",
+		// Discord's plain webhook POST returns 204 with an empty body, so there is
+		// no message id to quote back. The dedupe key is the same correlation
+		// handle every other provider reports.
+		providerReference: input.context.dedupeKey,
+	}),
+}

--- a/apps/api/src/services/alerts/delivery/transports/email.ts
+++ b/apps/api/src/services/alerts/delivery/transports/email.ts
@@ -1,0 +1,79 @@
+import { Effect } from "effect"
+import { buildAlertEmailContent } from "../../alert-email"
+import { makeDeliveryError } from "../runTransport"
+import type { EffectTransport, EffectTransportDeps, RenderInput, SecretConfigOf } from "../Transport"
+
+type Config = SecretConfigOf<"email">
+
+/**
+ * The one non-HTTP provider: it fans out over the destination's workspace
+ * members through the platform email channel.
+ *
+ * Custom notification templates are deliberately not consulted — HTML email
+ * cannot safely render arbitrary user Markdown — so email always uses the
+ * built-in format.
+ */
+export const emailTransport: EffectTransport<Config> = {
+	kind: "effect",
+	type: "email",
+	peerService: "email",
+	providerLabel: "Email",
+	send: (input: RenderInput<Config>, deps: EffectTransportDeps) =>
+		Effect.gen(function* () {
+			const { subject, html } = yield* buildAlertEmailContent(
+				input.context,
+				input.linkUrl,
+				input.chatUrl,
+			)
+			const members = input.config.members
+			const outcomes = yield* Effect.forEach(members, (member) =>
+				deps.sendEmail(member.email, subject, html).pipe(
+					Effect.match({
+						onSuccess: () => ({ member, error: null as string | null }),
+						onFailure: (error) => ({ member, error: error.message }),
+					}),
+				),
+			)
+			const failures = outcomes.filter((outcome) => outcome.error != null)
+			const count = members.length
+
+			if (failures.length === count && count > 0) {
+				// Nobody received it — safe to fail retryable; the retry re-sends to
+				// members who all got nothing. Keep the first failure message
+				// verbatim so timeout classification survives the aggregation.
+				return yield* Effect.fail(
+					makeDeliveryError(
+						`Email delivery failed for all ${count} member${count === 1 ? "" : "s"}: ${failures[0]!.error}`,
+						"email",
+					),
+				)
+			}
+
+			if (failures.length > 0) {
+				// Partial success is TERMINAL: there is no per-member attempt state,
+				// so retrying would re-email the members who already received it.
+				// Report success and surface the failures.
+				yield* Effect.annotateCurrentSpan({ "maple.delivery.degraded": true })
+				yield* Effect.logWarning("Alert email delivered to a subset of members").pipe(
+					Effect.annotateLogs({
+						failedCount: failures.length,
+						memberCount: count,
+						firstError: failures[0]!.error,
+					}),
+				)
+				return {
+					providerMessage: `Emailed ${count - failures.length} of ${count} members; failed: ${failures
+						.map((failure) => `${failure.member.email} (${failure.error})`)
+						.join(", ")}`,
+					providerReference: null,
+					responseCode: null,
+				}
+			}
+
+			return {
+				providerMessage: `Emailed ${count} member${count === 1 ? "" : "s"}`,
+				providerReference: null,
+				responseCode: null,
+			}
+		}),
+}

--- a/apps/api/src/services/alerts/delivery/transports/hazel.ts
+++ b/apps/api/src/services/alerts/delivery/transports/hazel.ts
@@ -1,0 +1,43 @@
+import type { HttpTransport, RenderInput, SecretConfigOf } from "../Transport"
+
+type Config = SecretConfigOf<"hazel-oauth">
+
+/**
+ * Hazel exposes per-integration sibling endpoints under the same
+ * `:webhookId/:token` prefix. The stored `webhookUrl` is the base; `/maple`
+ * selects the `executeMaple` handler — without it the payload routes to the
+ * Discord-style `execute` endpoint and is rejected.
+ */
+export const hazelTransport: HttpTransport<Config> = {
+	kind: "http",
+	type: "hazel-oauth",
+	peerService: "hazel",
+	providerLabel: "Hazel",
+	render: (input: RenderInput<Config>) => ({
+		url: `${input.config.webhookUrl.replace(/\/$/, "")}/maple`,
+		headers: {
+			"content-type": "application/json",
+			"x-maple-event-type": input.context.eventType,
+			"x-maple-delivery-key": input.context.deliveryKey,
+		},
+		// User-configured host, and the delivery token is a path segment.
+		guarded: true,
+		sensitivePath: true,
+		// Hazel used to build its own near-copy of the wire payload, which had
+		// drifted (it dropped `thresholdUpper` and recomputed `incidentStatus`
+		// from `eventType` instead of carrying it). It now ships the canonical
+		// payload, same as the webhook destination.
+		body: input.payloadJson,
+	}),
+	describeStatus: (status) => {
+		if (status === 401 || status === 403) {
+			return "Hazel rejected the webhook token — reconfigure the channel"
+		}
+		if (status === 404) return "Hazel webhook no longer exists — pick a different channel"
+		return null
+	},
+	ack: (input) => ({
+		providerMessage: `Delivered to Hazel #${input.config.hazelChannelName}`,
+		providerReference: input.context.dedupeKey,
+	}),
+}

--- a/apps/api/src/services/alerts/delivery/transports/pagerduty.ts
+++ b/apps/api/src/services/alerts/delivery/transports/pagerduty.ts
@@ -1,0 +1,119 @@
+import { Duration, Effect } from "effect"
+import { truncate } from "../../alert-formatting"
+import type { HttpTransport, RenderInput, SecretConfigOf } from "../Transport"
+
+type Config = SecretConfigOf<"pagerduty">
+
+/**
+ * PagerDuty Events API v2. The body is machine-facing, so `custom_details`
+ * carries raw numbers rather than the formatted strings the chat providers
+ * render, and a custom template contributes only the summary line and a
+ * `message` detail — the envelope itself is fixed by the API.
+ */
+export const pagerDutyTransport: HttpTransport<Config> = {
+	kind: "http",
+	type: "pagerduty",
+	peerService: "pagerduty",
+	providerLabel: "PagerDuty",
+	render: (input: RenderInput<Config>) => {
+		const { context, templated, linkUrl, chatUrl } = input
+		return {
+			// Fixed vendor host: nothing user-supplied to guard against, and the
+			// path carries no credential (the routing key rides in the body).
+			url: "https://events.pagerduty.com/v2/enqueue",
+			headers: { "content-type": "application/json" },
+			guarded: false,
+			sensitivePath: false,
+			body: JSON.stringify({
+				routing_key: input.config.integrationKey,
+				event_action: context.eventType === "resolve" ? "resolve" : "trigger",
+				dedup_key: context.dedupeKey,
+				payload: {
+					summary: truncate(templated?.title ?? `${context.ruleName} ${context.eventType}`, 1024),
+					source: context.groupKey ?? "maple-alerts",
+					severity: context.severity === "critical" ? "critical" : "warning",
+					custom_details: {
+						...(templated ? { message: templated.body } : {}),
+						ruleName: context.ruleName,
+						signalType: context.signalType,
+						value: context.value,
+						threshold: context.threshold,
+						thresholdUpper: context.thresholdUpper,
+						comparator: context.comparator,
+						groupKey: context.groupKey,
+						linkUrl,
+						chatUrl,
+					},
+				},
+				links: [
+					{ href: linkUrl, text: "Open in Maple" },
+					{ href: chatUrl, text: "Ask Maple AI" },
+				],
+			}),
+		}
+	},
+	ack: (input) => ({
+		providerMessage: "Delivered to PagerDuty",
+		providerReference: input.context.dedupeKey,
+	}),
+}
+
+/**
+ * A PagerDuty Events API v2 integration ("routing") key is exactly 32
+ * alphanumeric characters. A REST API token — the usual wrong paste — is shorter
+ * and may contain `+`/`_`/`-`, so the length+charset check alone rejects it.
+ */
+export const PAGERDUTY_ROUTING_KEY_PATTERN = /^[A-Za-z0-9]{32}$/
+
+export type PagerDutyKeyVerification =
+	| { status: "valid" }
+	| { status: "invalid"; reason: string }
+	/** Network error / timeout / 429 / 5xx — can't conclude; caller should fail open. */
+	| { status: "unknown" }
+
+/**
+ * Verify a PagerDuty routing key actually works by enqueuing a no-op `resolve`
+ * event. PagerDuty validates the routing key before the action, so a valid key
+ * returns 2xx (resolving an unknown dedup_key creates no incident and pages no
+ * one) and an invalid key returns 400 "Invalid routing key". Never fails — any
+ * transport/ambiguous response collapses to `unknown` so the caller owns policy.
+ *
+ * This runs at destination-save time, not delivery time, so it deliberately does
+ * not go through the transport runner: there is no notification to render and no
+ * delivery span to attribute it to.
+ */
+export const verifyPagerDutyRoutingKey = (
+	integrationKey: string,
+	fetchFn: typeof fetch,
+	timeoutMs: number,
+	dedupKey: string,
+): Effect.Effect<PagerDutyKeyVerification> =>
+	Effect.tryPromise(() =>
+		fetchFn("https://events.pagerduty.com/v2/enqueue", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				routing_key: integrationKey,
+				event_action: "resolve",
+				dedup_key: dedupKey,
+			}),
+		}),
+	).pipe(
+		Effect.timeoutOrElse({
+			duration: Duration.millis(timeoutMs),
+			orElse: () => Effect.fail(new Error("timeout")),
+		}),
+		Effect.flatMap((response) => {
+			if (response.ok) return Effect.succeed<PagerDutyKeyVerification>({ status: "valid" })
+			if (response.status === 400) {
+				return Effect.promise(() => response.text().catch(() => "")).pipe(
+					Effect.map((body): PagerDutyKeyVerification => {
+						const reason = truncate(body.trim().replace(/\s+/g, " "), 500)
+						return { status: "invalid", reason: reason || "Invalid routing key" }
+					}),
+				)
+			}
+			return Effect.succeed<PagerDutyKeyVerification>({ status: "unknown" })
+		}),
+		Effect.orElseSucceed(() => ({ status: "unknown" as const })),
+	)

--- a/apps/api/src/services/alerts/delivery/transports/pagerduty.ts
+++ b/apps/api/src/services/alerts/delivery/transports/pagerduty.ts
@@ -99,10 +99,6 @@ export const verifyPagerDutyRoutingKey = (
 			}),
 		}),
 	).pipe(
-		Effect.timeoutOrElse({
-			duration: Duration.millis(timeoutMs),
-			orElse: () => Effect.fail(new Error("timeout")),
-		}),
 		Effect.flatMap((response) => {
 			if (response.ok) return Effect.succeed<PagerDutyKeyVerification>({ status: "valid" })
 			if (response.status === 400) {
@@ -114,6 +110,14 @@ export const verifyPagerDutyRoutingKey = (
 				)
 			}
 			return Effect.succeed<PagerDutyKeyVerification>({ status: "unknown" })
+		}),
+		// A timeout is one more way to not know, so it produces the verdict
+		// directly rather than a placeholder failure for `orElseSucceed` to
+		// swallow one line later. Wrapping the whole pipeline also bounds the
+		// 400-body read, which the previous fetch-only timeout left open.
+		Effect.timeoutOrElse({
+			duration: Duration.millis(timeoutMs),
+			orElse: () => Effect.succeed<PagerDutyKeyVerification>({ status: "unknown" }),
 		}),
 		Effect.orElseSucceed(() => ({ status: "unknown" as const })),
 	)

--- a/apps/api/src/services/alerts/delivery/transports/render.test.ts
+++ b/apps/api/src/services/alerts/delivery/transports/render.test.ts
@@ -1,0 +1,244 @@
+import type { AlertDestinationRow } from "@maple/db"
+import { AlertDestinationId } from "@maple/domain/http"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import type { DispatchContext } from "../context"
+import type { HttpRequestSpec, RenderInput } from "../Transport"
+import { discordTransport } from "./discord"
+import { hazelTransport } from "./hazel"
+import { pagerDutyTransport } from "./pagerduty"
+import { makeSlackTransport } from "./slack"
+import { webhookTransport } from "./webhook"
+
+/**
+ * `render` is pure — no Effect, no fetch, no Clock — so a provider's wire shape
+ * is assertable as a plain function call with no stub of any kind. That is the
+ * point of the transport split: these cases used to need a fetch stub, a
+ * destination row and a full deps bag each, which is why four of the six
+ * providers had no coverage at all.
+ */
+
+const DESTINATION_ID = Schema.decodeUnknownSync(AlertDestinationId)("7c6b5a49-3821-4e0f-9d8c-7b6a59483726")
+
+const LINK = "https://web.localhost/alerts"
+const CHAT = "https://web.localhost/chat"
+
+const destinationRow: AlertDestinationRow = {
+	id: DESTINATION_ID,
+	orgId: "org_1" as AlertDestinationRow["orgId"],
+	name: "Destination",
+	type: "webhook",
+	enabled: true,
+	configJson: {},
+	secretCiphertext: "",
+	secretIv: "",
+	secretTag: "",
+	lastTestedAt: null,
+	lastTestError: null,
+	createdAt: new Date(0),
+	updatedAt: new Date(0),
+	createdBy: "user_1",
+	updatedBy: "user_1",
+}
+
+const context: DispatchContext = {
+	deliveryKey: "org_1:dest_1:delivery",
+	destination: destinationRow,
+	publicConfig: { summary: "Checkout error rate", channelLabel: null },
+	secretConfig: { type: "webhook", url: "https://unused.test", signingSecret: null },
+	ruleId: "rule_1",
+	ruleName: "Checkout error rate",
+	groupKey: "checkout",
+	signalType: "error_rate",
+	severity: "critical",
+	comparator: "gt",
+	threshold: 0.05,
+	thresholdUpper: null,
+	eventType: "trigger",
+	incidentId: "inc_1",
+	incidentStatus: "open",
+	dedupeKey: "org_1:rule_1:checkout",
+	windowMinutes: 5,
+	value: 0.08,
+	sampleCount: 1200,
+	template: null,
+	sentAtMs: Date.parse("2026-06-02T00:00:00.000Z"),
+}
+
+const inputFor = <Config>(
+	config: Config,
+	overrides: Partial<RenderInput<Config>> = {},
+): RenderInput<Config> => ({
+	config,
+	context,
+	linkUrl: LINK,
+	chatUrl: CHAT,
+	payloadJson: '{"canonical":"payload"}',
+	templated: null,
+	...overrides,
+})
+
+const TEMPLATED = { title: "Custom title", body: "Custom **body**" }
+
+describe("transport render: guard flags", () => {
+	/**
+	 * `guarded` decides whether the request goes through the SSRF guard, and
+	 * `sensitivePath` decides whether the URL path may appear on a span. Both are
+	 * a function of where the host came from, so a provider getting either wrong
+	 * is either an SSRF hole or a token leak into telemetry.
+	 */
+	const specs: ReadonlyArray<readonly [string, HttpRequestSpec]> = [
+		[
+			"slack-bot",
+			makeSlackTransport({ resolveSlackBotToken: () => Effect.succeed("t") }).render(
+				inputFor({ type: "slack-bot", channelId: "C1", channelName: "ops" }),
+				"xoxb-token",
+			),
+		],
+		["pagerduty", pagerDutyTransport.render(inputFor({ type: "pagerduty", integrationKey: "k" }))],
+		[
+			"webhook",
+			webhookTransport.render(
+				inputFor({ type: "webhook", url: "https://hooks.test/x", signingSecret: null }),
+			),
+		],
+		[
+			"discord",
+			discordTransport.render(
+				inputFor({ type: "discord", webhookUrl: "https://discord.com/api/w/1/tok" }),
+			),
+		],
+		[
+			"hazel-oauth",
+			hazelTransport.render(
+				inputFor({
+					type: "hazel-oauth",
+					hazelOrganizationId: "o",
+					hazelOrganizationName: "Acme",
+					hazelChannelId: "c",
+					hazelChannelName: "ops",
+					webhookId: "w",
+					webhookUrl: "https://hazel.test/api/webhooks/w/tok",
+					webhookToken: "tok",
+				}),
+			),
+		],
+	]
+
+	it("guards exactly the user-configured hosts", () => {
+		const guarded = specs.filter(([, spec]) => spec.guarded).map(([name]) => name)
+		// slack + pagerduty post to compile-time vendor constants: there is no
+		// attacker-controlled URL to validate, so the guard would only cost a
+		// redirect walk.
+		assert.deepStrictEqual(guarded, ["webhook", "discord", "hazel-oauth"])
+	})
+
+	it("marks exactly the providers whose token rides in the URL path", () => {
+		const sensitive = specs.filter(([, spec]) => spec.sensitivePath).map(([name]) => name)
+		assert.deepStrictEqual(sensitive, ["discord", "hazel-oauth"])
+	})
+
+	it("always produces a parseable JSON body", () => {
+		for (const [name, spec] of specs) {
+			assert.doesNotThrow(() => JSON.parse(spec.body), `${name} body must be JSON`)
+		}
+	})
+
+	it("is deterministic — no Clock, no randomness in a render", () => {
+		const render = () => pagerDutyTransport.render(inputFor({ type: "pagerduty", integrationKey: "k" }))
+		assert.deepStrictEqual(render(), render())
+	})
+})
+
+describe("transport render: templates", () => {
+	it("slack-bot puts the template title in the header and the body in a section", () => {
+		const spec = makeSlackTransport({ resolveSlackBotToken: () => Effect.succeed("t") }).render(
+			inputFor({ type: "slack-bot", channelId: "C1", channelName: "ops" }, { templated: TEMPLATED }),
+			"xoxb-token",
+		)
+		const body = JSON.parse(spec.body)
+		const blocks = body.attachments[0].blocks
+		assert.strictEqual(blocks[0].text.text, "Custom title")
+		// Markdown is rewritten to Slack mrkdwn: **b** → *b*.
+		assert.strictEqual(blocks[1].text.text, "Custom *body*")
+		// The notification preview falls back to the template title.
+		assert.strictEqual(body.attachments[0].fallback, "Custom title")
+	})
+
+	it("discord uses the template title for both the content line and the embed", () => {
+		const spec = discordTransport.render(
+			inputFor(
+				{ type: "discord", webhookUrl: "https://discord.com/api/w/1/tok" },
+				{ templated: TEMPLATED },
+			),
+		)
+		const body = JSON.parse(spec.body)
+		assert.strictEqual(body.content, "Custom title")
+		assert.strictEqual(body.embeds[0].title, "Custom title")
+		assert.strictEqual(body.embeds[0].description, "Custom **body**")
+	})
+
+	it("pagerduty takes only the summary and a custom_details message from a template", () => {
+		const spec = pagerDutyTransport.render(
+			inputFor({ type: "pagerduty", integrationKey: "k" }, { templated: TEMPLATED }),
+		)
+		const body = JSON.parse(spec.body)
+		assert.strictEqual(body.payload.summary, "Custom title")
+		assert.strictEqual(body.payload.custom_details.message, "Custom **body**")
+		// The envelope is fixed by the Events v2 API — a template cannot reshape it.
+		assert.strictEqual(body.event_action, "trigger")
+		assert.strictEqual(body.routing_key, "k")
+	})
+
+	it("webhook and hazel ignore templates — they ship the canonical payload", () => {
+		for (const spec of [
+			webhookTransport.render(
+				inputFor(
+					{ type: "webhook", url: "https://hooks.test/x", signingSecret: null },
+					{ templated: TEMPLATED },
+				),
+			),
+			hazelTransport.render(
+				inputFor(
+					{
+						type: "hazel-oauth",
+						hazelOrganizationId: "o",
+						hazelOrganizationName: "Acme",
+						hazelChannelId: "c",
+						hazelChannelName: "ops",
+						webhookId: "w",
+						webhookUrl: "https://hazel.test/api/webhooks/w/tok",
+						webhookToken: "tok",
+					},
+					{ templated: TEMPLATED },
+				),
+			),
+		]) {
+			assert.strictEqual(spec.body, '{"canonical":"payload"}')
+		}
+	})
+})
+
+describe("transport render: event types", () => {
+	for (const eventType of ["trigger", "resolve", "test"] as const) {
+		it(`every provider renders a ${eventType} event without throwing`, () => {
+			const withEvent = { context: { ...context, eventType } }
+			assert.doesNotThrow(() => {
+				pagerDutyTransport.render(inputFor({ type: "pagerduty", integrationKey: "k" }, withEvent))
+				webhookTransport.render(
+					inputFor(
+						{ type: "webhook", url: "https://hooks.test/x", signingSecret: null },
+						withEvent,
+					),
+				)
+				discordTransport.render(
+					inputFor({ type: "discord", webhookUrl: "https://discord.com/api/w/1/tok" }, withEvent),
+				)
+				makeSlackTransport({ resolveSlackBotToken: () => Effect.succeed("t") }).render(
+					inputFor({ type: "slack-bot", channelId: "C1", channelName: "ops" }, withEvent),
+					"xoxb-token",
+				)
+			})
+		})
+	}
+})

--- a/apps/api/src/services/alerts/delivery/transports/slack.ts
+++ b/apps/api/src/services/alerts/delivery/transports/slack.ts
@@ -1,0 +1,109 @@
+import { AlertDeliveryError, type OrgId } from "@maple/domain/http"
+import { Effect, Result, Schema } from "effect"
+import {
+	buildSlackBlocks,
+	buildSlackBlocksFromTemplate,
+	buildSlackFallbackText,
+} from "../../AlertDeliveryDispatch"
+import { slackAttachmentColor } from "../../alert-formatting"
+import type { HttpTransport, ProviderAck, RenderInput, SecretConfigOf } from "../Transport"
+
+type Config = SecretConfigOf<"slack-bot">
+
+export interface SlackTransportDeps {
+	readonly resolveSlackBotToken: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryError>
+}
+
+/**
+ * Slack Web API `chat.postMessage` response envelope. Slack returns HTTP 200
+ * with `{ ok: false, error }` on logical failures, so the body — not the status
+ * — is the source of truth.
+ */
+const SlackPostMessageResponseSchema = Schema.Struct({
+	ok: Schema.optionalKey(Schema.Boolean),
+	error: Schema.optionalKey(Schema.String),
+	ts: Schema.optionalKey(Schema.String),
+})
+const decodeSlackResponse = Schema.decodeUnknownResult(SlackPostMessageResponseSchema)
+
+const slackError = (message: string) => new AlertDeliveryError({ message, destinationType: "slack-bot" })
+
+/**
+ * The bot token is not in the destination's secret config — it is resolved per
+ * org from the `slack_workspaces` row — which is why this is the one transport
+ * with a `prepare` step.
+ */
+export const makeSlackTransport = (deps: SlackTransportDeps): HttpTransport<Config, string> => ({
+	kind: "http",
+	type: "slack-bot",
+	peerService: "slack",
+	providerLabel: "Slack",
+	prepare: (input) => deps.resolveSlackBotToken(input.context.destination.orgId),
+	render: (input: RenderInput<Config>, botToken: string) => {
+		const { context, templated, linkUrl, chatUrl } = input
+		const blocks = templated
+			? buildSlackBlocksFromTemplate(templated.title, templated.body, context, linkUrl, chatUrl)
+			: buildSlackBlocks(context, linkUrl, chatUrl)
+		return {
+			// Fixed vendor host; the credential is a header, not a path segment.
+			url: "https://slack.com/api/chat.postMessage",
+			headers: {
+				"content-type": "application/json; charset=utf-8",
+				authorization: `Bearer ${botToken}`,
+			},
+			guarded: false,
+			sensitivePath: false,
+			body: JSON.stringify({
+				channel: input.config.channelId,
+				// Blocks ride inside a colored attachment so the message carries the
+				// severity color bar (which has no Block Kit equivalent). No
+				// top-level `text`: alongside attachments Slack renders it as a
+				// duplicate line above the bar, so `fallback` carries the
+				// notification-preview one-liner instead.
+				attachments: [
+					{
+						color: slackAttachmentColor(context.eventType, context.severity),
+						fallback: templated?.title ?? buildSlackFallbackText(context),
+						blocks,
+					},
+				],
+			}),
+		}
+	},
+	interpret: (input, rawBody): Result.Result<ProviderAck, AlertDeliveryError> => {
+		const parsed = Result.try({
+			try: (): unknown => JSON.parse(rawBody),
+			catch: () => slackError("Slack returned a non-JSON response"),
+		})
+		if (Result.isFailure(parsed)) return Result.fail(parsed.failure)
+
+		const decoded = decodeSlackResponse(parsed.success)
+		if (Result.isFailure(decoded)) {
+			return Result.fail(
+				slackError(`Slack returned an unexpected response payload: ${decoded.failure.message}`),
+			)
+		}
+
+		const payload = decoded.success
+		if (!payload.ok) {
+			const error = payload.error ?? "unknown_error"
+			return Result.fail(
+				slackError(
+					error === "not_in_channel" || error === "channel_not_found"
+						? `Slack rejected the message (${error}) — invite the Maple bot to the channel and try again`
+						: `Slack rejected the message: ${error}`,
+				),
+			)
+		}
+		return Result.succeed({
+			providerMessage: `Delivered to Slack #${input.config.channelName ?? input.config.channelId}`,
+			providerReference: payload.ts ?? null,
+		})
+	},
+	// Unreachable: `interpret` always claims the response. Present because the
+	// interface requires a success shape for the no-interpret path.
+	ack: (input) => ({
+		providerMessage: `Delivered to Slack #${input.config.channelName ?? input.config.channelId}`,
+		providerReference: null,
+	}),
+})

--- a/apps/api/src/services/alerts/delivery/transports/slack.ts
+++ b/apps/api/src/services/alerts/delivery/transports/slack.ts
@@ -1,4 +1,9 @@
-import { AlertDeliveryError, type OrgId } from "@maple/domain/http"
+import {
+	AlertDeliveryError,
+	AlertDeliveryTargetMissingError,
+	type AlertDeliveryFailure,
+	type OrgId,
+} from "@maple/domain/http"
 import { Effect, Result, Schema } from "effect"
 import {
 	buildSlackBlocks,
@@ -11,7 +16,7 @@ import type { HttpTransport, ProviderAck, RenderInput, SecretConfigOf } from "..
 type Config = SecretConfigOf<"slack-bot">
 
 export interface SlackTransportDeps {
-	readonly resolveSlackBotToken: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryError>
+	readonly resolveSlackBotToken: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryFailure>
 }
 
 /**
@@ -26,7 +31,12 @@ const SlackPostMessageResponseSchema = Schema.Struct({
 })
 const decodeSlackResponse = Schema.decodeUnknownResult(SlackPostMessageResponseSchema)
 
-const slackError = (message: string) => new AlertDeliveryError({ message, destinationType: "slack-bot" })
+const slackError = (message: string, providerErrorCode?: string) =>
+	new AlertDeliveryError({
+		message,
+		destinationType: "slack-bot",
+		...(providerErrorCode === undefined ? {} : { providerErrorCode }),
+	})
 
 /**
  * The bot token is not in the destination's secret config — it is resolved per
@@ -70,7 +80,7 @@ export const makeSlackTransport = (deps: SlackTransportDeps): HttpTransport<Conf
 			}),
 		}
 	},
-	interpret: (input, rawBody): Result.Result<ProviderAck, AlertDeliveryError> => {
+	interpret: (input, rawBody): Result.Result<ProviderAck, AlertDeliveryFailure> => {
 		const parsed = Result.try({
 			try: (): unknown => JSON.parse(rawBody),
 			catch: () => slackError("Slack returned a non-JSON response"),
@@ -87,13 +97,20 @@ export const makeSlackTransport = (deps: SlackTransportDeps): HttpTransport<Conf
 		const payload = decoded.success
 		if (!payload.ok) {
 			const error = payload.error ?? "unknown_error"
-			return Result.fail(
-				slackError(
-					error === "not_in_channel" || error === "channel_not_found"
-						? `Slack rejected the message (${error}) — invite the Maple bot to the channel and try again`
-						: `Slack rejected the message: ${error}`,
-				),
-			)
+			// Slack reports channel problems as HTTP 200 + `ok:false`, so the status
+			// classifier never sees them. These are the dominant operational failure
+			// (a rename or a kick) and no amount of retrying fixes either — someone
+			// has to re-invite the bot or repoint the destination.
+			if (error === "not_in_channel" || error === "channel_not_found") {
+				return Result.fail(
+					new AlertDeliveryTargetMissingError({
+						message: `Slack rejected the message (${error}) — invite the Maple bot to the channel and try again`,
+						destinationType: "slack-bot",
+						providerErrorCode: error,
+					}),
+				)
+			}
+			return Result.fail(slackError(`Slack rejected the message: ${error}`, error))
 		}
 		return Result.succeed({
 			providerMessage: `Delivered to Slack #${input.config.channelName ?? input.config.channelId}`,

--- a/apps/api/src/services/alerts/delivery/transports/webhook.ts
+++ b/apps/api/src/services/alerts/delivery/transports/webhook.ts
@@ -1,0 +1,41 @@
+import { createHmac } from "node:crypto"
+import type { HttpTransport, RenderInput, SecretConfigOf } from "../Transport"
+
+type Config = SecretConfigOf<"webhook">
+
+/**
+ * The customer's own endpoint. Unlike every other provider this ships the
+ * canonical wire payload verbatim — the body is a published contract, and the
+ * signature is computed over exactly the bytes sent, so consumers can verify it
+ * by re-HMACing the raw request body.
+ */
+export const webhookTransport: HttpTransport<Config> = {
+	kind: "http",
+	type: "webhook",
+	peerService: "webhook",
+	providerLabel: "Webhook",
+	render: (input: RenderInput<Config>) => ({
+		url: input.config.url,
+		headers: {
+			"content-type": "application/json",
+			"x-maple-event-type": input.context.eventType,
+			"x-maple-delivery-key": input.context.deliveryKey,
+			...(input.config.signingSecret
+				? {
+						"x-maple-signature": createHmac("sha256", input.config.signingSecret)
+							.update(input.payloadJson)
+							.digest("hex"),
+					}
+				: {}),
+		},
+		body: input.payloadJson,
+		// Customer-supplied host: this is exactly what the SSRF guard is for.
+		guarded: true,
+		// The token, if any, rides in the signature header rather than the path.
+		sensitivePath: false,
+	}),
+	ack: (input) => ({
+		providerMessage: "Delivered to webhook",
+		providerReference: input.context.dedupeKey,
+	}),
+}

--- a/apps/api/src/services/integrations/slack-bot-token.ts
+++ b/apps/api/src/services/integrations/slack-bot-token.ts
@@ -1,5 +1,5 @@
 import { slackWorkspaces } from "@maple/db"
-import { AlertDeliveryError, OrgId } from "@maple/domain/http"
+import { AlertDeliveryAuthError, OrgId } from "@maple/domain/http"
 import { and, eq, isNull } from "drizzle-orm"
 import { Context, Effect, Layer, Option, Redacted, Schema } from "effect"
 import { decryptAes256Gcm, parseBase64Aes256GcmKey } from "@/platform/Crypto"
@@ -39,11 +39,18 @@ export const loadActiveWorkspaceByOrg = Effect.fnUntraced(function* (database: D
 	return Option.fromNullishOr(rows[0])
 })
 
-const notConnected = (message: string) => new AlertDeliveryError({ message, destinationType: "slack-bot" })
+/**
+ * No active Slack install means no token will ever be resolved until someone
+ * reconnects the workspace, so this must be the non-retryable class — the
+ * delivery queue reads `retryable` off the failure to decide whether to
+ * re-enqueue, and retrying this five times accomplishes nothing.
+ */
+const notConnected = (message: string) =>
+	new AlertDeliveryAuthError({ message, destinationType: "slack-bot" })
 
 /**
  * Resolve the decrypted Slack bot token for an org's active installation.
- * Fails with an {@link AlertDeliveryError} when there is no active install.
+ * Fails with an {@link AlertDeliveryAuthError} when there is no active install.
  */
 export const resolveSlackBotTokenForDispatch = Effect.fn("SlackBotTokenResolver.resolve")(function* (
 	database: DatabaseShape,
@@ -80,7 +87,7 @@ class SlackBotTokenConfigError extends Schema.TaggedError<SlackBotTokenConfigErr
 ) {}
 
 export interface SlackBotTokenResolverShape {
-	readonly resolve: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryError>
+	readonly resolve: (orgId: OrgId) => Effect.Effect<string, AlertDeliveryAuthError>
 }
 
 const make: Effect.Effect<SlackBotTokenResolverShape, SlackBotTokenConfigError, Database | Env> = Effect.gen(

--- a/apps/api/src/services/integrations/vcs/vendor/github/__tests__/GithubAppClient.span.test.ts
+++ b/apps/api/src/services/integrations/vcs/vendor/github/__tests__/GithubAppClient.span.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { generateKeyPairSync } from "node:crypto"
 import { ConfigProvider, Effect, Layer, Tracer } from "effect"
 import { Env } from "@/platform/Env"
+import { makeRecordingTracer, spansNamed } from "@/testing/recording-tracer"
 import { GithubAppClient } from "@/services/integrations/vcs/vendor/github/GithubAppClient"
 import { GithubHttp, type GithubHttpShape } from "@/services/integrations/vcs/vendor/github/GithubHttp"
 
@@ -35,21 +36,7 @@ const env = Env.layer.pipe(
 	),
 )
 
-/** Records every span so the request span's kind and attributes are assertable. */
-const makeRecordingTracer = () => {
-	const spans: Array<Tracer.NativeSpan> = []
-	const tracer = Tracer.make({
-		span(options) {
-			const span = new Tracer.NativeSpan(options)
-			spans.push(span)
-			return span
-		},
-	})
-	return { spans, tracer }
-}
-
-const requestSpans = (spans: ReadonlyArray<Tracer.NativeSpan>) =>
-	spans.filter((span) => span.name === "GithubAppClient.request")
+const requestSpans = (spans: ReadonlyArray<Tracer.NativeSpan>) => spansNamed(spans, "GithubAppClient.request")
 
 const jsonResponse = (body: unknown, status = 200) =>
 	new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } })

--- a/apps/api/src/testing/recording-tracer.ts
+++ b/apps/api/src/testing/recording-tracer.ts
@@ -1,0 +1,30 @@
+import { Tracer } from "effect"
+
+/**
+ * A tracer that keeps every span it opens, so a test can assert on span names,
+ * kinds and attributes.
+ *
+ * Use with `Effect.withTracer(tracer)` on the effect under test, then read
+ * `spans`. Spans are recorded at open time, so they are present even when the
+ * effect fails — which is the point for failure-path assertions (an upstream
+ * 4xx must still land on the span).
+ *
+ * `Tracer.NativeSpan` exposes `name`, `kind` and `attributes`; it does NOT
+ * expose the exit status. A test that needs the recorded status has to capture
+ * it separately (see `apps/api/src/http/server-error-span.test.ts`).
+ */
+export const makeRecordingTracer = () => {
+	const spans: Array<Tracer.NativeSpan> = []
+	const tracer = Tracer.make({
+		span(options) {
+			const span = new Tracer.NativeSpan(options)
+			spans.push(span)
+			return span
+		},
+	})
+	return { spans, tracer }
+}
+
+/** All recorded spans with the given name, in open order. */
+export const spansNamed = (spans: ReadonlyArray<Tracer.NativeSpan>, name: string) =>
+	spans.filter((span) => span.name === name)

--- a/apps/web/src/components/chat/alert-context.ts
+++ b/apps/web/src/components/chat/alert-context.ts
@@ -70,7 +70,12 @@ export const signalLabel = (signalType: string): string => {
 			return "Apdex"
 		case "throughput":
 			return "throughput"
+		case "builder_query":
+			return "query result"
+		case "raw_query":
+			return "SQL query result"
 		default:
-			return signalType
+			// Never leak a raw enum into prose — these read mid-sentence.
+			return signalType.replace(/[_-]+/g, " ")
 	}
 }

--- a/packages/domain/src/http/alerts.ts
+++ b/packages/domain/src/http/alerts.ts
@@ -895,13 +895,34 @@ export type AlertNotFoundError =
 	| AlertDestinationNotFoundError
 	| AlertIncidentNotFoundError
 
+// Alert delivery failures are one class per failure mode, discriminated by
+// `_tag`/`catchTags`, for the same reason the warehouse errors are (see the
+// header comment in `warehouse-errors.ts`): `retryable` is derived from the
+// class policy and baked into each endpoint's OpenAPI as a literal, so a
+// `reason` field inside a single class could not change it without the
+// published schema lying.
+//
+// It also matters operationally. Every delivery failure used to be one
+// `AlertDeliveryError` carrying `retry: "backoff"`, and the queue reads
+// `error.error.retryable` to decide whether to re-enqueue — so a destination
+// whose token had been revoked was retried the full `MAX_DELIVERY_ATTEMPTS`
+// against a provider that would never accept it. Splitting the class is what
+// makes "reconfigure the channel" terminal.
+
+const alertDeliveryErrorFields = {
+	message: Schema.String,
+	destinationType: Schema.optionalKey(AlertDestinationType),
+	/** Provider HTTP status, when the failure came from a response. */
+	providerStatus: Schema.optionalKey(Schema.Number),
+	/** Provider-specific failure code, e.g. Slack's `not_in_channel`. */
+	providerErrorCode: Schema.optionalKey(Schema.String),
+	cause: Schema.optionalKey(Schema.Defect()),
+}
+
+/** Transient provider failure — timeout, network, 5xx, 429. Worth retrying. */
 export class AlertDeliveryError extends HttpTaggedError<AlertDeliveryError>()(
 	"@maple/http/errors/AlertDeliveryError",
-	{
-		message: Schema.String,
-		destinationType: Schema.optionalKey(AlertDestinationType),
-		cause: Schema.optionalKey(Schema.Defect()),
-	},
+	alertDeliveryErrorFields,
 	{
 		status: 502,
 		code: "alert_delivery_failed",
@@ -912,6 +933,65 @@ export class AlertDeliveryError extends HttpTaggedError<AlertDeliveryError>()(
 		exposure: "redacted",
 	},
 ) {}
+
+/** Provider rejected our credentials (401/403). Terminal until reconfigured. */
+export class AlertDeliveryAuthError extends HttpTaggedError<AlertDeliveryAuthError>()(
+	"@maple/http/errors/AlertDeliveryAuthError",
+	alertDeliveryErrorFields,
+	{
+		status: 502,
+		code: "alert_delivery_auth_failed",
+		title: "Alert destination rejected our credentials",
+		message: "The destination rejected Maple's credentials. Reconnect it in settings.",
+		retry: "never",
+		recovery: "reconnect",
+		exposure: "redacted",
+	},
+) {}
+
+/**
+ * The target channel/endpoint is gone or unreachable as configured — a 404, a
+ * deleted webhook, or a Slack channel the bot is not a member of. Retrying
+ * cannot fix it; the destination has to be pointed somewhere else.
+ */
+export class AlertDeliveryTargetMissingError extends HttpTaggedError<AlertDeliveryTargetMissingError>()(
+	"@maple/http/errors/AlertDeliveryTargetMissingError",
+	alertDeliveryErrorFields,
+	{
+		status: 502,
+		code: "alert_delivery_target_missing",
+		title: "Alert destination no longer exists",
+		message: "The destination no longer exists or is not reachable. Update it in settings.",
+		retry: "never",
+		recovery: "fix_request",
+		exposure: "redacted",
+	},
+) {}
+
+/** Provider refused the request itself (a non-auth 4xx). Retrying re-sends the same rejected payload. */
+export class AlertDeliveryRejectedError extends HttpTaggedError<AlertDeliveryRejectedError>()(
+	"@maple/http/errors/AlertDeliveryRejectedError",
+	alertDeliveryErrorFields,
+	{
+		status: 502,
+		code: "alert_delivery_rejected",
+		title: "Alert provider rejected the request",
+		message: "The alert provider rejected the request.",
+		retry: "never",
+		recovery: "contact_support",
+		exposure: "redacted",
+	},
+) {}
+
+/**
+ * Any delivery failure. Use at seams that only propagate; `catchTags` on the
+ * individual classes where the distinction matters.
+ */
+export type AlertDeliveryFailure =
+	| AlertDeliveryError
+	| AlertDeliveryAuthError
+	| AlertDeliveryTargetMissingError
+	| AlertDeliveryRejectedError
 
 export class AlertDestinationInUseError extends HttpTaggedError<AlertDestinationInUseError>()(
 	"@maple/http/errors/AlertDestinationInUseError",

--- a/packages/domain/src/http/v2/alert-destinations.ts
+++ b/packages/domain/src/http/v2/alert-destinations.ts
@@ -2,7 +2,10 @@ import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { Schema } from "effect"
 import { HazelChannelId, HazelOrganizationId, PostgresTransactionId, UserId } from "../../primitives"
 import {
+	AlertDeliveryAuthError,
 	AlertDeliveryError,
+	AlertDeliveryRejectedError,
+	AlertDeliveryTargetMissingError,
 	AlertDestinationDecryptionError,
 	AlertDestinationEncryptionError,
 	AlertDestinationNotFoundError,
@@ -355,12 +358,22 @@ export const V2AlertDestinationTestResult = Schema.Struct({
 })
 export type V2AlertDestinationTestResult = Schema.Schema.Type<typeof V2AlertDestinationTestResult>
 
-const [alertForbidden, alertValidation, alertPersistence, alertNotFound, alertDelivery] = publicErrors(
+const [alertForbidden, alertValidation, alertPersistence, alertNotFound] = publicErrors(
 	AlertForbiddenError,
 	AlertValidationError,
 	AlertPersistenceError,
 	AlertDestinationNotFoundError,
+)
+/**
+ * Delivery fails as one of four classes, split by whether the failure is worth
+ * retrying (see `alerts.ts`). All four must be declared here — an endpoint that
+ * can produce an error it cannot encode answers 500 instead of the real status.
+ */
+const alertDeliveryErrors = publicErrors(
 	AlertDeliveryError,
+	AlertDeliveryAuthError,
+	AlertDeliveryTargetMissingError,
+	AlertDeliveryRejectedError,
 )
 const hazelWebhookProvisionErrors = publicErrors(
 	IntegrationsNotConnectedError,
@@ -486,7 +499,13 @@ export class V2AlertDestinationsApiGroup extends HttpApiGroup.make("alertDestina
 		HttpApiEndpoint.post("test", "/:id/test", {
 			params: { id: AlertDestinationPublicId },
 			success: V2AlertDestinationTestResult,
-			error: [alertForbidden, alertPersistence, alertNotFound, alertDelivery, ...destinationReadErrors],
+			error: [
+				alertForbidden,
+				alertPersistence,
+				alertNotFound,
+				...alertDeliveryErrors,
+				...destinationReadErrors,
+			],
 		}).annotateMerge(
 			OpenApi.annotations({
 				identifier: "testAlertDestination",

--- a/packages/domain/src/http/v2/alert-rules.ts
+++ b/packages/domain/src/http/v2/alert-rules.ts
@@ -8,7 +8,10 @@ import {
 	AlertEvaluationStatus,
 	AlertIncidentTransition,
 	AlertNotificationTemplate,
+	AlertDeliveryAuthError,
 	AlertDeliveryError,
+	AlertDeliveryRejectedError,
+	AlertDeliveryTargetMissingError,
 	AlertDestinationDecryptionError,
 	AlertDestinationStoredConfigInvalidError,
 	AlertForbiddenError,
@@ -630,12 +633,22 @@ const ChecksQuery = Schema.Struct({
 	description: "Pagination plus optional group/time filters for a rule's check history.",
 })
 
-const [alertForbidden, alertValidation, alertPersistence, alertRuleNotFound, alertDelivery] = publicErrors(
+const [alertForbidden, alertValidation, alertPersistence, alertRuleNotFound] = publicErrors(
 	AlertForbiddenError,
 	AlertValidationError,
 	AlertPersistenceError,
 	AlertRuleNotFoundError,
+)
+/**
+ * Delivery fails as one of four classes, split by whether the failure is worth
+ * retrying (see `alerts.ts`). All four must be declared here — an endpoint that
+ * can produce an error it cannot encode answers 500 instead of the real status.
+ */
+const alertDeliveryErrors = publicErrors(
 	AlertDeliveryError,
+	AlertDeliveryAuthError,
+	AlertDeliveryTargetMissingError,
+	AlertDeliveryRejectedError,
 )
 const alertRuleDestinationNotFound = publicError(AlertRuleDestinationNotFoundError)
 const alertRuleStoredConfigInvalid = publicError(AlertRuleStoredConfigInvalidError)
@@ -799,7 +812,7 @@ export class V2AlertRulesApiGroup extends HttpApiGroup.make("alertRules")
 				alertValidation,
 				alertPersistence,
 				alertRuleDestinationNotFound,
-				alertDelivery,
+				...alertDeliveryErrors,
 				...alertDestinationStorageErrors,
 				...V2WarehouseErrors,
 				...V2QueryEngineRouteErrors,


### PR DESCRIPTION
## Why

Slack alerts for query-driven rules read:

> **builder_query** is **1041923** — above the 500000 threshold, measured over the last 5m.

`builder_query` is the rule's *query-kind enum*, not a metric name. Fixing that meant threading one more field through four hand-copied context shapes — which is the real problem, so this fixes both.

## Naming the signal

`formatSignalLabel` mapped only the five preset signals and ended in `labels[signal] ?? signal`, so `builder_query` and `raw_query` leaked the enum verbatim. `formatSignalMetric` had no arm for them either, hence the bare unitless integer. The data for a good label was **already decoded at dispatch time** and simply never used.

`resolveSignalDisplay` now derives `{ label, unit }` from the rule:

| rule | before | after |
|---|---|---|
| metrics query | `builder_query is 1041923` | `sum(db.query.duration) is 1,041,923` |
| traces query | `builder_query is 1041923` | `p95(duration) is 1,041,923ms` |
| raw SQL | `raw_query is 1041923` | `SQL result (sum) is 1,041,923` |

Traces labels reuse the query builder's own aggregation option labels, so the notification names the aggregation exactly as the rule author picked it in the UI. Values format by **unit** rather than by query kind, keeping observed value and threshold in the same unit. Anything unmapped is humanized, so no enum can leak again.

Slack, Discord, email, PagerDuty preview text and the `{{ signal.label }}` template variable all route through those two formatters, so one fix covers every channel. **Preset signals render exactly as before.** No payload-schema change or backfill.

## Delivery structure

The six providers were inline arms of one `Match` in an 897-line file. The sentence `"<Provider> delivery failed with <status>: <detail>"` was written out five times, `publicConfig` was threaded through everything and read by nobody, and the wire payload was built three independent times — one copy had already drifted.

Transport now lives in `delivery/`: one file per provider (~60 lines each) declaring only what is provider-specific behind a **pure `render` step**, plus a `runTransport` wrapper owning spans, timeout, SSRF guard and error construction. `AlertDeliveryDispatch.ts` drops 897 → 376 lines and is now purely message rendering.

Dispatch is a `Match` exhaustive over the secret-config union, so **a seventh destination type fails to compile until it has a transport**.

## Observability

Every provider call is now a Client-kind `AlertDelivery.http` span carrying `peer.service` — which makes Slack, PagerDuty, Discord and Hazel **service-map nodes** with attributable latency and status. They had no span at all before.

Metrics are deliberately not the vehicle: `apps/api` has no metric reader anywhere in its OTel wiring, so `alerting.*` has always been write-only. Span-first is the only thing that actually reaches the pipeline.

## Security note

Discord and Hazel webhook URLs embed their delivery token **in the path**, so annotating `url.path` on those spans would have published a working credential to the traces table. Transports declare `sensitivePath`; those two annotate `server.address` only, and a test asserts no span attribute on any provider contains a token.

`safeFetch` is applied where it means something — user-configured hosts (webhook, discord, hazel). Slack and PagerDuty post to compile-time vendor constants where the guard would only cost a redirect walk. A test pins which three are guarded so it cannot silently drift.

## Behaviour changes

- **Hazel** ships the canonical wire payload — gains `thresholdUpper`, stops recomputing `incidentStatus` from `eventType`.
- **Discord** reports a provider reference like every other provider.
- Error message wording unified across providers.

Message content for Slack, Discord and email is byte-identical — the existing formatter tests are the guard.

## Reviewing this

`discord`, `pagerduty`, `webhook` and `hazel` had **zero** direct dispatch coverage. They were pinned against the pre-refactor code *first*, deliberately including the two defects above, so the normalization shows up as an explicit diff rather than a silent change. 258 of 260 tests then passed untouched through the extraction, and the only two failures were exactly those two pinned defects.

Suggested order: `delivery/Transport.ts` (the seam) → `delivery/runTransport.ts` (what became shared) → one transport → `delivery/dispatch.ts`.

## Verification

- 281 alerts tests, 58 web tests
- `bun typecheck` clean across all 40 packages; oxlint and oxfmt clean
- New: per-provider render tests, span tests, and `apps/api/src/testing/recording-tracer.ts` extracted from the existing GitHub span test

## Follow-ups (not in this PR)

Staged deliberately; this is stage 1 of 5.

1. **Error taxonomy + retry correctness.** `AlertDeliveryError` carries a fixed `retry: "backoff"` and the retry decision reads `retryable` straight off it, so **every** delivery failure is retried 5× with backoff — including a Hazel 401 whose own message says "reconfigure the channel". Next up.
2. Collapse the remaining context shapes onto one canonical notification value.
3. Merge the escalation / error-issue path onto the same pipeline (it emits zero telemetry today).
4. Tagged metric attributes, for when a metric reader lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789326068&installation_model_id=427786&pr_number=470&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F470&signature=aa65b0814999f6702ca5c6640d5a432ebe086d039eb73f37b404efa8bd6fef68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->