### PR TITLE
fix(alerts): stop leaking the ungrouped storage sentinel into notifications

### DIFF
--- a/apps/api/src/services/alerts/AlertDeliveryDispatch.test.ts
+++ b/apps/api/src/services/alerts/AlertDeliveryDispatch.test.ts
@@ -4,6 +4,7 @@ import {
 	AlertDeliveryRejectedError,
 	AlertDeliveryTargetMissingError,
 	AlertDestinationId,
+	UNGROUPED_GROUP_KEY,
 } from "@maple/domain/http"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Fiber, Schema } from "effect"
@@ -110,6 +111,11 @@ describe("buildTemplateContext", () => {
 		assert.strictEqual(ctx.thresholdUpper, "")
 	})
 
+	it("renders the ungrouped sentinel as `all`, never as `__total__`", () => {
+		const ungrouped = buildTemplateContext({ ...baseContext, groupKey: UNGROUPED_GROUP_KEY }, LINK, CHAT)
+		assert.strictEqual(ungrouped.group, "all")
+	})
+
 	it("renders the default templates without any missing variables", () => {
 		const title = renderTemplate(DEFAULT_TITLE_TEMPLATE, ctx)
 		const body = renderTemplate(DEFAULT_BODY_TEMPLATE, ctx)
@@ -166,6 +172,22 @@ describe("buildSlackBlocks (default format)", () => {
 		const blocks = buildSlackBlocks(baseContext, LINK, CHAT)
 		const section = blocks[1] as SectionBlock
 		assert.isTrue(section.fields.some((f) => f.text.includes("\u{1F534} Critical")))
+	})
+
+	/**
+	 * Regression: an ungrouped rule stores `UNGROUPED_GROUP_KEY` ("__total__")
+	 * as its group key — a storage sentinel, not a group anyone named — and it
+	 * was rendering verbatim as a `Group` field reading `__total__`.
+	 */
+	it("treats the ungrouped sentinel as no grouping at all", () => {
+		const fields = (
+			buildSlackBlocks({ ...baseContext, groupKey: UNGROUPED_GROUP_KEY }, LINK, CHAT)[1] as SectionBlock
+		).fields
+		assert.isFalse(
+			fields.some((field) => field.text.startsWith("*Group*")),
+			"the ungrouped sentinel must not render a Group field",
+		)
+		for (const field of fields) assert.notInclude(field.text, "__total__")
 	})
 
 	it("omits the group field when the rule has no grouping, escapes it when present", () => {

--- a/apps/api/src/services/alerts/AlertDeliveryDispatch.ts
+++ b/apps/api/src/services/alerts/AlertDeliveryDispatch.ts
@@ -18,6 +18,7 @@ import type { DispatchContext } from "./delivery/context"
 import {
 	comparatorBreachPhrase,
 	discordEmbedColor,
+	displayGroupKey,
 	eventTypeEmoji,
 	formatComparator,
 	formatEventTypeLabel,
@@ -170,6 +171,16 @@ const buildSlackContextBlock = (context: Pick<DispatchContext, "sentAtMs" | "inc
 	return { type: "context", elements: [{ type: "mrkdwn", text: parts.join("  ·  ") }] }
 }
 
+/**
+ * The `Group` field, present only when the rule is actually grouped. An
+ * ungrouped rule has no group to report — showing its `__total__` storage
+ * sentinel is worse than showing nothing.
+ */
+const groupField = (groupKey: string | null) => {
+	const group = displayGroupKey(groupKey)
+	return group == null ? [] : [{ type: "mrkdwn", text: `*Group*\n\`${escapeSlackMrkdwn(group)}\`` }]
+}
+
 export const buildSlackBlocks = (context: TemplateRenderContext, linkUrl: string, chatUrl: string) => [
 	{
 		type: "header",
@@ -190,9 +201,7 @@ export const buildSlackBlocks = (context: TemplateRenderContext, linkUrl: string
 				type: "mrkdwn",
 				text: `*Severity*\n${severityEmoji(context.severity)} ${formatSeverityLabel(context.severity)}`,
 			},
-			...(context.groupKey != null
-				? [{ type: "mrkdwn", text: `*Group*\n\`${escapeSlackMrkdwn(context.groupKey)}\`` }]
-				: []),
+			...groupField(context.groupKey),
 		],
 	},
 	buildSlackActionsBlock(linkUrl, chatUrl),
@@ -214,7 +223,7 @@ export const buildDiscordEmbeds = (context: DispatchContext, linkUrl: string, ch
 		fields: [
 			{ name: "Severity", value: context.severity, inline: true },
 			{ name: "Signal", value: formatSignalLabel(context), inline: true },
-			{ name: "Group", value: context.groupKey ?? "all", inline: true },
+			{ name: "Group", value: displayGroupKey(context.groupKey) ?? "all", inline: true },
 			{ name: "Observed", value: formatObservedSummary(context), inline: true },
 			{ name: "Window", value: formatWindow(context.windowMinutes), inline: true },
 			{
@@ -266,7 +275,7 @@ export const buildTemplateContext = (
 		observed: formatSignalMetric(context.value, display),
 		"observed.summary": formatObservedSummary(context),
 		sampleCount: context.sampleCount != null ? String(context.sampleCount) : "",
-		group: context.groupKey ?? "all",
+		group: displayGroupKey(context.groupKey) ?? "all",
 		window: formatWindow(context.windowMinutes),
 		incidentId: context.incidentId ?? "",
 		incidentStatus: context.incidentStatus,

--- a/apps/api/src/services/alerts/alert-email.ts
+++ b/apps/api/src/services/alerts/alert-email.ts
@@ -2,6 +2,7 @@ import { AlertDeliveryError } from "@maple/domain/http"
 import { renderAlertNotification } from "@maple/email/alert-notification"
 import { Effect } from "effect"
 import {
+	displayGroupKey,
 	eventTypeEmoji,
 	formatEventTypeLabel,
 	formatObservedSummary,
@@ -38,7 +39,7 @@ export const buildAlertEmailContent = (
 				eventEmoji: emoji,
 				severity: context.severity,
 				signalLabel: formatSignalLabel(context),
-				group: context.groupKey ?? "all",
+				group: displayGroupKey(context.groupKey) ?? "all",
 				observedSummary: formatObservedSummary(context),
 				window: formatWindow(context.windowMinutes),
 				accentColor: slackAttachmentColor(context.eventType, context.severity),

--- a/apps/api/src/services/alerts/alert-formatting.ts
+++ b/apps/api/src/services/alerts/alert-formatting.ts
@@ -1,4 +1,10 @@
-import type { AlertComparator, AlertEventType, AlertSeverity, AlertSignalType } from "@maple/domain/http"
+import {
+	UNGROUPED_GROUP_KEY,
+	type AlertComparator,
+	type AlertEventType,
+	type AlertSeverity,
+	type AlertSignalType,
+} from "@maple/domain/http"
 import { Match, Option } from "effect"
 import { resolveSignalDisplay, type SignalDisplay } from "./alert-signal-display"
 import type { NotificationTemplateConfig } from "./alert-templating/renderer"
@@ -33,6 +39,19 @@ const round = (value: number, decimals = 2): string => {
 	const factor = 10 ** decimals
 	return (Math.round(value * factor) / factor).toString()
 }
+
+/**
+ * The group key as a human should see it, or `null` when the rule is not
+ * grouped.
+ *
+ * An ungrouped rule stores `UNGROUPED_GROUP_KEY` (`"__total__"`) as its group
+ * key — a storage sentinel meaning "the whole rule", not a group anyone named.
+ * It was reaching notifications verbatim, so Slack rendered a `Group` field
+ * reading `__total__`. `issue-hub.ts` and the web alert-source card already
+ * guard against it; the notification path did not.
+ */
+export const displayGroupKey = (groupKey: string | null): string | null =>
+	groupKey == null || groupKey === UNGROUPED_GROUP_KEY ? null : groupKey
 
 /** Clamp to a provider's field limit, marking the cut with an ellipsis. */
 export const truncate = (value: string, max: number): string =>

--- a/apps/api/src/services/alerts/delivery/transports/pagerduty.ts
+++ b/apps/api/src/services/alerts/delivery/transports/pagerduty.ts
@@ -1,5 +1,5 @@
 import { Duration, Effect } from "effect"
-import { truncate } from "../../alert-formatting"
+import { displayGroupKey, truncate } from "../../alert-formatting"
 import type { HttpTransport, RenderInput, SecretConfigOf } from "../Transport"
 
 type Config = SecretConfigOf<"pagerduty">
@@ -30,7 +30,7 @@ export const pagerDutyTransport: HttpTransport<Config> = {
 				dedup_key: context.dedupeKey,
 				payload: {
 					summary: truncate(templated?.title ?? `${context.ruleName} ${context.eventType}`, 1024),
-					source: context.groupKey ?? "maple-alerts",
+					source: displayGroupKey(context.groupKey) ?? "maple-alerts",
 					severity: context.severity === "critical" ? "critical" : "warning",
 					custom_details: {
 						...(templated ? { message: templated.body } : {}),


### PR DESCRIPTION
## The bug

Slack alerts for ungrouped rules render a `Group` field reading `__total__`:

> **Group**
> `__total__`

`__total__` is `UNGROUPED_GROUP_KEY` — an internal **storage sentinel** meaning "this rule isn't grouped, the value is the total". It's never a group anyone named, and it should never have reached a human.

Two other places already guard against it — [`issue-hub.ts:69`](apps/api/src/services/errors/issue-hub.ts#L69) and the web [`alert-source-card.tsx:23`](apps/web/src/components/errors/alert-source-card.tsx#L23) — but the notification path never did.

## The fix

`displayGroupKey` in `alert-formatting.ts` treats the sentinel exactly like "no grouping", and every human-facing render site goes through it.

This also settles an inconsistency underneath: for a genuinely ungrouped rule, Slack **omitted** the Group field while Discord, email and the `{{ group }}` template variable said **"all"** — three behaviours for one concept. Now all four agree: Slack omits, the rest say "all".

| surface | before (ungrouped rule) | after |
|---|---|---|
| Slack | `Group: __total__` | field omitted |
| Discord | `Group: __total__` | `Group: all` |
| Email | `__total__` | `all` |
| `{{ group }}` template var | `__total__` | `all` |
| PagerDuty `payload.source` | `__total__` | `maple-alerts` |

## Deliberately not changed

PagerDuty's `custom_details.groupKey` and the webhook/Hazel wire payload still carry the raw `__total__`. Those are **machine-facing**, consumers may already branch on the sentinel, and normalizing them would be a contract change rather than a display fix. Happy to do it as a follow-up if we'd rather the sentinel never leave the API at all.

## Verification

- 282 alerts tests, `bun typecheck` clean across all 40 packages, `lint:effect` and oxfmt clean
- Two new regression tests: the sentinel produces no Slack `Group` field (and no attribute containing `__total__`), and renders as `all` in the template context

Follow-up to #470, which was merged before this landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789330417&installation_model_id=427786&pr_number=471&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F471&signature=c6bb6d858ff201001cf7a8fcc019d7988ea51966e23d5baf7bfa006c7816e037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
