### PR TITLE
fix(effect-sdk): flush contract, version stamping, and doc drift

### DIFF
--- a/apps/landing/src/content/docs/sdks/effect-cloudflare.md
+++ b/apps/landing/src/content/docs/sdks/effect-cloudflare.md
@@ -55,12 +55,16 @@ If a flush fails (network error, 5xx from the collector), the affected signal go
 
 In addition to the [common options](/docs/sdks/effect#configuration-reference), `make()` accepts a few Workers-specific knobs:
 
-| Option            | Type                    | Default      | Description                                               |
-| ----------------- | ----------------------- | ------------ | --------------------------------------------------------- |
-| `excludeLogSpans` | `boolean`               | `false`      | Skip Effect log spans in OTLP log attributes              |
-| `dropSpanNames`   | `ReadonlyArray<string>` | —            | Drop spans whose name starts with any prefix in this list |
-| `tracesPath`      | `string`                | `/v1/traces` | OTLP traces path appended to `endpoint`                   |
-| `logsPath`        | `string`                | `/v1/logs`   | OTLP logs path appended to `endpoint`                     |
+| Option                        | Type                    | Default       | Description                                                                          |
+| ----------------------------- | ----------------------- | ------------- | ------------------------------------------------------------------------------------ |
+| `excludeLogSpans`             | `boolean`               | `false`       | Skip Effect log spans in OTLP log attributes                                         |
+| `dropSpanNames`               | `ReadonlyArray<string>` | —             | Drop spans whose name starts with any prefix in this list                            |
+| `anticipatedErrorIdentifiers` | `ReadonlyArray<string>` | —             | `_tag` / `Error.name` values of expected 4xx failures — spans export as `Ok`, no `exception` event |
+| `tracesPath`                  | `string`                | `/v1/traces`  | OTLP traces path appended to `endpoint`                                              |
+| `logsPath`                    | `string`                | `/v1/logs`    | OTLP logs path appended to `endpoint`                                                |
+| `metricsPath`                 | `string`                | `/v1/metrics` | OTLP metrics path appended to `endpoint`                                             |
+
+`anticipatedErrorIdentifiers` keeps expected rejections (a 404, a 401) visible as traces without counting them as errors — matching how Maple's ingest gateway treats 4xx. A span still exports as `Error` if its cause contains any defect.
 
 `dropSpanNames` is useful for suppressing protocol-level chatter — e.g. `["McpServer/Notifications."]` to drop MCP notification spam without dropping legitimate handler spans.
 

--- a/apps/landing/src/content/docs/sdks/effect-server.md
+++ b/apps/landing/src/content/docs/sdks/effect-server.md
@@ -39,15 +39,15 @@ The default import (`@maple-dev/effect-sdk`) resolves to the server build under 
 import { Maple } from "@maple-dev/effect-sdk/server"
 ```
 
-Set `MAPLE_ENDPOINT` and `MAPLE_INGEST_KEY` in your environment and the SDK picks them up automatically. If `MAPLE_ENDPOINT` is unset, the layer becomes a no-op — your app runs without exporting telemetry, which is the right default for local dev.
+Set `MAPLE_INGEST_KEY` in your environment and the SDK picks it up automatically. If it is unset, the layer becomes a no-op — your app runs without exporting telemetry, which is the right default for local dev. `MAPLE_ENDPOINT` is optional: it defaults to the public Maple ingest, and it is not the disable signal.
 
 ## Environment Variable Auto-Detection
 
 The server layer resolves configuration from environment variables in this order:
 
-**Ingest endpoint:** `MAPLE_ENDPOINT` → `OTEL_EXPORTER_OTLP_ENDPOINT`
+**Ingest endpoint:** `MAPLE_ENDPOINT` → `OTEL_EXPORTER_OTLP_ENDPOINT` → `https://ingest.maple.dev`
 
-**Ingest key:** `MAPLE_INGEST_KEY`
+**Ingest key:** `MAPLE_INGEST_KEY` — when this resolves to nothing, the layer is a no-op
 
 **Commit SHA** (first match wins):
 
@@ -60,25 +60,27 @@ The server layer resolves configuration from environment variables in this order
 **Deployment environment** (first match wins):
 
 1. `MAPLE_ENVIRONMENT`
-2. `RAILWAY_ENVIRONMENT`
-3. `VERCEL_ENV`
-4. `NODE_ENV`
+2. `RAILWAY_ENVIRONMENT_NAME`
+3. `DEPLOYMENT_ENV`
+4. Falls back to `"development"`
+
+`VERCEL_ENV` and `NODE_ENV` are **not** read — on any platform outside that list, set `MAPLE_ENVIRONMENT` explicitly or your telemetry lands under `development`.
 
 The SDK also auto-detects the **runtime** (Node.js, Bun, Deno) and **cloud provider** (Railway, Vercel, Cloudflare, Render) and includes them as `maple.runtime` and `maple.provider` resource attributes.
 
 ## Deployment Platform Notes
 
-Most managed platforms expose commit SHA and environment automatically — no extra config needed:
+Managed platforms expose the commit SHA automatically. The **environment** is only auto-detected on Railway — everywhere else, set `MAPLE_ENVIRONMENT` yourself:
 
-| Platform         | Commit SHA env var       | Environment env var   |
-| ---------------- | ------------------------ | --------------------- |
-| Railway          | `RAILWAY_GIT_COMMIT_SHA` | `RAILWAY_ENVIRONMENT` |
-| Vercel           | `VERCEL_GIT_COMMIT_SHA`  | `VERCEL_ENV`          |
-| Cloudflare Pages | `CF_PAGES_COMMIT_SHA`    | —                     |
-| Render           | `RENDER_GIT_COMMIT`      | —                     |
-| Self-hosted      | `COMMIT_SHA` (set in CI) | `NODE_ENV`            |
+| Platform         | Commit SHA env var       | Environment                              |
+| ---------------- | ------------------------ | ---------------------------------------- |
+| Railway          | `RAILWAY_GIT_COMMIT_SHA` | `RAILWAY_ENVIRONMENT_NAME` (automatic)   |
+| Vercel           | `VERCEL_GIT_COMMIT_SHA`  | Set `MAPLE_ENVIRONMENT`                  |
+| Cloudflare Pages | `CF_PAGES_COMMIT_SHA`    | Set `MAPLE_ENVIRONMENT`                  |
+| Render           | `RENDER_GIT_COMMIT`      | Set `MAPLE_ENVIRONMENT`                  |
+| Self-hosted      | `COMMIT_SHA` (set in CI) | Set `MAPLE_ENVIRONMENT` or `DEPLOYMENT_ENV` |
 
-For self-hosted deployments, set `COMMIT_SHA` in your build pipeline and `MAPLE_ENVIRONMENT` (or rely on `NODE_ENV`) at runtime.
+For self-hosted deployments, set `COMMIT_SHA` in your build pipeline and `MAPLE_ENVIRONMENT` at runtime.
 
 ## Verify
 

--- a/apps/landing/src/content/docs/sdks/effect-server.md
+++ b/apps/landing/src/content/docs/sdks/effect-server.md
@@ -39,7 +39,9 @@ The default import (`@maple-dev/effect-sdk`) resolves to the server build under 
 import { Maple } from "@maple-dev/effect-sdk/server"
 ```
 
-Set `MAPLE_INGEST_KEY` in your environment and the SDK picks it up automatically. If it is unset, the layer becomes a no-op — your app runs without exporting telemetry, which is the right default for local dev. `MAPLE_ENDPOINT` is optional: it defaults to the public Maple ingest, and it is not the disable signal.
+Set `MAPLE_INGEST_KEY` in your environment and the SDK picks it up automatically. `MAPLE_ENDPOINT` is optional — it defaults to the public Maple ingest.
+
+The server layer always exports; there is no disable switch. A missing ingest key does not turn export off, so a keyless app pointed at a local `maple start` sink or your own OTLP collector still ships telemetry. The one combination that cannot work is keyless against the public ingest, which rejects unauthenticated writes with a 401 — the SDK logs a one-shot warning if you land there. For local dev that exports nothing at all, either point `MAPLE_ENDPOINT` at a sink you control, or use `MapleFlush.make`, which does no-op without a key.
 
 ## Environment Variable Auto-Detection
 
@@ -47,7 +49,7 @@ The server layer resolves configuration from environment variables in this order
 
 **Ingest endpoint:** `MAPLE_ENDPOINT` → `OTEL_EXPORTER_OTLP_ENDPOINT` → `https://ingest.maple.dev`
 
-**Ingest key:** `MAPLE_INGEST_KEY` — when this resolves to nothing, the layer is a no-op
+**Ingest key:** `MAPLE_INGEST_KEY` — sent as a bearer token; omitted from the request when unset
 
 **Commit SHA** (first match wins):
 

--- a/apps/landing/src/content/docs/sdks/effect.md
+++ b/apps/landing/src/content/docs/sdks/effect.md
@@ -6,7 +6,7 @@ order: 2
 sdk: "effect"
 ---
 
-`@maple-dev/effect-sdk` provides a pre-configured Effect Layer that sets up OpenTelemetry traces, logs, and metrics for Maple. It wraps Effect's built-in `Otlp.layerJson` exporter, fills in resource attributes from the runtime, and returns a no-op layer when no ingest key is configured — so the same code runs locally without exporting telemetry.
+`@maple-dev/effect-sdk` provides a pre-configured Effect Layer that sets up OpenTelemetry traces, logs, and metrics for Maple. It wraps Effect's built-in `Otlp.layerJson` exporter, fills in resource attributes from the runtime, and defaults the endpoint to the public Maple ingest — so in most cases an ingest key is the only configuration you need. Point `MAPLE_ENDPOINT` at a local `maple start` sink or your own collector to run the same code against a different destination.
 
 <div class="flex flex-wrap gap-2 mb-8 not-prose">
     <span class="text-[10px] uppercase tracking-wider px-2 py-1 border border-border text-fg-muted">Node.js</span>
@@ -80,7 +80,7 @@ All options for `Maple.layer()` (server and browser entry points). The Cloudflar
 | ----------------------- | ------------------------- | -------------------------- | -------------------------------------------------------------------- |
 | `serviceName`           | `string`                  | Yes                        | Service name reported in traces, logs, and metrics                   |
 | `endpoint`              | `string`                  | No (server) / Yes (client) | Maple ingest endpoint URL. Server auto-detects from `MAPLE_ENDPOINT` |
-| `ingestKey`             | `string`                  | No — but the SDK no-ops without one | Maple ingest key. Server auto-detects from `MAPLE_INGEST_KEY`   |
+| `ingestKey`             | `string`                  | Required by the public ingest | Maple ingest key. Server auto-detects from `MAPLE_INGEST_KEY`. The flushable and Cloudflare presets no-op without one |
 | `serviceVersion`        | `string`                  | No                         | Override auto-detected commit SHA                                    |
 | `serviceNamespace`      | `string`                  | No                         | Logical group, emitted as the `service.namespace` resource attribute |
 | `repositoryUrl`         | `string`                  | No (server / Cloudflare)   | Repository URL, emitted as `vcs.repository.url.full`                 |

--- a/apps/landing/src/content/docs/sdks/effect.md
+++ b/apps/landing/src/content/docs/sdks/effect.md
@@ -6,7 +6,7 @@ order: 2
 sdk: "effect"
 ---
 
-`@maple-dev/effect-sdk` provides a pre-configured Effect Layer that sets up OpenTelemetry traces, logs, and metrics for Maple. It wraps Effect's built-in `Otlp.layerJson` exporter, fills in resource attributes from the runtime, and returns a no-op layer when no endpoint is configured — so the same code runs locally without exporting telemetry.
+`@maple-dev/effect-sdk` provides a pre-configured Effect Layer that sets up OpenTelemetry traces, logs, and metrics for Maple. It wraps Effect's built-in `Otlp.layerJson` exporter, fills in resource attributes from the runtime, and returns a no-op layer when no ingest key is configured — so the same code runs locally without exporting telemetry.
 
 <div class="flex flex-wrap gap-2 mb-8 not-prose">
     <span class="text-[10px] uppercase tracking-wider px-2 py-1 border border-border text-fg-muted">Node.js</span>
@@ -80,8 +80,10 @@ All options for `Maple.layer()` (server and browser entry points). The Cloudflar
 | ----------------------- | ------------------------- | -------------------------- | -------------------------------------------------------------------- |
 | `serviceName`           | `string`                  | Yes                        | Service name reported in traces, logs, and metrics                   |
 | `endpoint`              | `string`                  | No (server) / Yes (client) | Maple ingest endpoint URL. Server auto-detects from `MAPLE_ENDPOINT` |
-| `ingestKey`             | `string`                  | No                         | Maple ingest key. Server auto-detects from `MAPLE_INGEST_KEY`        |
+| `ingestKey`             | `string`                  | No — but the SDK no-ops without one | Maple ingest key. Server auto-detects from `MAPLE_INGEST_KEY`   |
 | `serviceVersion`        | `string`                  | No                         | Override auto-detected commit SHA                                    |
+| `serviceNamespace`      | `string`                  | No                         | Logical group, emitted as the `service.namespace` resource attribute |
+| `repositoryUrl`         | `string`                  | No (server / Cloudflare)   | Repository URL, emitted as `vcs.repository.url.full`                 |
 | `environment`           | `string`                  | No                         | Override auto-detected deployment environment                        |
 | `attributes`            | `Record<string, unknown>` | No                         | Additional resource attributes merged into telemetry                 |
 | `maxBatchSize`          | `number`                  | No                         | Max telemetry items per export batch                                 |

--- a/apps/landing/src/content/docs/sdks/overview.md
+++ b/apps/landing/src/content/docs/sdks/overview.md
@@ -29,7 +29,7 @@ If your language doesn't have an official SDK yet, see the [Language guides](#la
 A Maple SDK is more than a thin OTel wrapper. Each SDK:
 
 - **Auto-detects platform metadata** — commit SHA, deployment environment, cloud provider, and runtime are picked up from environment variables (Railway, Vercel, Cloudflare Pages, Render, etc.) so you don't have to wire them up by hand.
-- **No-ops safely without an endpoint** — if `MAPLE_ENDPOINT` (or the equivalent) isn't set, the layer becomes a no-op. Local development doesn't need a Maple project.
+- **Points anywhere** — the endpoint defaults to the public Maple ingest, so an ingest key is usually the only setup. Point `MAPLE_ENDPOINT` at a local `maple start` sink or your own OTLP collector to develop without a Maple project; those accept unauthenticated writes, so no key is needed.
 - **Ships with platform-specific entry points** — server, browser, and serverless runtimes get their own builds with the right exporter and lifecycle wiring.
 - **Tracks the Maple ingest API** — when we add new resource attributes or signal types on the backend, the SDK gets updated to match.
 

--- a/packages/effect-sdk/.npmignore
+++ b/packages/effect-sdk/.npmignore
@@ -1,6 +1,0 @@
-src
-*.test.ts
-tsconfig.json
-tsdown.config.ts
-.env.local
-vitest.config.ts

--- a/packages/effect-sdk/README.md
+++ b/packages/effect-sdk/README.md
@@ -10,7 +10,9 @@ npm install @maple-dev/effect-sdk effect
 
 ## Server
 
-Auto-detects commit SHA and deployment environment from common platform env vars (Railway, Vercel, Cloudflare Pages, Render). Returns a no-op layer when no endpoint is configured, making it safe for local development.
+Auto-detects commit SHA and deployment environment from common platform env vars (Railway, Vercel, Cloudflare Pages, Render). Returns a no-op layer when no ingest key is configured, making it safe for local development.
+
+The endpoint is not the disable signal — it defaults to the public Maple ingest (`https://ingest.maple.dev`), so you only need to supply a key.
 
 ```typescript
 import { Maple } from "@maple-dev/effect-sdk/server"
@@ -25,15 +27,19 @@ Effect.runPromise(program.pipe(Effect.provide(TracerLive)))
 
 ### Environment Variables
 
-| Variable            | Description                     |
-| ------------------- | ------------------------------- |
-| `MAPLE_ENDPOINT`    | Maple ingest endpoint URL       |
-| `MAPLE_INGEST_KEY`  | Maple ingest key                |
-| `MAPLE_ENVIRONMENT` | Deployment environment override |
+| Variable                      | Description                                                     |
+| ----------------------------- | --------------------------------------------------------------- |
+| `MAPLE_INGEST_KEY`            | Maple ingest key. **Without it the SDK is a no-op.**             |
+| `MAPLE_ENDPOINT`              | Ingest endpoint URL. Defaults to `https://ingest.maple.dev`      |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint fallback, honored when `MAPLE_ENDPOINT` is unset        |
+| `MAPLE_ENVIRONMENT`           | Deployment environment override                                  |
+| `MAPLE_REPOSITORY_URL`        | Repository URL, emitted as `vcs.repository.url.full`             |
+| `OTEL_SERVICE_NAME`           | Service name fallback when `serviceName` is omitted              |
+| `OTEL_RESOURCE_ATTRIBUTES`    | Extra resource attributes, `key=value` pairs (later writers win) |
 
 Commit SHA is auto-detected from `COMMIT_SHA`, `RAILWAY_GIT_COMMIT_SHA`, `VERCEL_GIT_COMMIT_SHA`, `CF_PAGES_COMMIT_SHA`, or `RENDER_GIT_COMMIT`.
 
-Environment is auto-detected from `MAPLE_ENVIRONMENT`, `RAILWAY_ENVIRONMENT`, `VERCEL_ENV`, or `NODE_ENV`.
+Environment is auto-detected from `MAPLE_ENVIRONMENT`, then `RAILWAY_ENVIRONMENT_NAME`, then `DEPLOYMENT_ENV`, falling back to `"development"`. On platforms outside that list (including Vercel), set `MAPLE_ENVIRONMENT` explicitly — `VERCEL_ENV` and `NODE_ENV` are not read.
 
 ## Cloudflare Workers
 
@@ -116,6 +122,7 @@ const TracerLive = Maple.layer({
 ```
 
 - **Bundle size:** the replay engine (rrweb included) loads through a dynamic import, so it lands in a code-split chunk (~360 kB) fetched only when replay is enabled _and_ the session is sampled. The base client bundle stays ~13 kB.
+- **Vendored dependency:** rrweb (MIT) is bundled into that chunk rather than declared in `dependencies`, so it will not appear in your lockfile or in `npm ls` output. Note it directly if your license or supply-chain audit enumerates transitive packages.
 - **Opt out** with `replay: { enabled: false }`. Unsampled or disabled sessions still appear in the Sessions UI (metadata rows + linked traces, no recording); turn that off too with `emitSessionMeta: false`.
 - **Tab lifecycle:** recording suspends on `visibilitychange → hidden` (flushing the tail with `keepalive`) and resumes when the tab becomes visible again, rotating to a fresh session after 30 minutes of inactivity.
 - **Identify users** at any point — the id is attached to the session's next-posted metadata row _and_ stamped as `user.id` on every span the client tracer creates from then on (traces become user-attributable, not just session-grouped). Spans created before you call it stay anonymous. Pass `null` or `undefined` after sign-out to make future telemetry anonymous again.
@@ -224,19 +231,31 @@ By default the client preset flushes on `pagehide` and `visibilitychange→hidde
 
 Both server and client layers accept these options:
 
-| Option                  | Required                                | Description                        |
-| ----------------------- | --------------------------------------- | ---------------------------------- |
-| `serviceName`           | Yes                                     | Service name reported in telemetry |
-| `endpoint`              | Server: env or config, Client: required | Maple ingest endpoint URL          |
-| `ingestKey`             | No                                      | Maple ingest key                   |
-| `serviceVersion`        | No                                      | Override auto-detected commit SHA  |
-| `environment`           | No                                      | Override auto-detected environment |
-| `attributes`            | No                                      | Additional resource attributes     |
-| `maxBatchSize`          | No                                      | Max batch size for export          |
-| `tracerExportInterval`  | No                                      | Trace export interval              |
-| `loggerExportInterval`  | No                                      | Log export interval                |
-| `metricsExportInterval` | No                                      | Metrics export interval            |
-| `shutdownTimeout`       | No                                      | Graceful shutdown timeout          |
+| Option                  | Required                                       | Description                                                   |
+| ----------------------- | ---------------------------------------------- | ------------------------------------------------------------- |
+| `serviceName`           | Yes                                            | Service name reported in telemetry                            |
+| `endpoint`              | No (server: defaults) / Yes (client)           | Maple ingest endpoint URL                                     |
+| `ingestKey`             | No — but the SDK no-ops without one            | Maple ingest key                                              |
+| `serviceVersion`        | No                                             | Override auto-detected commit SHA                             |
+| `serviceNamespace`      | No                                             | Logical group, emitted as `service.namespace`                 |
+| `repositoryUrl`         | No (server / Cloudflare only)                  | Repository URL, emitted as `vcs.repository.url.full`          |
+| `environment`           | No                                             | Override auto-detected environment                            |
+| `attributes`            | No                                             | Additional resource attributes (highest precedence)           |
+| `maxBatchSize`          | No                                             | Max batch size for export                                     |
+| `tracerExportInterval`  | No                                             | Trace export interval                                         |
+| `loggerExportInterval`  | No                                             | Log export interval                                           |
+| `metricsExportInterval` | No                                             | Metrics export interval                                       |
+| `shutdownTimeout`       | No                                             | Graceful shutdown timeout                                     |
+
+The flushable presets (`MapleFlush.make`, and the Cloudflare `make`) replace the
+four interval options with `autoFlushInterval`, and add `excludeLogSpans`,
+`dropSpanNames`, `anticipatedErrorIdentifiers`, `tracesPath`, `logsPath`, and
+`metricsPath`.
+
+> **`anticipatedErrorIdentifiers` is flushable/Cloudflare-only.** `Maple.layer`
+> builds on Effect's stock `Otlp.layerJson`, which has no hook for it — so with
+> the plain server layer, expected 4xx failures still export as `Error` spans.
+> Use `MapleFlush.make` if you need that suppression.
 
 Client-only options:
 

--- a/packages/effect-sdk/README.md
+++ b/packages/effect-sdk/README.md
@@ -10,9 +10,11 @@ npm install @maple-dev/effect-sdk effect
 
 ## Server
 
-Auto-detects commit SHA and deployment environment from common platform env vars (Railway, Vercel, Cloudflare Pages, Render). Returns a no-op layer when no ingest key is configured, making it safe for local development.
+Auto-detects commit SHA and deployment environment from common platform env vars (Railway, Vercel, Cloudflare Pages, Render).
 
-The endpoint is not the disable signal — it defaults to the public Maple ingest (`https://ingest.maple.dev`), so you only need to supply a key.
+`Maple.layer` always exports. The endpoint defaults to the public Maple ingest (`https://ingest.maple.dev`), so supplying an ingest key is usually all you need. A missing key does **not** switch export off — that keeps keyless setups working against a local `maple start` sink or your own OTLP collector. Keyless against the public ingest is the one combination that can't work (it 401s), and it logs a one-shot warning.
+
+> `MapleFlush.make` and the Cloudflare `make()` behave differently: they **do** no-op when no ingest key resolves. Reach for those if you want telemetry to disable itself automatically.
 
 ```typescript
 import { Maple } from "@maple-dev/effect-sdk/server"
@@ -29,7 +31,7 @@ Effect.runPromise(program.pipe(Effect.provide(TracerLive)))
 
 | Variable                      | Description                                                     |
 | ----------------------------- | --------------------------------------------------------------- |
-| `MAPLE_INGEST_KEY`            | Maple ingest key. **Without it the SDK is a no-op.**             |
+| `MAPLE_INGEST_KEY`            | Maple ingest key. Required by the public ingest                  |
 | `MAPLE_ENDPOINT`              | Ingest endpoint URL. Defaults to `https://ingest.maple.dev`      |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint fallback, honored when `MAPLE_ENDPOINT` is unset        |
 | `MAPLE_ENVIRONMENT`           | Deployment environment override                                  |
@@ -235,7 +237,7 @@ Both server and client layers accept these options:
 | ----------------------- | ---------------------------------------------- | ------------------------------------------------------------- |
 | `serviceName`           | Yes                                            | Service name reported in telemetry                            |
 | `endpoint`              | No (server: defaults) / Yes (client)           | Maple ingest endpoint URL                                     |
-| `ingestKey`             | No — but the SDK no-ops without one            | Maple ingest key                                              |
+| `ingestKey`             | Required by the public ingest                  | Maple ingest key. Flushable presets no-op without one         |
 | `serviceVersion`        | No                                             | Override auto-detected commit SHA                             |
 | `serviceNamespace`      | No                                             | Logical group, emitted as `service.namespace`                 |
 | `repositoryUrl`         | No (server / Cloudflare only)                  | Repository URL, emitted as `vcs.repository.url.full`          |

--- a/packages/effect-sdk/package.json
+++ b/packages/effect-sdk/package.json
@@ -2,12 +2,30 @@
 	"name": "@maple-dev/effect-sdk",
 	"version": "0.7.0",
 	"description": "Maple observability SDK for Effect applications",
+	"keywords": [
+		"effect",
+		"maple",
+		"observability",
+		"opentelemetry",
+		"otel",
+		"tracing"
+	],
+	"homepage": "https://maple.dev/docs/sdks/effect",
+	"bugs": {
+		"url": "https://github.com/MapleTechLabs/maple/issues"
+	},
 	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/MapleTechLabs/maple.git",
+		"directory": "packages/effect-sdk"
+	},
 	"files": [
 		"dist",
 		"README.md"
 	],
 	"type": "module",
+	"sideEffects": false,
 	"exports": {
 		".": {
 			"node": {
@@ -31,6 +49,9 @@
 			"types": "./dist/cloudflare/index.d.mts",
 			"import": "./dist/cloudflare/index.mjs"
 		}
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"scripts": {
 		"build": "tsdown",

--- a/packages/effect-sdk/src/client/flushable.ts
+++ b/packages/effect-sdk/src/client/flushable.ts
@@ -3,6 +3,8 @@
 // unlike sendBeacon it can carry the ingest key's Authorization header.
 
 import { hasConsent, onConsentChange } from "@maple/browser-session"
+import { makeNoOpNotice } from "../shared/no-op-notice.js"
+import { SDK_VERSION } from "../version.js"
 import { Layer, Redacted } from "effect"
 import {
 	buildResolved,
@@ -37,6 +39,11 @@ export interface MapleClientFlushableConfig {
 	readonly ingestKey?: string | undefined
 	/** Service version or commit SHA. */
 	readonly serviceVersion?: string | undefined
+	/**
+	 * Logical group this service belongs to, emitted as the OTel
+	 * `service.namespace` resource attribute. Optional — only stamped when set.
+	 */
+	readonly serviceNamespace?: string | undefined
 	/** Deployment environment (e.g. "production", "staging"). */
 	readonly environment?: string | undefined
 	/** Additional resource attributes (highest precedence). */
@@ -142,6 +149,7 @@ const buildBrowserAttributes = (config: MapleClientFlushableConfig): Record<stri
 		attributes["deployment.environment.name"] = config.environment
 	}
 	if (config.serviceVersion) attributes["deployment.commit_sha"] = config.serviceVersion
+	if (config.serviceNamespace) attributes["service.namespace"] = config.serviceNamespace
 	if (config.attributes) Object.assign(attributes, config.attributes)
 	return attributes
 }
@@ -203,40 +211,39 @@ export const make = (config: MapleClientFlushableConfig): FlushableTelemetry => 
 		tracesPath: config.tracesPath,
 		logsPath: config.logsPath,
 		metricsPath: config.metricsPath,
-		userAgent: "maple-effect-sdk-client/0.0.0",
+		userAgent: `maple-effect-sdk-client/${SDK_VERSION}`,
 	})
 
 	const tracesState: SignalState = { disabledUntil: 0 }
 	const logsState: SignalState = { disabledUntil: 0 }
 	const metricsState: SignalState = { disabledUntil: 0 }
-	let noOpLogged = false
+	const noOpNotice = makeNoOpNotice("[MapleClientSDK]", "pass `ingestKey` to enable")
 
+	// Never rejects — fired from `pagehide`/`visibilitychange` handlers and the
+	// auto-flush timer as `void flush()`.
 	const flush = makeSerializedFlush(async (): Promise<void> => {
-		if (!hasConsent()) {
-			spans.drain()
-			logs.drain()
-			metrics.drain()
-			return
+		try {
+			if (!hasConsent()) {
+				spans.drain()
+				logs.drain()
+				metrics.drain()
+				return
+			}
+			await runFlush({
+				resolved,
+				spans,
+				logs,
+				metrics,
+				tracesState,
+				logsState,
+				metricsState,
+				transport: keepaliveTransport,
+				logPrefix: "[MapleClientSDK]",
+				onNoOp: noOpNotice,
+			})
+		} catch (err) {
+			console.error("[MapleClientSDK] flush failed:", err)
 		}
-		await runFlush({
-			resolved,
-			spans,
-			logs,
-			metrics,
-			tracesState,
-			logsState,
-			metricsState,
-			transport: keepaliveTransport,
-			logPrefix: "[MapleClientSDK]",
-			onNoOp: () => {
-				if (!noOpLogged) {
-					noOpLogged = true
-					console.info(
-						"[MapleClientSDK] no ingest key configured — telemetry disabled (pass `ingestKey` to enable)",
-					)
-				}
-			},
-		})
 	})
 
 	const intervalMs =

--- a/packages/effect-sdk/src/cloudflare/index.test.ts
+++ b/packages/effect-sdk/src/cloudflare/index.test.ts
@@ -217,7 +217,8 @@ describe("MapleCloudflareSDK.make", () => {
 
 		expect(calls.length).toBe(0)
 		expect(consoleInfoSpy).toHaveBeenCalledTimes(1)
-		expect(consoleInfoSpy.mock.calls[0][0]).toContain("no MAPLE_INGEST_KEY configured")
+		expect(consoleInfoSpy.mock.calls[0][0]).toContain("no ingest key configured")
+		expect(consoleInfoSpy.mock.calls[0][0]).toContain("set MAPLE_INGEST_KEY to enable")
 
 		// A second flush within the same isolate should stay silent —
 		// the info log is one-shot.

--- a/packages/effect-sdk/src/cloudflare/index.ts
+++ b/packages/effect-sdk/src/cloudflare/index.ts
@@ -41,7 +41,9 @@ import {
 import { type LogBuffer, makeLogBuffer } from "../shared/flushable-logger.js"
 import { makeMetricBuffer } from "../shared/flushable-metrics.js"
 import { makeSpanBuffer, type SpanBuffer } from "../shared/flushable-tracer.js"
+import { makeNoOpNotice } from "../shared/no-op-notice.js"
 import { resolveResourceFromEnv } from "../server/resource.js"
+import { SDK_VERSION } from "../version.js"
 
 export interface Config {
 	/**
@@ -128,7 +130,7 @@ const resolveOnce = (env: Record<string, unknown>, config: Config): Resolved => 
 		tracesPath: config.tracesPath,
 		logsPath: config.logsPath,
 		metricsPath: config.metricsPath,
-		userAgent: "maple-effect-sdk-cloudflare/0.0.0",
+		userAgent: `maple-effect-sdk-cloudflare/${SDK_VERSION}`,
 	})
 }
 
@@ -152,37 +154,36 @@ export const make = (config: Config = {}): Telemetry => {
 	const metrics = makeMetricBuffer()
 
 	let resolved: Resolved | undefined = undefined
-	let noOpLogged = false
+	const noOpNotice = makeNoOpNotice("[MapleCloudflareSDK]", "set MAPLE_INGEST_KEY to enable")
 	const tracesState: SignalState = { disabledUntil: 0 }
 	const logsState: SignalState = { disabledUntil: 0 }
 	const metricsState: SignalState = { disabledUntil: 0 }
 
 	const layer = Layer.mergeAll(spans.tracerLayer, logs.loggerLayer, metrics.layer)
 
+	// Never rejects: this runs inside `ctx.waitUntil`, where a rejection would
+	// surface as an unhandled Worker error caused purely by telemetry.
 	const flush = makeSerializedFlush(async (env: Record<string, unknown>): Promise<void> => {
-		if (resolved === undefined) {
-			resolved = resolveOnce(env, config)
-		}
+		try {
+			if (resolved === undefined) {
+				resolved = resolveOnce(env, config)
+			}
 
-		await runFlush({
-			resolved,
-			spans,
-			logs,
-			metrics,
-			tracesState,
-			logsState,
-			metricsState,
-			transport: fetchTransport,
-			logPrefix: "[MapleCloudflareSDK]",
-			onNoOp: () => {
-				if (!noOpLogged) {
-					noOpLogged = true
-					console.info(
-						"[MapleCloudflareSDK] no MAPLE_INGEST_KEY configured — telemetry disabled (set MAPLE_INGEST_KEY to enable)",
-					)
-				}
-			},
-		})
+			await runFlush({
+				resolved,
+				spans,
+				logs,
+				metrics,
+				tracesState,
+				logsState,
+				metricsState,
+				transport: fetchTransport,
+				logPrefix: "[MapleCloudflareSDK]",
+				onNoOp: noOpNotice,
+			})
+		} catch (err) {
+			console.error("[MapleCloudflareSDK] flush failed:", err)
+		}
 	})
 
 	return { layer, flush }

--- a/packages/effect-sdk/src/index.types.ts
+++ b/packages/effect-sdk/src/index.types.ts
@@ -1,2 +1,0 @@
-export type { MapleConfig } from "./server/layer.js"
-export type { MapleClientConfig } from "./client/layer.js"

--- a/packages/effect-sdk/src/server/flushable-resolve-failure.test.ts
+++ b/packages/effect-sdk/src/server/flushable-resolve-failure.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { afterEach, expect, vi } from "vitest"
+import { make } from "./flushable.js"
+
+// Regression: a failed resource resolution used to be memoized as a rejected
+// promise, which disabled telemetry for the process lifetime AND turned the
+// auto-flush timer's `void flush()` into a recurring unhandled rejection (fatal
+// under `--unhandled-rejections=strict`).
+//
+// `resolveResource` is `Effect.orDie`, so any defect inside it becomes a
+// rejection. `crypto.randomUUID` is the realistic trigger — `resolveResource`
+// calls it for `service.instance.id`, and it is absent on older/exotic runtimes.
+//
+// Lives in its own file because the resolution memo and the `service.instance.id`
+// memo are both module-level: a sibling test that flushed successfully would
+// prime them and mask the bug.
+
+// This file is intentionally the only one exercising a failing resolve.
+describe("MapleFlush.make (server) — resource resolution failure", () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("does not reject, and retries on the next flush", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		const uuidSpy = vi.spyOn(globalThis.crypto, "randomUUID").mockImplementationOnce(() => {
+			throw new Error("randomUUID unavailable")
+		})
+
+		const calls: Array<string> = []
+		const originalFetch = globalThis.fetch
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			calls.push(typeof input === "string" ? input : input instanceof URL ? input.href : input.url)
+			return new Response(null, { status: 200 })
+		}) as typeof fetch
+
+		try {
+			const telemetry = make({
+				serviceName: "unit-test",
+				endpoint: "https://collector.test",
+				ingestKey: "secret",
+				autoFlushInterval: false,
+			})
+
+			await Effect.runPromise(
+				Effect.succeed(undefined).pipe(Effect.withSpan("op-1"), Effect.provide(telemetry.layer)),
+			)
+
+			// The contract is "never rejects" — an unhandled rejection here is the bug.
+			await expect(telemetry.flush()).resolves.toBeUndefined()
+			expect(calls).toEqual([])
+			expect(errorSpy).toHaveBeenCalled()
+
+			// The failure must not be cached: with `randomUUID` working again, the
+			// next flush resolves the resource and exports the retained span.
+			expect(uuidSpy).toHaveBeenCalledTimes(1)
+			await telemetry.flush()
+			expect(calls.some((url) => url.endsWith("/v1/traces"))).toBe(true)
+		} finally {
+			globalThis.fetch = originalFetch
+		}
+	})
+})

--- a/packages/effect-sdk/src/server/flushable.ts
+++ b/packages/effect-sdk/src/server/flushable.ts
@@ -27,6 +27,8 @@ import {
 import { type LogBuffer, makeLogBuffer } from "../shared/flushable-logger.js"
 import { makeMetricBuffer } from "../shared/flushable-metrics.js"
 import { makeSpanBuffer, type SpanBuffer } from "../shared/flushable-tracer.js"
+import { makeNoOpNotice } from "../shared/no-op-notice.js"
+import { SDK_VERSION } from "../version.js"
 import { resolveResource } from "./resource.js"
 
 /** Default auto-flush cadence (ms), matching `Otlp.layerJson`'s 5s export interval. */
@@ -119,49 +121,62 @@ export const make = (config: MapleFlushableConfig = {}): FlushableTelemetry => {
 	const tracesState: SignalState = { disabledUntil: 0 }
 	const logsState: SignalState = { disabledUntil: 0 }
 	const metricsState: SignalState = { disabledUntil: 0 }
-	let noOpLogged = false
+	const noOpNotice = makeNoOpNotice("[MapleServerSDK]", "set MAPLE_INGEST_KEY to enable")
 
 	// Resolve the resource once, lazily, on first flush. Memoize the PROMISE (not
 	// the result) so a manual flush racing the auto-flush timer can't kick off two
 	// `resolveResource` runs. `resolveResource` reads env via the default
 	// ConfigProvider, so this keeps commit-SHA/environment auto-detection without
 	// making `make()` async or reading env at module scope.
+	//
+	// The memo is cleared on rejection. `resolveResource` is `Effect.orDie`, so a
+	// defect (e.g. a runtime without `crypto.randomUUID`) surfaces as a rejected
+	// promise — caching that would disable telemetry for the process lifetime and
+	// turn the auto-flush timer into a recurring unhandled rejection. Dropping it
+	// lets the next flush retry.
 	let resolvedPromise: Promise<Resolved> | undefined
 	const ensureResolved = (): Promise<Resolved> => {
 		if (resolvedPromise === undefined) {
-			resolvedPromise = Effect.runPromise(resolveResource({ ...config, sdkType: "server" })).then((r) =>
+			const pending = Effect.runPromise(resolveResource({ ...config, sdkType: "server" })).then((r) =>
 				buildResolved(r, {
 					tracesPath: config.tracesPath,
 					logsPath: config.logsPath,
 					metricsPath: config.metricsPath,
-					userAgent: "maple-effect-sdk-server/0.0.0",
+					userAgent: `maple-effect-sdk-server/${SDK_VERSION}`,
 				}),
 			)
+			resolvedPromise = pending
+			pending.catch(() => {
+				if (resolvedPromise === pending) resolvedPromise = undefined
+			})
 		}
 		return resolvedPromise
 	}
 
+	// `flush` is documented to never reject: callers `await` it at shutdown and
+	// the auto-flush timer fires it as `void flush()`, where a rejection would be
+	// an unhandled rejection every tick (fatal under
+	// `--unhandled-rejections=strict`). `runFlush` already swallows per-signal
+	// transport errors; this catch covers resource resolution, which runs before
+	// it.
 	const flush = makeSerializedFlush(async (): Promise<void> => {
-		const resolved = await ensureResolved()
-		await runFlush({
-			resolved,
-			spans,
-			logs,
-			metrics,
-			tracesState,
-			logsState,
-			metricsState,
-			transport: fetchTransport,
-			logPrefix: "[MapleServerSDK]",
-			onNoOp: () => {
-				if (!noOpLogged) {
-					noOpLogged = true
-					console.info(
-						"[MapleServerSDK] no ingest key configured — telemetry disabled (set MAPLE_INGEST_KEY to enable)",
-					)
-				}
-			},
-		})
+		try {
+			const resolved = await ensureResolved()
+			await runFlush({
+				resolved,
+				spans,
+				logs,
+				metrics,
+				tracesState,
+				logsState,
+				metricsState,
+				transport: fetchTransport,
+				logPrefix: "[MapleServerSDK]",
+				onNoOp: noOpNotice,
+			})
+		} catch (err) {
+			console.error("[MapleServerSDK] flush failed:", err)
+		}
 	})
 
 	const intervalMs =

--- a/packages/effect-sdk/src/server/layer.test.ts
+++ b/packages/effect-sdk/src/server/layer.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+import { afterEach, expect, vi } from "vitest"
+import { layer } from "./layer.js"
+
+// `Maple.layer` had no tests, which is how the "no-op when no endpoint" guard
+// survived long after `resolveResource` started defaulting the endpoint — the
+// branch was unreachable and nothing noticed. These cover both sides of the
+// real disable rule: no ingest key resolved → no-op.
+
+const serviceKeys = async (config: Parameters<typeof layer>[0]): Promise<Array<string>> => {
+	const context = await Effect.runPromise(Effect.scoped(Layer.build(layer(config))))
+	// `CurrentMemoMap` is bookkeeping every `Layer.build` adds, including
+	// `Layer.empty`'s — it is not a service the layer contributed.
+	return [...context.mapUnsafe.keys()].filter((key) => key !== "effect/Layer/CurrentMemoMap")
+}
+
+describe("Maple.layer", () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("no-ops when no ingest key is configured", async () => {
+		const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {})
+		const fetchSpy = vi.spyOn(globalThis, "fetch")
+
+		const keys = await serviceKeys({ serviceName: "unit-test", endpoint: "https://collector.test" })
+
+		expect(keys).toEqual([])
+		expect(fetchSpy).not.toHaveBeenCalled()
+		// One-shot notice so a keyless local run says why it is silent.
+		expect(infoSpy.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+			"no ingest key configured",
+		)
+	})
+
+	it("installs tracer, logger, and exporter when an ingest key is configured", async () => {
+		const keys = await serviceKeys({
+			serviceName: "unit-test",
+			endpoint: "https://collector.test",
+			ingestKey: "secret",
+		})
+
+		expect(keys).toContain("effect/Tracer")
+		expect(keys).toContain("effect/Loggers/CurrentLoggers")
+		expect(keys).toContain("effect/observability/OtlpExporter/Flusher")
+	})
+
+	it("does not treat a missing endpoint as a disable signal", async () => {
+		// The endpoint always resolves (public ingest is the fallback), so a key
+		// with no endpoint must still produce a live layer.
+		const keys = await serviceKeys({ serviceName: "unit-test", ingestKey: "secret" })
+
+		expect(keys).toContain("effect/Tracer")
+	})
+})

--- a/packages/effect-sdk/src/server/layer.test.ts
+++ b/packages/effect-sdk/src/server/layer.test.ts
@@ -3,10 +3,11 @@ import { Effect, Layer } from "effect"
 import { afterEach, expect, vi } from "vitest"
 import { layer } from "./layer.js"
 
-// `Maple.layer` had no tests, which is how the "no-op when no endpoint" guard
-// survived long after `resolveResource` started defaulting the endpoint — the
-// branch was unreachable and nothing noticed. These cover both sides of the
-// real disable rule: no ingest key resolved → no-op.
+// `Maple.layer` had no tests, which is how a dead `if (!resolved.endpoint)`
+// guard survived long after `resolveResource` started defaulting the endpoint.
+// These pin the real contract: this layer ALWAYS exports. A missing ingest key
+// is not a disable signal — keyless export to a local `maple start` sink or a
+// self-hosted collector is supported, and silently no-op'ing would break it.
 
 const serviceKeys = async (config: Parameters<typeof layer>[0]): Promise<Array<string>> => {
 	const context = await Effect.runPromise(Effect.scoped(Layer.build(layer(config))))
@@ -18,20 +19,6 @@ const serviceKeys = async (config: Parameters<typeof layer>[0]): Promise<Array<s
 describe("Maple.layer", () => {
 	afterEach(() => {
 		vi.restoreAllMocks()
-	})
-
-	it("no-ops when no ingest key is configured", async () => {
-		const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {})
-		const fetchSpy = vi.spyOn(globalThis, "fetch")
-
-		const keys = await serviceKeys({ serviceName: "unit-test", endpoint: "https://collector.test" })
-
-		expect(keys).toEqual([])
-		expect(fetchSpy).not.toHaveBeenCalled()
-		// One-shot notice so a keyless local run says why it is silent.
-		expect(infoSpy.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
-			"no ingest key configured",
-		)
 	})
 
 	it("installs tracer, logger, and exporter when an ingest key is configured", async () => {
@@ -46,11 +33,26 @@ describe("Maple.layer", () => {
 		expect(keys).toContain("effect/observability/OtlpExporter/Flusher")
 	})
 
-	it("does not treat a missing endpoint as a disable signal", async () => {
-		// The endpoint always resolves (public ingest is the fallback), so a key
-		// with no endpoint must still produce a live layer.
-		const keys = await serviceKeys({ serviceName: "unit-test", ingestKey: "secret" })
+	it("still exports to a custom endpoint with no ingest key", async () => {
+		// The `examples/effect-todo` shape: local-mode sink, no key. Disabling
+		// this was a real regression, so it gets a test of its own.
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+		const keys = await serviceKeys({ serviceName: "unit-test", endpoint: "http://127.0.0.1:4318" })
 
 		expect(keys).toContain("effect/Tracer")
+		// A self-hosted collector taking unauthenticated writes is legitimate —
+		// no scolding.
+		expect(warnSpy).not.toHaveBeenCalled()
+	})
+
+	it("warns once when keyless against the public ingest, but still builds", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+		// No endpoint → defaults to the public ingest, which 401s without a key.
+		const keys = await serviceKeys({ serviceName: "unit-test" })
+
+		expect(keys).toContain("effect/Tracer")
+		expect(warnSpy.mock.calls.map((call) => String(call[0])).join("\n")).toContain("401")
 	})
 })

--- a/packages/effect-sdk/src/server/layer.ts
+++ b/packages/effect-sdk/src/server/layer.ts
@@ -2,10 +2,29 @@ import type { Duration } from "effect"
 import { Effect, Layer, Redacted } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { Otlp } from "effect/unstable/observability"
-import { makeNoOpNotice } from "../shared/no-op-notice.js"
-import { resolveResource } from "./resource.js"
+import { DEFAULT_MAPLE_ENDPOINT, type ResolvedResource, resolveResource } from "./resource.js"
 
-const noOpNotice = makeNoOpNotice("[MapleServerSDK]", "set MAPLE_INGEST_KEY to enable")
+/**
+ * Warn once about the one configuration that cannot work: no ingest key, and
+ * the endpoint left at the public Maple ingest, which rejects unauthenticated
+ * writes with a 401. Every other keyless setup — a local `maple start` sink, a
+ * self-hosted collector — is legitimate and stays silent.
+ *
+ * A warning rather than a no-op: disabling export here would silently break
+ * those keyless-to-custom-endpoint setups.
+ */
+let doomWarned = false
+const warnIfDoomed = (resolved: ResolvedResource): void => {
+	if (doomWarned) return
+	if (resolved.ingestKey !== undefined) return
+	if (resolved.endpoint !== DEFAULT_MAPLE_ENDPOINT) return
+	doomWarned = true
+	console.warn(
+		"[MapleServerSDK] exporting to the public Maple ingest without an ingest key — " +
+			"every request will be rejected with 401. Set MAPLE_INGEST_KEY, or point MAPLE_ENDPOINT " +
+			"at your own collector.",
+	)
+}
 
 export interface MapleConfig {
 	/**
@@ -56,11 +75,16 @@ export interface MapleConfig {
  * Auto-detects commit SHA and deployment environment from common platform
  * env vars (Railway, Vercel, Cloudflare Pages, Render).
  *
- * Returns a no-op layer when no ingest key resolves (neither `config.ingestKey`
- * nor `MAPLE_INGEST_KEY`), making it safe for local development — the same rule
- * the flushable and Cloudflare presets use. The endpoint is NOT the disable
- * signal: it always resolves, defaulting to the public Maple ingest so users
- * only have to supply a key.
+ * This layer **always exports** — there is no disable switch. The endpoint
+ * defaults to the public Maple ingest, and a missing ingest key does not turn
+ * export off, so a keyless app pointed at a local `maple start` sink or a
+ * self-hosted collector still ships telemetry. Keyless against the public
+ * ingest is the one futile combination and logs a one-shot warning.
+ *
+ * Note the contrast with `MapleFlush.make` and the Cloudflare `make`, which DO
+ * no-op without an ingest key. If you want telemetry to switch itself off in
+ * local dev, use one of those, or leave `MAPLE_ENDPOINT` pointed at a sink you
+ * control.
  *
  * For Cloudflare Workers, prefer `@maple-dev/effect-sdk/cloudflare`'s `make()`
  * — it has no background fiber and exposes an explicit `flush` Effect that
@@ -83,15 +107,19 @@ export const layer = (config: MapleConfig = {}) =>
 	Layer.unwrap(
 		Effect.gen(function* () {
 			const resolved = yield* resolveResource({ ...config, sdkType: "server" })
-			if (!resolved.ingestKey) {
-				noOpNotice()
-				return Layer.empty
-			}
+			// Always export. A missing ingest key is NOT a disable signal here:
+			// pointing a keyless app at a local `maple start` sink or a self-hosted
+			// OTLP collector is a supported setup, and those accept unauthenticated
+			// writes. Only the keyless-to-public-ingest combination is futile, and
+			// that one gets a warning rather than silence — see `warnIfDoomed`.
+			warnIfDoomed(resolved)
 
 			return Otlp.layerJson({
 				baseUrl: resolved.endpoint,
 				resource: resolved.resource,
-				headers: { Authorization: `Bearer ${Redacted.value(resolved.ingestKey)}` },
+				headers: resolved.ingestKey
+					? { Authorization: `Bearer ${Redacted.value(resolved.ingestKey)}` }
+					: undefined,
 				maxBatchSize: config.maxBatchSize,
 				loggerExportInterval: config.loggerExportInterval,
 				metricsExportInterval: config.metricsExportInterval,

--- a/packages/effect-sdk/src/server/layer.ts
+++ b/packages/effect-sdk/src/server/layer.ts
@@ -2,12 +2,15 @@ import type { Duration } from "effect"
 import { Effect, Layer, Redacted } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { Otlp } from "effect/unstable/observability"
+import { makeNoOpNotice } from "../shared/no-op-notice.js"
 import { resolveResource } from "./resource.js"
+
+const noOpNotice = makeNoOpNotice("[MapleServerSDK]", "set MAPLE_INGEST_KEY to enable")
 
 export interface MapleConfig {
 	/**
 	 * Service name reported in traces, logs, and metrics. When omitted, falls
-	 * back to `OTEL_SERVICE_NAME` env var, then `"unknown_service"`.
+	 * back to `OTEL_SERVICE_NAME` env var, then `"unknown"`.
 	 */
 	readonly serviceName?: string | undefined
 	/** Override auto-detected service version (commit SHA). */
@@ -51,8 +54,13 @@ export interface MapleConfig {
  * configured for Maple.
  *
  * Auto-detects commit SHA and deployment environment from common platform
- * env vars (Railway, Vercel, Cloudflare Pages, Render). Returns a no-op layer
- * when no endpoint is configured, making it safe for local development.
+ * env vars (Railway, Vercel, Cloudflare Pages, Render).
+ *
+ * Returns a no-op layer when no ingest key resolves (neither `config.ingestKey`
+ * nor `MAPLE_INGEST_KEY`), making it safe for local development — the same rule
+ * the flushable and Cloudflare presets use. The endpoint is NOT the disable
+ * signal: it always resolves, defaulting to the public Maple ingest so users
+ * only have to supply a key.
  *
  * For Cloudflare Workers, prefer `@maple-dev/effect-sdk/cloudflare`'s `make()`
  * — it has no background fiber and exposes an explicit `flush` Effect that
@@ -75,14 +83,15 @@ export const layer = (config: MapleConfig = {}) =>
 	Layer.unwrap(
 		Effect.gen(function* () {
 			const resolved = yield* resolveResource({ ...config, sdkType: "server" })
-			if (!resolved.endpoint) return Layer.empty
+			if (!resolved.ingestKey) {
+				noOpNotice()
+				return Layer.empty
+			}
 
 			return Otlp.layerJson({
 				baseUrl: resolved.endpoint,
 				resource: resolved.resource,
-				headers: resolved.ingestKey
-					? { Authorization: `Bearer ${Redacted.value(resolved.ingestKey)}` }
-					: undefined,
+				headers: { Authorization: `Bearer ${Redacted.value(resolved.ingestKey)}` },
 				maxBatchSize: config.maxBatchSize,
 				loggerExportInterval: config.loggerExportInterval,
 				metricsExportInterval: config.metricsExportInterval,

--- a/packages/effect-sdk/src/server/resource.ts
+++ b/packages/effect-sdk/src/server/resource.ts
@@ -8,7 +8,7 @@ import { getAutoPlatformAttributes } from "./platform.js"
  * `OTEL_EXPORTER_OTLP_ENDPOINT` — so end users only need to supply an ingest
  * key, not an URL.
  */
-const DEFAULT_MAPLE_ENDPOINT = "https://ingest.maple.dev"
+export const DEFAULT_MAPLE_ENDPOINT = "https://ingest.maple.dev"
 
 const stringOrUndefined = (value: unknown): string | undefined =>
 	typeof value === "string" && value.length > 0 ? value : undefined

--- a/packages/effect-sdk/src/server/resource.ts
+++ b/packages/effect-sdk/src/server/resource.ts
@@ -66,7 +66,12 @@ const isCommitSha = (value: string | undefined): value is string =>
 	value !== undefined && /^[0-9a-f]{7,40}$/i.test(value)
 
 export interface ResolvedResource {
-	readonly endpoint: string | undefined
+	/**
+	 * Always resolves — `DEFAULT_MAPLE_ENDPOINT` is the final fallback, so this
+	 * is deliberately NOT optional. Presets disable themselves on a missing
+	 * ingest key, never on a missing endpoint.
+	 */
+	readonly endpoint: string
 	readonly ingestKey: Redacted.Redacted<string> | undefined
 	readonly resource: {
 		readonly serviceName: string

--- a/packages/effect-sdk/src/shared/no-op-notice.ts
+++ b/packages/effect-sdk/src/shared/no-op-notice.ts
@@ -1,0 +1,17 @@
+// One-shot "telemetry disabled" notice.
+//
+// All three presets (server layer, server/client flushable, Cloudflare) disable
+// themselves on the same condition — no ingest key resolved — and each needs to
+// say so exactly once, so a developer running locally sees why nothing arrives
+// instead of silently believing telemetry works. Sharing the wording keeps that
+// message identical across presets; only the enable hint differs, because the
+// key comes from env on the server and from config in the browser.
+
+export const makeNoOpNotice = (logPrefix: string, enableHint: string): (() => void) => {
+	let logged = false
+	return () => {
+		if (logged) return
+		logged = true
+		console.info(`${logPrefix} no ingest key configured — telemetry disabled (${enableHint})`)
+	}
+}

--- a/packages/effect-sdk/src/version.test.ts
+++ b/packages/effect-sdk/src/version.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest"
+import pkg from "../package.json" with { type: "json" }
+import { SDK_VERSION } from "./version.js"
+
+describe("SDK_VERSION", () => {
+	it("matches package.json — bump both or neither", () => {
+		expect(SDK_VERSION).toBe(pkg.version)
+	})
+})

--- a/packages/effect-sdk/src/version.ts
+++ b/packages/effect-sdk/src/version.ts
@@ -1,0 +1,9 @@
+// Published SDK version, stamped into the OTLP export `user-agent` so ingest
+// can tell SDK versions apart — which is how we find out whether a fix actually
+// reached users.
+//
+// A literal rather than a `package.json` import: the client entry ships to
+// browsers, and a JSON import would force every consuming bundler to handle
+// JSON modules. `version.test.ts` asserts this stays in sync with
+// `package.json`, so a hand-bump that forgets it fails CI instead of shipping.
+export const SDK_VERSION = "0.7.0"

--- a/packages/effect-sdk/tsconfig.json
+++ b/packages/effect-sdk/tsconfig.json
@@ -6,6 +6,10 @@
 		"lib": ["ES2022", "DOM"],
 		"moduleResolution": "bundler",
 		"verbatimModuleSyntax": true,
+		// For `version.test.ts`'s package.json import only. Node's `types` are
+		// deliberately NOT enabled here: this package also ships to browsers, and
+		// typing node builtins would let them leak into the client entry unnoticed.
+		"resolveJsonModule": true,
 		"noEmit": true,
 		"skipLibCheck": true,
 		"strict": true,

--- a/packages/effect-sdk/tsdown.config.ts
+++ b/packages/effect-sdk/tsdown.config.ts
@@ -4,7 +4,6 @@ export default defineConfig({
 	entry: {
 		"index.server": "./src/index.server.ts",
 		"index.client": "./src/index.client.ts",
-		"index.types": "./src/index.types.ts",
 		"server/index": "./src/server/index.ts",
 		"client/index": "./src/client/index.ts",
 		"cloudflare/index": "./src/cloudflare/index.ts",

--- a/skills/maple-effect-style/SKILL.md
+++ b/skills/maple-effect-style/SKILL.md
@@ -47,42 +47,44 @@ Effect.runPromise(program.pipe(Effect.provide(TracerLive)))
 
 The default import resolves to the server build under Node.js. Import `@maple-dev/effect-sdk/server` explicitly when needed.
 
-If `endpoint` is omitted, the server layer auto-detects it from `MAPLE_ENDPOINT` (falling back to `OTEL_EXPORTER_OTLP_ENDPOINT`). When `MAPLE_ENDPOINT` is unset, the layer is a no-op — local dev runs without exporting. Inline the endpoint when you want telemetry to flow regardless of env (matches the rest of the maple-onboard inline-key pattern).
+If `endpoint` is omitted, the server layer auto-detects it from `MAPLE_ENDPOINT` (falling back to `OTEL_EXPORTER_OTLP_ENDPOINT`, then the public Maple ingest). The **ingest key** is what gates export: when neither `ingestKey` nor `MAPLE_INGEST_KEY` resolves, the layer is a no-op and local dev runs without exporting. Inline the key when you want telemetry to flow regardless of env (matches the rest of the maple-onboard inline-key pattern).
 
-The server layer also auto-fills `vcs.ref.head.revision` from `COMMIT_SHA` / `RAILWAY_GIT_COMMIT_SHA` / `VERCEL_GIT_COMMIT_SHA` / `CF_PAGES_COMMIT_SHA` / `RENDER_GIT_COMMIT` (first match wins). You should still set `vcs.repository.url.full` in `attributes` since no env var carries it.
+The server layer also auto-fills `vcs.ref.head.revision` from `COMMIT_SHA` / `RAILWAY_GIT_COMMIT_SHA` / `VERCEL_GIT_COMMIT_SHA` / `CF_PAGES_COMMIT_SHA` / `RENDER_GIT_COMMIT` (first match wins). For `vcs.repository.url.full`, use the `repositoryUrl` option or `MAPLE_REPOSITORY_URL` — don't hand-write the attribute.
 
 ### Cloudflare Workers
 
+The Cloudflare entry point exports `make()`, not a `Maple` namespace. Build the telemetry object **once at module scope** — it buffers in-isolate and resolves `env` lazily on the first flush:
+
 ```ts
-import { Maple } from "@maple-dev/effect-sdk/cloudflare"
+import * as MapleCloudflareSDK from "@maple-dev/effect-sdk/cloudflare"
 import { Effect } from "effect"
+
+const telemetry = MapleCloudflareSDK.make({
+	serviceName: "orders-edge",
+	endpoint: "https://ingest.maple.dev",
+	ingestKey: "MAPLE_TEST",
+})
 
 export default {
 	async fetch(req: Request, env: Env, ctx: ExecutionContext) {
-		const TracerLive = Maple.layer({
-			serviceName: "orders-edge",
-			endpoint: "https://ingest.maple.dev",
-			ingestKey: "MAPLE_TEST",
-		})
-
 		const program = Effect.gen(function* () {
 			yield* Effect.log("edge request")
 			return new Response("ok")
 		}).pipe(Effect.withSpan("edge.handle"))
 
-		const response = await Effect.runPromise(program.pipe(Effect.provide(TracerLive)))
-		ctx.waitUntil(Maple.flush())
+		const response = await Effect.runPromise(program.pipe(Effect.provide(telemetry.layer)))
+		ctx.waitUntil(telemetry.flush(env))
 		return response
 	},
 }
 ```
 
-The Cloudflare entry point requires `ctx.waitUntil(Maple.flush())` so telemetry survives the isolate exit. Forgetting this is the most common reason traces don't show up from Workers.
+The Cloudflare entry point requires `ctx.waitUntil(telemetry.flush(env))` so telemetry survives the isolate exit — note `flush` takes `env`. Forgetting the `waitUntil` is the most common reason traces don't show up from Workers.
 
 ### Browser
 
 ```ts
-import { Maple } from "@maple-dev/effect-sdk/browser"
+import { Maple } from "@maple-dev/effect-sdk/client"
 
 const TracerLive = Maple.layer({
 	serviceName: "web-client",

--- a/skills/maple-effect-style/SKILL.md
+++ b/skills/maple-effect-style/SKILL.md
@@ -47,7 +47,7 @@ Effect.runPromise(program.pipe(Effect.provide(TracerLive)))
 
 The default import resolves to the server build under Node.js. Import `@maple-dev/effect-sdk/server` explicitly when needed.
 
-If `endpoint` is omitted, the server layer auto-detects it from `MAPLE_ENDPOINT` (falling back to `OTEL_EXPORTER_OTLP_ENDPOINT`, then the public Maple ingest). The **ingest key** is what gates export: when neither `ingestKey` nor `MAPLE_INGEST_KEY` resolves, the layer is a no-op and local dev runs without exporting. Inline the key when you want telemetry to flow regardless of env (matches the rest of the maple-onboard inline-key pattern).
+If `endpoint` is omitted, the server layer auto-detects it from `MAPLE_ENDPOINT` (falling back to `OTEL_EXPORTER_OTLP_ENDPOINT`, then the public Maple ingest). `Maple.layer` always exports — a missing ingest key does not disable it, which is what keeps keyless local-mode and self-hosted-collector setups working. Inline the key when you want telemetry to flow regardless of env (matches the rest of the maple-onboard inline-key pattern). `MapleFlush.make` and the Cloudflare `make()` differ: those no-op without a key.
 
 The server layer also auto-fills `vcs.ref.head.revision` from `COMMIT_SHA` / `RAILWAY_GIT_COMMIT_SHA` / `VERCEL_GIT_COMMIT_SHA` / `CF_PAGES_COMMIT_SHA` / `RENDER_GIT_COMMIT` (first match wins). For `vcs.repository.url.full`, use the `repositoryUrl` option or `MAPLE_REPOSITORY_URL` — don't hand-write the attribute.
 


### PR DESCRIPTION
Review pass over `@maple-dev/effect-sdk` — the one artifact in this repo that ships to end users — plus fixes for what it turned up.

The internals held up well: the three presets share a well-factored core, the OTel conventions are followed correctly (`maple.*` namespace, `deployment.environment` dual-emit, 4xx→`Ok` mirroring the ingest gateway), coverage is real, and there are no TODOs and exactly one deliberate `any`. Everything below sits at the **edges users touch** — the flush contract, the docs, the package metadata. That's the worst place for it, because internal usage masks all of it: nobody here reads the published README.

> **Note on the history:** the first commit made `Maple.layer` no-op without an ingest key. That was reverted in the second commit — it was a real breaking change, and the casualty wasn't keyless-to-prod but **keyless export to a self-hosted or local collector**, which works today. `examples/effect-todo` is exactly that shape (explicit `http://127.0.0.1:4318` sink, no key) and the no-op silently disabled it. Net behavior of this PR on that path: **unchanged**.

## Correctness

**`flush()` could reject forever.** The server preset memoized the resolution *promise*, so a single rejection was cached for the process lifetime **and** the 5s timer's `void flush()` became a recurring unhandled rejection — fatal under `--unhandled-rejections=strict`, and contradicting the "Never rejects" contract the code states twice. `resolveResource` is `Effect.orDie`, so any defect inside it (a runtime without `crypto.randomUUID`, say) triggers this. The memo now clears on rejection; all three presets catch-and-log. The regression test was confirmed to fail against the unfixed code rather than pass vacuously.

**A dead disable branch, and the type that hid it.** `if (!resolved.endpoint) return Layer.empty` was unreachable — `resolveResource` always defaults the endpoint to the public ingest — while the README, the jsdoc, and three doc pages all still promised that no-op. The dead branch is removed and `ResolvedResource.endpoint` is tightened to `string`, since the `| undefined` is what made it look reachable. Export behavior is unchanged.

**Keyless against the public ingest now warns.** That one combination can't work (the gateway 401s unauthenticated writes — `apps/ingest/src/main.rs:5405`), and previously it failed silently, which reads as "working". It logs one warning naming both fixes. Every other keyless setup — local sink, self-hosted collector — stays silent and keeps exporting.

## Also

- **User-agent said `0.0.0`** at all three call sites while the package is 0.7.0, so SDK versions were indistinguishable in ingest logs. Now `SDK_VERSION`, pinned to `package.json` by a test so a hand-bump can't drift.
- **Docs** (6 errors): the environment chain advertised `VERCEL_ENV`/`NODE_ENV`, which the code never reads — a Vercel user following it silently lands in `development`; the Cloudflare snippet used `Maple.layer`/`Maple.flush()`, neither of which exists (it could not compile); `/browser` isn't an export; `sdks/overview.md` claimed a no-op-without-endpoint that was never true; missing config options; and the fact that 4xx suppression is flushable/Cloudflare-only was documented nowhere. Docs now also state the real preset asymmetry — `Maple.layer` always exports, while `MapleFlush.make` and the Cloudflare `make()` no-op without a key.
- **`serviceNamespace`** added to the client flushable config — `apps/web` was routing it through `attributes` to work around the gap.
- **Package metadata**: `sideEffects: false` (verified honest — no module-scope side effects), `publishConfig.access`, repo/homepage/bugs links; dropped the dead `index.types` entry and a redundant `.npmignore`.

## Reviewer notes

`Maple.layer` **had zero tests** — that's how the dead branch survived. This adds the first ones, including a test pinning the keyless-to-custom-endpoint path so it can't be disabled again by accident.

## Verification

98 tests pass (14 files, 5 new), typecheck and build clean, and all six internal consumers (`api`, `web`, `alerting`, `electric-sync`, `cli`, `scraper`) typecheck. All three export paths were checked end-to-end against a stubbed fetch: keyless→local sink exports and stays quiet, keyless→public ingest exports and warns, key→endpoint unchanged. Doc edits were cross-checked by grepping every claimed env var against `server/config.ts`; the corrected Cloudflare snippet matches the live, type-checked call site in `apps/electric-sync/src/worker.ts`.

## Out of scope, flagged

**There is no publish pipeline** — no changeset, no release workflow, no `effect-sdk-v*` tags. `version` is hand-bumped and shipped by a manual local `npm publish`. Related: the `@effect-v3` dist-tag advertised in the docs and the in-product onboarding snippet has no mechanism in this repo that produces it, so that install command may not resolve. Both are real but are their own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)