### PR TITLE
feat(dashboards): render shared boards through the real canvas

### DIFF
--- a/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.test.tsx
+++ b/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.test.tsx
@@ -63,6 +63,31 @@ describe("SharedWidgetRenderer", () => {
 	// — so mounting one here would put edit affordances and links into authed
 	// routes on a page served without a session. This is the guard against
 	// someone later "fixing" the missing provider.
+	// The server returns rows and the stored transform is what collapses them.
+	// It reaches the client precisely because the redaction seam keeps it, so a
+	// share that never applies it renders every stat as an em dash — which is
+	// what shipped. Asserted on the rendered number, not on the call, because
+	// the em dash is the symptom a reader actually sees.
+	it("applies the stored transform, so a stat reduces to a single value", () => {
+		const stat: ShareWidget = {
+			...widget("w-stat"),
+			dataSource: { kind: "query", transform: { reduceToValue: { field: "hits", aggregate: "sum" } } },
+		}
+
+		render(
+			<ShareWidgetStatesProvider
+				states={{
+					"w-stat": { status: "ready", data: [{ hits: 40 }, { hits: 2 }] },
+				}}
+			>
+				<SharedWidgetRenderer widget={stat} />
+			</ShareWidgetStatesProvider>,
+		)
+
+		expect(screen.getByText("42")).toBeTruthy()
+		expect(screen.queryByText("—")).toBeNull()
+	})
+
 	it("exposes no widget actions at all", () => {
 		render(
 			<ShareWidgetStatesProvider states={{}}>

--- a/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.test.tsx
+++ b/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+/**
+ * The two properties that let a dashboard render on a page with no session.
+ *
+ * Both are seams rather than features, and both fail silently if broken — a
+ * thrown context error only on the share route, or an edit menu quietly
+ * appearing on a public link — so they are asserted here rather than left to a
+ * manual pass over the shared page.
+ */
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, beforeAll, describe, expect, it } from "vitest"
+import { vi } from "vitest"
+
+import { DashboardGrid } from "@/components/dashboard-builder/canvas/dashboard-canvas"
+import { GRID_TIERS } from "@/components/dashboard-builder/canvas/grid-breakpoints"
+import { ShareWidgetStatesProvider, SharedWidgetRenderer } from "@/components/share/shared-widget-renderer"
+import type { ShareWidget } from "@/hooks/use-share-dashboard"
+
+beforeAll(() => {
+	class noop {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	}
+	vi.stubGlobal("ResizeObserver", noop)
+})
+
+afterEach(cleanup)
+
+const widget = (id: string): ShareWidget => ({
+	id,
+	visualization: "stat",
+	display: { title: "Requests" },
+	layout: { x: 0, y: 0, w: 6, h: 4 },
+	dataSource: { kind: "query" },
+})
+
+describe("DashboardGrid outside a dashboard", () => {
+	// The share page and the full-screen board have no mutation store, so
+	// `DashboardActionsProvider` is never mounted above them. Before the optional
+	// read this threw on render and took the whole route with it.
+	it("renders with no DashboardActionsProvider above it", () => {
+		expect(() =>
+			render(
+				<ShareWidgetStatesProvider states={{}}>
+					<DashboardGrid
+						widgets={[widget("w-1")]}
+						width={1200}
+						tier={GRID_TIERS[0]}
+						editable={false}
+						renderWidget={SharedWidgetRenderer}
+					/>
+				</ShareWidgetStatesProvider>,
+			),
+		).not.toThrow()
+	})
+})
+
+describe("SharedWidgetRenderer", () => {
+	// `WidgetActionsProvider` always defines `remove` and offers `createAlert`,
+	// and `WidgetShell` shows its menu in view mode whenever `createAlert` exists
+	// — so mounting one here would put edit affordances and links into authed
+	// routes on a page served without a session. This is the guard against
+	// someone later "fixing" the missing provider.
+	it("exposes no widget actions at all", () => {
+		render(
+			<ShareWidgetStatesProvider states={{}}>
+				<SharedWidgetRenderer widget={widget("w-1")} />
+			</ShareWidgetStatesProvider>,
+		)
+
+		expect(screen.queryByRole("button")).toBeNull()
+		expect(screen.queryByText(/create alert/i)).toBeNull()
+		expect(screen.queryByText(/remove/i)).toBeNull()
+	})
+})

--- a/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.tsx
+++ b/apps/web/src/components/dashboard-builder/canvas/dashboard-canvas.tsx
@@ -1,5 +1,5 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { dataSourceTransform } from "@maple/widgets/dashboard"
+import { useCallback, useMemo, type ComponentType } from "react"
+import type { SectionMembership } from "@maple/widgets/dashboard"
 import { GridLayout, noCompactor, verticalCompactor } from "react-grid-layout"
 import type { Layout } from "react-grid-layout"
 import "react-grid-layout/css/styles.css"
@@ -8,13 +8,9 @@ import {
 	GRID_ROW_HEIGHT,
 	projectLayout,
 	type GridTier,
+	type PlacedWidget,
 } from "@/components/dashboard-builder/canvas/grid-breakpoints"
-import type { DashboardWidget } from "@/components/dashboard-builder/types"
-import { useDashboardActions } from "@/components/dashboard-builder/dashboard-actions-context"
-import { WidgetActionsProvider } from "@/components/dashboard-builder/widgets/widget-actions-context"
-import { WidgetTimeRangeProvider } from "@/components/dashboard-builder/widgets/widget-time-range-context"
-import { visualizationFor } from "@/components/dashboard-builder/widgets/types"
-import { useWidgetData } from "@/hooks/use-widget-data"
+import { useDashboardActionsOptional } from "@/components/dashboard-builder/dashboard-actions-context"
 
 /** Same widgets in the same boxes, ignoring order. */
 function sameLayout(a: Layout, b: Layout): boolean {
@@ -32,83 +28,31 @@ function sameLayout(a: Layout, b: Layout): boolean {
 	})
 }
 
+/** What the canvas needs of a widget: somewhere to put it, and which group it's in. */
+export interface CanvasWidget extends PlacedWidget, SectionMembership {}
+
 /**
- * Latches `true` the first time the element scrolls into (near) the viewport,
- * then stays latched. Tiles fetch their data lazily on first reveal and keep it
- * — unlatching would unmount the tile's atom, and a non-sticky flag would then
- * refetch every time it scrolled back into view. The 200ms debounce absorbs
- * react-grid-layout's mount-time reflow, where tiles can briefly flash into
- * view before the layout settles.
+ * How one widget draws itself.
+ *
+ * A component type rather than a `(widget) => ReactNode` callback: renderers
+ * call hooks, and a function prop invoked inline would splice them into the
+ * grid child's hook slot. Mirrors `visualizationFor`, which already returns a
+ * component.
  */
-function useInViewportSticky() {
-	const ref = useRef<HTMLDivElement>(null)
-	const [visible, setVisible] = useState(false)
+export type WidgetRendererComponent<W> = ComponentType<{ widget: W }>
 
-	useEffect(() => {
-		if (visible) return
-		const element = ref.current
-		if (!element) return
-		if (typeof IntersectionObserver === "undefined") {
-			setVisible(true)
-			return
-		}
-
-		let timer: ReturnType<typeof setTimeout> | undefined
-		const observer = new IntersectionObserver(
-			(entries) => {
-				const isIntersecting = entries.some((entry) => entry.isIntersecting)
-				if (isIntersecting && timer == null) {
-					timer = setTimeout(() => setVisible(true), 200)
-				} else if (!isIntersecting && timer != null) {
-					clearTimeout(timer)
-					timer = undefined
-				}
-			},
-			{ rootMargin: "200px" },
-		)
-		observer.observe(element)
-		return () => {
-			if (timer != null) clearTimeout(timer)
-			observer.disconnect()
-		}
-	}, [visible])
-
-	return { ref, visible }
-}
-
-const WidgetRenderer = memo(function WidgetRenderer({ widget }: { widget: DashboardWidget }) {
-	const { mode } = useDashboardActions()
-	const { ref, visible } = useInViewportSticky()
-	const { dataState, narrowRange, narrowRangeLabel } = useWidgetData(widget, visible)
-	const Visualization = visualizationFor(widget.visualization)
-
-	return (
-		<div ref={ref} className="h-full w-full">
-			<WidgetTimeRangeProvider timeRange={widget.timeRange}>
-				<WidgetActionsProvider
-					widget={widget}
-					dataState={dataState}
-					narrowRange={narrowRange}
-					narrowRangeLabel={narrowRangeLabel}
-				>
-					<Visualization
-						dataState={dataState}
-						display={widget.display}
-						mode={mode}
-						rowLimit={dataSourceTransform(widget.dataSource)?.limit}
-					/>
-				</WidgetActionsProvider>
-			</WidgetTimeRangeProvider>
-		</div>
-	)
-})
-
-interface DashboardGridProps {
-	widgets: DashboardWidget[]
+interface DashboardGridProps<W extends CanvasWidget> {
+	widgets: ReadonlyArray<W>
 	/** Measured container width in px. The caller owns measurement. */
 	width: number
 	tier: GridTier
 	editable: boolean
+	/**
+	 * Required, never defaulted: a default cannot type-check against an
+	 * arbitrary `W`, and naming the renderer at each mount point is what stops a
+	 * read-only surface silently inheriting the authed data path.
+	 */
+	renderWidget: WidgetRendererComponent<W>
 }
 
 /**
@@ -121,9 +65,21 @@ interface DashboardGridProps {
  *
  * Every widget's `layout.x/y` is relative to *this* grid, so each instance is an
  * independent coordinate space starting at (0, 0).
+ *
+ * Generic over the widget because the read-only surfaces render a redacted
+ * widget whose data source cannot inhabit the stored union. The type parameter
+ * carries that difference; nothing here needs a cast.
  */
-export function DashboardGrid({ widgets, width, tier, editable }: DashboardGridProps) {
-	const { updateWidgetLayouts } = useDashboardActions()
+export function DashboardGrid<W extends CanvasWidget>({
+	widgets,
+	width,
+	tier,
+	editable,
+	renderWidget: Renderer,
+}: DashboardGridProps<W>) {
+	// Optional: a share link and a full-screen board mount this grid with no
+	// store behind them. They are never editable, so there is nothing to persist.
+	const actions = useDashboardActionsOptional()
 
 	const layout = useMemo(() => projectLayout(widgets, tier), [widgets, tier])
 
@@ -143,9 +99,9 @@ export function DashboardGrid({ widgets, width, tier, editable }: DashboardGridP
 		(next: Layout) => {
 			if (!editable) return
 			if (sameLayout(next, layout)) return
-			updateWidgetLayouts(next.map((l) => ({ i: l.i, x: l.x, y: l.y, w: l.w, h: l.h })))
+			actions?.updateWidgetLayouts(next.map((l) => ({ i: l.i, x: l.x, y: l.y, w: l.w, h: l.h })))
 		},
-		[editable, layout, updateWidgetLayouts],
+		[editable, layout, actions],
 	)
 
 	return (
@@ -175,7 +131,7 @@ export function DashboardGrid({ widgets, width, tier, editable }: DashboardGridP
 		>
 			{widgets.map((widget) => (
 				<div key={widget.id}>
-					<WidgetRenderer widget={widget} />
+					<Renderer widget={widget} />
 				</div>
 			))}
 		</GridLayout>

--- a/apps/web/src/components/dashboard-builder/canvas/grid-breakpoints.test.ts
+++ b/apps/web/src/components/dashboard-builder/canvas/grid-breakpoints.test.ts
@@ -5,17 +5,14 @@ import {
 	GRID_TIERS,
 	projectLayout,
 	tierForWidth,
+	type PlacedWidget,
 } from "@/components/dashboard-builder/canvas/grid-breakpoints"
-import type { DashboardWidget } from "@/components/dashboard-builder/types"
 
-function widget(id: string, x: number, y: number, w: number, h: number): DashboardWidget {
-	return {
-		id,
-		visualization: "stat",
-		dataSource: {},
-		display: {},
-		layout: { x, y, w, h },
-	} as DashboardWidget
+// No cast: placement reads `id` and `layout`, and nothing else. That is the
+// whole reason a redacted share widget can go through the same projection as a
+// stored one.
+function widget(id: string, x: number, y: number, w: number, h: number): PlacedWidget {
+	return { id, layout: { x, y, w, h } }
 }
 
 /** A realistic authored dashboard: a row of stats over charts over a wide table. */
@@ -147,5 +144,22 @@ describe("projectLayout", () => {
 
 	it("returns an empty layout for a dashboard with no widgets", () => {
 		expect(projectLayout([], GRID_TIERS[2])).toEqual([])
+	})
+})
+
+describe("PlacedWidget", () => {
+	// Guards the seam rather than the maths: re-widening the parameter back to a
+	// full `DashboardWidget` would break every read-only surface, and it would
+	// break here first.
+	it("projects a widget carrying nothing but an id and a layout", () => {
+		const redactedWidgets = [
+			{ id: "a", layout: { x: 0, y: 0, w: 6, h: 4 } },
+			{ id: "b", layout: { x: 6, y: 0, w: 6, h: 4 } },
+		]
+
+		expect(projectLayout(redactedWidgets, GRID_TIERS[0])).toMatchObject([
+			{ i: "a", x: 0, y: 0, w: 6, h: 4 },
+			{ i: "b", x: 6, y: 0, w: 6, h: 4 },
+		])
 	})
 })

--- a/apps/web/src/components/dashboard-builder/canvas/grid-breakpoints.ts
+++ b/apps/web/src/components/dashboard-builder/canvas/grid-breakpoints.ts
@@ -1,6 +1,18 @@
 import type { Layout, LayoutItem } from "react-grid-layout"
+import type { WidgetLayoutSchema } from "@maple/widgets/dashboard"
 
-import type { DashboardWidget } from "@/components/dashboard-builder/types"
+/**
+ * The minimum a widget must expose to be placed on the grid.
+ *
+ * Narrower than `DashboardWidget` on purpose: the read-only surfaces render a
+ * *redacted* widget whose data source is deliberately not the stored one, and
+ * placement never needed either. Typed against what the projection actually
+ * reads, both shapes satisfy it without a cast.
+ */
+export interface PlacedWidget {
+	readonly id: string
+	readonly layout: typeof WidgetLayoutSchema.Type
+}
 
 /**
  * Grid geometry for the dashboard canvas.
@@ -77,7 +89,7 @@ function clamp(value: number, min: number, max: number): number {
  * width exactly. Rows stay rows, order is preserved, and nothing overlaps —
  * which is why the canvas pairs this with `noCompactor` on derived tiers.
  */
-export function projectLayout(widgets: DashboardWidget[], tier: GridTier): Layout {
+export function projectLayout(widgets: ReadonlyArray<PlacedWidget>, tier: GridTier): Layout {
 	const base = widgets.map((w) => ({
 		i: w.id,
 		x: w.layout.x,

--- a/apps/web/src/components/dashboard-builder/canvas/live-widget-renderer.tsx
+++ b/apps/web/src/components/dashboard-builder/canvas/live-widget-renderer.tsx
@@ -1,0 +1,90 @@
+/**
+ * The authed dashboard's widget renderer: live data, and the full action set.
+ *
+ * Deliberately not in `dashboard-canvas.tsx`. The grid itself is now mounted by
+ * read-only surfaces too — a share link, a full-screen board — which fetch
+ * through a different path and must expose no actions at all. Keeping
+ * `useWidgetData`, `useDashboardActions` and `WidgetActionsProvider` out of the
+ * grid module is what makes that reuse honest rather than conditional: the grid
+ * takes a renderer, and each mount point names the one it means.
+ */
+import { memo, useEffect, useRef, useState } from "react"
+import { dataSourceTransform } from "@maple/widgets/dashboard"
+
+import type { DashboardWidget } from "@/components/dashboard-builder/types"
+import { useDashboardActions } from "@/components/dashboard-builder/dashboard-actions-context"
+import { WidgetActionsProvider } from "@/components/dashboard-builder/widgets/widget-actions-context"
+import { WidgetTimeRangeProvider } from "@/components/dashboard-builder/widgets/widget-time-range-context"
+import { visualizationFor } from "@/components/dashboard-builder/widgets/types"
+import { useWidgetData } from "@/hooks/use-widget-data"
+
+/**
+ * Latches `true` the first time the element scrolls into (near) the viewport,
+ * then stays latched. Tiles fetch their data lazily on first reveal and keep it
+ * — unlatching would unmount the tile's atom, and a non-sticky flag would then
+ * refetch every time it scrolled back into view. The 200ms debounce absorbs
+ * react-grid-layout's mount-time reflow, where tiles can briefly flash into
+ * view before the layout settles.
+ */
+function useInViewportSticky() {
+	const ref = useRef<HTMLDivElement>(null)
+	const [visible, setVisible] = useState(false)
+
+	useEffect(() => {
+		if (visible) return
+		const element = ref.current
+		if (!element) return
+		if (typeof IntersectionObserver === "undefined") {
+			setVisible(true)
+			return
+		}
+
+		let timer: ReturnType<typeof setTimeout> | undefined
+		const observer = new IntersectionObserver(
+			(entries) => {
+				const isIntersecting = entries.some((entry) => entry.isIntersecting)
+				if (isIntersecting && timer == null) {
+					timer = setTimeout(() => setVisible(true), 200)
+				} else if (!isIntersecting && timer != null) {
+					clearTimeout(timer)
+					timer = undefined
+				}
+			},
+			{ rootMargin: "200px" },
+		)
+		observer.observe(element)
+		return () => {
+			if (timer != null) clearTimeout(timer)
+			observer.disconnect()
+		}
+	}, [visible])
+
+	return { ref, visible }
+}
+
+export const LiveWidgetRenderer = memo(function LiveWidgetRenderer({ widget }: { widget: DashboardWidget }) {
+	const { mode } = useDashboardActions()
+	const { ref, visible } = useInViewportSticky()
+	const { dataState, narrowRange, narrowRangeLabel } = useWidgetData(widget, visible)
+	const Visualization = visualizationFor(widget.visualization)
+
+	return (
+		<div ref={ref} className="h-full w-full">
+			<WidgetTimeRangeProvider timeRange={widget.timeRange}>
+				<WidgetActionsProvider
+					widget={widget}
+					dataState={dataState}
+					narrowRange={narrowRange}
+					narrowRangeLabel={narrowRangeLabel}
+				>
+					<Visualization
+						dataState={dataState}
+						display={widget.display}
+						mode={mode}
+						rowLimit={dataSourceTransform(widget.dataSource)?.limit}
+					/>
+				</WidgetActionsProvider>
+			</WidgetTimeRangeProvider>
+		</div>
+	)
+})

--- a/apps/web/src/components/dashboard-builder/dashboard-actions-context.tsx
+++ b/apps/web/src/components/dashboard-builder/dashboard-actions-context.tsx
@@ -265,8 +265,25 @@ export function DashboardActionsProvider({
 	return <DashboardActionsContext value={ctx}>{children}</DashboardActionsContext>
 }
 
+/**
+ * The dashboard's actions, or `null` when rendered outside a provider.
+ *
+ * The read-only surfaces — a share link, a full-screen board — mount the same
+ * canvas with no store behind it, and every mutation here needs one. `null`
+ * says exactly that: on this surface no action exists.
+ *
+ * Deliberately not a no-op stub provider. A non-null context makes
+ * `WidgetActionsProvider` viable downstream, and that provider always defines
+ * `remove` and offers `createAlert`, which `WidgetShell` shows in view mode —
+ * so a stub would put edit affordances and authed-route navigation on a public
+ * page. Absence is the only honest empty action set.
+ */
+export function useDashboardActionsOptional(): DashboardActionsContextValue | null {
+	return React.use(DashboardActionsContext)
+}
+
 export function useDashboardActions(): DashboardActionsContextValue {
-	const ctx = React.use(DashboardActionsContext)
+	const ctx = useDashboardActionsOptional()
 	if (!ctx) throw new Error("useDashboardActions must be used within DashboardActionsProvider")
 	return ctx
 }

--- a/apps/web/src/components/dashboard-builder/history/previewed-canvas.tsx
+++ b/apps/web/src/components/dashboard-builder/history/previewed-canvas.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/dashboards/section-view-state"
 import type { DashboardSection, DashboardWidget } from "@/components/dashboard-builder/types"
 import { DashboardSections } from "@/components/dashboard-builder/sections/dashboard-sections"
+import { LiveWidgetRenderer } from "@/components/dashboard-builder/canvas/live-widget-renderer"
 import { PreviewBanner } from "./preview-banner"
 import { useDashboardVersionDetail } from "./use-dashboard-history"
 import type { PreviewedVersion } from "@/atoms/dashboard-history-atoms"
@@ -39,6 +40,7 @@ export function PreviewedCanvas({ dashboardId, preview, onCancel, onRestored }: 
 				// restoring it would actually produce. Read-only, and the view
 				// callbacks are inert — a preview has no URL state of its own.
 				<DashboardSections
+					renderWidget={LiveWidgetRenderer}
 					widgets={result.value.snapshot.widgets as DashboardWidget[]}
 					sections={(result.value.snapshot.sections ?? []) as DashboardSection[]}
 					// Local, not URL-backed: browsing a preview's groups is throwaway

--- a/apps/web/src/components/dashboard-builder/read-only-dashboard-view.tsx
+++ b/apps/web/src/components/dashboard-builder/read-only-dashboard-view.tsx
@@ -1,0 +1,72 @@
+/**
+ * A dashboard with nothing to act on: the board, its groups, and its tiles at
+ * the sizes they were authored at.
+ *
+ * One component, two mount points — a share link (redacted widgets, data from
+ * the public share API) and the full-screen view of a live board. They render
+ * through the same canvas as the editable dashboard, so a tile can never end up
+ * a different size here than it is there; the only thing that varies is which
+ * renderer draws a widget, which is the `renderWidget` prop.
+ *
+ * Read-only is enforced twice over and deliberately so: `readOnly` is passed
+ * down, and outside a `DashboardActionsProvider` `mode` falls back to `"view"`.
+ * Either alone makes `editable` false — no drag handles, no resize, no layout
+ * writes, and no "widen the window to rearrange" hint.
+ */
+import { useState, type ReactNode } from "react"
+import type { DashboardSection } from "@maple/widgets/dashboard"
+
+import type {
+	CanvasWidget,
+	WidgetRendererComponent,
+} from "@/components/dashboard-builder/canvas/dashboard-canvas"
+import { DashboardSections } from "@/components/dashboard-builder/sections/dashboard-sections"
+import {
+	withActiveTab,
+	withSectionCollapsed,
+	type SectionViewSearch,
+} from "@/lib/dashboards/section-view-state"
+
+interface ReadOnlyDashboardViewProps<W extends CanvasWidget> {
+	widgets: ReadonlyArray<W>
+	sections: ReadonlyArray<DashboardSection>
+	renderWidget: WidgetRendererComponent<W>
+	/** Rendered above the board, when the surface wants a heading of its own. */
+	header?: ReactNode
+}
+
+export function ReadOnlyDashboardView<W extends CanvasWidget>({
+	widgets,
+	sections,
+	renderWidget,
+	header,
+}: ReadOnlyDashboardViewProps<W>) {
+	// Local, not URL-backed. Which group a reader has open is throwaway state,
+	// and on a share every search param becomes part of a public link's
+	// contract — the same call `PreviewedCanvas` makes, for the same reason.
+	const [viewSearch, setViewSearch] = useState<SectionViewSearch>({})
+
+	return (
+		<div className="flex h-full min-h-0 w-full flex-col">
+			{header}
+			<div className="min-h-0 flex-1 overflow-y-auto">
+				<DashboardSections
+					widgets={widgets}
+					sections={sections}
+					search={viewSearch}
+					onToggleCollapsed={(sectionId, collapsed) =>
+						setViewSearch((prev) => withSectionCollapsed(prev, sectionId, collapsed))
+					}
+					onSelectTab={(sectionId, tabId) =>
+						setViewSearch((prev) => withActiveTab(prev, sectionId, tabId))
+					}
+					// Nothing to add to: the "+" is gated on `editable`, which is false
+					// here, so this never fires.
+					onAddWidget={() => undefined}
+					readOnly
+					renderWidget={renderWidget}
+				/>
+			</div>
+		</div>
+	)
+}

--- a/apps/web/src/components/dashboard-builder/sections/dashboard-section.tsx
+++ b/apps/web/src/components/dashboard-builder/sections/dashboard-section.tsx
@@ -11,18 +11,22 @@ import {
 import { cn } from "@maple/ui/lib/utils"
 import { ArrowUpIcon, DotsVerticalIcon, PlusIcon, TrashIcon } from "@/components/icons"
 
-import { DashboardGrid } from "@/components/dashboard-builder/canvas/dashboard-canvas"
+import {
+	DashboardGrid,
+	type CanvasWidget,
+	type WidgetRendererComponent,
+} from "@/components/dashboard-builder/canvas/dashboard-canvas"
 import type { GridTier } from "@/components/dashboard-builder/canvas/grid-breakpoints"
 import { InlineEditableText } from "@/components/dashboard-builder/sections/inline-editable-text"
 import { SectionTabBar } from "@/components/dashboard-builder/sections/section-tab-bar"
 import { DeleteSectionDialog, DeleteTabDialog } from "@/components/dashboard-builder/sections/section-dialogs"
-import { useDashboardActions } from "@/components/dashboard-builder/dashboard-actions-context"
-import type { DashboardSection, DashboardWidget } from "@/components/dashboard-builder/types"
+import { useDashboardActionsOptional } from "@/components/dashboard-builder/dashboard-actions-context"
+import type { DashboardSection } from "@maple/widgets/dashboard"
 
-interface DashboardSectionViewProps {
+interface DashboardSectionViewProps<W extends CanvasWidget> {
 	section: DashboardSection
 	/** Widgets in this section's active tab, already filtered by the parent. */
-	widgets: DashboardWidget[]
+	widgets: ReadonlyArray<W>
 	/** Every widget in the section, across tabs — for the delete confirmations. */
 	sectionWidgetCount: number
 	activeTabId: string
@@ -37,6 +41,7 @@ interface DashboardSectionViewProps {
 	onAddWidget: (tabId: string) => void
 	/** Widgets in a specific tab — for the tab delete confirmation's count. */
 	widgetCountInTab: (tabId: string) => number
+	renderWidget: WidgetRendererComponent<W>
 }
 
 /**
@@ -48,7 +53,7 @@ interface DashboardSectionViewProps {
  * mounting is what stops the query — no `enabled={false}` plumbing, and strictly
  * stronger than hiding with CSS, which would leave the tile fetching.
  */
-export function DashboardSectionView({
+export function DashboardSectionView<W extends CanvasWidget>({
 	section,
 	widgets,
 	sectionWidgetCount,
@@ -63,17 +68,13 @@ export function DashboardSectionView({
 	onSelectTab,
 	onAddWidget,
 	widgetCountInTab,
-}: DashboardSectionViewProps) {
-	const {
-		renameSection,
-		setSectionCollapsedDefault,
-		setSectionCollapsible,
-		reorderSections,
-		deleteSection,
-		addTab,
-		renameTab,
-		deleteTab,
-	} = useDashboardActions()
+	renderWidget,
+}: DashboardSectionViewProps<W>) {
+	// Optional, and every call below is optional with it: a read-only surface
+	// mounts this with no store. Safe by construction rather than by luck —
+	// each of these entry points already sits behind `editable`, or behind a
+	// dialog only reachable from a menu that `editable` gates.
+	const actions = useDashboardActionsOptional()
 
 	const [deleteSectionOpen, setDeleteSectionOpen] = useState(false)
 	const [tabPendingDelete, setTabPendingDelete] = useState<string | null>(null)
@@ -113,7 +114,7 @@ export function DashboardSectionView({
 					value={section.title}
 					ariaLabel={`Rename group ${section.title}`}
 					readOnly={!editable}
-					onChange={(title) => renameSection(section.id, title)}
+					onChange={(title) => actions?.renameSection(section.id, title)}
 					className="truncate text-sm font-semibold"
 				/>
 
@@ -124,9 +125,9 @@ export function DashboardSectionView({
 							activeTabId={activeTabId}
 							editable={editable}
 							onSelect={onSelectTab}
-							onRename={(tabId, title) => renameTab(section.id, tabId, title)}
+							onRename={(tabId, title) => actions?.renameTab(section.id, tabId, title)}
 							onDelete={(tabId) => setTabPendingDelete(tabId)}
-							onAddTab={() => addTab(section.id)}
+							onAddTab={() => actions?.addTab(section.id)}
 						/>
 					</div>
 				)}
@@ -156,20 +157,20 @@ export function DashboardSectionView({
 								}
 							/>
 							<DropdownMenuContent align="end">
-								<DropdownMenuItem onClick={() => addTab(section.id)}>
+								<DropdownMenuItem onClick={() => actions?.addTab(section.id)}>
 									<PlusIcon size={14} />
 									Add tab
 								</DropdownMenuItem>
 								<DropdownMenuItem
 									disabled={index === 0}
-									onClick={() => reorderSections(index, index - 1)}
+									onClick={() => actions?.reorderSections(index, index - 1)}
 								>
 									<ArrowUpIcon size={14} />
 									Move up
 								</DropdownMenuItem>
 								<DropdownMenuItem
 									disabled={index === sectionCount - 1}
-									onClick={() => reorderSections(index, index + 1)}
+									onClick={() => actions?.reorderSections(index, index + 1)}
 								>
 									<ArrowUpIcon size={14} className="rotate-180" />
 									Move down
@@ -182,7 +183,7 @@ export function DashboardSectionView({
 								{collapsible && (
 									<DropdownMenuItem
 										onClick={() =>
-											setSectionCollapsedDefault(
+											actions?.setSectionCollapsedDefault(
 												section.id,
 												!(section.collapsed ?? false),
 											)
@@ -192,7 +193,7 @@ export function DashboardSectionView({
 									</DropdownMenuItem>
 								)}
 								<DropdownMenuItem
-									onClick={() => setSectionCollapsible(section.id, !collapsible)}
+									onClick={() => actions?.setSectionCollapsible(section.id, !collapsible)}
 								>
 									{collapsible ? "Always expanded" : "Allow collapsing"}
 								</DropdownMenuItem>
@@ -218,7 +219,13 @@ export function DashboardSectionView({
 					</p>
 				) : (
 					<div className="pt-2">
-						<DashboardGrid widgets={widgets} width={width} tier={tier} editable={editable} />
+						<DashboardGrid
+							widgets={widgets}
+							width={width}
+							tier={tier}
+							editable={editable}
+							renderWidget={renderWidget}
+						/>
 					</div>
 				))}
 
@@ -227,7 +234,7 @@ export function DashboardSectionView({
 				onOpenChange={setDeleteSectionOpen}
 				sectionTitle={section.title}
 				widgetCount={sectionWidgetCount}
-				onConfirm={(action) => deleteSection(section.id, action)}
+				onConfirm={(action) => actions?.deleteSection(section.id, action)}
 			/>
 
 			{pendingTab && destinationTab && (
@@ -239,7 +246,7 @@ export function DashboardSectionView({
 					tabTitle={pendingTab.title}
 					destinationTitle={destinationTab.title}
 					widgetCount={widgetCountInTab(pendingTab.id)}
-					onConfirm={(action) => deleteTab(section.id, pendingTab.id, action)}
+					onConfirm={(action) => actions?.deleteTab(section.id, pendingTab.id, action)}
 				/>
 			)}
 		</section>

--- a/apps/web/src/components/dashboard-builder/sections/dashboard-sections.tsx
+++ b/apps/web/src/components/dashboard-builder/sections/dashboard-sections.tsx
@@ -1,24 +1,29 @@
 import { useMemo, useRef } from "react"
 import { useContainerSize } from "@maple/ui/hooks/use-container-size"
 import { cn } from "@maple/ui/lib/utils"
-import { containerKeyFor, containerKeyOf, ROOT_CONTAINER_KEY } from "@maple/domain/http"
+import { containerKeyFor, groupWidgetsByContainer, ROOT_CONTAINER_KEY } from "@maple/domain/http"
+import type { DashboardSection } from "@maple/widgets/dashboard"
 
-import { DashboardGrid } from "@/components/dashboard-builder/canvas/dashboard-canvas"
+import {
+	DashboardGrid,
+	type CanvasWidget,
+	type WidgetRendererComponent,
+} from "@/components/dashboard-builder/canvas/dashboard-canvas"
 import { tierForWidth } from "@/components/dashboard-builder/canvas/grid-breakpoints"
 import { DashboardSectionView } from "@/components/dashboard-builder/sections/dashboard-section"
-import { useDashboardActions } from "@/components/dashboard-builder/dashboard-actions-context"
-import type { DashboardSection, DashboardWidget } from "@/components/dashboard-builder/types"
+import { useDashboardActionsOptional } from "@/components/dashboard-builder/dashboard-actions-context"
 import { resolveSectionView, type SectionViewSearch } from "@/lib/dashboards/section-view-state"
 
-interface DashboardSectionsProps {
-	widgets: DashboardWidget[]
-	sections: DashboardSection[]
+interface DashboardSectionsProps<W extends CanvasWidget> {
+	widgets: ReadonlyArray<W>
+	sections: ReadonlyArray<DashboardSection>
 	/** Per-viewer view state from the URL. */
 	search: SectionViewSearch
 	onToggleCollapsed: (sectionId: string, collapsed: boolean) => void
 	onSelectTab: (sectionId: string, tabId: string) => void
 	onAddWidget: (sectionId: string, tabId: string) => void
 	readOnly?: boolean
+	renderWidget: WidgetRendererComponent<W>
 }
 
 /**
@@ -30,7 +35,7 @@ interface DashboardSectionsProps {
  * rearrangeable, its neighbour locked — and would spin up a `ResizeObserver` per
  * group. One measurement, one `tier`, every grid agrees.
  */
-export function DashboardSections({
+export function DashboardSections<W extends CanvasWidget>({
 	widgets,
 	sections,
 	search,
@@ -38,8 +43,11 @@ export function DashboardSections({
 	onSelectTab,
 	onAddWidget,
 	readOnly = false,
-}: DashboardSectionsProps) {
-	const { mode } = useDashboardActions()
+	renderWidget,
+}: DashboardSectionsProps<W>) {
+	// A read-only surface (share link, full-screen board) mounts this with no
+	// store behind it, and a board with no actions is a board in view mode.
+	const mode = useDashboardActionsOptional()?.mode ?? "view"
 
 	const containerRef = useRef<HTMLDivElement>(null)
 	const { width: measuredWidth } = useContainerSize(containerRef)
@@ -57,20 +65,7 @@ export function DashboardSections({
 	// Bucket once per (widgets, sections) identity and hand each grid a
 	// referentially stable subset, so dragging inside one group doesn't
 	// re-render its siblings.
-	const byContainer = useMemo(() => {
-		const buckets = new Map<string, DashboardWidget[]>()
-		buckets.set(ROOT_CONTAINER_KEY, [])
-		for (const section of sections) {
-			for (const tab of section.tabs) {
-				buckets.set(containerKeyFor({ sectionId: section.id, tabId: tab.id }), [])
-			}
-		}
-		for (const widget of widgets) {
-			const bucket = buckets.get(containerKeyOf(widget)) ?? buckets.get(ROOT_CONTAINER_KEY)
-			bucket?.push(widget)
-		}
-		return buckets
-	}, [widgets, sections])
+	const byContainer = useMemo(() => groupWidgetsByContainer({ widgets, sections }), [widgets, sections])
 
 	// Resolved as a derivation, not an effect: a `?widget=` deep link has to
 	// force its section open *before* first paint, or the target tile mounts
@@ -93,7 +88,13 @@ export function DashboardSections({
 			{measured && (
 				<>
 					{rootWidgets.length > 0 && (
-						<DashboardGrid widgets={rootWidgets} width={width} tier={tier} editable={editable} />
+						<DashboardGrid
+							widgets={rootWidgets}
+							width={width}
+							tier={tier}
+							editable={editable}
+							renderWidget={renderWidget}
+						/>
 					)}
 
 					{sections.map((section, index) => {
@@ -124,6 +125,7 @@ export function DashboardSections({
 								onToggleCollapsed={(collapsed) => onToggleCollapsed(section.id, collapsed)}
 								onSelectTab={(tabId) => onSelectTab(section.id, tabId)}
 								onAddWidget={(tabId) => onAddWidget(section.id, tabId)}
+								renderWidget={renderWidget}
 							/>
 						)
 					})}

--- a/apps/web/src/components/dashboard-builder/sections/section-tab-bar.tsx
+++ b/apps/web/src/components/dashboard-builder/sections/section-tab-bar.tsx
@@ -3,10 +3,10 @@ import { Button } from "@maple/ui/components/ui/button"
 import { PlusIcon, TrashIcon } from "@/components/icons"
 
 import { InlineEditableText } from "@/components/dashboard-builder/sections/inline-editable-text"
-import type { DashboardSectionTab } from "@/components/dashboard-builder/types"
+import type { DashboardSectionTab } from "@maple/widgets/dashboard"
 
 interface SectionTabBarProps {
-	tabs: DashboardSectionTab[]
+	tabs: ReadonlyArray<DashboardSectionTab>
 	activeTabId: string
 	editable: boolean
 	onSelect: (tabId: string) => void

--- a/apps/web/src/components/share/shared-widget-renderer.tsx
+++ b/apps/web/src/components/share/shared-widget-renderer.tsx
@@ -1,0 +1,63 @@
+/**
+ * How a tile draws itself on a share link.
+ *
+ * The counterpart to `LiveWidgetRenderer`, and the differences are the whole
+ * point of the split. Data arrives page-level, already fetched in batches by
+ * `useShareWidgetData` — a share's document carries no data source to build a
+ * request from — so a tile reads its own state out of a context instead of
+ * owning a query.
+ *
+ * No `WidgetActionsProvider`, and deliberately not `WidgetActionsScope` with a
+ * trimmed set either. Outside any provider `useWidgetActions()` returns `null`,
+ * so `WidgetShell`'s `showMenu` is false and there is no kebab, no "Create
+ * alert", no "Remove", and no navigation into authed routes. On a page served
+ * without a session the safest action set is the empty one, and absence is how
+ * you spell it. `WidgetActionsScope` stays the right hatch the day a share
+ * wants a genuinely public action.
+ *
+ * Also no `useInViewportSticky`: its only job is gating `useWidgetData`'s lazy
+ * fetch. Share data is batched whether or not a tile is on screen, so the
+ * observer would gate nothing and cost a 200ms delay per tile.
+ */
+import { createContext, memo, use, type ReactNode } from "react"
+
+import type { WidgetDataState } from "@/components/dashboard-builder/types"
+import { visualizationFor } from "@/components/dashboard-builder/widgets/types"
+import { WidgetTimeRangeProvider } from "@/components/dashboard-builder/widgets/widget-time-range-context"
+import type { ShareWidget } from "@/hooks/use-share-dashboard"
+
+const ShareWidgetStatesContext = createContext<Readonly<Record<string, WidgetDataState>>>({})
+
+export function ShareWidgetStatesProvider({
+	states,
+	children,
+}: {
+	states: Readonly<Record<string, WidgetDataState>>
+	children: ReactNode
+}) {
+	return <ShareWidgetStatesContext value={states}>{children}</ShareWidgetStatesContext>
+}
+
+export const SharedWidgetRenderer = memo(function SharedWidgetRenderer({ widget }: { widget: ShareWidget }) {
+	const states = use(ShareWidgetStatesContext)
+	const dataState = states[widget.id] ?? { status: "loading" as const }
+	const Visualization = visualizationFor(widget.visualization)
+
+	return (
+		<div className="h-full w-full">
+			{/* Pure display — the "this tile has its own window" badge. The share
+			    document carries `timeRange`, and dropping it here would silently
+			    misrepresent a pinned tile as being on the board's range. */}
+			<WidgetTimeRangeProvider timeRange={widget.timeRange}>
+				<Visualization
+					dataState={dataState}
+					display={widget.display}
+					// Always "view": a share has no editing affordances to gate, and
+					// passing anything else would surface them.
+					mode="view"
+					rowLimit={(widget.dataSource.transform as { limit?: number } | undefined)?.limit}
+				/>
+			</WidgetTimeRangeProvider>
+		</div>
+	)
+})

--- a/apps/web/src/components/share/shared-widget-renderer.tsx
+++ b/apps/web/src/components/share/shared-widget-renderer.tsx
@@ -19,12 +19,35 @@
  * fetch. Share data is batched whether or not a tile is on screen, so the
  * observer would gate nothing and cost a 200ms delay per tile.
  */
-import { createContext, memo, use, type ReactNode } from "react"
+import { createContext, memo, use, useMemo, type ReactNode } from "react"
+import { WidgetDataSourceTransformSchema } from "@maple/widgets/dashboard"
+import { Schema } from "effect"
 
 import type { WidgetDataState } from "@/components/dashboard-builder/types"
 import { visualizationFor } from "@/components/dashboard-builder/widgets/types"
 import { WidgetTimeRangeProvider } from "@/components/dashboard-builder/widgets/widget-time-range-context"
+import { applyTransform } from "@/hooks/use-widget-data"
 import type { ShareWidget } from "@/hooks/use-share-dashboard"
+
+const decodeTransform = Schema.decodeUnknownSync(WidgetDataSourceTransformSchema)
+
+/**
+ * The widget's transform, or nothing when it doesn't decode.
+ *
+ * Decoded here rather than in the share document's schema so a transform this
+ * build doesn't recognise costs one tile its formatting instead of failing the
+ * whole page — the same trade the section decode makes. `transform` is kept
+ * deliberately loose on the wire (`Schema.Unknown`) for that reason.
+ */
+const shareTransform = (raw: unknown): typeof WidgetDataSourceTransformSchema.Type | undefined => {
+	if (raw === undefined) return undefined
+	try {
+		return decodeTransform(raw)
+	} catch {
+		console.warn("[share] widget transform could not be decoded — rendering untransformed")
+		return undefined
+	}
+}
 
 const ShareWidgetStatesContext = createContext<Readonly<Record<string, WidgetDataState>>>({})
 
@@ -40,8 +63,19 @@ export function ShareWidgetStatesProvider({
 
 export const SharedWidgetRenderer = memo(function SharedWidgetRenderer({ widget }: { widget: ShareWidget }) {
 	const states = use(ShareWidgetStatesContext)
-	const dataState = states[widget.id] ?? { status: "loading" as const }
 	const Visualization = visualizationFor(widget.visualization)
+
+	const transform = useMemo(() => shareTransform(widget.dataSource.transform), [widget.dataSource])
+
+	// The server returns rows; the transform is what turns them into what the
+	// renderer expects. Without it a stat gets its whole result set where a
+	// single number belongs and formats it as an em dash — which is what a
+	// shared board's stat tiles used to show, on every board.
+	const dataState = useMemo<WidgetDataState>(() => {
+		const state = states[widget.id] ?? { status: "loading" as const }
+		if (state.status !== "ready" || transform === undefined) return state
+		return { ...state, data: applyTransform(state.data, transform) }
+	}, [states, widget.id, transform])
 
 	return (
 		<div className="h-full w-full">
@@ -55,7 +89,7 @@ export const SharedWidgetRenderer = memo(function SharedWidgetRenderer({ widget 
 					// Always "view": a share has no editing affordances to gate, and
 					// passing anything else would surface them.
 					mode="view"
-					rowLimit={(widget.dataSource.transform as { limit?: number } | undefined)?.limit}
+					rowLimit={transform?.limit}
 				/>
 			</WidgetTimeRangeProvider>
 		</div>

--- a/apps/web/src/hooks/use-share-dashboard.test.ts
+++ b/apps/web/src/hooks/use-share-dashboard.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The share transport, decoded.
+ *
+ * Payloads are built by running the real `redactForShare` over a stored-shaped
+ * document rather than hand-typing a literal, so these tests fail if the server
+ * projection and the client decoder ever stop agreeing — which is exactly the
+ * drift that produced a flat, uniformly-sized shared board in the first place.
+ */
+import { describe, expect, it } from "vitest"
+import { redactForShare } from "@maple/widgets/dashboard"
+
+import { decodeShare } from "@/hooks/use-share-dashboard"
+
+const storedDocument = {
+	id: "dash-1",
+	name: "Ops",
+	timeRange: { type: "relative" as const, value: "12h" },
+	widgets: [
+		{
+			id: "w-root",
+			visualization: "stat",
+			display: { title: "Requests" },
+			layout: { x: 0, y: 0, w: 3, h: 4, minW: 2, maxH: 8 },
+			dataSource: { kind: "raw_sql", sql: "SELECT 1", transform: { limit: 10 } },
+		},
+		{
+			id: "w-grouped",
+			visualization: "line",
+			display: { title: "Latency" },
+			layout: { x: 3, y: 0, w: 9, h: 4 },
+			sectionId: "sec-1",
+			tabId: "tab-1",
+			timeRange: { type: "relative" as const, value: "7d" },
+			dataSource: { kind: "query", resultShape: "timeseries", queries: [] },
+		},
+	],
+	sections: [{ id: "sec-1", title: "Latency", tabs: [{ id: "tab-1", title: "Overview" }] }],
+}
+
+const resolvePayload = (document: unknown, scope: "dashboard" | "widget" = "dashboard") => ({
+	mode: "public" as const,
+	scope,
+	dashboard: document,
+	limits: { maxRangeSeconds: 86_400, maxListRangeSeconds: 3_600 },
+	embeddable: false,
+})
+
+describe("decodeShare", () => {
+	it("carries the placement the canvas lays out from", async () => {
+		const share = await decodeShare(resolvePayload(redactForShare(storedDocument)))
+
+		expect(share.dashboard.widgets[0]?.layout).toEqual({ x: 0, y: 0, w: 3, h: 4, minW: 2, maxH: 8 })
+		expect(share.dashboard.widgets[1]).toMatchObject({
+			sectionId: "sec-1",
+			tabId: "tab-1",
+			timeRange: { type: "relative", value: "7d" },
+		})
+		expect(share.dashboard.sections).toEqual([
+			{ id: "sec-1", title: "Latency", tabs: [{ id: "tab-1", title: "Overview" }] },
+		])
+	})
+
+	it("decodes a single-chart share, which carries no sections at all", async () => {
+		const share = await decodeShare(resolvePayload(redactForShare(storedDocument, "w-grouped"), "widget"))
+
+		expect(share.dashboard.widgets).toHaveLength(1)
+		expect(share.dashboard.sections).toEqual([])
+		// Lifted out of its group by the redaction seam, so there is nothing left
+		// to place it against.
+		expect(share.dashboard.widgets[0]?.sectionId).toBeUndefined()
+	})
+
+	// An older client reading a newer board must still draw something.
+	// `widgetTypeFor` already decides what an unknown type falls back to; the
+	// decoder must not pre-empt that by refusing the payload.
+	it("accepts a visualization this build doesn't know", async () => {
+		const document = redactForShare({
+			...storedDocument,
+			widgets: [{ ...storedDocument.widgets[0], visualization: "sankey-from-the-future" }],
+		})
+
+		const share = await decodeShare(resolvePayload(document))
+		expect(share.dashboard.widgets[0]?.visualization).toBe("sankey-from-the-future")
+	})
+
+	it("ignores fields it doesn't model, so a newer server can add them", async () => {
+		const document = { ...redactForShare(storedDocument), somethingNew: { nested: true } }
+
+		const share = await decodeShare(resolvePayload(document))
+		expect(share.dashboard.widgets).toHaveLength(2)
+	})
+
+	// The tiles are the dashboard; the grouping is only how they're arranged.
+	it("renders ungrouped rather than failing when sections don't decode", async () => {
+		const document = { ...redactForShare(storedDocument), sections: [{ nonsense: true }] }
+
+		const share = await decodeShare(resolvePayload(document))
+		expect(share.dashboard.sections).toEqual([])
+		expect(share.dashboard.widgets).toHaveLength(2)
+	})
+
+	it("rejects a payload whose widgets have no placement", async () => {
+		const document = {
+			...redactForShare(storedDocument),
+			widgets: [{ id: "w", visualization: "stat", display: {}, dataSource: { kind: "query" } }],
+		}
+
+		await expect(decodeShare(resolvePayload(document))).rejects.toThrow()
+	})
+})

--- a/apps/web/src/hooks/use-share-dashboard.ts
+++ b/apps/web/src/hooks/use-share-dashboard.ts
@@ -22,6 +22,7 @@ import type { WidgetDataState } from "@/components/dashboard-builder/types"
 import { apiBaseUrl } from "@/lib/services/common/api-base-url"
 import { getMapleAuthHeaders } from "@/lib/services/common/auth-headers"
 import { ShareWidgetDataResponse } from "@maple/domain/http"
+import { DashboardSectionSchema, TimeRangeSchema, WidgetLayoutSchema } from "@maple/widgets/dashboard"
 import { Schema } from "effect"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
@@ -33,34 +34,81 @@ export interface ShareTimeRange {
 	readonly endTime: string
 }
 
-export interface SharedDashboardDocument {
-	readonly id: string
-	readonly name: string
-	readonly description?: string
-	readonly timeRange: unknown
-	readonly widgets: ReadonlyArray<{
-		readonly id: string
-		readonly visualization: string
-		readonly display: Record<string, unknown>
-		readonly layout: { readonly x: number; readonly y: number; readonly w: number; readonly h: number }
-		readonly dataSource: { readonly kind: string; readonly transform?: unknown }
-	}>
-	readonly variables?: ReadonlyArray<{
-		readonly name: string
-		readonly type: string
-		readonly label?: string
-		readonly options?: ReadonlyArray<{ readonly value: string; readonly label?: string }>
-		readonly defaultValue?: string
-		readonly includeAll?: boolean
-	}>
-}
+/**
+ * A widget as a share publishes it.
+ *
+ * Decoded rather than asserted, because the page now *lays out* from this
+ * payload: `layout`, `sectionId` and `tabId` decide where a tile lands, so a
+ * field arriving in the wrong shape has to fail here rather than silently
+ * collapse the board into a flat grid.
+ *
+ * `WidgetLayoutSchema` and `TimeRangeSchema` are the same schemas the stored
+ * document uses — reusing them is what makes this an adapter and not a cast:
+ * the decoded `layout` *is* the canvas's `PlacedWidget["layout"]`.
+ */
+const ShareWidgetSchema = Schema.Struct({
+	id: Schema.String,
+	// Deliberately a plain string, not the closed `WidgetVisualization` union:
+	// an older client reading a newer board must still render. `widgetTypeFor`
+	// is the one place that decides what an unknown type draws as, and it
+	// already warns and falls back.
+	visualization: Schema.String,
+	// Left loose on purpose. The display config's real schema is parameterised
+	// on a data source (`display.sparkline` embeds a whole one), and a share's
+	// data source is redacted — so decoding it strictly here would assert a
+	// shape the share transport does not promise. Passed through to the
+	// visualization exactly as before.
+	display: Schema.Record(Schema.String, Schema.Unknown),
+	layout: WidgetLayoutSchema,
+	sectionId: Schema.optionalKey(Schema.String),
+	tabId: Schema.optionalKey(Schema.String),
+	timeRange: Schema.optionalKey(TimeRangeSchema),
+	dataSource: Schema.Struct({
+		kind: Schema.String,
+		resultShape: Schema.optionalKey(Schema.String),
+		transform: Schema.optionalKey(Schema.Unknown),
+	}),
+})
 
-export interface SharedDashboard {
-	readonly mode: "public" | "org"
-	readonly scope: "dashboard" | "widget"
-	readonly dashboard: SharedDashboardDocument
-	readonly limits: { readonly maxRangeSeconds: number; readonly maxListRangeSeconds: number }
-	readonly embeddable: boolean
+export type ShareWidget = typeof ShareWidgetSchema.Type
+
+/**
+ * `sections` decodes separately from the rest of the document, and failure
+ * degrades to an ungrouped board rather than a dead page: `redactForShare`
+ * passes stored sections through verbatim, so an older stored shape should cost
+ * the grouping, not the dashboard.
+ */
+const ShareSectionsSchema = Schema.Array(DashboardSectionSchema)
+
+const SharedDashboardDocumentSchema = Schema.Struct({
+	id: Schema.String,
+	name: Schema.String,
+	description: Schema.optionalKey(Schema.String),
+	timeRange: Schema.Unknown,
+	widgets: Schema.Array(ShareWidgetSchema),
+	// Decoded leniently here, then narrowed below — see `ShareSectionsSchema`.
+	sections: Schema.optionalKey(Schema.Unknown),
+	variables: Schema.optionalKey(Schema.Array(Schema.Unknown)),
+	refreshIntervalSeconds: Schema.optionalKey(Schema.Number),
+})
+
+const SharedDashboardResponseSchema = Schema.Struct({
+	mode: Schema.Literals(["public", "org"]),
+	scope: Schema.Literals(["dashboard", "widget"]),
+	dashboard: SharedDashboardDocumentSchema,
+	limits: Schema.Struct({
+		maxRangeSeconds: Schema.Number,
+		maxListRangeSeconds: Schema.Number,
+	}),
+	embeddable: Schema.Boolean,
+})
+
+export type SharedDashboardDocument = typeof SharedDashboardDocumentSchema.Type
+
+export interface SharedDashboard extends Omit<typeof SharedDashboardResponseSchema.Type, "dashboard"> {
+	readonly dashboard: SharedDashboardDocument & {
+		readonly sections: ReadonlyArray<typeof DashboardSectionSchema.Type>
+	}
 }
 
 /** Why a share failed to open, as the page needs to distinguish it. */
@@ -106,6 +154,29 @@ const toResolveError = (status: number, payload: unknown): ShareResolveError => 
 	}
 }
 
+const decodeSharedDashboard = Schema.decodeUnknownPromise(SharedDashboardResponseSchema)
+const decodeShareSections = Schema.decodeUnknownSync(ShareSectionsSchema)
+
+/**
+ * Decode a resolve payload, keeping a board whose groups fail to decode.
+ *
+ * The tiles are the dashboard; the grouping is how they are arranged. A stored
+ * section shape this build doesn't recognise should drop the grouping and
+ * render an ungrouped board, never blank the page.
+ */
+export const decodeShare = async (payload: unknown): Promise<SharedDashboard> => {
+	const decoded = await decodeSharedDashboard(payload)
+	let sections: ReadonlyArray<typeof DashboardSectionSchema.Type> = []
+	if (decoded.dashboard.sections !== undefined) {
+		try {
+			sections = decodeShareSections(decoded.dashboard.sections)
+		} catch {
+			console.warn("[share] dashboard sections could not be decoded — rendering ungrouped")
+		}
+	}
+	return { ...decoded, dashboard: { ...decoded.dashboard, sections } }
+}
+
 export function useSharedDashboard(token: string, isSignedIn: boolean) {
 	const [state, setState] = useState<
 		| { status: "loading" }
@@ -124,7 +195,12 @@ export function useSharedDashboard(token: string, isSignedIn: boolean) {
 					setState({ status: "error", error: toResolveError(response.status, payload) })
 					return
 				}
-				setState({ status: "ready", share: payload as SharedDashboard })
+				// A payload that fails to decode lands in the same "unavailable" state
+				// a 5xx does, via the `.catch` below — the page must not throw
+				// through the route on a malformed body.
+				const share = await decodeShare(payload)
+				if (cancelled) return
+				setState({ status: "ready", share })
 			})
 			.catch(() => {
 				if (!cancelled) {

--- a/apps/web/src/hooks/use-widget-data.ts
+++ b/apps/web/src/hooks/use-widget-data.ts
@@ -105,7 +105,17 @@ function filterHiddenSeriesRows(
 	})
 }
 
-function applyTransform(
+/**
+ * Collapse, remap and cap the rows a query returned, per the widget's stored
+ * transform.
+ *
+ * Exported because both data paths need it. It runs client-side by design —
+ * the share redaction seam keeps `transform` on the wire for exactly this
+ * reason while dropping everything that describes the query — so a shared board
+ * has to apply it too, or a stat whose `reduceToValue` never runs renders its
+ * whole result set where a single number belongs.
+ */
+export function applyTransform(
 	// react-doctor-disable-next-line typescript/no-explicit-any -- This legacy transform boundary accepts heterogeneous query payloads and narrows before keyed reads.
 	data: any,
 	// The readonly schema type, not the app's deep-mutable `WidgetDataSource`

--- a/apps/web/src/lib/dashboards/section-view-state.ts
+++ b/apps/web/src/lib/dashboards/section-view-state.ts
@@ -1,4 +1,4 @@
-import type { DashboardSection, DashboardWidget } from "@/components/dashboard-builder/types"
+import type { DashboardSection, SectionMembership } from "@maple/widgets/dashboard"
 
 // Per-viewer section view state, encoded in the URL.
 //
@@ -145,7 +145,9 @@ export interface ResolvedSectionView {
  */
 export function resolveSectionView(
 	sections: ReadonlyArray<DashboardSection>,
-	widgets: ReadonlyArray<DashboardWidget>,
+	// Only `id`, `sectionId` and `tabId` are read, so a redacted share widget
+	// resolves its groups exactly as a stored one does.
+	widgets: ReadonlyArray<{ readonly id: string } & SectionMembership>,
 	search: SectionViewSearch,
 ): ResolvedSectionView {
 	const target =

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,1453 +8,1453 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root"
-import { Route as IndexRouteImport } from "./routes/index"
-import { Route as AccountRouteImport } from "./routes/account"
-import { Route as ChatRouteImport } from "./routes/chat"
-import { Route as CliLoginRouteImport } from "./routes/cli-login"
-import { Route as ConnectorsRouteImport } from "./routes/connectors"
-import { Route as DeveloperRouteImport } from "./routes/developer"
-import { Route as FlowLabRouteImport } from "./routes/flow-lab"
-import { Route as InfraBenchRouteImport } from "./routes/infra-bench"
-import { Route as IntegrationsRouteImport } from "./routes/integrations"
-import { Route as LogsBenchRouteImport } from "./routes/logs-bench"
-import { Route as McpRouteImport } from "./routes/mcp"
-import { Route as McpAuthorizeRouteImport } from "./routes/mcp-authorize"
-import { Route as NodeLabRouteImport } from "./routes/node-lab"
-import { Route as OrgRequiredRouteImport } from "./routes/org-required"
-import { Route as OverviewBenchRouteImport } from "./routes/overview-bench"
-import { Route as QueryBuilderLabRouteImport } from "./routes/query-builder-lab"
-import { Route as QuickStartRouteImport } from "./routes/quick-start"
-import { Route as SelectPlanRouteImport } from "./routes/select-plan"
-import { Route as ServiceDetailBenchRouteImport } from "./routes/service-detail-bench"
-import { Route as ServiceMapRouteImport } from "./routes/service-map"
-import { Route as ServiceMapBenchRouteImport } from "./routes/service-map-bench"
-import { Route as SettingsRouteImport } from "./routes/settings"
-import { Route as SignInRouteImport } from "./routes/sign-in"
-import { Route as SignUpRouteImport } from "./routes/sign-up"
-import { Route as TimelineLabRouteImport } from "./routes/timeline-lab"
-import { Route as WidgetLabRouteImport } from "./routes/widget-lab"
-import { Route as AlertsIndexRouteImport } from "./routes/alerts/index"
-import { Route as AlertsRuleIdRouteImport } from "./routes/alerts/$ruleId"
-import { Route as AlertsCreateRouteImport } from "./routes/alerts/create"
-import { Route as AnalyticsIndexRouteImport } from "./routes/analytics/index"
-import { Route as AnomaliesIndexRouteImport } from "./routes/anomalies/index"
-import { Route as AnomaliesIncidentIdRouteImport } from "./routes/anomalies/$incidentId"
-import { Route as DashboardsIndexRouteImport } from "./routes/dashboards/index"
-import { Route as DashboardsDashboardIdRouteImport } from "./routes/dashboards/$dashboardId"
-import { Route as DashboardsTemplatesRouteImport } from "./routes/dashboards/templates"
-import { Route as ErrorsIndexRouteImport } from "./routes/errors/index"
-import { Route as ErrorsErrorTypeRouteImport } from "./routes/errors/$errorType"
-import { Route as InfraIndexRouteImport } from "./routes/infra/index"
-import { Route as InfraHostNameRouteImport } from "./routes/infra/$hostName"
-import { Route as InvestigationsIndexRouteImport } from "./routes/investigations/index"
-import { Route as InvestigationsIdRouteImport } from "./routes/investigations/$id"
-import { Route as LogsIndexRouteImport } from "./routes/logs/index"
-import { Route as LogsLogIdRouteImport } from "./routes/logs/$logId"
-import { Route as MetricsIndexRouteImport } from "./routes/metrics/index"
-import { Route as MetricsMetricNameRouteImport } from "./routes/metrics/$metricName"
-import { Route as RecommendationsRecommendationKeyRouteImport } from "./routes/recommendations/$recommendationKey"
-import { Route as ReplaysIndexRouteImport } from "./routes/replays/index"
-import { Route as ReplaysSessionIdRouteImport } from "./routes/replays/$sessionId"
-import { Route as ServicesIndexRouteImport } from "./routes/services/index"
-import { Route as ServicesServiceNameRouteImport } from "./routes/services/$serviceName"
-import { Route as ShareTokenRouteImport } from "./routes/share/$token"
-import { Route as TracesIndexRouteImport } from "./routes/traces/index"
-import { Route as TracesTraceIdRouteImport } from "./routes/traces/$traceId"
-import { Route as AlertsIncidentsIncidentIdRouteImport } from "./routes/alerts/incidents/$incidentId"
-import { Route as ErrorsIssuesIndexRouteImport } from "./routes/errors/issues/index"
-import { Route as ErrorsIssuesIssueIdRouteImport } from "./routes/errors/issues/$issueId"
-import { Route as InfraCloudflareIndexRouteImport } from "./routes/infra/cloudflare/index"
-import { Route as InfraCloudflareZoneNameRouteImport } from "./routes/infra/cloudflare/$zoneName"
-import { Route as InfraPlanetscaleIndexRouteImport } from "./routes/infra/planetscale/index"
-import { Route as InfraPlanetscaleDbNameRouteImport } from "./routes/infra/planetscale/$dbName"
-import { Route as DashboardsDashboardIdWidgetsWidgetIdRouteImport } from "./routes/dashboards/$dashboardId_.widgets.$widgetId"
-import { Route as InfraKubernetesNodesIndexRouteImport } from "./routes/infra/kubernetes/nodes/index"
-import { Route as InfraKubernetesNodesNodeNameRouteImport } from "./routes/infra/kubernetes/nodes/$nodeName"
-import { Route as InfraKubernetesPodsIndexRouteImport } from "./routes/infra/kubernetes/pods/index"
-import { Route as InfraKubernetesPodsPodNameRouteImport } from "./routes/infra/kubernetes/pods/$podName"
-import { Route as InfraKubernetesWorkloadsIndexRouteImport } from "./routes/infra/kubernetes/workloads/index"
-import { Route as InfraKubernetesWorkloadsKindWorkloadNameRouteImport } from "./routes/infra/kubernetes/workloads/$kind/$workloadName"
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as AccountRouteImport } from './routes/account'
+import { Route as ChatRouteImport } from './routes/chat'
+import { Route as CliLoginRouteImport } from './routes/cli-login'
+import { Route as ConnectorsRouteImport } from './routes/connectors'
+import { Route as DeveloperRouteImport } from './routes/developer'
+import { Route as FlowLabRouteImport } from './routes/flow-lab'
+import { Route as InfraBenchRouteImport } from './routes/infra-bench'
+import { Route as IntegrationsRouteImport } from './routes/integrations'
+import { Route as LogsBenchRouteImport } from './routes/logs-bench'
+import { Route as McpRouteImport } from './routes/mcp'
+import { Route as McpAuthorizeRouteImport } from './routes/mcp-authorize'
+import { Route as NodeLabRouteImport } from './routes/node-lab'
+import { Route as OrgRequiredRouteImport } from './routes/org-required'
+import { Route as OverviewBenchRouteImport } from './routes/overview-bench'
+import { Route as QueryBuilderLabRouteImport } from './routes/query-builder-lab'
+import { Route as QuickStartRouteImport } from './routes/quick-start'
+import { Route as SelectPlanRouteImport } from './routes/select-plan'
+import { Route as ServiceDetailBenchRouteImport } from './routes/service-detail-bench'
+import { Route as ServiceMapRouteImport } from './routes/service-map'
+import { Route as ServiceMapBenchRouteImport } from './routes/service-map-bench'
+import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as SignInRouteImport } from './routes/sign-in'
+import { Route as SignUpRouteImport } from './routes/sign-up'
+import { Route as TimelineLabRouteImport } from './routes/timeline-lab'
+import { Route as WidgetLabRouteImport } from './routes/widget-lab'
+import { Route as AlertsIndexRouteImport } from './routes/alerts/index'
+import { Route as AlertsRuleIdRouteImport } from './routes/alerts/$ruleId'
+import { Route as AlertsCreateRouteImport } from './routes/alerts/create'
+import { Route as AnalyticsIndexRouteImport } from './routes/analytics/index'
+import { Route as AnomaliesIndexRouteImport } from './routes/anomalies/index'
+import { Route as AnomaliesIncidentIdRouteImport } from './routes/anomalies/$incidentId'
+import { Route as DashboardsIndexRouteImport } from './routes/dashboards/index'
+import { Route as DashboardsDashboardIdRouteImport } from './routes/dashboards/$dashboardId'
+import { Route as DashboardsTemplatesRouteImport } from './routes/dashboards/templates'
+import { Route as ErrorsIndexRouteImport } from './routes/errors/index'
+import { Route as ErrorsErrorTypeRouteImport } from './routes/errors/$errorType'
+import { Route as InfraIndexRouteImport } from './routes/infra/index'
+import { Route as InfraHostNameRouteImport } from './routes/infra/$hostName'
+import { Route as InvestigationsIndexRouteImport } from './routes/investigations/index'
+import { Route as InvestigationsIdRouteImport } from './routes/investigations/$id'
+import { Route as LogsIndexRouteImport } from './routes/logs/index'
+import { Route as LogsLogIdRouteImport } from './routes/logs/$logId'
+import { Route as MetricsIndexRouteImport } from './routes/metrics/index'
+import { Route as MetricsMetricNameRouteImport } from './routes/metrics/$metricName'
+import { Route as RecommendationsRecommendationKeyRouteImport } from './routes/recommendations/$recommendationKey'
+import { Route as ReplaysIndexRouteImport } from './routes/replays/index'
+import { Route as ReplaysSessionIdRouteImport } from './routes/replays/$sessionId'
+import { Route as ServicesIndexRouteImport } from './routes/services/index'
+import { Route as ServicesServiceNameRouteImport } from './routes/services/$serviceName'
+import { Route as ShareTokenRouteImport } from './routes/share/$token'
+import { Route as TracesIndexRouteImport } from './routes/traces/index'
+import { Route as TracesTraceIdRouteImport } from './routes/traces/$traceId'
+import { Route as AlertsIncidentsIncidentIdRouteImport } from './routes/alerts/incidents/$incidentId'
+import { Route as ErrorsIssuesIndexRouteImport } from './routes/errors/issues/index'
+import { Route as ErrorsIssuesIssueIdRouteImport } from './routes/errors/issues/$issueId'
+import { Route as InfraCloudflareIndexRouteImport } from './routes/infra/cloudflare/index'
+import { Route as InfraCloudflareZoneNameRouteImport } from './routes/infra/cloudflare/$zoneName'
+import { Route as InfraPlanetscaleIndexRouteImport } from './routes/infra/planetscale/index'
+import { Route as InfraPlanetscaleDbNameRouteImport } from './routes/infra/planetscale/$dbName'
+import { Route as DashboardsDashboardIdWidgetsWidgetIdRouteImport } from './routes/dashboards/$dashboardId_.widgets.$widgetId'
+import { Route as InfraKubernetesNodesIndexRouteImport } from './routes/infra/kubernetes/nodes/index'
+import { Route as InfraKubernetesNodesNodeNameRouteImport } from './routes/infra/kubernetes/nodes/$nodeName'
+import { Route as InfraKubernetesPodsIndexRouteImport } from './routes/infra/kubernetes/pods/index'
+import { Route as InfraKubernetesPodsPodNameRouteImport } from './routes/infra/kubernetes/pods/$podName'
+import { Route as InfraKubernetesWorkloadsIndexRouteImport } from './routes/infra/kubernetes/workloads/index'
+import { Route as InfraKubernetesWorkloadsKindWorkloadNameRouteImport } from './routes/infra/kubernetes/workloads/$kind/$workloadName'
 
 const IndexRoute = IndexRouteImport.update({
-	id: "/",
-	path: "/",
-	getParentRoute: () => rootRouteImport,
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AccountRoute = AccountRouteImport.update({
-	id: "/account",
-	path: "/account",
-	getParentRoute: () => rootRouteImport,
+  id: '/account',
+  path: '/account',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ChatRoute = ChatRouteImport.update({
-	id: "/chat",
-	path: "/chat",
-	getParentRoute: () => rootRouteImport,
+  id: '/chat',
+  path: '/chat',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CliLoginRoute = CliLoginRouteImport.update({
-	id: "/cli-login",
-	path: "/cli-login",
-	getParentRoute: () => rootRouteImport,
+  id: '/cli-login',
+  path: '/cli-login',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ConnectorsRoute = ConnectorsRouteImport.update({
-	id: "/connectors",
-	path: "/connectors",
-	getParentRoute: () => rootRouteImport,
+  id: '/connectors',
+  path: '/connectors',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DeveloperRoute = DeveloperRouteImport.update({
-	id: "/developer",
-	path: "/developer",
-	getParentRoute: () => rootRouteImport,
+  id: '/developer',
+  path: '/developer',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const FlowLabRoute = FlowLabRouteImport.update({
-	id: "/flow-lab",
-	path: "/flow-lab",
-	getParentRoute: () => rootRouteImport,
+  id: '/flow-lab',
+  path: '/flow-lab',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const InfraBenchRoute = InfraBenchRouteImport.update({
-	id: "/infra-bench",
-	path: "/infra-bench",
-	getParentRoute: () => rootRouteImport,
+  id: '/infra-bench',
+  path: '/infra-bench',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const IntegrationsRoute = IntegrationsRouteImport.update({
-	id: "/integrations",
-	path: "/integrations",
-	getParentRoute: () => rootRouteImport,
+  id: '/integrations',
+  path: '/integrations',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const LogsBenchRoute = LogsBenchRouteImport.update({
-	id: "/logs-bench",
-	path: "/logs-bench",
-	getParentRoute: () => rootRouteImport,
+  id: '/logs-bench',
+  path: '/logs-bench',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const McpRoute = McpRouteImport.update({
-	id: "/mcp",
-	path: "/mcp",
-	getParentRoute: () => rootRouteImport,
+  id: '/mcp',
+  path: '/mcp',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const McpAuthorizeRoute = McpAuthorizeRouteImport.update({
-	id: "/mcp-authorize",
-	path: "/mcp-authorize",
-	getParentRoute: () => rootRouteImport,
+  id: '/mcp-authorize',
+  path: '/mcp-authorize',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const NodeLabRoute = NodeLabRouteImport.update({
-	id: "/node-lab",
-	path: "/node-lab",
-	getParentRoute: () => rootRouteImport,
+  id: '/node-lab',
+  path: '/node-lab',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const OrgRequiredRoute = OrgRequiredRouteImport.update({
-	id: "/org-required",
-	path: "/org-required",
-	getParentRoute: () => rootRouteImport,
+  id: '/org-required',
+  path: '/org-required',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const OverviewBenchRoute = OverviewBenchRouteImport.update({
-	id: "/overview-bench",
-	path: "/overview-bench",
-	getParentRoute: () => rootRouteImport,
+  id: '/overview-bench',
+  path: '/overview-bench',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const QueryBuilderLabRoute = QueryBuilderLabRouteImport.update({
-	id: "/query-builder-lab",
-	path: "/query-builder-lab",
-	getParentRoute: () => rootRouteImport,
+  id: '/query-builder-lab',
+  path: '/query-builder-lab',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const QuickStartRoute = QuickStartRouteImport.update({
-	id: "/quick-start",
-	path: "/quick-start",
-	getParentRoute: () => rootRouteImport,
+  id: '/quick-start',
+  path: '/quick-start',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const SelectPlanRoute = SelectPlanRouteImport.update({
-	id: "/select-plan",
-	path: "/select-plan",
-	getParentRoute: () => rootRouteImport,
+  id: '/select-plan',
+  path: '/select-plan',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ServiceDetailBenchRoute = ServiceDetailBenchRouteImport.update({
-	id: "/service-detail-bench",
-	path: "/service-detail-bench",
-	getParentRoute: () => rootRouteImport,
+  id: '/service-detail-bench',
+  path: '/service-detail-bench',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ServiceMapRoute = ServiceMapRouteImport.update({
-	id: "/service-map",
-	path: "/service-map",
-	getParentRoute: () => rootRouteImport,
+  id: '/service-map',
+  path: '/service-map',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ServiceMapBenchRoute = ServiceMapBenchRouteImport.update({
-	id: "/service-map-bench",
-	path: "/service-map-bench",
-	getParentRoute: () => rootRouteImport,
+  id: '/service-map-bench',
+  path: '/service-map-bench',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const SettingsRoute = SettingsRouteImport.update({
-	id: "/settings",
-	path: "/settings",
-	getParentRoute: () => rootRouteImport,
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const SignInRoute = SignInRouteImport.update({
-	id: "/sign-in",
-	path: "/sign-in",
-	getParentRoute: () => rootRouteImport,
+  id: '/sign-in',
+  path: '/sign-in',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const SignUpRoute = SignUpRouteImport.update({
-	id: "/sign-up",
-	path: "/sign-up",
-	getParentRoute: () => rootRouteImport,
+  id: '/sign-up',
+  path: '/sign-up',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const TimelineLabRoute = TimelineLabRouteImport.update({
-	id: "/timeline-lab",
-	path: "/timeline-lab",
-	getParentRoute: () => rootRouteImport,
+  id: '/timeline-lab',
+  path: '/timeline-lab',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const WidgetLabRoute = WidgetLabRouteImport.update({
-	id: "/widget-lab",
-	path: "/widget-lab",
-	getParentRoute: () => rootRouteImport,
+  id: '/widget-lab',
+  path: '/widget-lab',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AlertsIndexRoute = AlertsIndexRouteImport.update({
-	id: "/alerts/",
-	path: "/alerts/",
-	getParentRoute: () => rootRouteImport,
+  id: '/alerts/',
+  path: '/alerts/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AlertsRuleIdRoute = AlertsRuleIdRouteImport.update({
-	id: "/alerts/$ruleId",
-	path: "/alerts/$ruleId",
-	getParentRoute: () => rootRouteImport,
+  id: '/alerts/$ruleId',
+  path: '/alerts/$ruleId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AlertsCreateRoute = AlertsCreateRouteImport.update({
-	id: "/alerts/create",
-	path: "/alerts/create",
-	getParentRoute: () => rootRouteImport,
+  id: '/alerts/create',
+  path: '/alerts/create',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AnalyticsIndexRoute = AnalyticsIndexRouteImport.update({
-	id: "/analytics/",
-	path: "/analytics/",
-	getParentRoute: () => rootRouteImport,
+  id: '/analytics/',
+  path: '/analytics/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AnomaliesIndexRoute = AnomaliesIndexRouteImport.update({
-	id: "/anomalies/",
-	path: "/anomalies/",
-	getParentRoute: () => rootRouteImport,
+  id: '/anomalies/',
+  path: '/anomalies/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AnomaliesIncidentIdRoute = AnomaliesIncidentIdRouteImport.update({
-	id: "/anomalies/$incidentId",
-	path: "/anomalies/$incidentId",
-	getParentRoute: () => rootRouteImport,
+  id: '/anomalies/$incidentId',
+  path: '/anomalies/$incidentId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardsIndexRoute = DashboardsIndexRouteImport.update({
-	id: "/dashboards/",
-	path: "/dashboards/",
-	getParentRoute: () => rootRouteImport,
+  id: '/dashboards/',
+  path: '/dashboards/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardsDashboardIdRoute = DashboardsDashboardIdRouteImport.update({
-	id: "/dashboards/$dashboardId",
-	path: "/dashboards/$dashboardId",
-	getParentRoute: () => rootRouteImport,
+  id: '/dashboards/$dashboardId',
+  path: '/dashboards/$dashboardId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardsTemplatesRoute = DashboardsTemplatesRouteImport.update({
-	id: "/dashboards/templates",
-	path: "/dashboards/templates",
-	getParentRoute: () => rootRouteImport,
+  id: '/dashboards/templates',
+  path: '/dashboards/templates',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ErrorsIndexRoute = ErrorsIndexRouteImport.update({
-	id: "/errors/",
-	path: "/errors/",
-	getParentRoute: () => rootRouteImport,
+  id: '/errors/',
+  path: '/errors/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ErrorsErrorTypeRoute = ErrorsErrorTypeRouteImport.update({
-	id: "/errors/$errorType",
-	path: "/errors/$errorType",
-	getParentRoute: () => rootRouteImport,
+  id: '/errors/$errorType',
+  path: '/errors/$errorType',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const InfraIndexRoute = InfraIndexRouteImport.update({
-	id: "/infra/",
-	path: "/infra/",
-	getParentRoute: () => rootRouteImport,
+  id: '/infra/',
+  path: '/infra/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const InfraHostNameRoute = InfraHostNameRouteImport.update({
-	id: "/infra/$hostName",
-	path: "/infra/$hostName",
-	getParentRoute: () => rootRouteImport,
+  id: '/infra/$hostName',
+  path: '/infra/$hostName',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const InvestigationsIndexRoute = InvestigationsIndexRouteImport.update({
-	id: "/investigations/",
-	path: "/investigations/",
-	getParentRoute: () => rootRouteImport,
+  id: '/investigations/',
+  path: '/investigations/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const InvestigationsIdRoute = InvestigationsIdRouteImport.update({
-	id: "/investigations/$id",
-	path: "/investigations/$id",
-	getParentRoute: () => rootRouteImport,
+  id: '/investigations/$id',
+  path: '/investigations/$id',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const LogsIndexRoute = LogsIndexRouteImport.update({
-	id: "/logs/",
-	path: "/logs/",
-	getParentRoute: () => rootRouteImport,
+  id: '/logs/',
+  path: '/logs/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const LogsLogIdRoute = LogsLogIdRouteImport.update({
-	id: "/logs/$logId",
-	path: "/logs/$logId",
-	getParentRoute: () => rootRouteImport,
+  id: '/logs/$logId',
+  path: '/logs/$logId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const MetricsIndexRoute = MetricsIndexRouteImport.update({
-	id: "/metrics/",
-	path: "/metrics/",
-	getParentRoute: () => rootRouteImport,
+  id: '/metrics/',
+  path: '/metrics/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const MetricsMetricNameRoute = MetricsMetricNameRouteImport.update({
-	id: "/metrics/$metricName",
-	path: "/metrics/$metricName",
-	getParentRoute: () => rootRouteImport,
+  id: '/metrics/$metricName',
+  path: '/metrics/$metricName',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const RecommendationsRecommendationKeyRoute =
-	RecommendationsRecommendationKeyRouteImport.update({
-		id: "/recommendations/$recommendationKey",
-		path: "/recommendations/$recommendationKey",
-		getParentRoute: () => rootRouteImport,
-	} as any)
+  RecommendationsRecommendationKeyRouteImport.update({
+    id: '/recommendations/$recommendationKey',
+    path: '/recommendations/$recommendationKey',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ReplaysIndexRoute = ReplaysIndexRouteImport.update({
-	id: "/replays/",
-	path: "/replays/",
-	getParentRoute: () => rootRouteImport,
+  id: '/replays/',
+  path: '/replays/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ReplaysSessionIdRoute = ReplaysSessionIdRouteImport.update({
-	id: "/replays/$sessionId",
-	path: "/replays/$sessionId",
-	getParentRoute: () => rootRouteImport,
+  id: '/replays/$sessionId',
+  path: '/replays/$sessionId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ServicesIndexRoute = ServicesIndexRouteImport.update({
-	id: "/services/",
-	path: "/services/",
-	getParentRoute: () => rootRouteImport,
+  id: '/services/',
+  path: '/services/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ServicesServiceNameRoute = ServicesServiceNameRouteImport.update({
-	id: "/services/$serviceName",
-	path: "/services/$serviceName",
-	getParentRoute: () => rootRouteImport,
+  id: '/services/$serviceName',
+  path: '/services/$serviceName',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ShareTokenRoute = ShareTokenRouteImport.update({
-	id: "/share/$token",
-	path: "/share/$token",
-	getParentRoute: () => rootRouteImport,
+  id: '/share/$token',
+  path: '/share/$token',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const TracesIndexRoute = TracesIndexRouteImport.update({
-	id: "/traces/",
-	path: "/traces/",
-	getParentRoute: () => rootRouteImport,
+  id: '/traces/',
+  path: '/traces/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const TracesTraceIdRoute = TracesTraceIdRouteImport.update({
-	id: "/traces/$traceId",
-	path: "/traces/$traceId",
-	getParentRoute: () => rootRouteImport,
+  id: '/traces/$traceId',
+  path: '/traces/$traceId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AlertsIncidentsIncidentIdRoute =
-	AlertsIncidentsIncidentIdRouteImport.update({
-		id: "/alerts/incidents/$incidentId",
-		path: "/alerts/incidents/$incidentId",
-		getParentRoute: () => rootRouteImport,
-	} as any)
+  AlertsIncidentsIncidentIdRouteImport.update({
+    id: '/alerts/incidents/$incidentId',
+    path: '/alerts/incidents/$incidentId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ErrorsIssuesIndexRoute = ErrorsIssuesIndexRouteImport.update({
-	id: "/errors/issues/",
-	path: "/errors/issues/",
-	getParentRoute: () => rootRouteImport,
+  id: '/errors/issues/',
+  path: '/errors/issues/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ErrorsIssuesIssueIdRoute = ErrorsIssuesIssueIdRouteImport.update({
-	id: "/errors/issues/$issueId",
-	path: "/errors/issues/$issueId",
-	getParentRoute: () => rootRouteImport,
+  id: '/errors/issues/$issueId',
+  path: '/errors/issues/$issueId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const InfraCloudflareIndexRoute = InfraCloudflareIndexRouteImport.update({
-	id: "/infra/cloudflare/",
-	path: "/infra/cloudflare/",
-	getParentRoute: () => rootRouteImport,
+  id: '/infra/cloudflare/',
+  path: '/infra/cloudflare/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const InfraCloudflareZoneNameRoute = InfraCloudflareZoneNameRouteImport.update({
-	id: "/infra/cloudflare/$zoneName",
-	path: "/infra/cloudflare/$zoneName",
-	getParentRoute: () => rootRouteImport,
+  id: '/infra/cloudflare/$zoneName',
+  path: '/infra/cloudflare/$zoneName',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const InfraPlanetscaleIndexRoute = InfraPlanetscaleIndexRouteImport.update({
-	id: "/infra/planetscale/",
-	path: "/infra/planetscale/",
-	getParentRoute: () => rootRouteImport,
+  id: '/infra/planetscale/',
+  path: '/infra/planetscale/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const InfraPlanetscaleDbNameRoute = InfraPlanetscaleDbNameRouteImport.update({
-	id: "/infra/planetscale/$dbName",
-	path: "/infra/planetscale/$dbName",
-	getParentRoute: () => rootRouteImport,
+  id: '/infra/planetscale/$dbName',
+  path: '/infra/planetscale/$dbName',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardsDashboardIdWidgetsWidgetIdRoute =
-	DashboardsDashboardIdWidgetsWidgetIdRouteImport.update({
-		id: "/dashboards/$dashboardId_/widgets/$widgetId",
-		path: "/dashboards/$dashboardId/widgets/$widgetId",
-		getParentRoute: () => rootRouteImport,
-	} as any)
+  DashboardsDashboardIdWidgetsWidgetIdRouteImport.update({
+    id: '/dashboards/$dashboardId_/widgets/$widgetId',
+    path: '/dashboards/$dashboardId/widgets/$widgetId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const InfraKubernetesNodesIndexRoute =
-	InfraKubernetesNodesIndexRouteImport.update({
-		id: "/infra/kubernetes/nodes/",
-		path: "/infra/kubernetes/nodes/",
-		getParentRoute: () => rootRouteImport,
-	} as any)
+  InfraKubernetesNodesIndexRouteImport.update({
+    id: '/infra/kubernetes/nodes/',
+    path: '/infra/kubernetes/nodes/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const InfraKubernetesNodesNodeNameRoute =
-	InfraKubernetesNodesNodeNameRouteImport.update({
-		id: "/infra/kubernetes/nodes/$nodeName",
-		path: "/infra/kubernetes/nodes/$nodeName",
-		getParentRoute: () => rootRouteImport,
-	} as any)
+  InfraKubernetesNodesNodeNameRouteImport.update({
+    id: '/infra/kubernetes/nodes/$nodeName',
+    path: '/infra/kubernetes/nodes/$nodeName',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const InfraKubernetesPodsIndexRoute =
-	InfraKubernetesPodsIndexRouteImport.update({
-		id: "/infra/kubernetes/pods/",
-		path: "/infra/kubernetes/pods/",
-		getParentRoute: () => rootRouteImport,
-	} as any)
+  InfraKubernetesPodsIndexRouteImport.update({
+    id: '/infra/kubernetes/pods/',
+    path: '/infra/kubernetes/pods/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const InfraKubernetesPodsPodNameRoute =
-	InfraKubernetesPodsPodNameRouteImport.update({
-		id: "/infra/kubernetes/pods/$podName",
-		path: "/infra/kubernetes/pods/$podName",
-		getParentRoute: () => rootRouteImport,
-	} as any)
+  InfraKubernetesPodsPodNameRouteImport.update({
+    id: '/infra/kubernetes/pods/$podName',
+    path: '/infra/kubernetes/pods/$podName',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const InfraKubernetesWorkloadsIndexRoute =
-	InfraKubernetesWorkloadsIndexRouteImport.update({
-		id: "/infra/kubernetes/workloads/",
-		path: "/infra/kubernetes/workloads/",
-		getParentRoute: () => rootRouteImport,
-	} as any)
+  InfraKubernetesWorkloadsIndexRouteImport.update({
+    id: '/infra/kubernetes/workloads/',
+    path: '/infra/kubernetes/workloads/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const InfraKubernetesWorkloadsKindWorkloadNameRoute =
-	InfraKubernetesWorkloadsKindWorkloadNameRouteImport.update({
-		id: "/infra/kubernetes/workloads/$kind/$workloadName",
-		path: "/infra/kubernetes/workloads/$kind/$workloadName",
-		getParentRoute: () => rootRouteImport,
-	} as any)
+  InfraKubernetesWorkloadsKindWorkloadNameRouteImport.update({
+    id: '/infra/kubernetes/workloads/$kind/$workloadName',
+    path: '/infra/kubernetes/workloads/$kind/$workloadName',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
-	"/": typeof IndexRoute
-	"/account": typeof AccountRoute
-	"/chat": typeof ChatRoute
-	"/cli-login": typeof CliLoginRoute
-	"/connectors": typeof ConnectorsRoute
-	"/developer": typeof DeveloperRoute
-	"/flow-lab": typeof FlowLabRoute
-	"/infra-bench": typeof InfraBenchRoute
-	"/integrations": typeof IntegrationsRoute
-	"/logs-bench": typeof LogsBenchRoute
-	"/mcp": typeof McpRoute
-	"/mcp-authorize": typeof McpAuthorizeRoute
-	"/node-lab": typeof NodeLabRoute
-	"/org-required": typeof OrgRequiredRoute
-	"/overview-bench": typeof OverviewBenchRoute
-	"/query-builder-lab": typeof QueryBuilderLabRoute
-	"/quick-start": typeof QuickStartRoute
-	"/select-plan": typeof SelectPlanRoute
-	"/service-detail-bench": typeof ServiceDetailBenchRoute
-	"/service-map": typeof ServiceMapRoute
-	"/service-map-bench": typeof ServiceMapBenchRoute
-	"/settings": typeof SettingsRoute
-	"/sign-in": typeof SignInRoute
-	"/sign-up": typeof SignUpRoute
-	"/timeline-lab": typeof TimelineLabRoute
-	"/widget-lab": typeof WidgetLabRoute
-	"/alerts/$ruleId": typeof AlertsRuleIdRoute
-	"/alerts/create": typeof AlertsCreateRoute
-	"/anomalies/$incidentId": typeof AnomaliesIncidentIdRoute
-	"/dashboards/$dashboardId": typeof DashboardsDashboardIdRoute
-	"/dashboards/templates": typeof DashboardsTemplatesRoute
-	"/errors/$errorType": typeof ErrorsErrorTypeRoute
-	"/infra/$hostName": typeof InfraHostNameRoute
-	"/investigations/$id": typeof InvestigationsIdRoute
-	"/logs/$logId": typeof LogsLogIdRoute
-	"/metrics/$metricName": typeof MetricsMetricNameRoute
-	"/recommendations/$recommendationKey": typeof RecommendationsRecommendationKeyRoute
-	"/replays/$sessionId": typeof ReplaysSessionIdRoute
-	"/services/$serviceName": typeof ServicesServiceNameRoute
-	"/share/$token": typeof ShareTokenRoute
-	"/traces/$traceId": typeof TracesTraceIdRoute
-	"/alerts/": typeof AlertsIndexRoute
-	"/analytics/": typeof AnalyticsIndexRoute
-	"/anomalies/": typeof AnomaliesIndexRoute
-	"/dashboards/": typeof DashboardsIndexRoute
-	"/errors/": typeof ErrorsIndexRoute
-	"/infra/": typeof InfraIndexRoute
-	"/investigations/": typeof InvestigationsIndexRoute
-	"/logs/": typeof LogsIndexRoute
-	"/metrics/": typeof MetricsIndexRoute
-	"/replays/": typeof ReplaysIndexRoute
-	"/services/": typeof ServicesIndexRoute
-	"/traces/": typeof TracesIndexRoute
-	"/alerts/incidents/$incidentId": typeof AlertsIncidentsIncidentIdRoute
-	"/errors/issues/$issueId": typeof ErrorsIssuesIssueIdRoute
-	"/infra/cloudflare/$zoneName": typeof InfraCloudflareZoneNameRoute
-	"/infra/planetscale/$dbName": typeof InfraPlanetscaleDbNameRoute
-	"/errors/issues/": typeof ErrorsIssuesIndexRoute
-	"/infra/cloudflare/": typeof InfraCloudflareIndexRoute
-	"/infra/planetscale/": typeof InfraPlanetscaleIndexRoute
-	"/dashboards/$dashboardId/widgets/$widgetId": typeof DashboardsDashboardIdWidgetsWidgetIdRoute
-	"/infra/kubernetes/nodes/$nodeName": typeof InfraKubernetesNodesNodeNameRoute
-	"/infra/kubernetes/pods/$podName": typeof InfraKubernetesPodsPodNameRoute
-	"/infra/kubernetes/nodes/": typeof InfraKubernetesNodesIndexRoute
-	"/infra/kubernetes/pods/": typeof InfraKubernetesPodsIndexRoute
-	"/infra/kubernetes/workloads/": typeof InfraKubernetesWorkloadsIndexRoute
-	"/infra/kubernetes/workloads/$kind/$workloadName": typeof InfraKubernetesWorkloadsKindWorkloadNameRoute
+  '/': typeof IndexRoute
+  '/account': typeof AccountRoute
+  '/chat': typeof ChatRoute
+  '/cli-login': typeof CliLoginRoute
+  '/connectors': typeof ConnectorsRoute
+  '/developer': typeof DeveloperRoute
+  '/flow-lab': typeof FlowLabRoute
+  '/infra-bench': typeof InfraBenchRoute
+  '/integrations': typeof IntegrationsRoute
+  '/logs-bench': typeof LogsBenchRoute
+  '/mcp': typeof McpRoute
+  '/mcp-authorize': typeof McpAuthorizeRoute
+  '/node-lab': typeof NodeLabRoute
+  '/org-required': typeof OrgRequiredRoute
+  '/overview-bench': typeof OverviewBenchRoute
+  '/query-builder-lab': typeof QueryBuilderLabRoute
+  '/quick-start': typeof QuickStartRoute
+  '/select-plan': typeof SelectPlanRoute
+  '/service-detail-bench': typeof ServiceDetailBenchRoute
+  '/service-map': typeof ServiceMapRoute
+  '/service-map-bench': typeof ServiceMapBenchRoute
+  '/settings': typeof SettingsRoute
+  '/sign-in': typeof SignInRoute
+  '/sign-up': typeof SignUpRoute
+  '/timeline-lab': typeof TimelineLabRoute
+  '/widget-lab': typeof WidgetLabRoute
+  '/alerts/$ruleId': typeof AlertsRuleIdRoute
+  '/alerts/create': typeof AlertsCreateRoute
+  '/anomalies/$incidentId': typeof AnomaliesIncidentIdRoute
+  '/dashboards/$dashboardId': typeof DashboardsDashboardIdRoute
+  '/dashboards/templates': typeof DashboardsTemplatesRoute
+  '/errors/$errorType': typeof ErrorsErrorTypeRoute
+  '/infra/$hostName': typeof InfraHostNameRoute
+  '/investigations/$id': typeof InvestigationsIdRoute
+  '/logs/$logId': typeof LogsLogIdRoute
+  '/metrics/$metricName': typeof MetricsMetricNameRoute
+  '/recommendations/$recommendationKey': typeof RecommendationsRecommendationKeyRoute
+  '/replays/$sessionId': typeof ReplaysSessionIdRoute
+  '/services/$serviceName': typeof ServicesServiceNameRoute
+  '/share/$token': typeof ShareTokenRoute
+  '/traces/$traceId': typeof TracesTraceIdRoute
+  '/alerts/': typeof AlertsIndexRoute
+  '/analytics/': typeof AnalyticsIndexRoute
+  '/anomalies/': typeof AnomaliesIndexRoute
+  '/dashboards/': typeof DashboardsIndexRoute
+  '/errors/': typeof ErrorsIndexRoute
+  '/infra/': typeof InfraIndexRoute
+  '/investigations/': typeof InvestigationsIndexRoute
+  '/logs/': typeof LogsIndexRoute
+  '/metrics/': typeof MetricsIndexRoute
+  '/replays/': typeof ReplaysIndexRoute
+  '/services/': typeof ServicesIndexRoute
+  '/traces/': typeof TracesIndexRoute
+  '/alerts/incidents/$incidentId': typeof AlertsIncidentsIncidentIdRoute
+  '/errors/issues/$issueId': typeof ErrorsIssuesIssueIdRoute
+  '/infra/cloudflare/$zoneName': typeof InfraCloudflareZoneNameRoute
+  '/infra/planetscale/$dbName': typeof InfraPlanetscaleDbNameRoute
+  '/errors/issues/': typeof ErrorsIssuesIndexRoute
+  '/infra/cloudflare/': typeof InfraCloudflareIndexRoute
+  '/infra/planetscale/': typeof InfraPlanetscaleIndexRoute
+  '/dashboards/$dashboardId/widgets/$widgetId': typeof DashboardsDashboardIdWidgetsWidgetIdRoute
+  '/infra/kubernetes/nodes/$nodeName': typeof InfraKubernetesNodesNodeNameRoute
+  '/infra/kubernetes/pods/$podName': typeof InfraKubernetesPodsPodNameRoute
+  '/infra/kubernetes/nodes/': typeof InfraKubernetesNodesIndexRoute
+  '/infra/kubernetes/pods/': typeof InfraKubernetesPodsIndexRoute
+  '/infra/kubernetes/workloads/': typeof InfraKubernetesWorkloadsIndexRoute
+  '/infra/kubernetes/workloads/$kind/$workloadName': typeof InfraKubernetesWorkloadsKindWorkloadNameRoute
 }
 export interface FileRoutesByTo {
-	"/": typeof IndexRoute
-	"/account": typeof AccountRoute
-	"/chat": typeof ChatRoute
-	"/cli-login": typeof CliLoginRoute
-	"/connectors": typeof ConnectorsRoute
-	"/developer": typeof DeveloperRoute
-	"/flow-lab": typeof FlowLabRoute
-	"/infra-bench": typeof InfraBenchRoute
-	"/integrations": typeof IntegrationsRoute
-	"/logs-bench": typeof LogsBenchRoute
-	"/mcp": typeof McpRoute
-	"/mcp-authorize": typeof McpAuthorizeRoute
-	"/node-lab": typeof NodeLabRoute
-	"/org-required": typeof OrgRequiredRoute
-	"/overview-bench": typeof OverviewBenchRoute
-	"/query-builder-lab": typeof QueryBuilderLabRoute
-	"/quick-start": typeof QuickStartRoute
-	"/select-plan": typeof SelectPlanRoute
-	"/service-detail-bench": typeof ServiceDetailBenchRoute
-	"/service-map": typeof ServiceMapRoute
-	"/service-map-bench": typeof ServiceMapBenchRoute
-	"/settings": typeof SettingsRoute
-	"/sign-in": typeof SignInRoute
-	"/sign-up": typeof SignUpRoute
-	"/timeline-lab": typeof TimelineLabRoute
-	"/widget-lab": typeof WidgetLabRoute
-	"/alerts/$ruleId": typeof AlertsRuleIdRoute
-	"/alerts/create": typeof AlertsCreateRoute
-	"/anomalies/$incidentId": typeof AnomaliesIncidentIdRoute
-	"/dashboards/$dashboardId": typeof DashboardsDashboardIdRoute
-	"/dashboards/templates": typeof DashboardsTemplatesRoute
-	"/errors/$errorType": typeof ErrorsErrorTypeRoute
-	"/infra/$hostName": typeof InfraHostNameRoute
-	"/investigations/$id": typeof InvestigationsIdRoute
-	"/logs/$logId": typeof LogsLogIdRoute
-	"/metrics/$metricName": typeof MetricsMetricNameRoute
-	"/recommendations/$recommendationKey": typeof RecommendationsRecommendationKeyRoute
-	"/replays/$sessionId": typeof ReplaysSessionIdRoute
-	"/services/$serviceName": typeof ServicesServiceNameRoute
-	"/share/$token": typeof ShareTokenRoute
-	"/traces/$traceId": typeof TracesTraceIdRoute
-	"/alerts": typeof AlertsIndexRoute
-	"/analytics": typeof AnalyticsIndexRoute
-	"/anomalies": typeof AnomaliesIndexRoute
-	"/dashboards": typeof DashboardsIndexRoute
-	"/errors": typeof ErrorsIndexRoute
-	"/infra": typeof InfraIndexRoute
-	"/investigations": typeof InvestigationsIndexRoute
-	"/logs": typeof LogsIndexRoute
-	"/metrics": typeof MetricsIndexRoute
-	"/replays": typeof ReplaysIndexRoute
-	"/services": typeof ServicesIndexRoute
-	"/traces": typeof TracesIndexRoute
-	"/alerts/incidents/$incidentId": typeof AlertsIncidentsIncidentIdRoute
-	"/errors/issues/$issueId": typeof ErrorsIssuesIssueIdRoute
-	"/infra/cloudflare/$zoneName": typeof InfraCloudflareZoneNameRoute
-	"/infra/planetscale/$dbName": typeof InfraPlanetscaleDbNameRoute
-	"/errors/issues": typeof ErrorsIssuesIndexRoute
-	"/infra/cloudflare": typeof InfraCloudflareIndexRoute
-	"/infra/planetscale": typeof InfraPlanetscaleIndexRoute
-	"/dashboards/$dashboardId/widgets/$widgetId": typeof DashboardsDashboardIdWidgetsWidgetIdRoute
-	"/infra/kubernetes/nodes/$nodeName": typeof InfraKubernetesNodesNodeNameRoute
-	"/infra/kubernetes/pods/$podName": typeof InfraKubernetesPodsPodNameRoute
-	"/infra/kubernetes/nodes": typeof InfraKubernetesNodesIndexRoute
-	"/infra/kubernetes/pods": typeof InfraKubernetesPodsIndexRoute
-	"/infra/kubernetes/workloads": typeof InfraKubernetesWorkloadsIndexRoute
-	"/infra/kubernetes/workloads/$kind/$workloadName": typeof InfraKubernetesWorkloadsKindWorkloadNameRoute
+  '/': typeof IndexRoute
+  '/account': typeof AccountRoute
+  '/chat': typeof ChatRoute
+  '/cli-login': typeof CliLoginRoute
+  '/connectors': typeof ConnectorsRoute
+  '/developer': typeof DeveloperRoute
+  '/flow-lab': typeof FlowLabRoute
+  '/infra-bench': typeof InfraBenchRoute
+  '/integrations': typeof IntegrationsRoute
+  '/logs-bench': typeof LogsBenchRoute
+  '/mcp': typeof McpRoute
+  '/mcp-authorize': typeof McpAuthorizeRoute
+  '/node-lab': typeof NodeLabRoute
+  '/org-required': typeof OrgRequiredRoute
+  '/overview-bench': typeof OverviewBenchRoute
+  '/query-builder-lab': typeof QueryBuilderLabRoute
+  '/quick-start': typeof QuickStartRoute
+  '/select-plan': typeof SelectPlanRoute
+  '/service-detail-bench': typeof ServiceDetailBenchRoute
+  '/service-map': typeof ServiceMapRoute
+  '/service-map-bench': typeof ServiceMapBenchRoute
+  '/settings': typeof SettingsRoute
+  '/sign-in': typeof SignInRoute
+  '/sign-up': typeof SignUpRoute
+  '/timeline-lab': typeof TimelineLabRoute
+  '/widget-lab': typeof WidgetLabRoute
+  '/alerts/$ruleId': typeof AlertsRuleIdRoute
+  '/alerts/create': typeof AlertsCreateRoute
+  '/anomalies/$incidentId': typeof AnomaliesIncidentIdRoute
+  '/dashboards/$dashboardId': typeof DashboardsDashboardIdRoute
+  '/dashboards/templates': typeof DashboardsTemplatesRoute
+  '/errors/$errorType': typeof ErrorsErrorTypeRoute
+  '/infra/$hostName': typeof InfraHostNameRoute
+  '/investigations/$id': typeof InvestigationsIdRoute
+  '/logs/$logId': typeof LogsLogIdRoute
+  '/metrics/$metricName': typeof MetricsMetricNameRoute
+  '/recommendations/$recommendationKey': typeof RecommendationsRecommendationKeyRoute
+  '/replays/$sessionId': typeof ReplaysSessionIdRoute
+  '/services/$serviceName': typeof ServicesServiceNameRoute
+  '/share/$token': typeof ShareTokenRoute
+  '/traces/$traceId': typeof TracesTraceIdRoute
+  '/alerts': typeof AlertsIndexRoute
+  '/analytics': typeof AnalyticsIndexRoute
+  '/anomalies': typeof AnomaliesIndexRoute
+  '/dashboards': typeof DashboardsIndexRoute
+  '/errors': typeof ErrorsIndexRoute
+  '/infra': typeof InfraIndexRoute
+  '/investigations': typeof InvestigationsIndexRoute
+  '/logs': typeof LogsIndexRoute
+  '/metrics': typeof MetricsIndexRoute
+  '/replays': typeof ReplaysIndexRoute
+  '/services': typeof ServicesIndexRoute
+  '/traces': typeof TracesIndexRoute
+  '/alerts/incidents/$incidentId': typeof AlertsIncidentsIncidentIdRoute
+  '/errors/issues/$issueId': typeof ErrorsIssuesIssueIdRoute
+  '/infra/cloudflare/$zoneName': typeof InfraCloudflareZoneNameRoute
+  '/infra/planetscale/$dbName': typeof InfraPlanetscaleDbNameRoute
+  '/errors/issues': typeof ErrorsIssuesIndexRoute
+  '/infra/cloudflare': typeof InfraCloudflareIndexRoute
+  '/infra/planetscale': typeof InfraPlanetscaleIndexRoute
+  '/dashboards/$dashboardId/widgets/$widgetId': typeof DashboardsDashboardIdWidgetsWidgetIdRoute
+  '/infra/kubernetes/nodes/$nodeName': typeof InfraKubernetesNodesNodeNameRoute
+  '/infra/kubernetes/pods/$podName': typeof InfraKubernetesPodsPodNameRoute
+  '/infra/kubernetes/nodes': typeof InfraKubernetesNodesIndexRoute
+  '/infra/kubernetes/pods': typeof InfraKubernetesPodsIndexRoute
+  '/infra/kubernetes/workloads': typeof InfraKubernetesWorkloadsIndexRoute
+  '/infra/kubernetes/workloads/$kind/$workloadName': typeof InfraKubernetesWorkloadsKindWorkloadNameRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport
-	"/": typeof IndexRoute
-	"/account": typeof AccountRoute
-	"/chat": typeof ChatRoute
-	"/cli-login": typeof CliLoginRoute
-	"/connectors": typeof ConnectorsRoute
-	"/developer": typeof DeveloperRoute
-	"/flow-lab": typeof FlowLabRoute
-	"/infra-bench": typeof InfraBenchRoute
-	"/integrations": typeof IntegrationsRoute
-	"/logs-bench": typeof LogsBenchRoute
-	"/mcp": typeof McpRoute
-	"/mcp-authorize": typeof McpAuthorizeRoute
-	"/node-lab": typeof NodeLabRoute
-	"/org-required": typeof OrgRequiredRoute
-	"/overview-bench": typeof OverviewBenchRoute
-	"/query-builder-lab": typeof QueryBuilderLabRoute
-	"/quick-start": typeof QuickStartRoute
-	"/select-plan": typeof SelectPlanRoute
-	"/service-detail-bench": typeof ServiceDetailBenchRoute
-	"/service-map": typeof ServiceMapRoute
-	"/service-map-bench": typeof ServiceMapBenchRoute
-	"/settings": typeof SettingsRoute
-	"/sign-in": typeof SignInRoute
-	"/sign-up": typeof SignUpRoute
-	"/timeline-lab": typeof TimelineLabRoute
-	"/widget-lab": typeof WidgetLabRoute
-	"/alerts/$ruleId": typeof AlertsRuleIdRoute
-	"/alerts/create": typeof AlertsCreateRoute
-	"/anomalies/$incidentId": typeof AnomaliesIncidentIdRoute
-	"/dashboards/$dashboardId": typeof DashboardsDashboardIdRoute
-	"/dashboards/templates": typeof DashboardsTemplatesRoute
-	"/errors/$errorType": typeof ErrorsErrorTypeRoute
-	"/infra/$hostName": typeof InfraHostNameRoute
-	"/investigations/$id": typeof InvestigationsIdRoute
-	"/logs/$logId": typeof LogsLogIdRoute
-	"/metrics/$metricName": typeof MetricsMetricNameRoute
-	"/recommendations/$recommendationKey": typeof RecommendationsRecommendationKeyRoute
-	"/replays/$sessionId": typeof ReplaysSessionIdRoute
-	"/services/$serviceName": typeof ServicesServiceNameRoute
-	"/share/$token": typeof ShareTokenRoute
-	"/traces/$traceId": typeof TracesTraceIdRoute
-	"/alerts/": typeof AlertsIndexRoute
-	"/analytics/": typeof AnalyticsIndexRoute
-	"/anomalies/": typeof AnomaliesIndexRoute
-	"/dashboards/": typeof DashboardsIndexRoute
-	"/errors/": typeof ErrorsIndexRoute
-	"/infra/": typeof InfraIndexRoute
-	"/investigations/": typeof InvestigationsIndexRoute
-	"/logs/": typeof LogsIndexRoute
-	"/metrics/": typeof MetricsIndexRoute
-	"/replays/": typeof ReplaysIndexRoute
-	"/services/": typeof ServicesIndexRoute
-	"/traces/": typeof TracesIndexRoute
-	"/alerts/incidents/$incidentId": typeof AlertsIncidentsIncidentIdRoute
-	"/errors/issues/$issueId": typeof ErrorsIssuesIssueIdRoute
-	"/infra/cloudflare/$zoneName": typeof InfraCloudflareZoneNameRoute
-	"/infra/planetscale/$dbName": typeof InfraPlanetscaleDbNameRoute
-	"/errors/issues/": typeof ErrorsIssuesIndexRoute
-	"/infra/cloudflare/": typeof InfraCloudflareIndexRoute
-	"/infra/planetscale/": typeof InfraPlanetscaleIndexRoute
-	"/dashboards/$dashboardId_/widgets/$widgetId": typeof DashboardsDashboardIdWidgetsWidgetIdRoute
-	"/infra/kubernetes/nodes/$nodeName": typeof InfraKubernetesNodesNodeNameRoute
-	"/infra/kubernetes/pods/$podName": typeof InfraKubernetesPodsPodNameRoute
-	"/infra/kubernetes/nodes/": typeof InfraKubernetesNodesIndexRoute
-	"/infra/kubernetes/pods/": typeof InfraKubernetesPodsIndexRoute
-	"/infra/kubernetes/workloads/": typeof InfraKubernetesWorkloadsIndexRoute
-	"/infra/kubernetes/workloads/$kind/$workloadName": typeof InfraKubernetesWorkloadsKindWorkloadNameRoute
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/account': typeof AccountRoute
+  '/chat': typeof ChatRoute
+  '/cli-login': typeof CliLoginRoute
+  '/connectors': typeof ConnectorsRoute
+  '/developer': typeof DeveloperRoute
+  '/flow-lab': typeof FlowLabRoute
+  '/infra-bench': typeof InfraBenchRoute
+  '/integrations': typeof IntegrationsRoute
+  '/logs-bench': typeof LogsBenchRoute
+  '/mcp': typeof McpRoute
+  '/mcp-authorize': typeof McpAuthorizeRoute
+  '/node-lab': typeof NodeLabRoute
+  '/org-required': typeof OrgRequiredRoute
+  '/overview-bench': typeof OverviewBenchRoute
+  '/query-builder-lab': typeof QueryBuilderLabRoute
+  '/quick-start': typeof QuickStartRoute
+  '/select-plan': typeof SelectPlanRoute
+  '/service-detail-bench': typeof ServiceDetailBenchRoute
+  '/service-map': typeof ServiceMapRoute
+  '/service-map-bench': typeof ServiceMapBenchRoute
+  '/settings': typeof SettingsRoute
+  '/sign-in': typeof SignInRoute
+  '/sign-up': typeof SignUpRoute
+  '/timeline-lab': typeof TimelineLabRoute
+  '/widget-lab': typeof WidgetLabRoute
+  '/alerts/$ruleId': typeof AlertsRuleIdRoute
+  '/alerts/create': typeof AlertsCreateRoute
+  '/anomalies/$incidentId': typeof AnomaliesIncidentIdRoute
+  '/dashboards/$dashboardId': typeof DashboardsDashboardIdRoute
+  '/dashboards/templates': typeof DashboardsTemplatesRoute
+  '/errors/$errorType': typeof ErrorsErrorTypeRoute
+  '/infra/$hostName': typeof InfraHostNameRoute
+  '/investigations/$id': typeof InvestigationsIdRoute
+  '/logs/$logId': typeof LogsLogIdRoute
+  '/metrics/$metricName': typeof MetricsMetricNameRoute
+  '/recommendations/$recommendationKey': typeof RecommendationsRecommendationKeyRoute
+  '/replays/$sessionId': typeof ReplaysSessionIdRoute
+  '/services/$serviceName': typeof ServicesServiceNameRoute
+  '/share/$token': typeof ShareTokenRoute
+  '/traces/$traceId': typeof TracesTraceIdRoute
+  '/alerts/': typeof AlertsIndexRoute
+  '/analytics/': typeof AnalyticsIndexRoute
+  '/anomalies/': typeof AnomaliesIndexRoute
+  '/dashboards/': typeof DashboardsIndexRoute
+  '/errors/': typeof ErrorsIndexRoute
+  '/infra/': typeof InfraIndexRoute
+  '/investigations/': typeof InvestigationsIndexRoute
+  '/logs/': typeof LogsIndexRoute
+  '/metrics/': typeof MetricsIndexRoute
+  '/replays/': typeof ReplaysIndexRoute
+  '/services/': typeof ServicesIndexRoute
+  '/traces/': typeof TracesIndexRoute
+  '/alerts/incidents/$incidentId': typeof AlertsIncidentsIncidentIdRoute
+  '/errors/issues/$issueId': typeof ErrorsIssuesIssueIdRoute
+  '/infra/cloudflare/$zoneName': typeof InfraCloudflareZoneNameRoute
+  '/infra/planetscale/$dbName': typeof InfraPlanetscaleDbNameRoute
+  '/errors/issues/': typeof ErrorsIssuesIndexRoute
+  '/infra/cloudflare/': typeof InfraCloudflareIndexRoute
+  '/infra/planetscale/': typeof InfraPlanetscaleIndexRoute
+  '/dashboards/$dashboardId_/widgets/$widgetId': typeof DashboardsDashboardIdWidgetsWidgetIdRoute
+  '/infra/kubernetes/nodes/$nodeName': typeof InfraKubernetesNodesNodeNameRoute
+  '/infra/kubernetes/pods/$podName': typeof InfraKubernetesPodsPodNameRoute
+  '/infra/kubernetes/nodes/': typeof InfraKubernetesNodesIndexRoute
+  '/infra/kubernetes/pods/': typeof InfraKubernetesPodsIndexRoute
+  '/infra/kubernetes/workloads/': typeof InfraKubernetesWorkloadsIndexRoute
+  '/infra/kubernetes/workloads/$kind/$workloadName': typeof InfraKubernetesWorkloadsKindWorkloadNameRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath
-	fullPaths:
-		| "/"
-		| "/account"
-		| "/chat"
-		| "/cli-login"
-		| "/connectors"
-		| "/developer"
-		| "/flow-lab"
-		| "/infra-bench"
-		| "/integrations"
-		| "/logs-bench"
-		| "/mcp"
-		| "/mcp-authorize"
-		| "/node-lab"
-		| "/org-required"
-		| "/overview-bench"
-		| "/query-builder-lab"
-		| "/quick-start"
-		| "/select-plan"
-		| "/service-detail-bench"
-		| "/service-map"
-		| "/service-map-bench"
-		| "/settings"
-		| "/sign-in"
-		| "/sign-up"
-		| "/timeline-lab"
-		| "/widget-lab"
-		| "/alerts/$ruleId"
-		| "/alerts/create"
-		| "/anomalies/$incidentId"
-		| "/dashboards/$dashboardId"
-		| "/dashboards/templates"
-		| "/errors/$errorType"
-		| "/infra/$hostName"
-		| "/investigations/$id"
-		| "/logs/$logId"
-		| "/metrics/$metricName"
-		| "/recommendations/$recommendationKey"
-		| "/replays/$sessionId"
-		| "/services/$serviceName"
-		| "/share/$token"
-		| "/traces/$traceId"
-		| "/alerts/"
-		| "/analytics/"
-		| "/anomalies/"
-		| "/dashboards/"
-		| "/errors/"
-		| "/infra/"
-		| "/investigations/"
-		| "/logs/"
-		| "/metrics/"
-		| "/replays/"
-		| "/services/"
-		| "/traces/"
-		| "/alerts/incidents/$incidentId"
-		| "/errors/issues/$issueId"
-		| "/infra/cloudflare/$zoneName"
-		| "/infra/planetscale/$dbName"
-		| "/errors/issues/"
-		| "/infra/cloudflare/"
-		| "/infra/planetscale/"
-		| "/dashboards/$dashboardId/widgets/$widgetId"
-		| "/infra/kubernetes/nodes/$nodeName"
-		| "/infra/kubernetes/pods/$podName"
-		| "/infra/kubernetes/nodes/"
-		| "/infra/kubernetes/pods/"
-		| "/infra/kubernetes/workloads/"
-		| "/infra/kubernetes/workloads/$kind/$workloadName"
-	fileRoutesByTo: FileRoutesByTo
-	to:
-		| "/"
-		| "/account"
-		| "/chat"
-		| "/cli-login"
-		| "/connectors"
-		| "/developer"
-		| "/flow-lab"
-		| "/infra-bench"
-		| "/integrations"
-		| "/logs-bench"
-		| "/mcp"
-		| "/mcp-authorize"
-		| "/node-lab"
-		| "/org-required"
-		| "/overview-bench"
-		| "/query-builder-lab"
-		| "/quick-start"
-		| "/select-plan"
-		| "/service-detail-bench"
-		| "/service-map"
-		| "/service-map-bench"
-		| "/settings"
-		| "/sign-in"
-		| "/sign-up"
-		| "/timeline-lab"
-		| "/widget-lab"
-		| "/alerts/$ruleId"
-		| "/alerts/create"
-		| "/anomalies/$incidentId"
-		| "/dashboards/$dashboardId"
-		| "/dashboards/templates"
-		| "/errors/$errorType"
-		| "/infra/$hostName"
-		| "/investigations/$id"
-		| "/logs/$logId"
-		| "/metrics/$metricName"
-		| "/recommendations/$recommendationKey"
-		| "/replays/$sessionId"
-		| "/services/$serviceName"
-		| "/share/$token"
-		| "/traces/$traceId"
-		| "/alerts"
-		| "/analytics"
-		| "/anomalies"
-		| "/dashboards"
-		| "/errors"
-		| "/infra"
-		| "/investigations"
-		| "/logs"
-		| "/metrics"
-		| "/replays"
-		| "/services"
-		| "/traces"
-		| "/alerts/incidents/$incidentId"
-		| "/errors/issues/$issueId"
-		| "/infra/cloudflare/$zoneName"
-		| "/infra/planetscale/$dbName"
-		| "/errors/issues"
-		| "/infra/cloudflare"
-		| "/infra/planetscale"
-		| "/dashboards/$dashboardId/widgets/$widgetId"
-		| "/infra/kubernetes/nodes/$nodeName"
-		| "/infra/kubernetes/pods/$podName"
-		| "/infra/kubernetes/nodes"
-		| "/infra/kubernetes/pods"
-		| "/infra/kubernetes/workloads"
-		| "/infra/kubernetes/workloads/$kind/$workloadName"
-	id:
-		| "__root__"
-		| "/"
-		| "/account"
-		| "/chat"
-		| "/cli-login"
-		| "/connectors"
-		| "/developer"
-		| "/flow-lab"
-		| "/infra-bench"
-		| "/integrations"
-		| "/logs-bench"
-		| "/mcp"
-		| "/mcp-authorize"
-		| "/node-lab"
-		| "/org-required"
-		| "/overview-bench"
-		| "/query-builder-lab"
-		| "/quick-start"
-		| "/select-plan"
-		| "/service-detail-bench"
-		| "/service-map"
-		| "/service-map-bench"
-		| "/settings"
-		| "/sign-in"
-		| "/sign-up"
-		| "/timeline-lab"
-		| "/widget-lab"
-		| "/alerts/$ruleId"
-		| "/alerts/create"
-		| "/anomalies/$incidentId"
-		| "/dashboards/$dashboardId"
-		| "/dashboards/templates"
-		| "/errors/$errorType"
-		| "/infra/$hostName"
-		| "/investigations/$id"
-		| "/logs/$logId"
-		| "/metrics/$metricName"
-		| "/recommendations/$recommendationKey"
-		| "/replays/$sessionId"
-		| "/services/$serviceName"
-		| "/share/$token"
-		| "/traces/$traceId"
-		| "/alerts/"
-		| "/analytics/"
-		| "/anomalies/"
-		| "/dashboards/"
-		| "/errors/"
-		| "/infra/"
-		| "/investigations/"
-		| "/logs/"
-		| "/metrics/"
-		| "/replays/"
-		| "/services/"
-		| "/traces/"
-		| "/alerts/incidents/$incidentId"
-		| "/errors/issues/$issueId"
-		| "/infra/cloudflare/$zoneName"
-		| "/infra/planetscale/$dbName"
-		| "/errors/issues/"
-		| "/infra/cloudflare/"
-		| "/infra/planetscale/"
-		| "/dashboards/$dashboardId_/widgets/$widgetId"
-		| "/infra/kubernetes/nodes/$nodeName"
-		| "/infra/kubernetes/pods/$podName"
-		| "/infra/kubernetes/nodes/"
-		| "/infra/kubernetes/pods/"
-		| "/infra/kubernetes/workloads/"
-		| "/infra/kubernetes/workloads/$kind/$workloadName"
-	fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/account'
+    | '/chat'
+    | '/cli-login'
+    | '/connectors'
+    | '/developer'
+    | '/flow-lab'
+    | '/infra-bench'
+    | '/integrations'
+    | '/logs-bench'
+    | '/mcp'
+    | '/mcp-authorize'
+    | '/node-lab'
+    | '/org-required'
+    | '/overview-bench'
+    | '/query-builder-lab'
+    | '/quick-start'
+    | '/select-plan'
+    | '/service-detail-bench'
+    | '/service-map'
+    | '/service-map-bench'
+    | '/settings'
+    | '/sign-in'
+    | '/sign-up'
+    | '/timeline-lab'
+    | '/widget-lab'
+    | '/alerts/$ruleId'
+    | '/alerts/create'
+    | '/anomalies/$incidentId'
+    | '/dashboards/$dashboardId'
+    | '/dashboards/templates'
+    | '/errors/$errorType'
+    | '/infra/$hostName'
+    | '/investigations/$id'
+    | '/logs/$logId'
+    | '/metrics/$metricName'
+    | '/recommendations/$recommendationKey'
+    | '/replays/$sessionId'
+    | '/services/$serviceName'
+    | '/share/$token'
+    | '/traces/$traceId'
+    | '/alerts/'
+    | '/analytics/'
+    | '/anomalies/'
+    | '/dashboards/'
+    | '/errors/'
+    | '/infra/'
+    | '/investigations/'
+    | '/logs/'
+    | '/metrics/'
+    | '/replays/'
+    | '/services/'
+    | '/traces/'
+    | '/alerts/incidents/$incidentId'
+    | '/errors/issues/$issueId'
+    | '/infra/cloudflare/$zoneName'
+    | '/infra/planetscale/$dbName'
+    | '/errors/issues/'
+    | '/infra/cloudflare/'
+    | '/infra/planetscale/'
+    | '/dashboards/$dashboardId/widgets/$widgetId'
+    | '/infra/kubernetes/nodes/$nodeName'
+    | '/infra/kubernetes/pods/$podName'
+    | '/infra/kubernetes/nodes/'
+    | '/infra/kubernetes/pods/'
+    | '/infra/kubernetes/workloads/'
+    | '/infra/kubernetes/workloads/$kind/$workloadName'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/account'
+    | '/chat'
+    | '/cli-login'
+    | '/connectors'
+    | '/developer'
+    | '/flow-lab'
+    | '/infra-bench'
+    | '/integrations'
+    | '/logs-bench'
+    | '/mcp'
+    | '/mcp-authorize'
+    | '/node-lab'
+    | '/org-required'
+    | '/overview-bench'
+    | '/query-builder-lab'
+    | '/quick-start'
+    | '/select-plan'
+    | '/service-detail-bench'
+    | '/service-map'
+    | '/service-map-bench'
+    | '/settings'
+    | '/sign-in'
+    | '/sign-up'
+    | '/timeline-lab'
+    | '/widget-lab'
+    | '/alerts/$ruleId'
+    | '/alerts/create'
+    | '/anomalies/$incidentId'
+    | '/dashboards/$dashboardId'
+    | '/dashboards/templates'
+    | '/errors/$errorType'
+    | '/infra/$hostName'
+    | '/investigations/$id'
+    | '/logs/$logId'
+    | '/metrics/$metricName'
+    | '/recommendations/$recommendationKey'
+    | '/replays/$sessionId'
+    | '/services/$serviceName'
+    | '/share/$token'
+    | '/traces/$traceId'
+    | '/alerts'
+    | '/analytics'
+    | '/anomalies'
+    | '/dashboards'
+    | '/errors'
+    | '/infra'
+    | '/investigations'
+    | '/logs'
+    | '/metrics'
+    | '/replays'
+    | '/services'
+    | '/traces'
+    | '/alerts/incidents/$incidentId'
+    | '/errors/issues/$issueId'
+    | '/infra/cloudflare/$zoneName'
+    | '/infra/planetscale/$dbName'
+    | '/errors/issues'
+    | '/infra/cloudflare'
+    | '/infra/planetscale'
+    | '/dashboards/$dashboardId/widgets/$widgetId'
+    | '/infra/kubernetes/nodes/$nodeName'
+    | '/infra/kubernetes/pods/$podName'
+    | '/infra/kubernetes/nodes'
+    | '/infra/kubernetes/pods'
+    | '/infra/kubernetes/workloads'
+    | '/infra/kubernetes/workloads/$kind/$workloadName'
+  id:
+    | '__root__'
+    | '/'
+    | '/account'
+    | '/chat'
+    | '/cli-login'
+    | '/connectors'
+    | '/developer'
+    | '/flow-lab'
+    | '/infra-bench'
+    | '/integrations'
+    | '/logs-bench'
+    | '/mcp'
+    | '/mcp-authorize'
+    | '/node-lab'
+    | '/org-required'
+    | '/overview-bench'
+    | '/query-builder-lab'
+    | '/quick-start'
+    | '/select-plan'
+    | '/service-detail-bench'
+    | '/service-map'
+    | '/service-map-bench'
+    | '/settings'
+    | '/sign-in'
+    | '/sign-up'
+    | '/timeline-lab'
+    | '/widget-lab'
+    | '/alerts/$ruleId'
+    | '/alerts/create'
+    | '/anomalies/$incidentId'
+    | '/dashboards/$dashboardId'
+    | '/dashboards/templates'
+    | '/errors/$errorType'
+    | '/infra/$hostName'
+    | '/investigations/$id'
+    | '/logs/$logId'
+    | '/metrics/$metricName'
+    | '/recommendations/$recommendationKey'
+    | '/replays/$sessionId'
+    | '/services/$serviceName'
+    | '/share/$token'
+    | '/traces/$traceId'
+    | '/alerts/'
+    | '/analytics/'
+    | '/anomalies/'
+    | '/dashboards/'
+    | '/errors/'
+    | '/infra/'
+    | '/investigations/'
+    | '/logs/'
+    | '/metrics/'
+    | '/replays/'
+    | '/services/'
+    | '/traces/'
+    | '/alerts/incidents/$incidentId'
+    | '/errors/issues/$issueId'
+    | '/infra/cloudflare/$zoneName'
+    | '/infra/planetscale/$dbName'
+    | '/errors/issues/'
+    | '/infra/cloudflare/'
+    | '/infra/planetscale/'
+    | '/dashboards/$dashboardId_/widgets/$widgetId'
+    | '/infra/kubernetes/nodes/$nodeName'
+    | '/infra/kubernetes/pods/$podName'
+    | '/infra/kubernetes/nodes/'
+    | '/infra/kubernetes/pods/'
+    | '/infra/kubernetes/workloads/'
+    | '/infra/kubernetes/workloads/$kind/$workloadName'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute
-	AccountRoute: typeof AccountRoute
-	ChatRoute: typeof ChatRoute
-	CliLoginRoute: typeof CliLoginRoute
-	ConnectorsRoute: typeof ConnectorsRoute
-	DeveloperRoute: typeof DeveloperRoute
-	FlowLabRoute: typeof FlowLabRoute
-	InfraBenchRoute: typeof InfraBenchRoute
-	IntegrationsRoute: typeof IntegrationsRoute
-	LogsBenchRoute: typeof LogsBenchRoute
-	McpRoute: typeof McpRoute
-	McpAuthorizeRoute: typeof McpAuthorizeRoute
-	NodeLabRoute: typeof NodeLabRoute
-	OrgRequiredRoute: typeof OrgRequiredRoute
-	OverviewBenchRoute: typeof OverviewBenchRoute
-	QueryBuilderLabRoute: typeof QueryBuilderLabRoute
-	QuickStartRoute: typeof QuickStartRoute
-	SelectPlanRoute: typeof SelectPlanRoute
-	ServiceDetailBenchRoute: typeof ServiceDetailBenchRoute
-	ServiceMapRoute: typeof ServiceMapRoute
-	ServiceMapBenchRoute: typeof ServiceMapBenchRoute
-	SettingsRoute: typeof SettingsRoute
-	SignInRoute: typeof SignInRoute
-	SignUpRoute: typeof SignUpRoute
-	TimelineLabRoute: typeof TimelineLabRoute
-	WidgetLabRoute: typeof WidgetLabRoute
-	AlertsRuleIdRoute: typeof AlertsRuleIdRoute
-	AlertsCreateRoute: typeof AlertsCreateRoute
-	AnomaliesIncidentIdRoute: typeof AnomaliesIncidentIdRoute
-	DashboardsDashboardIdRoute: typeof DashboardsDashboardIdRoute
-	DashboardsTemplatesRoute: typeof DashboardsTemplatesRoute
-	ErrorsErrorTypeRoute: typeof ErrorsErrorTypeRoute
-	InfraHostNameRoute: typeof InfraHostNameRoute
-	InvestigationsIdRoute: typeof InvestigationsIdRoute
-	LogsLogIdRoute: typeof LogsLogIdRoute
-	MetricsMetricNameRoute: typeof MetricsMetricNameRoute
-	RecommendationsRecommendationKeyRoute: typeof RecommendationsRecommendationKeyRoute
-	ReplaysSessionIdRoute: typeof ReplaysSessionIdRoute
-	ServicesServiceNameRoute: typeof ServicesServiceNameRoute
-	ShareTokenRoute: typeof ShareTokenRoute
-	TracesTraceIdRoute: typeof TracesTraceIdRoute
-	AlertsIndexRoute: typeof AlertsIndexRoute
-	AnalyticsIndexRoute: typeof AnalyticsIndexRoute
-	AnomaliesIndexRoute: typeof AnomaliesIndexRoute
-	DashboardsIndexRoute: typeof DashboardsIndexRoute
-	ErrorsIndexRoute: typeof ErrorsIndexRoute
-	InfraIndexRoute: typeof InfraIndexRoute
-	InvestigationsIndexRoute: typeof InvestigationsIndexRoute
-	LogsIndexRoute: typeof LogsIndexRoute
-	MetricsIndexRoute: typeof MetricsIndexRoute
-	ReplaysIndexRoute: typeof ReplaysIndexRoute
-	ServicesIndexRoute: typeof ServicesIndexRoute
-	TracesIndexRoute: typeof TracesIndexRoute
-	AlertsIncidentsIncidentIdRoute: typeof AlertsIncidentsIncidentIdRoute
-	ErrorsIssuesIssueIdRoute: typeof ErrorsIssuesIssueIdRoute
-	InfraCloudflareZoneNameRoute: typeof InfraCloudflareZoneNameRoute
-	InfraPlanetscaleDbNameRoute: typeof InfraPlanetscaleDbNameRoute
-	ErrorsIssuesIndexRoute: typeof ErrorsIssuesIndexRoute
-	InfraCloudflareIndexRoute: typeof InfraCloudflareIndexRoute
-	InfraPlanetscaleIndexRoute: typeof InfraPlanetscaleIndexRoute
-	DashboardsDashboardIdWidgetsWidgetIdRoute: typeof DashboardsDashboardIdWidgetsWidgetIdRoute
-	InfraKubernetesNodesNodeNameRoute: typeof InfraKubernetesNodesNodeNameRoute
-	InfraKubernetesPodsPodNameRoute: typeof InfraKubernetesPodsPodNameRoute
-	InfraKubernetesNodesIndexRoute: typeof InfraKubernetesNodesIndexRoute
-	InfraKubernetesPodsIndexRoute: typeof InfraKubernetesPodsIndexRoute
-	InfraKubernetesWorkloadsIndexRoute: typeof InfraKubernetesWorkloadsIndexRoute
-	InfraKubernetesWorkloadsKindWorkloadNameRoute: typeof InfraKubernetesWorkloadsKindWorkloadNameRoute
+  IndexRoute: typeof IndexRoute
+  AccountRoute: typeof AccountRoute
+  ChatRoute: typeof ChatRoute
+  CliLoginRoute: typeof CliLoginRoute
+  ConnectorsRoute: typeof ConnectorsRoute
+  DeveloperRoute: typeof DeveloperRoute
+  FlowLabRoute: typeof FlowLabRoute
+  InfraBenchRoute: typeof InfraBenchRoute
+  IntegrationsRoute: typeof IntegrationsRoute
+  LogsBenchRoute: typeof LogsBenchRoute
+  McpRoute: typeof McpRoute
+  McpAuthorizeRoute: typeof McpAuthorizeRoute
+  NodeLabRoute: typeof NodeLabRoute
+  OrgRequiredRoute: typeof OrgRequiredRoute
+  OverviewBenchRoute: typeof OverviewBenchRoute
+  QueryBuilderLabRoute: typeof QueryBuilderLabRoute
+  QuickStartRoute: typeof QuickStartRoute
+  SelectPlanRoute: typeof SelectPlanRoute
+  ServiceDetailBenchRoute: typeof ServiceDetailBenchRoute
+  ServiceMapRoute: typeof ServiceMapRoute
+  ServiceMapBenchRoute: typeof ServiceMapBenchRoute
+  SettingsRoute: typeof SettingsRoute
+  SignInRoute: typeof SignInRoute
+  SignUpRoute: typeof SignUpRoute
+  TimelineLabRoute: typeof TimelineLabRoute
+  WidgetLabRoute: typeof WidgetLabRoute
+  AlertsRuleIdRoute: typeof AlertsRuleIdRoute
+  AlertsCreateRoute: typeof AlertsCreateRoute
+  AnomaliesIncidentIdRoute: typeof AnomaliesIncidentIdRoute
+  DashboardsDashboardIdRoute: typeof DashboardsDashboardIdRoute
+  DashboardsTemplatesRoute: typeof DashboardsTemplatesRoute
+  ErrorsErrorTypeRoute: typeof ErrorsErrorTypeRoute
+  InfraHostNameRoute: typeof InfraHostNameRoute
+  InvestigationsIdRoute: typeof InvestigationsIdRoute
+  LogsLogIdRoute: typeof LogsLogIdRoute
+  MetricsMetricNameRoute: typeof MetricsMetricNameRoute
+  RecommendationsRecommendationKeyRoute: typeof RecommendationsRecommendationKeyRoute
+  ReplaysSessionIdRoute: typeof ReplaysSessionIdRoute
+  ServicesServiceNameRoute: typeof ServicesServiceNameRoute
+  ShareTokenRoute: typeof ShareTokenRoute
+  TracesTraceIdRoute: typeof TracesTraceIdRoute
+  AlertsIndexRoute: typeof AlertsIndexRoute
+  AnalyticsIndexRoute: typeof AnalyticsIndexRoute
+  AnomaliesIndexRoute: typeof AnomaliesIndexRoute
+  DashboardsIndexRoute: typeof DashboardsIndexRoute
+  ErrorsIndexRoute: typeof ErrorsIndexRoute
+  InfraIndexRoute: typeof InfraIndexRoute
+  InvestigationsIndexRoute: typeof InvestigationsIndexRoute
+  LogsIndexRoute: typeof LogsIndexRoute
+  MetricsIndexRoute: typeof MetricsIndexRoute
+  ReplaysIndexRoute: typeof ReplaysIndexRoute
+  ServicesIndexRoute: typeof ServicesIndexRoute
+  TracesIndexRoute: typeof TracesIndexRoute
+  AlertsIncidentsIncidentIdRoute: typeof AlertsIncidentsIncidentIdRoute
+  ErrorsIssuesIssueIdRoute: typeof ErrorsIssuesIssueIdRoute
+  InfraCloudflareZoneNameRoute: typeof InfraCloudflareZoneNameRoute
+  InfraPlanetscaleDbNameRoute: typeof InfraPlanetscaleDbNameRoute
+  ErrorsIssuesIndexRoute: typeof ErrorsIssuesIndexRoute
+  InfraCloudflareIndexRoute: typeof InfraCloudflareIndexRoute
+  InfraPlanetscaleIndexRoute: typeof InfraPlanetscaleIndexRoute
+  DashboardsDashboardIdWidgetsWidgetIdRoute: typeof DashboardsDashboardIdWidgetsWidgetIdRoute
+  InfraKubernetesNodesNodeNameRoute: typeof InfraKubernetesNodesNodeNameRoute
+  InfraKubernetesPodsPodNameRoute: typeof InfraKubernetesPodsPodNameRoute
+  InfraKubernetesNodesIndexRoute: typeof InfraKubernetesNodesIndexRoute
+  InfraKubernetesPodsIndexRoute: typeof InfraKubernetesPodsIndexRoute
+  InfraKubernetesWorkloadsIndexRoute: typeof InfraKubernetesWorkloadsIndexRoute
+  InfraKubernetesWorkloadsKindWorkloadNameRoute: typeof InfraKubernetesWorkloadsKindWorkloadNameRoute
 }
 
-declare module "@tanstack/react-router" {
-	interface FileRoutesByPath {
-		"/": {
-			id: "/"
-			path: "/"
-			fullPath: "/"
-			preLoaderRoute: typeof IndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/account": {
-			id: "/account"
-			path: "/account"
-			fullPath: "/account"
-			preLoaderRoute: typeof AccountRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/chat": {
-			id: "/chat"
-			path: "/chat"
-			fullPath: "/chat"
-			preLoaderRoute: typeof ChatRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/cli-login": {
-			id: "/cli-login"
-			path: "/cli-login"
-			fullPath: "/cli-login"
-			preLoaderRoute: typeof CliLoginRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/connectors": {
-			id: "/connectors"
-			path: "/connectors"
-			fullPath: "/connectors"
-			preLoaderRoute: typeof ConnectorsRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/developer": {
-			id: "/developer"
-			path: "/developer"
-			fullPath: "/developer"
-			preLoaderRoute: typeof DeveloperRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/flow-lab": {
-			id: "/flow-lab"
-			path: "/flow-lab"
-			fullPath: "/flow-lab"
-			preLoaderRoute: typeof FlowLabRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra-bench": {
-			id: "/infra-bench"
-			path: "/infra-bench"
-			fullPath: "/infra-bench"
-			preLoaderRoute: typeof InfraBenchRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/integrations": {
-			id: "/integrations"
-			path: "/integrations"
-			fullPath: "/integrations"
-			preLoaderRoute: typeof IntegrationsRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/logs-bench": {
-			id: "/logs-bench"
-			path: "/logs-bench"
-			fullPath: "/logs-bench"
-			preLoaderRoute: typeof LogsBenchRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/mcp": {
-			id: "/mcp"
-			path: "/mcp"
-			fullPath: "/mcp"
-			preLoaderRoute: typeof McpRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/mcp-authorize": {
-			id: "/mcp-authorize"
-			path: "/mcp-authorize"
-			fullPath: "/mcp-authorize"
-			preLoaderRoute: typeof McpAuthorizeRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/node-lab": {
-			id: "/node-lab"
-			path: "/node-lab"
-			fullPath: "/node-lab"
-			preLoaderRoute: typeof NodeLabRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/org-required": {
-			id: "/org-required"
-			path: "/org-required"
-			fullPath: "/org-required"
-			preLoaderRoute: typeof OrgRequiredRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/overview-bench": {
-			id: "/overview-bench"
-			path: "/overview-bench"
-			fullPath: "/overview-bench"
-			preLoaderRoute: typeof OverviewBenchRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/query-builder-lab": {
-			id: "/query-builder-lab"
-			path: "/query-builder-lab"
-			fullPath: "/query-builder-lab"
-			preLoaderRoute: typeof QueryBuilderLabRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/quick-start": {
-			id: "/quick-start"
-			path: "/quick-start"
-			fullPath: "/quick-start"
-			preLoaderRoute: typeof QuickStartRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/select-plan": {
-			id: "/select-plan"
-			path: "/select-plan"
-			fullPath: "/select-plan"
-			preLoaderRoute: typeof SelectPlanRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/service-detail-bench": {
-			id: "/service-detail-bench"
-			path: "/service-detail-bench"
-			fullPath: "/service-detail-bench"
-			preLoaderRoute: typeof ServiceDetailBenchRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/service-map": {
-			id: "/service-map"
-			path: "/service-map"
-			fullPath: "/service-map"
-			preLoaderRoute: typeof ServiceMapRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/service-map-bench": {
-			id: "/service-map-bench"
-			path: "/service-map-bench"
-			fullPath: "/service-map-bench"
-			preLoaderRoute: typeof ServiceMapBenchRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/settings": {
-			id: "/settings"
-			path: "/settings"
-			fullPath: "/settings"
-			preLoaderRoute: typeof SettingsRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/sign-in": {
-			id: "/sign-in"
-			path: "/sign-in"
-			fullPath: "/sign-in"
-			preLoaderRoute: typeof SignInRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/sign-up": {
-			id: "/sign-up"
-			path: "/sign-up"
-			fullPath: "/sign-up"
-			preLoaderRoute: typeof SignUpRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/timeline-lab": {
-			id: "/timeline-lab"
-			path: "/timeline-lab"
-			fullPath: "/timeline-lab"
-			preLoaderRoute: typeof TimelineLabRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/widget-lab": {
-			id: "/widget-lab"
-			path: "/widget-lab"
-			fullPath: "/widget-lab"
-			preLoaderRoute: typeof WidgetLabRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/alerts/": {
-			id: "/alerts/"
-			path: "/alerts"
-			fullPath: "/alerts/"
-			preLoaderRoute: typeof AlertsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/alerts/$ruleId": {
-			id: "/alerts/$ruleId"
-			path: "/alerts/$ruleId"
-			fullPath: "/alerts/$ruleId"
-			preLoaderRoute: typeof AlertsRuleIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/alerts/create": {
-			id: "/alerts/create"
-			path: "/alerts/create"
-			fullPath: "/alerts/create"
-			preLoaderRoute: typeof AlertsCreateRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/analytics/": {
-			id: "/analytics/"
-			path: "/analytics"
-			fullPath: "/analytics/"
-			preLoaderRoute: typeof AnalyticsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/anomalies/": {
-			id: "/anomalies/"
-			path: "/anomalies"
-			fullPath: "/anomalies/"
-			preLoaderRoute: typeof AnomaliesIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/anomalies/$incidentId": {
-			id: "/anomalies/$incidentId"
-			path: "/anomalies/$incidentId"
-			fullPath: "/anomalies/$incidentId"
-			preLoaderRoute: typeof AnomaliesIncidentIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/dashboards/": {
-			id: "/dashboards/"
-			path: "/dashboards"
-			fullPath: "/dashboards/"
-			preLoaderRoute: typeof DashboardsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/dashboards/$dashboardId": {
-			id: "/dashboards/$dashboardId"
-			path: "/dashboards/$dashboardId"
-			fullPath: "/dashboards/$dashboardId"
-			preLoaderRoute: typeof DashboardsDashboardIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/dashboards/templates": {
-			id: "/dashboards/templates"
-			path: "/dashboards/templates"
-			fullPath: "/dashboards/templates"
-			preLoaderRoute: typeof DashboardsTemplatesRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/errors/": {
-			id: "/errors/"
-			path: "/errors"
-			fullPath: "/errors/"
-			preLoaderRoute: typeof ErrorsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/errors/$errorType": {
-			id: "/errors/$errorType"
-			path: "/errors/$errorType"
-			fullPath: "/errors/$errorType"
-			preLoaderRoute: typeof ErrorsErrorTypeRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/": {
-			id: "/infra/"
-			path: "/infra"
-			fullPath: "/infra/"
-			preLoaderRoute: typeof InfraIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/$hostName": {
-			id: "/infra/$hostName"
-			path: "/infra/$hostName"
-			fullPath: "/infra/$hostName"
-			preLoaderRoute: typeof InfraHostNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/investigations/": {
-			id: "/investigations/"
-			path: "/investigations"
-			fullPath: "/investigations/"
-			preLoaderRoute: typeof InvestigationsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/investigations/$id": {
-			id: "/investigations/$id"
-			path: "/investigations/$id"
-			fullPath: "/investigations/$id"
-			preLoaderRoute: typeof InvestigationsIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/logs/": {
-			id: "/logs/"
-			path: "/logs"
-			fullPath: "/logs/"
-			preLoaderRoute: typeof LogsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/logs/$logId": {
-			id: "/logs/$logId"
-			path: "/logs/$logId"
-			fullPath: "/logs/$logId"
-			preLoaderRoute: typeof LogsLogIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/metrics/": {
-			id: "/metrics/"
-			path: "/metrics"
-			fullPath: "/metrics/"
-			preLoaderRoute: typeof MetricsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/metrics/$metricName": {
-			id: "/metrics/$metricName"
-			path: "/metrics/$metricName"
-			fullPath: "/metrics/$metricName"
-			preLoaderRoute: typeof MetricsMetricNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/recommendations/$recommendationKey": {
-			id: "/recommendations/$recommendationKey"
-			path: "/recommendations/$recommendationKey"
-			fullPath: "/recommendations/$recommendationKey"
-			preLoaderRoute: typeof RecommendationsRecommendationKeyRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/replays/": {
-			id: "/replays/"
-			path: "/replays"
-			fullPath: "/replays/"
-			preLoaderRoute: typeof ReplaysIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/replays/$sessionId": {
-			id: "/replays/$sessionId"
-			path: "/replays/$sessionId"
-			fullPath: "/replays/$sessionId"
-			preLoaderRoute: typeof ReplaysSessionIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/services/": {
-			id: "/services/"
-			path: "/services"
-			fullPath: "/services/"
-			preLoaderRoute: typeof ServicesIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/services/$serviceName": {
-			id: "/services/$serviceName"
-			path: "/services/$serviceName"
-			fullPath: "/services/$serviceName"
-			preLoaderRoute: typeof ServicesServiceNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/share/$token": {
-			id: "/share/$token"
-			path: "/share/$token"
-			fullPath: "/share/$token"
-			preLoaderRoute: typeof ShareTokenRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/traces/": {
-			id: "/traces/"
-			path: "/traces"
-			fullPath: "/traces/"
-			preLoaderRoute: typeof TracesIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/traces/$traceId": {
-			id: "/traces/$traceId"
-			path: "/traces/$traceId"
-			fullPath: "/traces/$traceId"
-			preLoaderRoute: typeof TracesTraceIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/alerts/incidents/$incidentId": {
-			id: "/alerts/incidents/$incidentId"
-			path: "/alerts/incidents/$incidentId"
-			fullPath: "/alerts/incidents/$incidentId"
-			preLoaderRoute: typeof AlertsIncidentsIncidentIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/errors/issues/": {
-			id: "/errors/issues/"
-			path: "/errors/issues"
-			fullPath: "/errors/issues/"
-			preLoaderRoute: typeof ErrorsIssuesIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/errors/issues/$issueId": {
-			id: "/errors/issues/$issueId"
-			path: "/errors/issues/$issueId"
-			fullPath: "/errors/issues/$issueId"
-			preLoaderRoute: typeof ErrorsIssuesIssueIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/cloudflare/": {
-			id: "/infra/cloudflare/"
-			path: "/infra/cloudflare"
-			fullPath: "/infra/cloudflare/"
-			preLoaderRoute: typeof InfraCloudflareIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/cloudflare/$zoneName": {
-			id: "/infra/cloudflare/$zoneName"
-			path: "/infra/cloudflare/$zoneName"
-			fullPath: "/infra/cloudflare/$zoneName"
-			preLoaderRoute: typeof InfraCloudflareZoneNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/planetscale/": {
-			id: "/infra/planetscale/"
-			path: "/infra/planetscale"
-			fullPath: "/infra/planetscale/"
-			preLoaderRoute: typeof InfraPlanetscaleIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/planetscale/$dbName": {
-			id: "/infra/planetscale/$dbName"
-			path: "/infra/planetscale/$dbName"
-			fullPath: "/infra/planetscale/$dbName"
-			preLoaderRoute: typeof InfraPlanetscaleDbNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/dashboards/$dashboardId_/widgets/$widgetId": {
-			id: "/dashboards/$dashboardId_/widgets/$widgetId"
-			path: "/dashboards/$dashboardId/widgets/$widgetId"
-			fullPath: "/dashboards/$dashboardId/widgets/$widgetId"
-			preLoaderRoute: typeof DashboardsDashboardIdWidgetsWidgetIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/kubernetes/nodes/": {
-			id: "/infra/kubernetes/nodes/"
-			path: "/infra/kubernetes/nodes"
-			fullPath: "/infra/kubernetes/nodes/"
-			preLoaderRoute: typeof InfraKubernetesNodesIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/kubernetes/nodes/$nodeName": {
-			id: "/infra/kubernetes/nodes/$nodeName"
-			path: "/infra/kubernetes/nodes/$nodeName"
-			fullPath: "/infra/kubernetes/nodes/$nodeName"
-			preLoaderRoute: typeof InfraKubernetesNodesNodeNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/kubernetes/pods/": {
-			id: "/infra/kubernetes/pods/"
-			path: "/infra/kubernetes/pods"
-			fullPath: "/infra/kubernetes/pods/"
-			preLoaderRoute: typeof InfraKubernetesPodsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/kubernetes/pods/$podName": {
-			id: "/infra/kubernetes/pods/$podName"
-			path: "/infra/kubernetes/pods/$podName"
-			fullPath: "/infra/kubernetes/pods/$podName"
-			preLoaderRoute: typeof InfraKubernetesPodsPodNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/kubernetes/workloads/": {
-			id: "/infra/kubernetes/workloads/"
-			path: "/infra/kubernetes/workloads"
-			fullPath: "/infra/kubernetes/workloads/"
-			preLoaderRoute: typeof InfraKubernetesWorkloadsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		"/infra/kubernetes/workloads/$kind/$workloadName": {
-			id: "/infra/kubernetes/workloads/$kind/$workloadName"
-			path: "/infra/kubernetes/workloads/$kind/$workloadName"
-			fullPath: "/infra/kubernetes/workloads/$kind/$workloadName"
-			preLoaderRoute: typeof InfraKubernetesWorkloadsKindWorkloadNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-	}
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/account': {
+      id: '/account'
+      path: '/account'
+      fullPath: '/account'
+      preLoaderRoute: typeof AccountRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/chat': {
+      id: '/chat'
+      path: '/chat'
+      fullPath: '/chat'
+      preLoaderRoute: typeof ChatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cli-login': {
+      id: '/cli-login'
+      path: '/cli-login'
+      fullPath: '/cli-login'
+      preLoaderRoute: typeof CliLoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/connectors': {
+      id: '/connectors'
+      path: '/connectors'
+      fullPath: '/connectors'
+      preLoaderRoute: typeof ConnectorsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/developer': {
+      id: '/developer'
+      path: '/developer'
+      fullPath: '/developer'
+      preLoaderRoute: typeof DeveloperRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/flow-lab': {
+      id: '/flow-lab'
+      path: '/flow-lab'
+      fullPath: '/flow-lab'
+      preLoaderRoute: typeof FlowLabRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra-bench': {
+      id: '/infra-bench'
+      path: '/infra-bench'
+      fullPath: '/infra-bench'
+      preLoaderRoute: typeof InfraBenchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/integrations': {
+      id: '/integrations'
+      path: '/integrations'
+      fullPath: '/integrations'
+      preLoaderRoute: typeof IntegrationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/logs-bench': {
+      id: '/logs-bench'
+      path: '/logs-bench'
+      fullPath: '/logs-bench'
+      preLoaderRoute: typeof LogsBenchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mcp': {
+      id: '/mcp'
+      path: '/mcp'
+      fullPath: '/mcp'
+      preLoaderRoute: typeof McpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mcp-authorize': {
+      id: '/mcp-authorize'
+      path: '/mcp-authorize'
+      fullPath: '/mcp-authorize'
+      preLoaderRoute: typeof McpAuthorizeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/node-lab': {
+      id: '/node-lab'
+      path: '/node-lab'
+      fullPath: '/node-lab'
+      preLoaderRoute: typeof NodeLabRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/org-required': {
+      id: '/org-required'
+      path: '/org-required'
+      fullPath: '/org-required'
+      preLoaderRoute: typeof OrgRequiredRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/overview-bench': {
+      id: '/overview-bench'
+      path: '/overview-bench'
+      fullPath: '/overview-bench'
+      preLoaderRoute: typeof OverviewBenchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/query-builder-lab': {
+      id: '/query-builder-lab'
+      path: '/query-builder-lab'
+      fullPath: '/query-builder-lab'
+      preLoaderRoute: typeof QueryBuilderLabRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quick-start': {
+      id: '/quick-start'
+      path: '/quick-start'
+      fullPath: '/quick-start'
+      preLoaderRoute: typeof QuickStartRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/select-plan': {
+      id: '/select-plan'
+      path: '/select-plan'
+      fullPath: '/select-plan'
+      preLoaderRoute: typeof SelectPlanRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/service-detail-bench': {
+      id: '/service-detail-bench'
+      path: '/service-detail-bench'
+      fullPath: '/service-detail-bench'
+      preLoaderRoute: typeof ServiceDetailBenchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/service-map': {
+      id: '/service-map'
+      path: '/service-map'
+      fullPath: '/service-map'
+      preLoaderRoute: typeof ServiceMapRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/service-map-bench': {
+      id: '/service-map-bench'
+      path: '/service-map-bench'
+      fullPath: '/service-map-bench'
+      preLoaderRoute: typeof ServiceMapBenchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sign-in': {
+      id: '/sign-in'
+      path: '/sign-in'
+      fullPath: '/sign-in'
+      preLoaderRoute: typeof SignInRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sign-up': {
+      id: '/sign-up'
+      path: '/sign-up'
+      fullPath: '/sign-up'
+      preLoaderRoute: typeof SignUpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/timeline-lab': {
+      id: '/timeline-lab'
+      path: '/timeline-lab'
+      fullPath: '/timeline-lab'
+      preLoaderRoute: typeof TimelineLabRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/widget-lab': {
+      id: '/widget-lab'
+      path: '/widget-lab'
+      fullPath: '/widget-lab'
+      preLoaderRoute: typeof WidgetLabRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/alerts/': {
+      id: '/alerts/'
+      path: '/alerts'
+      fullPath: '/alerts/'
+      preLoaderRoute: typeof AlertsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/alerts/$ruleId': {
+      id: '/alerts/$ruleId'
+      path: '/alerts/$ruleId'
+      fullPath: '/alerts/$ruleId'
+      preLoaderRoute: typeof AlertsRuleIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/alerts/create': {
+      id: '/alerts/create'
+      path: '/alerts/create'
+      fullPath: '/alerts/create'
+      preLoaderRoute: typeof AlertsCreateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/analytics/': {
+      id: '/analytics/'
+      path: '/analytics'
+      fullPath: '/analytics/'
+      preLoaderRoute: typeof AnalyticsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/anomalies/': {
+      id: '/anomalies/'
+      path: '/anomalies'
+      fullPath: '/anomalies/'
+      preLoaderRoute: typeof AnomaliesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/anomalies/$incidentId': {
+      id: '/anomalies/$incidentId'
+      path: '/anomalies/$incidentId'
+      fullPath: '/anomalies/$incidentId'
+      preLoaderRoute: typeof AnomaliesIncidentIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboards/': {
+      id: '/dashboards/'
+      path: '/dashboards'
+      fullPath: '/dashboards/'
+      preLoaderRoute: typeof DashboardsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboards/$dashboardId': {
+      id: '/dashboards/$dashboardId'
+      path: '/dashboards/$dashboardId'
+      fullPath: '/dashboards/$dashboardId'
+      preLoaderRoute: typeof DashboardsDashboardIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboards/templates': {
+      id: '/dashboards/templates'
+      path: '/dashboards/templates'
+      fullPath: '/dashboards/templates'
+      preLoaderRoute: typeof DashboardsTemplatesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/errors/': {
+      id: '/errors/'
+      path: '/errors'
+      fullPath: '/errors/'
+      preLoaderRoute: typeof ErrorsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/errors/$errorType': {
+      id: '/errors/$errorType'
+      path: '/errors/$errorType'
+      fullPath: '/errors/$errorType'
+      preLoaderRoute: typeof ErrorsErrorTypeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/': {
+      id: '/infra/'
+      path: '/infra'
+      fullPath: '/infra/'
+      preLoaderRoute: typeof InfraIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/$hostName': {
+      id: '/infra/$hostName'
+      path: '/infra/$hostName'
+      fullPath: '/infra/$hostName'
+      preLoaderRoute: typeof InfraHostNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/investigations/': {
+      id: '/investigations/'
+      path: '/investigations'
+      fullPath: '/investigations/'
+      preLoaderRoute: typeof InvestigationsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/investigations/$id': {
+      id: '/investigations/$id'
+      path: '/investigations/$id'
+      fullPath: '/investigations/$id'
+      preLoaderRoute: typeof InvestigationsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/logs/': {
+      id: '/logs/'
+      path: '/logs'
+      fullPath: '/logs/'
+      preLoaderRoute: typeof LogsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/logs/$logId': {
+      id: '/logs/$logId'
+      path: '/logs/$logId'
+      fullPath: '/logs/$logId'
+      preLoaderRoute: typeof LogsLogIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/metrics/': {
+      id: '/metrics/'
+      path: '/metrics'
+      fullPath: '/metrics/'
+      preLoaderRoute: typeof MetricsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/metrics/$metricName': {
+      id: '/metrics/$metricName'
+      path: '/metrics/$metricName'
+      fullPath: '/metrics/$metricName'
+      preLoaderRoute: typeof MetricsMetricNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/recommendations/$recommendationKey': {
+      id: '/recommendations/$recommendationKey'
+      path: '/recommendations/$recommendationKey'
+      fullPath: '/recommendations/$recommendationKey'
+      preLoaderRoute: typeof RecommendationsRecommendationKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/replays/': {
+      id: '/replays/'
+      path: '/replays'
+      fullPath: '/replays/'
+      preLoaderRoute: typeof ReplaysIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/replays/$sessionId': {
+      id: '/replays/$sessionId'
+      path: '/replays/$sessionId'
+      fullPath: '/replays/$sessionId'
+      preLoaderRoute: typeof ReplaysSessionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/services/': {
+      id: '/services/'
+      path: '/services'
+      fullPath: '/services/'
+      preLoaderRoute: typeof ServicesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/services/$serviceName': {
+      id: '/services/$serviceName'
+      path: '/services/$serviceName'
+      fullPath: '/services/$serviceName'
+      preLoaderRoute: typeof ServicesServiceNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/share/$token': {
+      id: '/share/$token'
+      path: '/share/$token'
+      fullPath: '/share/$token'
+      preLoaderRoute: typeof ShareTokenRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/traces/': {
+      id: '/traces/'
+      path: '/traces'
+      fullPath: '/traces/'
+      preLoaderRoute: typeof TracesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/traces/$traceId': {
+      id: '/traces/$traceId'
+      path: '/traces/$traceId'
+      fullPath: '/traces/$traceId'
+      preLoaderRoute: typeof TracesTraceIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/alerts/incidents/$incidentId': {
+      id: '/alerts/incidents/$incidentId'
+      path: '/alerts/incidents/$incidentId'
+      fullPath: '/alerts/incidents/$incidentId'
+      preLoaderRoute: typeof AlertsIncidentsIncidentIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/errors/issues/': {
+      id: '/errors/issues/'
+      path: '/errors/issues'
+      fullPath: '/errors/issues/'
+      preLoaderRoute: typeof ErrorsIssuesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/errors/issues/$issueId': {
+      id: '/errors/issues/$issueId'
+      path: '/errors/issues/$issueId'
+      fullPath: '/errors/issues/$issueId'
+      preLoaderRoute: typeof ErrorsIssuesIssueIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/cloudflare/': {
+      id: '/infra/cloudflare/'
+      path: '/infra/cloudflare'
+      fullPath: '/infra/cloudflare/'
+      preLoaderRoute: typeof InfraCloudflareIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/cloudflare/$zoneName': {
+      id: '/infra/cloudflare/$zoneName'
+      path: '/infra/cloudflare/$zoneName'
+      fullPath: '/infra/cloudflare/$zoneName'
+      preLoaderRoute: typeof InfraCloudflareZoneNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/planetscale/': {
+      id: '/infra/planetscale/'
+      path: '/infra/planetscale'
+      fullPath: '/infra/planetscale/'
+      preLoaderRoute: typeof InfraPlanetscaleIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/planetscale/$dbName': {
+      id: '/infra/planetscale/$dbName'
+      path: '/infra/planetscale/$dbName'
+      fullPath: '/infra/planetscale/$dbName'
+      preLoaderRoute: typeof InfraPlanetscaleDbNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboards/$dashboardId_/widgets/$widgetId': {
+      id: '/dashboards/$dashboardId_/widgets/$widgetId'
+      path: '/dashboards/$dashboardId/widgets/$widgetId'
+      fullPath: '/dashboards/$dashboardId/widgets/$widgetId'
+      preLoaderRoute: typeof DashboardsDashboardIdWidgetsWidgetIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/kubernetes/nodes/': {
+      id: '/infra/kubernetes/nodes/'
+      path: '/infra/kubernetes/nodes'
+      fullPath: '/infra/kubernetes/nodes/'
+      preLoaderRoute: typeof InfraKubernetesNodesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/kubernetes/nodes/$nodeName': {
+      id: '/infra/kubernetes/nodes/$nodeName'
+      path: '/infra/kubernetes/nodes/$nodeName'
+      fullPath: '/infra/kubernetes/nodes/$nodeName'
+      preLoaderRoute: typeof InfraKubernetesNodesNodeNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/kubernetes/pods/': {
+      id: '/infra/kubernetes/pods/'
+      path: '/infra/kubernetes/pods'
+      fullPath: '/infra/kubernetes/pods/'
+      preLoaderRoute: typeof InfraKubernetesPodsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/kubernetes/pods/$podName': {
+      id: '/infra/kubernetes/pods/$podName'
+      path: '/infra/kubernetes/pods/$podName'
+      fullPath: '/infra/kubernetes/pods/$podName'
+      preLoaderRoute: typeof InfraKubernetesPodsPodNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/kubernetes/workloads/': {
+      id: '/infra/kubernetes/workloads/'
+      path: '/infra/kubernetes/workloads'
+      fullPath: '/infra/kubernetes/workloads/'
+      preLoaderRoute: typeof InfraKubernetesWorkloadsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/infra/kubernetes/workloads/$kind/$workloadName': {
+      id: '/infra/kubernetes/workloads/$kind/$workloadName'
+      path: '/infra/kubernetes/workloads/$kind/$workloadName'
+      fullPath: '/infra/kubernetes/workloads/$kind/$workloadName'
+      preLoaderRoute: typeof InfraKubernetesWorkloadsKindWorkloadNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+  }
 }
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	AccountRoute: AccountRoute,
-	ChatRoute: ChatRoute,
-	CliLoginRoute: CliLoginRoute,
-	ConnectorsRoute: ConnectorsRoute,
-	DeveloperRoute: DeveloperRoute,
-	FlowLabRoute: FlowLabRoute,
-	InfraBenchRoute: InfraBenchRoute,
-	IntegrationsRoute: IntegrationsRoute,
-	LogsBenchRoute: LogsBenchRoute,
-	McpRoute: McpRoute,
-	McpAuthorizeRoute: McpAuthorizeRoute,
-	NodeLabRoute: NodeLabRoute,
-	OrgRequiredRoute: OrgRequiredRoute,
-	OverviewBenchRoute: OverviewBenchRoute,
-	QueryBuilderLabRoute: QueryBuilderLabRoute,
-	QuickStartRoute: QuickStartRoute,
-	SelectPlanRoute: SelectPlanRoute,
-	ServiceDetailBenchRoute: ServiceDetailBenchRoute,
-	ServiceMapRoute: ServiceMapRoute,
-	ServiceMapBenchRoute: ServiceMapBenchRoute,
-	SettingsRoute: SettingsRoute,
-	SignInRoute: SignInRoute,
-	SignUpRoute: SignUpRoute,
-	TimelineLabRoute: TimelineLabRoute,
-	WidgetLabRoute: WidgetLabRoute,
-	AlertsRuleIdRoute: AlertsRuleIdRoute,
-	AlertsCreateRoute: AlertsCreateRoute,
-	AnomaliesIncidentIdRoute: AnomaliesIncidentIdRoute,
-	DashboardsDashboardIdRoute: DashboardsDashboardIdRoute,
-	DashboardsTemplatesRoute: DashboardsTemplatesRoute,
-	ErrorsErrorTypeRoute: ErrorsErrorTypeRoute,
-	InfraHostNameRoute: InfraHostNameRoute,
-	InvestigationsIdRoute: InvestigationsIdRoute,
-	LogsLogIdRoute: LogsLogIdRoute,
-	MetricsMetricNameRoute: MetricsMetricNameRoute,
-	RecommendationsRecommendationKeyRoute: RecommendationsRecommendationKeyRoute,
-	ReplaysSessionIdRoute: ReplaysSessionIdRoute,
-	ServicesServiceNameRoute: ServicesServiceNameRoute,
-	ShareTokenRoute: ShareTokenRoute,
-	TracesTraceIdRoute: TracesTraceIdRoute,
-	AlertsIndexRoute: AlertsIndexRoute,
-	AnalyticsIndexRoute: AnalyticsIndexRoute,
-	AnomaliesIndexRoute: AnomaliesIndexRoute,
-	DashboardsIndexRoute: DashboardsIndexRoute,
-	ErrorsIndexRoute: ErrorsIndexRoute,
-	InfraIndexRoute: InfraIndexRoute,
-	InvestigationsIndexRoute: InvestigationsIndexRoute,
-	LogsIndexRoute: LogsIndexRoute,
-	MetricsIndexRoute: MetricsIndexRoute,
-	ReplaysIndexRoute: ReplaysIndexRoute,
-	ServicesIndexRoute: ServicesIndexRoute,
-	TracesIndexRoute: TracesIndexRoute,
-	AlertsIncidentsIncidentIdRoute: AlertsIncidentsIncidentIdRoute,
-	ErrorsIssuesIssueIdRoute: ErrorsIssuesIssueIdRoute,
-	InfraCloudflareZoneNameRoute: InfraCloudflareZoneNameRoute,
-	InfraPlanetscaleDbNameRoute: InfraPlanetscaleDbNameRoute,
-	ErrorsIssuesIndexRoute: ErrorsIssuesIndexRoute,
-	InfraCloudflareIndexRoute: InfraCloudflareIndexRoute,
-	InfraPlanetscaleIndexRoute: InfraPlanetscaleIndexRoute,
-	DashboardsDashboardIdWidgetsWidgetIdRoute:
-		DashboardsDashboardIdWidgetsWidgetIdRoute,
-	InfraKubernetesNodesNodeNameRoute: InfraKubernetesNodesNodeNameRoute,
-	InfraKubernetesPodsPodNameRoute: InfraKubernetesPodsPodNameRoute,
-	InfraKubernetesNodesIndexRoute: InfraKubernetesNodesIndexRoute,
-	InfraKubernetesPodsIndexRoute: InfraKubernetesPodsIndexRoute,
-	InfraKubernetesWorkloadsIndexRoute: InfraKubernetesWorkloadsIndexRoute,
-	InfraKubernetesWorkloadsKindWorkloadNameRoute:
-		InfraKubernetesWorkloadsKindWorkloadNameRoute,
+  IndexRoute: IndexRoute,
+  AccountRoute: AccountRoute,
+  ChatRoute: ChatRoute,
+  CliLoginRoute: CliLoginRoute,
+  ConnectorsRoute: ConnectorsRoute,
+  DeveloperRoute: DeveloperRoute,
+  FlowLabRoute: FlowLabRoute,
+  InfraBenchRoute: InfraBenchRoute,
+  IntegrationsRoute: IntegrationsRoute,
+  LogsBenchRoute: LogsBenchRoute,
+  McpRoute: McpRoute,
+  McpAuthorizeRoute: McpAuthorizeRoute,
+  NodeLabRoute: NodeLabRoute,
+  OrgRequiredRoute: OrgRequiredRoute,
+  OverviewBenchRoute: OverviewBenchRoute,
+  QueryBuilderLabRoute: QueryBuilderLabRoute,
+  QuickStartRoute: QuickStartRoute,
+  SelectPlanRoute: SelectPlanRoute,
+  ServiceDetailBenchRoute: ServiceDetailBenchRoute,
+  ServiceMapRoute: ServiceMapRoute,
+  ServiceMapBenchRoute: ServiceMapBenchRoute,
+  SettingsRoute: SettingsRoute,
+  SignInRoute: SignInRoute,
+  SignUpRoute: SignUpRoute,
+  TimelineLabRoute: TimelineLabRoute,
+  WidgetLabRoute: WidgetLabRoute,
+  AlertsRuleIdRoute: AlertsRuleIdRoute,
+  AlertsCreateRoute: AlertsCreateRoute,
+  AnomaliesIncidentIdRoute: AnomaliesIncidentIdRoute,
+  DashboardsDashboardIdRoute: DashboardsDashboardIdRoute,
+  DashboardsTemplatesRoute: DashboardsTemplatesRoute,
+  ErrorsErrorTypeRoute: ErrorsErrorTypeRoute,
+  InfraHostNameRoute: InfraHostNameRoute,
+  InvestigationsIdRoute: InvestigationsIdRoute,
+  LogsLogIdRoute: LogsLogIdRoute,
+  MetricsMetricNameRoute: MetricsMetricNameRoute,
+  RecommendationsRecommendationKeyRoute: RecommendationsRecommendationKeyRoute,
+  ReplaysSessionIdRoute: ReplaysSessionIdRoute,
+  ServicesServiceNameRoute: ServicesServiceNameRoute,
+  ShareTokenRoute: ShareTokenRoute,
+  TracesTraceIdRoute: TracesTraceIdRoute,
+  AlertsIndexRoute: AlertsIndexRoute,
+  AnalyticsIndexRoute: AnalyticsIndexRoute,
+  AnomaliesIndexRoute: AnomaliesIndexRoute,
+  DashboardsIndexRoute: DashboardsIndexRoute,
+  ErrorsIndexRoute: ErrorsIndexRoute,
+  InfraIndexRoute: InfraIndexRoute,
+  InvestigationsIndexRoute: InvestigationsIndexRoute,
+  LogsIndexRoute: LogsIndexRoute,
+  MetricsIndexRoute: MetricsIndexRoute,
+  ReplaysIndexRoute: ReplaysIndexRoute,
+  ServicesIndexRoute: ServicesIndexRoute,
+  TracesIndexRoute: TracesIndexRoute,
+  AlertsIncidentsIncidentIdRoute: AlertsIncidentsIncidentIdRoute,
+  ErrorsIssuesIssueIdRoute: ErrorsIssuesIssueIdRoute,
+  InfraCloudflareZoneNameRoute: InfraCloudflareZoneNameRoute,
+  InfraPlanetscaleDbNameRoute: InfraPlanetscaleDbNameRoute,
+  ErrorsIssuesIndexRoute: ErrorsIssuesIndexRoute,
+  InfraCloudflareIndexRoute: InfraCloudflareIndexRoute,
+  InfraPlanetscaleIndexRoute: InfraPlanetscaleIndexRoute,
+  DashboardsDashboardIdWidgetsWidgetIdRoute:
+    DashboardsDashboardIdWidgetsWidgetIdRoute,
+  InfraKubernetesNodesNodeNameRoute: InfraKubernetesNodesNodeNameRoute,
+  InfraKubernetesPodsPodNameRoute: InfraKubernetesPodsPodNameRoute,
+  InfraKubernetesNodesIndexRoute: InfraKubernetesNodesIndexRoute,
+  InfraKubernetesPodsIndexRoute: InfraKubernetesPodsIndexRoute,
+  InfraKubernetesWorkloadsIndexRoute: InfraKubernetesWorkloadsIndexRoute,
+  InfraKubernetesWorkloadsKindWorkloadNameRoute:
+    InfraKubernetesWorkloadsKindWorkloadNameRoute,
 }
 export const routeTree = rootRouteImport
-	._addFileChildren(rootRouteChildren)
-	._addFileTypes<FileRouteTypes>()
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/apps/web/src/routes/dashboards/$dashboardId.tsx
+++ b/apps/web/src/routes/dashboards/$dashboardId.tsx
@@ -5,6 +5,7 @@ import { Atom, useAtom } from "@/lib/effect-atom"
 
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { DashboardSections } from "@/components/dashboard-builder/sections/dashboard-sections"
+import { LiveWidgetRenderer } from "@/components/dashboard-builder/canvas/live-widget-renderer"
 import {
 	withActiveTab,
 	withSectionCollapsed,
@@ -389,6 +390,7 @@ function DashboardViewPage() {
 											</div>
 										) : (
 											<DashboardSections
+												renderWidget={LiveWidgetRenderer}
 												widgets={activeDashboard.widgets}
 												sections={activeDashboard.sections ?? []}
 												search={sectionViewSearch}

--- a/apps/web/src/routes/share/$token.tsx
+++ b/apps/web/src/routes/share/$token.tsx
@@ -21,6 +21,9 @@ import { useAuth } from "@clerk/clerk-react"
 import { Schema } from "effect"
 import { useMemo } from "react"
 import { visualizationFor } from "@/components/dashboard-builder/widgets/types"
+import type { WidgetDataState } from "@/components/dashboard-builder/types"
+import { ReadOnlyDashboardView } from "@/components/dashboard-builder/read-only-dashboard-view"
+import { SharedWidgetRenderer, ShareWidgetStatesProvider } from "@/components/share/shared-widget-renderer"
 import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 import {
 	useShareWidgetData,
@@ -111,8 +114,12 @@ function SharePageContent({ isSignedIn }: { isSignedIn: boolean }) {
 	}
 
 	return (
-		<ShareShell embed={search.embed === true} title={state.share.dashboard.name}>
-			<ShareGrid
+		<ShareShell
+			embed={search.embed === true}
+			scope={state.share.scope}
+			title={state.share.dashboard.name}
+		>
+			<ShareBody
 				share={state.share}
 				token={token}
 				timeRange={timeRange}
@@ -162,10 +169,13 @@ function NotEmbeddableCard() {
 function ShareShell({
 	children,
 	embed,
+	scope = "widget",
 	title,
 }: {
 	children: React.ReactNode
 	embed: boolean
+	/** A board scrolls; a single chart is sized to the frame. */
+	scope?: SharedDashboard["scope"]
 	title?: string
 }) {
 	if (embed) {
@@ -175,7 +185,13 @@ function ShareShell({
 		// `h-screen`, not `h-full`: the iframe's viewport IS the available height,
 		// and `h-full` on a chain with no sized ancestor collapses the chart to its
 		// header.
-		return <div className="h-screen w-full bg-background p-2">{children}</div>
+		//
+		// A whole board is the opposite case — it is as tall as its grid, so
+		// pinning it to the viewport would clip the lower rows with no way to
+		// scroll to them. `min-h-screen` still gives the canvas a definite width
+		// to measure, which is all `useContainerSize` needs.
+		const height = scope === "dashboard" ? "min-h-screen" : "h-screen"
+		return <div className={`${height} w-full bg-background p-2`}>{children}</div>
 	}
 
 	return (
@@ -274,7 +290,15 @@ function CenteredCard({
 	)
 }
 
-function ShareGrid({
+/**
+ * Data for every tile on the share, then the board.
+ *
+ * Both scopes fetch the same way — one batched call set for every widget id —
+ * and differ only in what they draw: a whole board goes through the same canvas
+ * the authed dashboard uses, so tiles land on their authored positions and
+ * sizes, while a single chart has no grid to be placed in at all.
+ */
+function ShareBody({
 	share,
 	token,
 	timeRange,
@@ -294,10 +318,39 @@ function ShareGrid({
 	const variableValues = useMemo<Record<string, string>>(() => ({}), [])
 	const { states } = useShareWidgetData(token, widgetIds, timeRange, variableValues, true, signedIn)
 
-	const single = share.scope === "widget"
+	if (share.scope === "widget") {
+		return <SingleWidgetShare share={share} states={states} embed={embed} />
+	}
 
 	return (
-		<div className={single ? "h-full w-full" : "grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"}>
+		<ShareWidgetStatesProvider states={states}>
+			<ReadOnlyDashboardView
+				widgets={share.dashboard.widgets}
+				sections={share.dashboard.sections}
+				renderWidget={SharedWidgetRenderer}
+			/>
+		</ShareWidgetStatesProvider>
+	)
+}
+
+/**
+ * A single shared chart, filling the page.
+ *
+ * Deliberately not the dashboard canvas: `redactForShare` lifts a single-widget
+ * share out of its section and publishes no layout context around it, so there
+ * is no grid to place it in and nothing for authored coordinates to mean.
+ */
+function SingleWidgetShare({
+	share,
+	states,
+	embed,
+}: {
+	share: SharedDashboard
+	states: Readonly<Record<string, WidgetDataState>>
+	embed: boolean
+}) {
+	return (
+		<div className="h-full w-full">
 			{share.dashboard.widgets.map((widget) => {
 				const Visualization = visualizationFor(widget.visualization)
 				const dataState = states[widget.id] ?? { status: "loading" as const }
@@ -311,13 +364,7 @@ function ShareGrid({
 						// Height is set against the viewport rather than a flex chain — the
 						// chart library measures its own container, and `h-full` through
 						// ancestors with no definite height collapses it to the title row.
-						className={
-							single
-								? embed
-									? "h-[calc(100vh-1rem)] w-full"
-									: "h-[calc(100vh-9rem)] w-full"
-								: "h-64"
-						}
+						className={embed ? "h-[calc(100vh-1rem)] w-full" : "h-[calc(100vh-9rem)] w-full"}
 					>
 						<Visualization
 							dataState={dataState}

--- a/packages/widgets/src/dashboard/redact.test.ts
+++ b/packages/widgets/src/dashboard/redact.test.ts
@@ -91,6 +91,18 @@ describe("redactForShare", () => {
 		expect(redacted?.refreshIntervalSeconds).toBe(60)
 	})
 
+	// A share renders through the same canvas the authed dashboard does, so these
+	// three fields decide where every tile lands. Dropping one no longer shows up
+	// as a missing field — it shows up as a board that silently reflows into a
+	// flat grid, which is why the contract is asserted in the package that owns it.
+	it("keeps the placement a share needs to lay itself out", () => {
+		const redacted = redactForShare(document)
+
+		expect(redacted?.widgets[0]?.layout).toEqual({ x: 0, y: 0, w: 6, h: 4 })
+		expect(redacted?.widgets[1]).toMatchObject({ sectionId: "sec-1", tabId: "tab-1" })
+		expect(redacted?.sections).toEqual([{ id: "sec-1", title: "Latency" }])
+	})
+
 	it("narrows a single-chart share to exactly one widget", () => {
 		const redacted = redactForShare(document, "w-query")
 


### PR DESCRIPTION
## What

A shared dashboard link looked nothing like the dashboard it shared — every tile the same size, in a flat 1/2/3-column flow, with no groups.

`ShareGrid` was a hand-rolled `grid-cols-1 md:grid-cols-2 xl:grid-cols-3` with each tile hard-coded to `h-64`. It mapped widgets in array order and never read `widget.layout`, `sectionId` or `tabId` — even though `redactWidget` already copies `layout` verbatim and keeps `sectionId`/`tabId`, and `redactForShare` keeps `sections` for whole-board shares. **Nothing was missing on the wire; this was purely a client rendering gap, so there is no API, domain or redaction change here.**

This replaces that grid with a `ReadOnlyDashboardView` built on the same `DashboardSections` → `DashboardGrid` the authed board uses. Tiles land on their authored `x/y/w/h`, get the 12/8/6/1 responsive tiers and `GRID_ROW_HEIGHT`, and sections render with working tabs.

One component rather than a share-specific one, so the two can't drift again — it is also what the dashboard's own full-screen button will mount (`renderWidget={LiveWidgetRenderer}`, inside the existing provider). The button itself is not in this PR.

## How

The canvas was bound to the authed page by exactly two wires:

- **`useDashboardActions()` threw outside its provider**, and that provider needs a full mutation store. Now `useDashboardActionsOptional()`, with `mode` defaulting to `"view"`.
- **`WidgetRenderer` called `useWidgetData`**. `DashboardGrid` now takes `renderWidget` as a prop; the authed renderer moved to `live-widget-renderer.tsx`, and the share path renders from `useShareWidgetData`'s already-batched states.

`DashboardGrid` is generic over its widget because a redacted share widget's `dataSource` (`{kind, resultShape?, transform?}`) cannot inhabit the stored union. Carrying that in a type parameter is what kept the whole change cast-free — `bun run typecheck` passing is the actual proof, and an `as` added to make it pass would mean the design was wrong.

Also: `useSharedDashboard` decodes with Effect Schema instead of `payload as SharedDashboard`, reusing `WidgetLayoutSchema` and `DashboardSectionSchema` so the decoded layout *is* what the canvas places from. `?embed` on a whole board scrolls instead of clipping; a single-widget share keeps its full-bleed sizing untouched.

## Reviewer notes

**The security-shaped decision.** `WidgetActionsProvider` is deliberately **not** mounted on the share page, and not `WidgetActionsScope` with a trimmed set either. `remove` is always defined there and `createAlert` whenever `dashboardId && alertable`, and `WidgetShell` shows its kebab in view mode when `createAlert` exists — so a stub actions provider would put "Create alert"/"Remove" and navigation into authed routes on a page served without a session. Outside any provider `useWidgetActions()` returns `null` and the menu never renders. This is also why the actions blocker is solved with an optional read rather than a no-op stub. A test in `dashboard-canvas.test.tsx` fails loudly if someone later "fixes" the missing provider.

**Degradation.** A document that fails to decode lands in the existing `unavailable` state. `sections` decode separately and fall back to an ungrouped board — stored sections pass through `redactForShare` verbatim, so an older shape should cost the grouping, not the page.

## Verification

- `bun run typecheck` clean, zero casts added; lint clean.
- 63 tests across the touched files, including: the grid rendering with no `DashboardActionsProvider` above it (the regression guard), a shared widget exposing no actions, decode tests built by running the real `redactForShare` over a fixture (so client and server projection can't silently diverge), and `layout`/`sectionId`/`tabId` now asserted in `redact.test.ts` since that contract is load-bearing for placement.
- Manually against a real shared board with groups: stats at authored widths in one row, section tabs switch correctly, charts get real data, no kebab on any tile, resize handles `display: none`. Fresh loads at 1280 / 760 / 400px each pick the right tier.

**Not verified:** live window resizing. A plain `ResizeObserver` attached in the page recorded zero callbacks across a 952→1192px change of the observed element, so the tooling used doesn't deliver them. The measurement hook and ref are untouched and shared with the authed dashboard, but a manual drag is worth doing.

## Follow-up worth filing (not in this PR)

`redactWidget` is careful about `dataSource` but copies `display` verbatim, and `display.sparkline.dataSource` embeds a *full* data source (`shared/display.ts:24` says so). A public share of a stat widget with a sparkline may be publishing the org's query or raw SQL. The existing "no stored query text, at any depth" property test only catches it if a fixture carries a sparkline — none does. Independent of this work, but worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789413231&installation_model_id=427786&pr_number=483&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F483&signature=86689d2c96a9c2bee401a781e70f0085e21c88f832b28faa84557151a35c0717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->