### PR TITLE
Make a closed Postgres connection scope terminal

### DIFF
--- a/apps/api/src/platform/DatabaseLive.ts
+++ b/apps/api/src/platform/DatabaseLive.ts
@@ -39,6 +39,34 @@ export const toDatabaseError = (cause: unknown): DatabaseError => {
 	})
 }
 
+/** Shared by both entry points below so the two can never describe different origins. */
+const DB_SPAN_OPTIONS = {
+	kind: "client",
+	attributes: {
+		"db.system.name": "postgresql",
+		"peer.service": "planetscale-postgres",
+	},
+} as const
+
+/**
+ * A `Database.execute` span for a call refused before any statement could run.
+ *
+ * The refusal is decided in Effect, so it fails in Effect — there is no promise
+ * to throw out of. It still gets a span: a call that reached `Database.execute`
+ * and was turned away is exactly the thing an operator needs to see, and a
+ * silent `Effect.fail` would leave the trace looking as though it never
+ * happened. `db.query.*` is absent on purpose — there is no statement.
+ */
+export const failExecuteWithSpan = Effect.fn(
+	"Database.execute",
+	DB_SPAN_OPTIONS,
+)(function* (error: DatabaseError, extraAttributes?: Record<string, unknown>) {
+	if (extraAttributes) {
+		yield* Effect.annotateCurrentSpan(extraAttributes)
+	}
+	return yield* Effect.fail(error)
+})
+
 /**
  * Wraps one Database.execute call in a Client-kind span per Maple's telemetry
  * conventions (db.system.name + peer.service power the service-map DB edge;
@@ -64,13 +92,10 @@ export const toDatabaseError = (cause: unknown): DatabaseError => {
  * `CONNECT_TIMEOUT` and a constraint violation are different classes, not
  * different durations.
  */
-export const executeWithSpan = Effect.fn("Database.execute", {
-	kind: "client",
-	attributes: {
-		"db.system.name": "postgresql",
-		"peer.service": "planetscale-postgres",
-	},
-})(function* <T>(run: (hooks: ExecuteHooks) => Promise<T>, extraAttributes?: Record<string, unknown>) {
+export const executeWithSpan = Effect.fn(
+	"Database.execute",
+	DB_SPAN_OPTIONS,
+)(function* <T>(run: (hooks: ExecuteHooks) => Promise<T>, extraAttributes?: Record<string, unknown>) {
 	if (extraAttributes) {
 		yield* Effect.annotateCurrentSpan(extraAttributes)
 	}

--- a/apps/api/src/platform/pg-connection-scope.test.ts
+++ b/apps/api/src/platform/pg-connection-scope.test.ts
@@ -8,6 +8,7 @@ import {
 	makePgConnectionScope,
 	PgConnectionScope,
 	type PgConnectionScopeApi,
+	PgConnectionScopeClosedError,
 	pgConnectionScopeFrom,
 	withPgConnectionScope,
 	withPgConnectionScopeOf,
@@ -245,6 +246,89 @@ describe("PgConnectionScope", () => {
 			yield* Effect.promise(() => scope.close())
 			yield* Effect.promise(() => scope.close())
 
+			assert.strictEqual(rec.creations(), 1)
+			assert.strictEqual(rec.ends(), 1)
+		}),
+	)
+
+	it.effect("refuses a call that arrives after the scope closed instead of dialing again", () =>
+		Effect.gen(function* () {
+			const rec = recorder()
+			const { spans, tracer } = makeRecordingTracer()
+			const scope = makePgConnectionScope("postgres://unused", undefined, {
+				openSocket: rec.openSocket,
+			})
+
+			yield* scope.run(noop)
+			yield* Effect.promise(() => scope.close())
+
+			// The bug this replaces: `close` set the handle back to `undefined`, which
+			// is also what "never dialed" looked like, so this call opened a second
+			// socket after the invocation that owned it had ended — on Workers, past
+			// the point where one may exist at all. Late work is a defect to report,
+			// not a connection to open.
+			const exit = yield* Effect.exit(scope.run(noop).pipe(Effect.withTracer(tracer)))
+
+			assert.isTrue(Exit.isFailure(exit))
+			assert.strictEqual(rec.creations(), 1)
+			assert.strictEqual(rec.ends(), 1)
+			const [span] = dbSpans(spans)
+			assert.isDefined(span)
+			assert.strictEqual(span.attributes.get("db.connect.scope_state"), "closed")
+			// Not a driver fault, so it must not land as an unlabelled database
+			// error beside real ones.
+			assert.strictEqual(span.attributes.get("error.type"), "SCOPE_CLOSED")
+		}),
+	)
+
+	it.effect("keeps the closed-scope failure discriminable behind the DatabaseError channel", () =>
+		Effect.gen(function* () {
+			const scope = makePgConnectionScope("postgres://unused", undefined, {
+				openSocket: recorder().openSocket,
+			})
+
+			yield* Effect.promise(() => scope.close())
+			const error = yield* Effect.flip(scope.run(noop))
+
+			// `run` stays typed as DatabaseError — ~200 call sites depend on that —
+			// but the reason travels as a tagged cause instead of flattened prose.
+			assert.strictEqual(error._tag, "@maple/api/lib/DatabaseError")
+			assert.instanceOf(error.cause, PgConnectionScopeClosedError)
+		}),
+	)
+
+	it.effect("refuses a first call after close without ever creating a connection", () =>
+		Effect.gen(function* () {
+			const rec = recorder()
+			const scope = makePgConnectionScope("postgres://unused", undefined, {
+				openSocket: rec.openSocket,
+			})
+
+			yield* Effect.promise(() => scope.close())
+			const exit = yield* Effect.exit(scope.run(noop))
+
+			assert.isTrue(Exit.isFailure(exit))
+			assert.strictEqual(rec.creations(), 0)
+		}),
+	)
+
+	it.effect("closes an in-flight connection and refuses the calls that follow it", () =>
+		Effect.gen(function* () {
+			const rec = recorder()
+			const scope = makePgConnectionScope("postgres://unused", undefined, {
+				openSocket: rec.openSocket,
+			})
+
+			// Close transitions to Closed before releasing, so a caller racing the
+			// teardown is refused rather than handed a socket being ended underneath it.
+			const running = yield* Effect.forkChild(scope.run(() => new Promise<string>(() => {})))
+			yield* Effect.yieldNow
+			yield* Effect.promise(() => scope.close())
+			yield* Fiber.interrupt(running)
+
+			const exit = yield* Effect.exit(scope.run(noop))
+
+			assert.isTrue(Exit.isFailure(exit))
 			assert.strictEqual(rec.creations(), 1)
 			assert.strictEqual(rec.ends(), 1)
 		}),

--- a/apps/api/src/platform/pg-connection-scope.ts
+++ b/apps/api/src/platform/pg-connection-scope.ts
@@ -5,10 +5,10 @@ import {
 	wrapMaplePgClient,
 } from "@maple/db/client"
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
-import { Context, Effect } from "effect"
+import { Context, Effect, Schema } from "effect"
 import type { HttpMiddleware } from "effect/unstable/http"
 import type { DatabaseClient, DatabaseError } from "./DatabaseLive"
-import { executeWithSpan } from "./DatabaseLive"
+import { executeWithSpan, failExecuteWithSpan, toDatabaseError } from "./DatabaseLive"
 import { resolveDbConnectionSource } from "./pg-connection-source"
 
 /**
@@ -73,6 +73,23 @@ export class PgConnectionScope extends Context.Reference<PgConnectionScopeApi | 
 ) {}
 
 /**
+ * A call arrived after its scope was released.
+ *
+ * Not a database failure — nothing was dialed and no statement ran — so it
+ * carries its own tag rather than being flattened into prose. `run` keeps the
+ * `DatabaseError` channel that ~200 call sites are typed against, and this
+ * travels as that error's `cause`, where a caller can still discriminate it and
+ * a span can name it as something other than a driver fault.
+ */
+export class PgConnectionScopeClosedError extends Schema.TaggedError<PgConnectionScopeClosedError>()(
+	"@maple/api/platform/PgConnectionScopeClosedError",
+	{ message: Schema.String },
+) {}
+
+const CLOSED_MESSAGE =
+	"Postgres connection scope is already closed — this call outlived the request, cron tick or Workflow run that owned the connection"
+
+/**
  * Test seam: how to create the scope's socket. Real callers pass nothing.
  *
  * It receives the options the real factory would have been given, so a test can
@@ -108,25 +125,56 @@ export const makePgConnectionScope = (
 		seams?.openSocket ?? ((opts: MaplePgSocketOptions) => createMaplePgSocket(connectionString, opts))
 	const openSocket = () => create(options)
 
-	let socket: MaplePgSocketHandle | undefined
+	// Three states, not a nullable handle. Cold and Closed both used to be
+	// `undefined`, which made "never dialed" and "already released" the same
+	// value — so a call arriving after the boundary silently dialed a SECOND
+	// socket, outside the invocation that is allowed to own one. Workers tie
+	// sockets to the invocation that opened them, and the call sites that do
+	// this are `Effect.ignore`d (see `fork-request-scoped.ts`), so the failure
+	// never surfaced. Closed is now terminal and refuses instead of reopening.
+	let state: { _tag: "Cold" } | { _tag: "Open"; handle: MaplePgSocketHandle } | { _tag: "Closed" } = {
+		_tag: "Cold",
+	}
 
 	return {
-		run: <T>(fn: (db: DatabaseClient) => Promise<T>) =>
-			executeWithSpan(async (hooks) => {
+		// `suspend` so the state is read when the effect runs, not when it is built
+		// — a call constructed before teardown must still be refused after it. It
+		// also settles the connection decision in one place: the promise body below
+		// receives a handle, so it can no longer reach a state that says Closed.
+		run: <T>(fn: (db: DatabaseClient) => Promise<T>): Effect.Effect<T, DatabaseError> =>
+			Effect.suspend(() => {
+				if (state._tag === "Closed") {
+					return failExecuteWithSpan(
+						toDatabaseError(new PgConnectionScopeClosedError({ message: CLOSED_MESSAGE })),
+						{
+							...extraAttributes,
+							"db.connect.scope_state": "closed",
+							// `error.type` because `postgresErrorType` has nothing to classify
+							// here: no driver was involved, so without this the span would land
+							// as an unlabelled database error next to real ones.
+							"error.type": "SCOPE_CLOSED",
+						},
+					)
+				}
 				// Lazy: an invocation that never touches the database never creates one.
-				const reused = socket !== undefined
-				const open = (socket ??= openSocket())
-				hooks.record({ "db.connect.reused": reused })
-				// Wrapped per call so each call's statements land in its own span.
-				// One shared wrapper would cross-attribute `db.query.text` between
-				// concurrent calls; the wrapper is cheap (relational config only).
-				return await fn(wrapMaplePgClient(open.sql, { onQuery: hooks.collect }))
-			}, extraAttributes),
+				const reused = state._tag === "Open"
+				const open = state._tag === "Open" ? state.handle : openSocket()
+				state = { _tag: "Open", handle: open }
+				return executeWithSpan(async (hooks) => {
+					hooks.record({ "db.connect.reused": reused })
+					// Wrapped per call so each call's statements land in its own span.
+					// One shared wrapper would cross-attribute `db.query.text` between
+					// concurrent calls; the wrapper is cheap (relational config only).
+					return await fn(wrapMaplePgClient(open.sql, { onQuery: hooks.collect }))
+				}, extraAttributes)
+			}),
 
+		// Closed first, then release: a call racing the teardown is refused
+		// rather than handed a socket that is being ended underneath it.
 		close: async () => {
-			const open = socket
-			socket = undefined
-			if (open !== undefined) await open.end().catch(() => undefined)
+			const previous = state
+			state = { _tag: "Closed" }
+			if (previous._tag === "Open") await previous.handle.end().catch(() => undefined)
 		},
 	}
 }


### PR DESCRIPTION
`R-API01-01`. Inside `makePgConnectionScope`, Cold and Closed were both `socket === undefined` — so a call arriving after the invocation boundary hit `socket ??= openSocket()` and dialed a **second** socket instead of failing. Workers tie sockets to the invocation that opened them, and the call sites that do this are `Effect.ignore`d (the hazard `fork-request-scoped.ts` already documents), so it never surfaced.

The scope now holds `Cold | Open(handle) | Closed`: `close` transitions to Closed before releasing, and a later call is refused with `db.connect.scope_state` on its span rather than opening a connection. Public API is unchanged, so no call site moves.

Four tests cover it: run-after-close, first-call-after-close, close racing an in-flight call, and the existing double-close. Stacked on #489.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789474738&installation_model_id=427786&pr_number=490&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F490&signature=4513c7454f7487c03d87bfc1bf3efc2edae08a529ac65a97d0b1895d59386839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->