### PR TITLE
Key the auth-token refresh to the identity that started it

### DIFF
--- a/apps/web/src/lib/services/common/auth-headers.test.ts
+++ b/apps/web/src/lib/services/common/auth-headers.test.ts
@@ -119,19 +119,86 @@ describe("auth-headers", () => {
 			const gate = new Promise<void>((resolve) => {
 				release = resolve
 			})
+			const stale = bearerExpiringIn(600)
+			const fresh = bearerExpiringIn(600).replace("signature", "signature-after-switch")
+			let call = 0
 			setMapleAuthHeadersProvider(async () => {
-				await gate
-				return { authorization: bearerExpiringIn(600) }
+				call += 1
+				if (call === 1) {
+					await gate
+					return { authorization: stale }
+				}
+				return { authorization: fresh }
 			})
 
 			const pending = getMapleAuthHeaders()
 			setActiveOrgId("org_switched_mid_flight")
 			release?.()
-			await pending
 
-			// The in-flight token belonged to the previous org — it must not populate
-			// the cache for the new one.
-			expect(hasCachedMapleAuthToken()).toBe(false)
+			// The in-flight token belonged to the previous org — it must reach
+			// neither the caller nor the cache for the new one.
+			await expect(pending).resolves.toEqual({ authorization: fresh })
+			await expect(getMapleAuthHeaders()).resolves.toEqual({ authorization: fresh })
+		})
+
+		it("never hands a caller the token of an identity it did not start under", async () => {
+			let release: (() => void) | undefined
+			const gate = new Promise<void>((resolve) => {
+				release = resolve
+			})
+			const first = bearerExpiringIn(600)
+			const second = bearerExpiringIn(600).replace("signature", "signature-second-org")
+			let call = 0
+			setMapleAuthHeadersProvider(async () => {
+				call += 1
+				if (call === 1) {
+					await gate
+					return { authorization: first }
+				}
+				return { authorization: second }
+			})
+
+			// Opens the refresh that belongs to the first org.
+			const beforeSwitch = getMapleAuthHeaders()
+			setActiveOrgId("org_second")
+			// Arrives after the switch: it used to join the open promise and send the
+			// first org's bearer, which the API resolves against the wrong tenant.
+			const afterSwitch = getMapleAuthHeaders()
+			release?.()
+
+			await expect(afterSwitch).resolves.toEqual({ authorization: second })
+			// The caller that started before the switch also re-resolves rather than
+			// returning a token for an org the user has left.
+			await expect(beforeSwitch).resolves.toEqual({ authorization: second })
+		})
+
+		it("lets a straggling refresh settle without evicting its successor", async () => {
+			let releaseFirst: (() => void) | undefined
+			const gate = new Promise<void>((resolve) => {
+				releaseFirst = resolve
+			})
+			const second = bearerExpiringIn(600)
+			let call = 0
+			setMapleAuthHeadersProvider(async () => {
+				call += 1
+				if (call === 1) {
+					await gate
+					return { authorization: bearerExpiringIn(600) }
+				}
+				return { authorization: second }
+			})
+
+			const orphaned = getMapleAuthHeaders()
+			setActiveOrgId("org_second")
+			const successor = getMapleAuthHeaders()
+			releaseFirst?.()
+			await Promise.all([orphaned, successor])
+
+			// The straggler's `finally` must not clear the successor's slot, and the
+			// cache must hold the current identity's token.
+			expect(hasCachedMapleAuthToken()).toBe(true)
+			await expect(getMapleAuthHeaders()).resolves.toEqual({ authorization: second })
+			expect(call).toBe(2)
 		})
 
 		it("drops the cached token on sign-out", async () => {

--- a/apps/web/src/lib/services/common/auth-headers.ts
+++ b/apps/web/src/lib/services/common/auth-headers.ts
@@ -21,13 +21,23 @@ interface CachedAuth {
 }
 
 let cachedAuth: CachedAuth | undefined
-let inFlightRefresh: Promise<MapleAuthHeaders> | undefined
 /**
  * Bumped whenever the identity changes (provider swap, sign-out, org switch).
- * A refresh started under an older generation must not populate the cache — its
- * token belongs to an identity we've since left.
+ * A refresh started under an older generation must not populate the cache, be
+ * joined by a later caller, or clear a newer refresh's slot — its token belongs
+ * to an identity we've since left.
  */
 let authGeneration = 0
+/**
+ * The refresh in flight, tagged with the identity that started it.
+ *
+ * Tagged rather than bare: a bare promise was shared with every caller that
+ * arrived while it was open, including callers that arrived *after* an org
+ * switch or sign-out — they awaited it and sent the previous identity's bearer.
+ * Its `finally` also cleared the slot unconditionally, so a straggler could
+ * evict the successor that replaced it.
+ */
+let inFlightRefresh: { readonly generation: number; readonly promise: Promise<MapleAuthHeaders> } | undefined
 
 const decodeBase64Url = (segment: string): string => {
 	const padded = segment.replace(/-/g, "+").replace(/_/g, "/")
@@ -52,11 +62,12 @@ const readBearerExpMs = (headers: MapleAuthHeaders): number | undefined => {
 }
 
 const refreshAuthHeaders = (): Promise<MapleAuthHeaders> => {
-	if (inFlightRefresh) return inFlightRefresh
+	// Only join a refresh belonging to the identity we are currently serving.
+	if (inFlightRefresh && inFlightRefresh.generation === authGeneration) return inFlightRefresh.promise
 	const provider = authHeadersProvider
 	if (!provider) return Promise.resolve({})
 	const generation = authGeneration
-	inFlightRefresh = Promise.resolve(provider())
+	const promise = Promise.resolve(provider())
 		.then((headers) => {
 			if (generation === authGeneration) {
 				const expMs = readBearerExpMs(headers)
@@ -65,15 +76,21 @@ const refreshAuthHeaders = (): Promise<MapleAuthHeaders> => {
 			return headers
 		})
 		.finally(() => {
-			inFlightRefresh = undefined
+			// Only ever clear our own slot — a straggler must not evict the
+			// successor started after the identity changed.
+			if (inFlightRefresh?.generation === generation) inFlightRefresh = undefined
 		})
-	return inFlightRefresh
+	inFlightRefresh = { generation, promise }
+	return promise
 }
 
 /** Drop the cached bearer token so the next request re-resolves it. */
 export const invalidateMapleAuthToken = () => {
 	authGeneration += 1
 	cachedAuth = undefined
+	// Orphan any refresh already open: it resolves into nothing rather than
+	// being handed to a caller that belongs to the new identity.
+	inFlightRefresh = undefined
 }
 
 /** Whether a bearer token is currently being served from cache. */
@@ -109,12 +126,11 @@ export const subscribeActiveOrgId = (notify: () => void): (() => void) => {
 	return () => activeOrgSubscribers.delete(notify)
 }
 
-export const getMapleAuthHeaders = async (): Promise<MapleAuthHeaders> => {
+/** Cached token if it has enough life left, otherwise a fresh resolve. */
+const resolveProvidedHeaders = async (): Promise<MapleAuthHeaders> => {
 	const cached = cachedAuth
 	const remainingMs = cached === undefined ? -1 : cached.expMs - Date.now()
-	let providedHeaders: MapleAuthHeaders
 	if (cached !== undefined && remainingMs > TOKEN_MIN_REMAINING_MS) {
-		providedHeaders = cached.headers
 		if (remainingMs <= TOKEN_REFRESH_AHEAD_MS) {
 			// Refresh ahead of the deadline. Deliberately not awaited: this request
 			// already has a valid token, and blocking it on Clerk is the cost this
@@ -122,9 +138,19 @@ export const getMapleAuthHeaders = async (): Promise<MapleAuthHeaders> => {
 			// for the next caller to retry.
 			void refreshAuthHeaders().catch(() => undefined)
 		}
-	} else {
-		providedHeaders = authHeadersProvider ? await refreshAuthHeaders() : {}
+		return cached.headers
 	}
+	return authHeadersProvider ? await refreshAuthHeaders() : {}
+}
+
+export const getMapleAuthHeaders = async (): Promise<MapleAuthHeaders> => {
+	const generation = authGeneration
+	let providedHeaders = await resolveProvidedHeaders()
+	// The identity changed while we were waiting, so what we are holding belongs
+	// to an org (or provider) the user has left — the API would resolve it
+	// against the wrong tenant. Resolve once more under the current identity;
+	// bounded to one retry so a burst of switches cannot spin here.
+	if (generation !== authGeneration) providedHeaders = await resolveProvidedHeaders()
 	return {
 		...providedHeaders,
 		...authHeaders,


### PR DESCRIPTION
`R-WEB02-01`. The generation guard in `auth-headers.ts` only protected the cache write. The in-flight promise itself was shared with every later caller, so a request issued after an org switch or sign-out joined it and sent the previous identity's bearer — which the API then resolves against the tenant the user just left. Its `finally` also cleared the slot unconditionally, letting a straggler evict the successor that replaced it.

The refresh now carries its generation: only callers of that same identity join it, it clears only its own slot, `invalidateMapleAuthToken` orphans anything already open, and a caller whose identity changed while waiting resolves once more (bounded to one retry) instead of returning the departed identity's headers.

Three tests: the post-switch caller gets the new token, the pre-switch caller re-resolves rather than returning a stale one, and a straggler settles without evicting its successor. Stacked on #490.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789474747&installation_model_id=427786&pr_number=491&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F491&signature=7a6052ff169e51ae6ce3b8c4d94d5260bfb2b2f43ed6d6bc628e8d18ba853947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->