### PR TITLE
fix(api): claim the source row before minting an API key successor

### DIFF
--- a/apps/api/src/services/org/ApiKeysService.test.ts
+++ b/apps/api/src/services/org/ApiKeysService.test.ts
@@ -104,6 +104,87 @@ describe("ApiKeysService.roll", () => {
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
+	/**
+	 * Both concurrency barriers live in one place: the conditional
+	 * `UPDATE … WHERE revoked = false` that opens the roll transaction. Each caller
+	 * reads the key as live before anyone writes (the reads interleave on the
+	 * async boundary), so without that predicate every caller would go on to
+	 * insert a successor — two live keys from one roll/roll race, and a live
+	 * successor for a key a concurrent revoke had already retired.
+	 */
+	describe("concurrency barriers", () => {
+		const countKeys = (testDb: TestDb, orgId: string) =>
+			Effect.promise(async () => {
+				const row = await queryFirstRow<{ total: number; active: number }>(
+					testDb,
+					`select count(*)::int as total, count(*) filter (where revoked = false)::int as active
+					 from api_keys where org_id = $1`,
+					[orgId],
+				)
+				return row
+			})
+
+		it.effect("roll vs roll: only one successor is ever created", () => {
+			const testDb = createTestDb(trackedDbs)
+
+			return Effect.gen(function* () {
+				const svc = yield* ApiKeysService
+				const orgId = asOrgId("org_roll_race")
+				const created = yield* svc.create(orgId, asUserId("user_a"), { name: "contended" })
+
+				const exits = yield* Effect.all(
+					[
+						Effect.exit(svc.roll(orgId, asUserId("user_a"), created.id, {})),
+						Effect.exit(svc.roll(orgId, asUserId("user_b"), created.id, {})),
+					],
+					{ concurrency: 2 },
+				)
+
+				const succeeded = exits.filter(Exit.isSuccess)
+				assert.strictEqual(succeeded.length, 1, "exactly one roll may win the source row")
+				const losers = exits.filter(Exit.isFailure)
+				assert.strictEqual(losers.length, 1)
+				assert.instanceOf(Option.getOrUndefined(Exit.findErrorOption(losers[0])), ApiKeyNotFoundError)
+
+				const counts = yield* countKeys(testDb, orgId)
+				assert.deepStrictEqual(
+					{ total: counts?.total, active: counts?.active },
+					{ total: 2, active: 1 },
+					"one successor, and the source is revoked",
+				)
+			}).pipe(Effect.provide(makeLayer(testDb)))
+		})
+
+		it.effect("revoke vs roll: a revoked key never gets a successor", () => {
+			const testDb = createTestDb(trackedDbs)
+
+			return Effect.gen(function* () {
+				const svc = yield* ApiKeysService
+				const orgId = asOrgId("org_revoke_race")
+				const created = yield* svc.create(orgId, asUserId("user_a"), { name: "contended" })
+
+				const [revoked, rollExit] = yield* Effect.all(
+					[
+						svc.revoke(orgId, created.id),
+						Effect.exit(svc.roll(orgId, asUserId("user_b"), created.id, {})),
+					],
+					{ concurrency: 2 },
+				)
+
+				assert.strictEqual(revoked.revoked, true)
+				assert.isTrue(Exit.isFailure(rollExit), "the roll must lose to the committed revoke")
+				assert.instanceOf(Option.getOrUndefined(Exit.findErrorOption(rollExit)), ApiKeyNotFoundError)
+
+				const counts = yield* countKeys(testDb, orgId)
+				assert.deepStrictEqual(
+					{ total: counts?.total, active: counts?.active },
+					{ total: 1, active: 0 },
+					"no successor row exists for the revoked key",
+				)
+			}).pipe(Effect.provide(makeLayer(testDb)))
+		})
+	})
+
 	it.effect("returns a reconciliation txid when revoking", () => {
 		const testDb = createTestDb(trackedDbs)
 

--- a/apps/api/src/services/org/ApiKeysService.ts
+++ b/apps/api/src/services/org/ApiKeysService.ts
@@ -14,7 +14,7 @@ import {
 	RoleName,
 } from "@maple/domain/http"
 import { API_KEY_PREFIX, apiKeys, generateApiKey, hashApiKey, parseIngestKeyLookupHmacKey } from "@maple/db"
-import { and, desc, eq, isNull, lt, or } from "drizzle-orm"
+import { and, desc, eq, getTableColumns, isNull, lt, or } from "drizzle-orm"
 import { Clock, Effect, Layer, Option, Redacted, Schema, Context } from "effect"
 import { Database } from "@/platform/DatabaseLive"
 import { readTxid, txidColumn } from "@/platform/electric-txid"
@@ -265,13 +265,6 @@ export class ApiKeysService extends Context.Service<ApiKeysService>()("@maple/ap
 				"tenant.userId": userId,
 				"maple.api_key.id": keyId,
 			})
-			const existing = yield* requireById(orgId, keyId)
-			if (existing.revoked) {
-				return yield* Effect.fail(
-					new ApiKeyNotFoundError({ keyId, message: "API key is already revoked" }),
-				)
-			}
-
 			const id = decodeApiKeyIdSync(randomUUID())
 			const rawKey = generateApiKey()
 			const keyHash = hashApiKey(rawKey, hmacKey)
@@ -279,44 +272,71 @@ export class ApiKeysService extends Context.Service<ApiKeysService>()("@maple/ap
 			const now = yield* Clock.currentTimeMillis
 			const createdByEmail = params.createdByEmail ?? null
 
-			const rolledRows = yield* database
+			// The revoke of the source row is the barrier, and it runs FIRST: the
+			// `revoked = false` predicate means exactly one concurrent roll can
+			// claim the row, and the row lock it takes makes a second roll (or a
+			// racing revoke) re-read the committed state and match zero rows. Only
+			// the transaction that actually claimed the source inserts a successor,
+			// so a roll/roll race can no longer mint two live keys and a
+			// revoke/roll race can no longer mint a successor for a dead one.
+			const rolled = yield* database
 				.execute((db) =>
 					db.transaction(async (tx) => {
+						const claimed = await tx
+							.update(apiKeys)
+							.set({ revoked: true, revokedAt: msToDate(now) })
+							.where(
+								and(
+									eq(apiKeys.id, keyId),
+									eq(apiKeys.orgId, orgId),
+									eq(apiKeys.revoked, false),
+								),
+							)
+							.returning({ ...getTableColumns(apiKeys), ...txidColumn })
+						if (claimed.length === 0) return undefined
+						const source = claimed[0]
+
 						await tx.insert(apiKeys).values({
 							id,
 							orgId,
-							name: existing.name,
-							description: existing.description ?? null,
+							name: source.name,
+							description: source.description ?? null,
 							keyHash,
 							keyPrefix,
-							kind: existing.kind,
-							scopes: existing.scopes ?? null,
+							kind: source.kind,
+							scopes: source.scopes ?? null,
 							// Carry the role metadata across: a rolled key that lost it
 							// would resolve with the null (= `root`) default, silently
 							// escalating a CLI/MCP key beyond its creator's roles.
-							metadataJson: existing.metadataJson,
+							metadataJson: source.metadataJson,
 							expiresAt: null,
-							createdAt: new Date(now),
+							createdAt: msToDate(now),
 							createdBy: userId,
 							createdByEmail,
 						})
-						return tx
-							.update(apiKeys)
-							.set({ revoked: true, revokedAt: new Date(now) })
-							.where(eq(apiKeys.id, keyId))
-							.returning(txidColumn)
+						return source
 					}),
 				)
 				.pipe(Effect.mapError(toPersistenceError))
-			const txid = readTxid(rolledRows)
+
+			if (rolled === undefined) {
+				// Lost the claim (or never had one): distinguish a key that does not
+				// exist from one that was revoked out from under this roll.
+				yield* requireById(orgId, keyId)
+				return yield* Effect.fail(
+					new ApiKeyNotFoundError({ keyId, message: "API key is already revoked" }),
+				)
+			}
+
+			const txid = readTxid([rolled])
 
 			return new ApiKeyCreatedResponse({
 				id,
-				name: existing.name,
-				description: existing.description ?? null,
+				name: rolled.name,
+				description: rolled.description ?? null,
 				keyPrefix,
-				kind: existing.kind,
-				scopes: existing.scopes ?? null,
+				kind: rolled.kind,
+				scopes: rolled.scopes ?? null,
 				revoked: false,
 				revokedAt: null,
 				lastUsedAt: null,
@@ -332,20 +352,29 @@ export class ApiKeysService extends Context.Service<ApiKeysService>()("@maple/ap
 		const revoke = Effect.fn("ApiKeysService.revoke")(function* (orgId: OrgId, keyId: ApiKeyId) {
 			yield* Effect.annotateCurrentSpan({ orgId, "maple.api_key.id": keyId })
 			const now = yield* Clock.currentTimeMillis
-			const row = yield* requireById(orgId, keyId)
 
+			// Conditional for the same reason `roll` is: a revoke that races a roll
+			// must either claim the live row or observe that it is already dead —
+			// never re-stamp `revoked_at` on a row someone else already retired
+			// (which would also replicate a pointless row out through Electric).
 			const revokedRows = yield* database
 				.execute((db) =>
 					db
 						.update(apiKeys)
-						.set({ revoked: true, revokedAt: new Date(now) })
-						.where(eq(apiKeys.id, keyId))
-						.returning(txidColumn),
+						.set({ revoked: true, revokedAt: msToDate(now) })
+						.where(
+							and(eq(apiKeys.id, keyId), eq(apiKeys.orgId, orgId), eq(apiKeys.revoked, false)),
+						)
+						.returning({ ...getTableColumns(apiKeys), ...txidColumn }),
 				)
 				.pipe(Effect.mapError(toPersistenceError))
-			const txid = readTxid(revokedRows)
 
-			return rowToResponse({ ...row, revoked: true, revokedAt: new Date(now) }, txid)
+			// Lost the claim: either the key never existed (404) or it was already
+			// revoked, in which case the stored row — not a freshly stamped copy —
+			// is the truth to report back.
+			if (revokedRows.length === 0) return rowToResponse(yield* requireById(orgId, keyId))
+
+			return rowToResponse(revokedRows[0], readTxid(revokedRows))
 		})
 
 		const resolveByKey = Effect.fn("ApiKeysService.resolveByKey")(function* (rawKey: string) {


### PR DESCRIPTION
Roll read the key, checked `revoked`, then inserted the successor and revoked
the source with no predicate on the state it had read. Two concurrent rolls
both saw an active key and both minted one, leaving two live successors for a
single roll; a revoke landing in the same window left a live successor for a
key that was already dead. The revoke is now the claim — conditional on the
row still being active, returning it — and only the caller that wins it
inserts a successor. Revoke takes the same predicate so a racing pair no
longer re-stamps `revoked_at`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789479335&installation_model_id=427786&pr_number=494&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F494&signature=6d3fc6990ecc774ff0ca54a5068aad6712d9c96ca9656ca79769f46d4cf002cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->