### PR TITLE
fix(scraper): make the scrape outcome and the pending-result buffer own their state

### DIFF
--- a/apps/scraper/src/ScrapeScheduler.test.ts
+++ b/apps/scraper/src/ScrapeScheduler.test.ts
@@ -1,17 +1,24 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Duration, Effect, Layer, Redacted, Schema } from "effect"
+import { Duration, Effect, Fiber, Layer, Metric, Redacted, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import { InternalScrapeTarget, ScrapeResultReport, ScrapeTargetId } from "@maple/domain/http"
 import { ApiClient, ApiRequestError, type ApiClientApi, type ScrapeProxyResponse } from "./ApiClient"
 import { OtlpIngest, OtlpIngestError, type OtlpIngestApi } from "./OtlpIngest"
 import {
+	backoffLogMessage,
 	initialJitterMs,
+	makeResultBuffer,
 	nextScrapeDelayMs,
+	outcomeError,
+	scrapeFailed,
+	scrapeSucceeded,
 	ScrapeScheduler,
 	sendResultsInChunks,
+	shouldBackOff,
 	type ScrapeOutcome,
 } from "./ScrapeScheduler"
 import { ScraperEnv, type ScraperEnvConfig } from "./Env"
+import { bufferedResults } from "./Metrics"
 import type { OtlpExportRequest } from "./prometheus/otlp"
 
 const decodeTarget = Schema.decodeUnknownSync(InternalScrapeTarget)
@@ -495,6 +502,99 @@ describe("ScrapeScheduler", () => {
 		}),
 	)
 
+	it.effect("backs off a target the upstream answers with 503 (rate limited)", () =>
+		Effect.gen(function* () {
+			const harness = makeHarness([mkTarget(TARGET_A, 10)])
+			harness.scrapeImpl = () => Effect.succeed(proxyResponse({ status: 503, body: "unavailable" }))
+			yield* startScheduler.pipe(Effect.provide(harnessLayer(harness)))
+
+			yield* TestClock.adjust(Duration.seconds(60))
+
+			// Same exponential ladder as a 429: t=0, 10, 30.
+			assert.strictEqual(harness.scrapeCalls.length, 3)
+			assert.include(harness.reportedResults[0]?.error ?? "", "HTTP 503")
+		}),
+	)
+
+	it.effect("backs off when the ingest gateway blocks delivery (402) instead of re-scraping", () =>
+		Effect.gen(function* () {
+			// Prod scenario: the org is over its billing limit, so every export is
+			// refused. Scraping again cannot help — the data has nowhere to go.
+			const harness = makeHarness([mkTarget(TARGET_A, 10)])
+			harness.ingestImpl = () =>
+				Effect.fail(
+					new OtlpIngestError({
+						message: "ingest gateway rejected metrics: billing limit reached (HTTP 402)",
+						status: 402,
+					}),
+				)
+			yield* startScheduler.pipe(Effect.provide(harnessLayer(harness)))
+
+			yield* TestClock.adjust(Duration.seconds(60))
+
+			// Exponential backoff off a 10s base: scrapes at t=0, 10, 30.
+			assert.strictEqual(harness.scrapeCalls.length, 3)
+			assert.include(harness.reportedResults[0]?.error ?? "", "billing limit")
+		}),
+	)
+
+	it.effect("holds the configured cadence on a generic failure instead of backing off", () =>
+		Effect.gen(function* () {
+			// A transport error is not a signal that the upstream wants us to slow
+			// down, so the loop must keep its interval (contrast with 429/403/402).
+			const harness = makeHarness([mkTarget(TARGET_A, 10)])
+			harness.scrapeImpl = () =>
+				Effect.fail(new ApiRequestError({ message: "Maple API unreachable: boom", status: null }))
+			yield* startScheduler.pipe(Effect.provide(harnessLayer(harness)))
+
+			yield* TestClock.adjust(Duration.seconds(60))
+
+			// Fixed 10s cadence → t=0,10,...,60 → 7 scrapes.
+			assert.strictEqual(harness.scrapeCalls.length, 7)
+			assert.include(harness.reportedResults[0]?.error ?? "", "boom")
+		}),
+	)
+
+	it.effect("keeps results and the gauge consistent when a flush is interrupted", () =>
+		Effect.gen(function* () {
+			// The drain empties the buffer before the POST; an interrupt (shutdown)
+			// mid-flight used to drop the whole batch and leave the gauge at 0.
+			const harness = makeHarness([mkTarget(TARGET_A, 60)])
+			const api: ApiClientApi = {
+				listTargets: () => Effect.sync(() => [...harness.targets]),
+				scrapeTarget: (targetId) =>
+					Effect.suspend(() => {
+						harness.scrapeCalls.push(targetId)
+						return harness.scrapeImpl(targetId)
+					}),
+				// Never settles: the flush is in flight when we interrupt.
+				reportResults: () => Effect.never,
+			}
+			const layer = ScrapeScheduler.layer.pipe(
+				Layer.provide(
+					Layer.mergeAll(
+						Layer.succeed(ApiClient, api),
+						Layer.succeed(OtlpIngest, { send: () => Effect.void }),
+						Layer.succeed(ScraperEnv, testEnv),
+					),
+				),
+			)
+			yield* Effect.gen(function* () {
+				const scheduler = yield* ScrapeScheduler
+				const fiber = yield* Effect.forkChild(scheduler.run)
+				yield* TestClock.adjust(Duration.millis(0))
+				// One scrape buffered; the flush at t=10s drains it and hangs.
+				yield* TestClock.adjust(Duration.seconds(11))
+
+				yield* Fiber.interrupt(fiber)
+
+				const stats = yield* scheduler.stats
+				assert.strictEqual(stats.pendingResults, 1)
+				assert.strictEqual((yield* Metric.value(bufferedResults)).value, 1)
+			}).pipe(Effect.provide(layer))
+		}),
+	)
+
 	it.effect("honors a longer Retry-After before the next scrape", () =>
 		Effect.gen(function* () {
 			const harness = makeHarness([mkTarget(TARGET_A, 10)])
@@ -632,34 +732,21 @@ describe("sendResultsInChunks", () => {
 })
 
 describe("nextScrapeDelayMs", () => {
-	const ok: ScrapeOutcome = {
-		error: null,
-		rateLimited: false,
-		authFailed: false,
-		deliveryBlocked: false,
-		retryAfterMs: null,
-	}
-	const limited = (retryAfterMs: number | null = null): ScrapeOutcome => ({
-		error: "target returned HTTP 429",
-		rateLimited: true,
-		authFailed: false,
-		deliveryBlocked: false,
-		retryAfterMs,
+	const ok: ScrapeOutcome = scrapeSucceeded({ samplesScraped: 1, samplesPostMetricRelabeling: 1 })
+	const limited = (retryAfterMs: number | null = null): ScrapeOutcome =>
+		scrapeFailed({ reason: "rate_limited", message: "target returned HTTP 429", retryAfterMs })
+	const authRejected: ScrapeOutcome = scrapeFailed({
+		reason: "auth_failed",
+		message: "target returned HTTP 403",
 	})
-	const authRejected: ScrapeOutcome = {
-		error: "target returned HTTP 403",
-		rateLimited: false,
-		authFailed: true,
-		deliveryBlocked: false,
-		retryAfterMs: null,
-	}
-	const deliveryBlocked: ScrapeOutcome = {
-		error: "ingest gateway rejected metrics: billing limit reached (HTTP 402)",
-		rateLimited: false,
-		authFailed: false,
-		deliveryBlocked: true,
-		retryAfterMs: null,
-	}
+	const deliveryBlocked: ScrapeOutcome = scrapeFailed({
+		reason: "delivery_blocked",
+		message: "ingest gateway rejected metrics: billing limit reached (HTTP 402)",
+	})
+	const generic: ScrapeOutcome = scrapeFailed({
+		reason: "scrape_failed",
+		message: "Maple API unreachable: boom",
+	})
 
 	it("holds the base interval on a healthy scrape, ignoring the counter", () => {
 		assert.strictEqual(nextScrapeDelayMs({ baseMs: 5_000, outcome: ok, consecutiveBackoffs: 3 }), 5_000)
@@ -709,6 +796,13 @@ describe("nextScrapeDelayMs", () => {
 		)
 	})
 
+	it("holds the base interval on a generic failure", () => {
+		assert.strictEqual(
+			nextScrapeDelayMs({ baseMs: 10_000, outcome: generic, consecutiveBackoffs: 4 }),
+			10_000,
+		)
+	})
+
 	it("caps the backoff at 5 minutes", () => {
 		assert.strictEqual(
 			nextScrapeDelayMs({ baseMs: 60_000, outcome: limited(), consecutiveBackoffs: 5 }),
@@ -729,6 +823,104 @@ describe("nextScrapeDelayMs", () => {
 			40_000,
 		)
 	})
+})
+
+describe("ScrapeOutcome", () => {
+	// One union, one place each decision is derived. Before this, policy, the
+	// span's `error.type` and the log line each re-derived from four parallel
+	// booleans — and a delivery-blocked (402) scrape logged itself as
+	// "Scrape rate-limited, backing off".
+	const reasons = ["rate_limited", "auth_failed", "delivery_blocked", "scrape_failed"] as const
+
+	it("backs off for every reason a retry cannot immediately clear, and only those", () => {
+		assert.deepStrictEqual(
+			reasons.map((reason) => shouldBackOff(scrapeFailed({ reason, message: reason }))),
+			[true, true, true, false],
+		)
+		assert.isFalse(shouldBackOff(scrapeSucceeded({ samplesScraped: 0, samplesPostMetricRelabeling: 0 })))
+	})
+
+	it("gives each reason its own backoff log line", () => {
+		const lines = reasons.map(backoffLogMessage)
+		assert.lengthOf(new Set(lines), reasons.length)
+		// The regression: 402 used to reuse the rate-limit line verbatim.
+		assert.notStrictEqual(backoffLogMessage("delivery_blocked"), backoffLogMessage("rate_limited"))
+		assert.include(backoffLogMessage("delivery_blocked"), "delivery")
+	})
+
+	it("reports the failure message and nothing on success", () => {
+		assert.strictEqual(
+			outcomeError(scrapeFailed({ reason: "auth_failed", message: "target returned HTTP 403" })),
+			"target returned HTTP 403",
+		)
+		assert.isNull(outcomeError(scrapeSucceeded({ samplesScraped: 3, samplesPostMetricRelabeling: 3 })))
+	})
+})
+
+describe("ResultBuffer", () => {
+	const decodeId = Schema.decodeUnknownSync(ScrapeTargetId)
+	const mkReport = (scrapedAt: number) =>
+		new ScrapeResultReport({ targetId: decodeId(TARGET_A), scrapedAt, error: null })
+	const gauge = Effect.map(Metric.value(bufferedResults), (state) => state.value)
+
+	it.effect("keeps the gauge equal to the buffer size across every transition", () =>
+		Effect.gen(function* () {
+			const buffer = yield* makeResultBuffer(10)
+			yield* Effect.forEach([0, 1, 2].map(mkReport), buffer.enqueue, { discard: true })
+			assert.strictEqual(yield* buffer.size, 3)
+			assert.strictEqual(yield* gauge, 3)
+
+			const drained = yield* buffer.take
+			assert.lengthOf(drained, 3)
+			assert.strictEqual(yield* buffer.size, 0)
+			assert.strictEqual(yield* gauge, 0)
+
+			yield* buffer.requeue(drained)
+			assert.strictEqual(yield* buffer.size, 3)
+			assert.strictEqual(yield* gauge, 3)
+		}),
+	)
+
+	it.effect("requeues in front of results enqueued while the flush was in flight", () =>
+		Effect.gen(function* () {
+			const buffer = yield* makeResultBuffer(10)
+			yield* buffer.enqueue(mkReport(1))
+			const inFlight = yield* buffer.take
+			// A scrape lands mid-flush; the requeue must not clobber it, and the
+			// gauge must count both (it used to be set to the unsent count alone).
+			yield* buffer.enqueue(mkReport(2))
+			yield* buffer.requeue(inFlight)
+
+			assert.strictEqual(yield* buffer.size, 2)
+			assert.strictEqual(yield* gauge, 2)
+			assert.deepStrictEqual(
+				(yield* buffer.take).map((r) => r.scrapedAt),
+				[1, 2],
+			)
+		}),
+	)
+
+	it.effect("caps at capacity by dropping the oldest, gauge included", () =>
+		Effect.gen(function* () {
+			const buffer = yield* makeResultBuffer(3)
+			yield* Effect.forEach([0, 1, 2, 3, 4].map(mkReport), buffer.enqueue, { discard: true })
+			assert.strictEqual(yield* buffer.size, 3)
+			assert.strictEqual(yield* gauge, 3)
+			assert.deepStrictEqual(
+				(yield* buffer.take).map((r) => r.scrapedAt),
+				[2, 3, 4],
+			)
+
+			// Overflow on requeue drops the oldest too, keeping the newest.
+			yield* buffer.requeue([0, 1, 2, 3].map(mkReport))
+			assert.strictEqual(yield* buffer.size, 3)
+			assert.strictEqual(yield* gauge, 3)
+			assert.deepStrictEqual(
+				(yield* buffer.take).map((r) => r.scrapedAt),
+				[1, 2, 3],
+			)
+		}),
+	)
 })
 
 describe("initialJitterMs", () => {

--- a/apps/scraper/src/ScrapeScheduler.ts
+++ b/apps/scraper/src/ScrapeScheduler.ts
@@ -2,7 +2,6 @@ import {
 	Cause,
 	Clock,
 	Context,
-	Data,
 	Duration,
 	Effect,
 	Fiber,
@@ -51,56 +50,122 @@ const RESULTS_FLUSH_CHUNK_SIZE = 1_000
 /** Upper bound on rate-limit backoff so a target keeps probing for recovery. */
 const MAX_BACKOFF_MS = Duration.toMillis(Duration.minutes(5))
 
-export interface ScrapeOutcome {
-	readonly error: string | null
-	readonly samplesScraped?: number
-	readonly samplesPostMetricRelabeling?: number
-	/** Upstream signalled a rate limit (HTTP 429/503) — back off before retrying. */
-	readonly rateLimited: boolean
-	/**
-	 * Upstream rejected the credential (HTTP 401/403) — back off like a rate
-	 * limit: the failure won't clear until the org's auth is fixed, so retrying
-	 * every interval just hammers the target (prod hit this with PlanetScale
-	 * rejecting OAuth bearers on metrics.psdb.cloud every 60s).
-	 */
-	readonly authFailed: boolean
-	/**
-	 * Maple's own ingest gateway refused the metrics for billing reasons (HTTP
-	 * 402) — distinct from `authFailed`, which is about the *target's*
-	 * credential. Scraping the target again cannot help: the data has nowhere to
-	 * go until the org's subscription is fixed, so back off instead of paying for
-	 * a scrape whose result is discarded (prod hit this at full cadence, ~7.2k
-	 * failures in 6h across the fleet).
-	 */
-	readonly deliveryBlocked: boolean
-	/** Upstream `Retry-After` translated to ms, when present. */
-	readonly retryAfterMs: number | null
+/**
+ * Why a scrape failed. Every downstream decision — retry policy, the span's
+ * `error.type`, the backoff log line — is derived from this one field, so the
+ * four cases can never disagree the way parallel booleans did (a 402 delivery
+ * rejection used to back off correctly but log itself as "rate-limited").
+ *
+ * - `rate_limited` — upstream signalled HTTP 429/503; back off before retrying.
+ * - `auth_failed` — upstream rejected the credential (HTTP 401/403). Back off
+ *   like a rate limit: the failure won't clear until the org's auth is fixed,
+ *   so retrying every interval just hammers the target (prod hit this with
+ *   PlanetScale rejecting OAuth bearers on metrics.psdb.cloud every 60s).
+ * - `delivery_blocked` — Maple's own ingest gateway refused the metrics for
+ *   billing reasons (HTTP 402). Distinct from `auth_failed`, which is about the
+ *   *target's* credential. Scraping the target again cannot help: the data has
+ *   nowhere to go until the org's subscription is fixed, so back off instead of
+ *   paying for a scrape whose result is discarded (prod hit this at full
+ *   cadence, ~7.2k failures in 6h across the fleet).
+ * - `scrape_failed` — anything else; hold the configured cadence.
+ */
+export const ScrapeFailureReason = Schema.Literals([
+	"rate_limited",
+	"auth_failed",
+	"delivery_blocked",
+	"scrape_failed",
+])
+export type ScrapeFailureReason = typeof ScrapeFailureReason.Type
+
+export interface ScrapeSucceeded {
+	readonly _tag: "Success"
+	readonly samplesScraped: number
+	readonly samplesPostMetricRelabeling: number
 }
 
-class ScrapeAttemptFailed extends Data.TaggedError("@maple/scraper/ScrapeAttemptFailed")<{
-	/**
-	 * The SDK derives a span's `status.message` from the failure's `Error.message`
-	 * (`Cause.prettyErrors`), so without this field every failed scrape produced an
-	 * Error span with a blank description and the reason lived only in the log line
-	 * emitted after the span had already closed.
-	 */
+export interface ScrapeFailed {
+	readonly _tag: "Failure"
+	readonly reason: ScrapeFailureReason
+	/** Human-readable failure text; reported to the API and used as span status. */
 	readonly message: string
-	readonly outcome: ScrapeOutcome
-}> {}
+	/** Upstream `Retry-After` translated to ms, when present. */
+	readonly retryAfterMs?: number
+}
+
+/** The single value a resolved scrape produces. */
+export type ScrapeOutcome = ScrapeSucceeded | ScrapeFailed
+
+export const scrapeSucceeded = (fields: {
+	readonly samplesScraped: number
+	readonly samplesPostMetricRelabeling: number
+}): ScrapeOutcome => ({ _tag: "Success", ...fields })
+
+export const scrapeFailed = (fields: {
+	readonly reason: ScrapeFailureReason
+	readonly message: string
+	readonly retryAfterMs?: number | null
+}): ScrapeOutcome => ({
+	_tag: "Failure",
+	reason: fields.reason,
+	message: fields.message,
+	...(fields.retryAfterMs != null ? { retryAfterMs: fields.retryAfterMs } : undefined),
+})
+
+/**
+ * Carries a resolved {@link ScrapeFailed} out of the span so the span closes as
+ * an error. The SDK derives a span's `status.message` from the failure's
+ * `Error.message` (`Cause.prettyErrors`), so without `message` every failed
+ * scrape produced an Error span with a blank description and the reason lived
+ * only in the log line emitted after the span had already closed.
+ */
+class ScrapeAttemptFailed extends Schema.TaggedError<ScrapeAttemptFailed>()(
+	"@maple/scraper/ScrapeAttemptFailed",
+	{
+		message: Schema.String,
+		reason: ScrapeFailureReason,
+		retryAfterMs: Schema.NullOr(Schema.Number),
+	},
+) {
+	get outcome(): ScrapeOutcome {
+		return scrapeFailed({
+			reason: this.reason,
+			message: this.message,
+			retryAfterMs: this.retryAfterMs,
+		})
+	}
+}
+
+/** The failure text to report to the API, or `null` for a healthy scrape. */
+export const outcomeError = (outcome: ScrapeOutcome): string | null =>
+	outcome._tag === "Failure" ? outcome.message : null
 
 /** A scrape outcome that must escalate the delay instead of holding cadence. */
 export const shouldBackOff = (outcome: ScrapeOutcome): boolean =>
-	outcome.rateLimited || outcome.authFailed || outcome.deliveryBlocked
+	outcome._tag === "Failure" && outcome.reason !== "scrape_failed"
+
+/** The log line for a backing-off scrape — one per reason, exhaustively. */
+export const backoffLogMessage = (reason: ScrapeFailureReason): string => {
+	switch (reason) {
+		case "rate_limited":
+			return "Scrape rate-limited, backing off"
+		case "auth_failed":
+			return "Scrape auth rejected, backing off"
+		case "delivery_blocked":
+			return "Scrape delivery blocked by the ingest gateway, backing off"
+		case "scrape_failed":
+			return "Scrape failed, backing off"
+	}
+}
 
 /**
  * The target period before a target's next scrape. The happy path returns the
  * configured interval; the caller ({@link ScrapeScheduler}'s target loop)
  * subtracts the scrape's own elapsed time so the happy-path cadence stays
- * start-to-start. A rate-limited or auth-rejected scrape escalates
- * exponentially — honoring `Retry-After` when it is longer — capped at
- * {@link MAX_BACKOFF_MS} so the target keeps probing for recovery (an auth fix
- * needs no restart: the credential is resolved server-side per scrape); that
- * delay runs from scrape end.
+ * start-to-start. A rate-limited, auth-rejected or delivery-blocked scrape
+ * escalates exponentially — honoring `Retry-After` when it is longer — capped
+ * at {@link MAX_BACKOFF_MS} so the target keeps probing for recovery (an auth
+ * fix needs no restart: the credential is resolved server-side per scrape);
+ * that delay runs from scrape end.
  */
 export const nextScrapeDelayMs = ({
 	baseMs,
@@ -115,7 +180,7 @@ export const nextScrapeDelayMs = ({
 	// exponential is always >= baseMs (consecutiveBackoffs >= 0), so baseMs
 	// never needs to be a floor here.
 	const exponential = baseMs * 2 ** consecutiveBackoffs
-	const retryAfter = outcome.retryAfterMs ?? 0
+	const retryAfter = (outcome._tag === "Failure" ? outcome.retryAfterMs : undefined) ?? 0
 	return Math.min(MAX_BACKOFF_MS, Math.max(exponential, retryAfter))
 }
 
@@ -189,6 +254,65 @@ export const sendResultsInChunks = <E>(
 		return { unsent: [], error: null }
 	})
 
+/**
+ * The pending scrape-result buffer. Contents, capacity, ordering and the
+ * `scraper.buffered_results` gauge used to be four independent statements
+ * (`enqueue` never touched the gauge at all; a flush zeroed it, sent over the
+ * network, then set it to the unsent count — losing anything enqueued in the
+ * meantime, and losing the whole batch outright if the flush was interrupted
+ * after the drain). Every transition below is atomic under one mutex, and the
+ * gauge is written from the same critical section that changed the contents, so
+ * the reported size is always the size that is actually buffered.
+ *
+ * Network I/O must stay OUTSIDE the lock: `take` drains and returns, the caller
+ * sends, then `requeue` puts back whatever did not make it.
+ */
+export interface ResultBuffer {
+	/** Append one result, dropping the oldest when at capacity. */
+	readonly enqueue: (result: ScrapeResultReport) => Effect.Effect<void>
+	/** Atomically drain everything buffered (gauge → 0). */
+	readonly take: Effect.Effect<ReadonlyArray<ScrapeResultReport>>
+	/** Put undelivered results back in front, keeping the newest at capacity. */
+	readonly requeue: (results: ReadonlyArray<ScrapeResultReport>) => Effect.Effect<void>
+	readonly size: Effect.Effect<number>
+}
+
+export const makeResultBuffer = (capacity: number): Effect.Effect<ResultBuffer> =>
+	Effect.gen(function* () {
+		const ref = yield* Ref.make<ReadonlyArray<ScrapeResultReport>>([])
+		const mutex = yield* Semaphore.make(1)
+
+		// Every transition: mutate contents and publish the resulting size in one
+		// critical section, so no interleaving can leave the gauge disagreeing
+		// with the buffer.
+		const transition = (
+			update: (buffered: ReadonlyArray<ScrapeResultReport>) => ReadonlyArray<ScrapeResultReport>,
+		) =>
+			mutex.withPermits(1)(
+				Effect.gen(function* () {
+					const next = update(yield* Ref.get(ref))
+					yield* Ref.set(ref, next)
+					yield* Metric.update(bufferedResults, next.length)
+				}),
+			)
+
+		return {
+			enqueue: (result) => transition((buffered) => [...buffered, result].slice(-capacity)),
+			take: mutex.withPermits(1)(
+				Effect.gen(function* () {
+					const drained = yield* Ref.getAndSet(ref, [])
+					yield* Metric.update(bufferedResults, 0)
+					return drained
+				}),
+			),
+			requeue: (results) =>
+				results.length === 0
+					? Effect.void
+					: transition((buffered) => [...results, ...buffered].slice(-capacity)),
+			size: Effect.map(Ref.get(ref), (buffered) => buffered.length),
+		} satisfies ResultBuffer
+	})
+
 export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSchedulerApi>()(
 	"@maple/scraper/ScrapeScheduler",
 	{
@@ -198,16 +322,9 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 			const otlp = yield* OtlpIngest
 
 			const semaphore = yield* Semaphore.make(env.SCRAPER_CONCURRENCY)
-			const resultsRef = yield* Ref.make<ReadonlyArray<ScrapeResultReport>>([])
+			const results = yield* makeResultBuffer(MAX_BUFFERED_RESULTS)
 			const fibersRef = yield* Ref.make(new Map<string, TargetEntry>())
 			const lastReconcileRef = yield* Ref.make<number | null>(null)
-
-			const enqueueResult = (result: ScrapeResultReport) =>
-				Ref.update(resultsRef, (buffered) =>
-					buffered.length >= MAX_BUFFERED_RESULTS
-						? [...buffered.slice(1), result]
-						: [...buffered, result],
-				)
 
 			const recordOutcome = (
 				target: InternalScrapeTarget,
@@ -215,20 +332,16 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 				durationMs: number,
 				outcome: ScrapeOutcome,
 			) =>
-				enqueueResult(
+				results.enqueue(
 					new ScrapeResultReport({
 						targetId: target.id,
 						scrapedAt,
-						error: outcome.error,
+						error: outcomeError(outcome),
 						subTargetKey: target.subTargetKey,
 						durationMs,
-						...(outcome.samplesScraped !== undefined
+						...(outcome._tag === "Success"
 							? {
 									samplesScraped: outcome.samplesScraped,
-								}
-							: undefined),
-						...(outcome.samplesPostMetricRelabeling !== undefined
-							? {
 									samplesPostMetricRelabeling: outcome.samplesPostMetricRelabeling,
 								}
 							: undefined),
@@ -244,16 +357,19 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 							const attempt = yield* Effect.gen(function* () {
 								const response = yield* api.scrapeTarget(target.id, target.subTargetKey)
 								if (response.status < 200 || response.status >= 300) {
-									return {
-										error: `target returned HTTP ${response.status}`,
-										rateLimited: response.status === 429 || response.status === 503,
-										authFailed: response.status === 401 || response.status === 403,
-										deliveryBlocked: false,
+									return scrapeFailed({
+										message: `target returned HTTP ${response.status}`,
+										reason:
+											response.status === 429 || response.status === 503
+												? "rate_limited"
+												: response.status === 401 || response.status === 403
+													? "auth_failed"
+													: "scrape_failed",
 										retryAfterMs:
 											response.retryAfterSeconds !== null
 												? response.retryAfterSeconds * 1000
 												: null,
-									} satisfies ScrapeOutcome
+									})
 								}
 
 								const parsed = parsePrometheusText(response.body)
@@ -278,8 +394,7 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 									"maple.scraper.dropped_series": converted.droppedSeriesCount,
 									"maple.scraper.skipped_lines": parsed.skippedLineCount,
 								})
-								return {
-									error: null,
+								return scrapeSucceeded({
 									samplesScraped: parsed.families.reduce(
 										(total, family) => total + family.samples.length,
 										0,
@@ -288,52 +403,41 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 										converted.dataPointCounts.sum +
 										converted.dataPointCounts.gauge +
 										converted.dataPointCounts.histogram,
-									rateLimited: false,
-									authFailed: false,
-									deliveryBlocked: false,
-									retryAfterMs: null,
-								} satisfies ScrapeOutcome
+								})
 							}).pipe(
 								Effect.catch((error) =>
-									Effect.succeed<ScrapeOutcome>({
-										error: error.message,
-										rateLimited: false,
-										authFailed: false,
-										// The gateway's 402 is the one failure in here that a
-										// retry provably cannot clear.
-										deliveryBlocked:
-											error._tag === "@maple/scraper/OtlpIngestError" &&
-											error.status === 402,
-										retryAfterMs: null,
-									}),
+									Effect.succeed(
+										scrapeFailed({
+											message: error.message,
+											// The gateway's 402 is the one failure in here that a
+											// retry provably cannot clear.
+											reason:
+												error._tag === "@maple/scraper/OtlpIngestError" &&
+												error.status === 402
+													? "delivery_blocked"
+													: "scrape_failed",
+										}),
+									),
 								),
 								Effect.catchDefect((defect) =>
-									Effect.succeed<ScrapeOutcome>({
-										error: Cause.pretty(Cause.die(defect)),
-										rateLimited: false,
-										authFailed: false,
-										deliveryBlocked: false,
-										retryAfterMs: null,
-									}),
+									Effect.succeed(
+										scrapeFailed({
+											message: Cause.pretty(Cause.die(defect)),
+											reason: "scrape_failed",
+										}),
+									),
 								),
 							)
 
-							if (attempt.error !== null) {
+							if (attempt._tag === "Failure") {
 								// `error.type` buckets the failure so the reason is groupable
-								// without parsing the free-text message.
-								yield* Effect.annotateCurrentSpan(
-									"error.type",
-									attempt.deliveryBlocked
-										? "delivery_blocked"
-										: attempt.rateLimited
-											? "rate_limited"
-											: attempt.authFailed
-												? "auth_failed"
-												: "scrape_failed",
-								)
+								// without parsing the free-text message — the same field the
+								// retry policy and the backoff log line read.
+								yield* Effect.annotateCurrentSpan("error.type", attempt.reason)
 								return yield* new ScrapeAttemptFailed({
-									message: attempt.error,
-									outcome: attempt,
+									message: attempt.message,
+									reason: attempt.reason,
+									retryAfterMs: attempt.retryAfterMs ?? null,
 								})
 							}
 							return attempt
@@ -361,21 +465,22 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 										: undefined),
 								},
 							}),
-							Effect.catchTag("@maple/scraper/ScrapeAttemptFailed", ({ outcome }) =>
-								Effect.succeed(outcome),
+							Effect.catchTag("@maple/scraper/ScrapeAttemptFailed", (failure) =>
+								Effect.succeed(failure.outcome),
 							),
 						)
 
 						const durationMs = (yield* Clock.currentTimeMillis) - scrapeTimeMs
 						yield* Metric.update(scrapeDurationMs, durationMs)
-						yield* Metric.update(scrapesTotal, outcome.error === null ? "ok" : "error")
+						yield* Metric.update(scrapesTotal, outcome._tag === "Success" ? "ok" : "error")
 						yield* recordOutcome(target, scrapeTimeMs, durationMs, outcome)
-						if (outcome.error !== null) {
+						if (outcome._tag === "Failure") {
 							yield* Effect.logWarning("Scrape failed").pipe(
 								Effect.annotateLogs({
 									targetId: target.id,
 									orgId: target.orgId,
-									error: outcome.error,
+									reason: outcome.reason,
+									error: outcome.message,
 								}),
 							)
 						}
@@ -397,20 +502,17 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 						const elapsedMs = (yield* Clock.currentTimeMillis) - startedAt
 						const backingOff = shouldBackOff(outcome)
 						const delayMs = nextScrapeDelayMs({ baseMs, outcome, consecutiveBackoffs })
-						if (backingOff) {
-							yield* Effect.logWarning(
-								outcome.authFailed
-									? "Scrape auth rejected, backing off"
-									: "Scrape rate-limited, backing off",
-							).pipe(
+						if (backingOff && outcome._tag === "Failure") {
+							yield* Effect.logWarning(backoffLogMessage(outcome.reason)).pipe(
 								Effect.annotateLogs({
 									targetId: target.id,
 									orgId: target.orgId,
 									...(target.subTargetKey
 										? { subTargetKey: target.subTargetKey }
 										: undefined),
+									reason: outcome.reason,
 									delayMs,
-									retryAfterMs: outcome.retryAfterMs,
+									retryAfterMs: outcome.retryAfterMs ?? null,
 									consecutiveBackoffs: consecutiveBackoffs + 1,
 								}),
 							)
@@ -493,27 +595,28 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 			)
 
 			const flushResults = Effect.gen(function* () {
-				const results = yield* Ref.getAndSet(resultsRef, [])
-				yield* Metric.update(bufferedResults, 0)
-				if (results.length === 0) return
+				const batch = yield* results.take
+				if (batch.length === 0) return
+				// `pending` shrinks as chunks land, so an interrupt mid-flush re-buffers
+				// exactly what was never delivered instead of dropping the whole batch
+				// (the drain already emptied the buffer).
+				const pending = yield* Ref.make(batch)
 				// Send in chunks so one POST never overwhelms the API Worker; re-buffer
 				// only what didn't make it (in front) and retry on the next flush.
-				const { unsent, error } = yield* sendResultsInChunks(
-					results,
-					RESULTS_FLUSH_CHUNK_SIZE,
-					api.reportResults,
-				)
+				const { error } = yield* sendResultsInChunks(batch, RESULTS_FLUSH_CHUNK_SIZE, (chunk) =>
+					api
+						.reportResults(chunk)
+						.pipe(Effect.tap(() => Ref.update(pending, (rest) => rest.slice(chunk.length)))),
+				).pipe(Effect.onInterrupt(() => Effect.flatMap(Ref.get(pending), results.requeue)))
+				const unsent = yield* Ref.get(pending)
 				if (unsent.length > 0) {
-					yield* Ref.update(resultsRef, (buffered) =>
-						[...unsent, ...buffered].slice(-MAX_BUFFERED_RESULTS),
-					)
+					yield* results.requeue(unsent)
 					yield* Effect.logWarning("Failed to report scrape results").pipe(
 						Effect.annotateLogs({
 							error: error?.message ?? "unknown",
 							bufferedResults: unsent.length,
 						}),
 					)
-					yield* Metric.update(bufferedResults, unsent.length)
 				}
 			}).pipe(Effect.withSpan("scraper.flush_results"))
 
@@ -530,11 +633,11 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 			const stats = Effect.gen(function* () {
 				const fibers = yield* Ref.get(fibersRef)
 				const lastReconcileAt = yield* Ref.get(lastReconcileRef)
-				const pending = yield* Ref.get(resultsRef)
+				const pendingResults = yield* results.size
 				return {
 					activeTargets: fibers.size,
 					lastReconcileAt,
-					pendingResults: pending.length,
+					pendingResults,
 				} satisfies SchedulerStats
 			})
 


### PR DESCRIPTION
Four independent flags described a scrape result, and three places re-derived
policy, telemetry and the log line from them; the log branch had no arm for a
delivery block, so an ingest 402 backed off, tagged its span `delivery_blocked`
and told the operator it had been rate-limited. The outcome is now a union
built once where the scrape resolves, and the three derivations read its reason
exhaustively.

The result buffer had the same split: contents lived in a Ref, the gauge was
written only inside the flush, and the drain-send-requeue sequence left both
disagreeing whenever a scrape landed mid-flush — and dropped the whole in-flight
batch on shutdown. Contents, capacity, order and the gauge now move together
behind one lock, with the network outside it and an interrupt requeueing exactly
what was never delivered.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789479339&installation_model_id=427786&pr_number=495&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F495&signature=a2553c05f7cedbe6e305696ef1d3738822a056b561a335b49d4f242ca6f0dce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->