### PR TITLE
fix(effect-sdk): drain deferred finalizers inside the Cloudflare flush

### DIFF
--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -71,6 +71,12 @@ const telemetry = MapleCloudflareSDK.make({
 // hasn't fired yet. Isolated requests (e.g. a GitHub webhook) freeze the isolate
 // before a subsequent request rescues it, so the trace is silently dropped.
 // Yield one macrotask first so `span.end` runs before we drain.
+//
+// The SDK now owns this drain — `telemetry.flush` yields a macrotask inside its
+// own serialized body. This local yield is kept deliberately redundant (an extra
+// macrotask is harmless) so a version skew between the worker and the published
+// SDK can't drop spans; remove it once the SDK version carrying that change is
+// pinned here.
 const flushTelemetry = async (env: Record<string, unknown>): Promise<void> => {
 	await new Promise<void>((resolve) => setTimeout(resolve, 0))
 	await telemetry.flush(env)

--- a/apps/electric-sync/src/worker.ts
+++ b/apps/electric-sync/src/worker.ts
@@ -53,6 +53,12 @@ const telemetry = MapleCloudflareSDK.make({
 // `HttpMiddleware.tracer` ends the root server span on a deferred macrotask, but
 // `telemetry.flush` drains synchronously. Yield one macrotask first so `span.end`
 // runs before we drain, otherwise isolated requests silently drop the trace.
+//
+// The SDK now owns this drain — `telemetry.flush` yields a macrotask inside its
+// own serialized body. This local yield is kept deliberately redundant (an extra
+// macrotask is harmless) so a version skew between the worker and the published
+// SDK can't drop spans; remove it once the SDK version carrying that change is
+// pinned here.
 const flushTelemetry = async (env: Record<string, unknown>): Promise<void> => {
 	await new Promise<void>((resolve) => setTimeout(resolve, 0))
 	await telemetry.flush(env)

--- a/packages/effect-sdk/src/cloudflare/index.test.ts
+++ b/packages/effect-sdk/src/cloudflare/index.test.ts
@@ -301,6 +301,81 @@ describe("MapleCloudflareSDK.make", () => {
 		expect(consoleErrorSpy).toHaveBeenCalled()
 	})
 
+	// Effect defers `span.end` and `withSpan` finalizers onto the scheduler's
+	// next macrotask (`scheduleTask(task, 0)`); the buffer drain is synchronous.
+	// A flush that resolves within the same task misses exactly the spans the
+	// request just produced. The flush must own that yield itself.
+	it("captures a span whose end is deferred to the next macrotask", async () => {
+		const { calls, restore: r } = setupFetch()
+		restore = r
+		const telemetry = make({ serviceName: "unit-test" })
+
+		// Stand-in for `HttpMiddleware.tracer`'s deferred `span.end`: the span is
+		// produced on the next macrotask, after `flush` has already been called.
+		setTimeout(() => {
+			void Effect.runPromise(
+				Effect.succeed(undefined).pipe(
+					Effect.withSpan("deferred-op"),
+					Effect.provide(telemetry.layer),
+				),
+			)
+		}, 0)
+
+		await telemetry.flush(env)
+
+		const traceCall = calls.find((c) => c.url.endsWith("/v1/traces"))
+		expect(traceCall, "expected the deferred span to be POSTed by the awaited flush").toBeDefined()
+		const body = traceCall!.body as {
+			resourceSpans: Array<{ scopeSpans: Array<{ spans: Array<{ name: string }> }> }>
+		}
+		expect(body.resourceSpans[0].scopeSpans[0].spans.map((s) => s.name)).toEqual(["deferred-op"])
+	})
+
+	it("serializes overlapping flushes without losing or duplicating spans", async () => {
+		let inFlight = 0
+		let maxInFlight = 0
+		const calls: Array<{ url: string; body: unknown }> = []
+		const original = globalThis.fetch
+		restore = () => void (globalThis.fetch = original)
+		globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url
+			inFlight += 1
+			maxInFlight = Math.max(maxInFlight, inFlight)
+			await new Promise<void>((resolve) => setTimeout(resolve, 5))
+			inFlight -= 1
+			calls.push({
+				url,
+				body: init?.body && typeof init.body === "string" ? JSON.parse(init.body) : undefined,
+			})
+			return new Response(null, { status: 200 })
+		}) as typeof fetch
+
+		const telemetry = make({ serviceName: "unit-test" })
+
+		await Effect.runPromise(
+			Effect.succeed(undefined).pipe(Effect.withSpan("overlap-a"), Effect.provide(telemetry.layer)),
+		)
+		const first = telemetry.flush(env)
+		await Effect.runPromise(
+			Effect.succeed(undefined).pipe(Effect.withSpan("overlap-b"), Effect.provide(telemetry.layer)),
+		)
+		const second = telemetry.flush(env)
+		await Promise.all([first, second])
+
+		expect(maxInFlight, "flushes must not interleave their exports").toBe(1)
+		const exported = calls
+			.filter((c) => c.url.endsWith("/v1/traces"))
+			.flatMap((c) => {
+				const body = c.body as {
+					resourceSpans: Array<{ scopeSpans: Array<{ spans: Array<{ name: string }> }> }>
+				}
+				return body.resourceSpans.flatMap((rs) =>
+					rs.scopeSpans.flatMap((ss) => ss.spans.map((s) => s.name)),
+				)
+			})
+		expect(exported.slice().sort()).toEqual(["overlap-a", "overlap-b"])
+	})
+
 	it("layer is stable across calls (same Tracer instance)", () => {
 		const telemetry = make({ serviceName: "unit-test" })
 		const a = telemetry.layer

--- a/packages/effect-sdk/src/cloudflare/index.ts
+++ b/packages/effect-sdk/src/cloudflare/index.ts
@@ -165,6 +165,17 @@ export const make = (config: Config = {}): Telemetry => {
 	// surface as an unhandled Worker error caused purely by telemetry.
 	const flush = makeSerializedFlush(async (env: Record<string, unknown>): Promise<void> => {
 		try {
+			// Effect defers work onto the scheduler's next macrotask
+			// (`scheduleTask(task, 0)`) — including `HttpMiddleware.tracer`'s
+			// `span.end` and `withSpan` finalizers — while the drain below is
+			// synchronous. Flushing in the same task therefore misses exactly the
+			// spans the request just produced, and an isolated request (e.g. a lone
+			// webhook) can freeze the isolate before a later flush rescues them.
+			// Yield one macrotask so those tasks run first. This sits INSIDE the
+			// serialized body, so overlapping flushes still queue rather than
+			// interleave.
+			await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
 			if (resolved === undefined) {
 				resolved = resolveOnce(env, config)
 			}


### PR DESCRIPTION
Effect ends a root server span from a scheduled task, which runs on the next
macrotask; the flush drained its buffers synchronously and resolved before that
task ran, so an awaited flush could return without the request's own span. Both
workers had independently grown the same `setTimeout(0)` around the call. The
yield now lives inside the serialized flush, where it composes with the existing
chaining rather than being re-derived per caller.

The caller workarounds stay for now — the SDK is published and the workers ship
against a pinned version, so removing them before the pin is the skew that would
drop the span this fixes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789479342&installation_model_id=427786&pr_number=496&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F496&signature=04331f82a2d13892298afa47d2925e2019d8c470889d0996ddfdf317684d6027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->