### PR TITLE
fix(k8s-infra): project the deployment environment under both keys from one helper

### DIFF
--- a/deploy/k8s-infra/Chart.yaml
+++ b/deploy/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maple-k8s-infra
 description: Kubernetes infrastructure collector for Maple using OpenTelemetry Collector Contrib.
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "0.141.0"
 keywords:
     - maple

--- a/deploy/k8s-infra/templates/_helpers.tpl
+++ b/deploy/k8s-infra/templates/_helpers.tpl
@@ -208,18 +208,50 @@ presets.otlpReceiver.http.enabled.
 {{- printf "%s/%s" .Release.Namespace .Values.autoInstrumentation.instrumentation.name -}}
 {{- end -}}
 
+{{/*
+The ONE deployment-environment projection for this chart.
+
+OTel renamed `deployment.environment` to `deployment.environment.name`. Maple
+dual-emits both keys — the canonical one for spec-compliant consumers, the
+legacy one because the Tinybird materialized views still pre-extract it. Every
+path in this chart (agent collector, cluster collector, auto-instrumentation CR)
+must project the value through this helper so a span carries the same keys no
+matter which path produced it.
+
+Renders comma-joined `key=value` pairs (OTEL_RESOURCE_ATTRIBUTES form), or the
+empty string when global.deploymentEnvironment is unset.
+*/}}
+{{- define "maple-k8s-infra.deploymentEnvironment.attrPairs" -}}
+{{- with .Values.global.deploymentEnvironment -}}
+{{- printf "deployment.environment.name=%s,deployment.environment=%s" . . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The same projection as YAML mapping lines, for CRD `resourceAttributes` blocks.
+Derived from attrPairs so the key set is defined exactly once.
+*/}}
+{{- define "maple-k8s-infra.deploymentEnvironment.attrYaml" -}}
+{{- $lines := list -}}
+{{- range (compact (splitList "," (include "maple-k8s-infra.deploymentEnvironment.attrPairs" .))) -}}
+{{- $kv := splitn "=" 2 . -}}
+{{- $lines = append $lines (printf "%s: %s" $kv._0 ($kv._1 | quote)) -}}
+{{- end -}}
+{{- join "\n" $lines -}}
+{{- end -}}
+
 {{- define "maple-k8s-infra.resourceAttributes.agent" -}}
 {{- $attrs := list "maple.collector.role=agent" (printf "k8s.cluster.name=%s" (include "maple-k8s-infra.clusterName" .)) "k8s.node.name=$(K8S_NODE_NAME)" "host.name=$(K8S_NODE_NAME)" -}}
-{{- if .Values.global.deploymentEnvironment -}}
-{{- $attrs = append $attrs (printf "deployment.environment=%s" .Values.global.deploymentEnvironment) -}}
+{{- with (include "maple-k8s-infra.deploymentEnvironment.attrPairs" .) -}}
+{{- $attrs = append $attrs . -}}
 {{- end -}}
 {{- join "," $attrs -}}
 {{- end -}}
 
 {{- define "maple-k8s-infra.resourceAttributes.cluster" -}}
 {{- $attrs := list "maple.collector.role=cluster" (printf "k8s.cluster.name=%s" (include "maple-k8s-infra.clusterName" .)) -}}
-{{- if .Values.global.deploymentEnvironment -}}
-{{- $attrs = append $attrs (printf "deployment.environment=%s" .Values.global.deploymentEnvironment) -}}
+{{- with (include "maple-k8s-infra.deploymentEnvironment.attrPairs" .) -}}
+{{- $attrs = append $attrs . -}}
 {{- end -}}
 {{- join "," $attrs -}}
 {{- end -}}

--- a/deploy/k8s-infra/templates/instrumentation.yaml
+++ b/deploy/k8s-infra/templates/instrumentation.yaml
@@ -43,8 +43,8 @@ spec:
   resource:
     resourceAttributes:
       k8s.cluster.name: {{ include "maple-k8s-infra.clusterName" . | quote }}
-      {{- if .Values.global.deploymentEnvironment }}
-      deployment.environment.name: {{ .Values.global.deploymentEnvironment | quote }}
+      {{- with (include "maple-k8s-infra.deploymentEnvironment.attrYaml" .) }}
+      {{- nindent 6 . }}
       {{- end }}
   # Pod-identity env vars injected via downward API. We then layer them into
   # OTEL_RESOURCE_ATTRIBUTES via $(VAR) interpolation so the user's OTel SDK


### PR DESCRIPTION
The agent and cluster collectors appended only the legacy
`deployment.environment`; the auto-instrumentation CR set only the canonical
`deployment.environment.name`. Every materialization reads the legacy key, so
an auto-instrumented user-app span — the one a chart user actually cares about
— materialized an empty environment, while collector self-telemetry did not.

Both keys now come from a single helper used by all three paths, matching what
the ingest gateway already emits. Chart bumped to 0.5.1 since rendered
manifests change.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789479345&installation_model_id=427786&pr_number=497&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F497&signature=fc49fdeb28f0f9913430ddbb0d70c70b41fdfdbbf0a99ee2c36c557f07277b63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->