### PR TITLE
fix(k8s-infra): gate every cluster-collector resource on one activation predicate

### DIFF
--- a/deploy/k8s-infra/Chart.yaml
+++ b/deploy/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maple-k8s-infra
 description: Kubernetes infrastructure collector for Maple using OpenTelemetry Collector Contrib.
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "0.141.0"
 keywords:
     - maple

--- a/deploy/k8s-infra/templates/_helpers.tpl
+++ b/deploy/k8s-infra/templates/_helpers.tpl
@@ -51,6 +51,27 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: agent
 {{- end -}}
 
+{{/*
+The ONE activation predicate for the cluster collector.
+
+The cluster collector is a single Deployment that only exists to host the
+cluster-scoped receivers (k8s_cluster, k8s_events, the Fargate prometheus
+scrape). It is active when it is switched on AND at least one of those
+receivers is enabled — otherwise it would run a collector with no receivers,
+or leave behind a ConfigMap/RBAC/ServiceAccount/Service for a workload that
+never runs. Every cluster-collector resource must gate on this helper so the
+resource set stays coherent for every receiver combination.
+
+Renders "true" or "false".
+*/}}
+{{- define "maple-k8s-infra.cluster.enabled" -}}
+{{- if and .Values.clusterCollector.enabled (or .Values.presets.clusterMetrics.enabled .Values.presets.k8sEvents.enabled .Values.presets.fargateMetrics.enabled) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
 {{- define "maple-k8s-infra.cluster.selectorLabels" -}}
 {{ include "maple-k8s-infra.selectorLabels" . }}
 app.kubernetes.io/component: cluster-collector

--- a/deploy/k8s-infra/templates/cluster-configmap.yaml
+++ b/deploy/k8s-infra/templates/cluster-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterCollector.enabled (or .Values.presets.clusterMetrics.enabled .Values.presets.k8sEvents.enabled .Values.presets.fargateMetrics.enabled) -}}
+{{- if eq (include "maple-k8s-infra.cluster.enabled" .) "true" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/k8s-infra/templates/cluster-rbac.yaml
+++ b/deploy/k8s-infra/templates/cluster-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterCollector.enabled (or .Values.presets.clusterMetrics.enabled .Values.presets.k8sEvents.enabled) -}}
+{{- if eq (include "maple-k8s-infra.cluster.enabled" .) "true" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/k8s-infra/templates/deployment.yaml
+++ b/deploy/k8s-infra/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterCollector.enabled (or .Values.presets.clusterMetrics.enabled .Values.presets.k8sEvents.enabled) -}}
+{{- if eq (include "maple-k8s-infra.cluster.enabled" .) "true" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/k8s-infra/templates/service.yaml
+++ b/deploy/k8s-infra/templates/service.yaml
@@ -32,10 +32,10 @@ spec:
       targetPort: health
       protocol: TCP
 {{- end }}
-{{- if and .Values.agent.enabled .Values.agent.service.enabled .Values.clusterCollector.enabled (or .Values.presets.clusterMetrics.enabled .Values.presets.k8sEvents.enabled) .Values.clusterCollector.service.enabled }}
+{{- if and .Values.agent.enabled .Values.agent.service.enabled (eq (include "maple-k8s-infra.cluster.enabled" .) "true") .Values.clusterCollector.service.enabled }}
 ---
 {{- end }}
-{{- if and .Values.clusterCollector.enabled (or .Values.presets.clusterMetrics.enabled .Values.presets.k8sEvents.enabled) .Values.clusterCollector.service.enabled }}
+{{- if and (eq (include "maple-k8s-infra.cluster.enabled" .) "true") .Values.clusterCollector.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/k8s-infra/templates/serviceaccount.yaml
+++ b/deploy/k8s-infra/templates/serviceaccount.yaml
@@ -7,10 +7,10 @@ metadata:
     {{- include "maple-k8s-infra.labels" . | nindent 4 }}
     app.kubernetes.io/component: agent
 {{- end }}
-{{- if and .Values.agent.enabled .Values.clusterCollector.enabled (or .Values.presets.clusterMetrics.enabled .Values.presets.k8sEvents.enabled) .Values.clusterCollector.serviceAccount.create }}
+{{- if and .Values.agent.enabled (eq (include "maple-k8s-infra.cluster.enabled" .) "true") .Values.clusterCollector.serviceAccount.create }}
 ---
 {{- end }}
-{{- if and .Values.clusterCollector.enabled (or .Values.presets.clusterMetrics.enabled .Values.presets.k8sEvents.enabled) .Values.clusterCollector.serviceAccount.create }}
+{{- if and (eq (include "maple-k8s-infra.cluster.enabled" .) "true") .Values.clusterCollector.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
The ConfigMap counted the Fargate receiver toward "is the cluster collector
doing anything"; the Deployment, RBAC, ServiceAccount and Service each carried
their own copy of the predicate that did not. So the Fargate setup the README
documents rendered a ConfigMap and nothing to read it — the cadvisor scrape
silently never ran.

One helper now answers the question and all six call sites ask it. Chart bumped
to 0.5.2 since rendered manifests change.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789483826&installation_model_id=427786&pr_number=500&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F500&signature=cfa6ef28cb8ea01f5626b0931871186894009bf6654967455d34c27b87858a7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->