### PR TITLE
fix(web): tell a failed alert-rule load apart from a loading one

### DIFF
--- a/apps/web/src/components/alerts/alert-create-page-content.test.ts
+++ b/apps/web/src/components/alerts/alert-create-page-content.test.ts
@@ -1,26 +1,200 @@
+import {
+	AlertRuleDocument,
+	AlertRuleId,
+	AlertRulesListResponse,
+	IsoDateTimeString,
+	UserId,
+} from "@maple/domain/http"
 import { describe, expect, it } from "vitest"
 
 import { Result } from "@/lib/effect-atom"
-import { deriveInitialRuleDraft } from "./alert-create-page-content"
+import { deriveRuleInitialization, type RuleDraft } from "./alert-create-page-content"
 
 /**
  * The starter-template deep link from the overview empty state. With no ruleId /
- * chart / dashboard params, `deriveInitialRuleDraft` reaches the template branch
- * before the rules/dashboards results ever matter, so `Result.initial()` stands
- * in for both.
+ * chart / dashboard params, `deriveRuleInitialization` reaches the template
+ * branch before the rules/dashboards results ever matter, so `Result.initial()`
+ * stands in for both.
  */
 const loading = Result.initial()
 
-describe("deriveInitialRuleDraft — template deep link", () => {
-	// `low_apdex` differs from the blank defaults on signal, comparator, and
-	// threshold, so a pass proves the template was applied (not just defaults).
-	it("pre-applies a known template and skips the first-touch overlay", () => {
-		const draft = deriveInitialRuleDraft({
-			search: { template: "low_apdex" },
+/** Narrows to the ready variant, failing the test if the draft is absent. */
+function readyDraft(init: ReturnType<typeof deriveRuleInitialization>): RuleDraft {
+	expect(init.status).toBe("ready")
+	if (init.status !== "ready") throw new Error("unreachable")
+	return init.draft
+}
+
+const iso = IsoDateTimeString.make("2026-08-16T00:00:00.000Z")
+
+/** `AlertRuleId` is a UUID brand, so the fixtures must carry real UUIDs. */
+const RULE_A = "11111111-1111-4111-8111-111111111111"
+const RULE_B = "22222222-2222-4222-8222-222222222222"
+const RULE_GONE = "33333333-3333-4333-8333-333333333333"
+
+const rule = (id: string) =>
+	new AlertRuleDocument({
+		id: AlertRuleId.make(id),
+		name: `Rule ${id}`,
+		notes: null,
+		notificationTemplate: null,
+		enabled: true,
+		severity: "warning",
+		serviceNames: [`svc-${id}`],
+		excludeServiceNames: [],
+		environments: [],
+		tags: [],
+		groupBy: null,
+		signalType: "error_rate",
+		comparator: "gt",
+		threshold: 0.05,
+		thresholdUpper: null,
+		windowMinutes: 15,
+		minimumSampleCount: 0,
+		consecutiveBreachesRequired: 1,
+		consecutiveHealthyRequired: 1,
+		renotifyIntervalMinutes: 60,
+		apdexThresholdMs: null,
+		queryBuilderDraft: null,
+		rawQuerySql: null,
+		rawQueryReducer: null,
+		destinationIds: [],
+		noDataBehavior: "skip",
+		lastEvaluationError: null,
+		lastEvaluatedAt: null,
+		lastScheduledAt: null,
+		createdAt: iso,
+		updatedAt: iso,
+		createdBy: UserId.make("user-1"),
+		updatedBy: UserId.make("user-1"),
+	})
+
+/** A resolved rules list — the shape `useAlertRulesList` reports on success. */
+const rulesLoaded = (...ids: string[]) => Result.success(new AlertRulesListResponse({ rules: ids.map(rule) }))
+
+/** The terminal failure `useAlertRulesList` reports when the shape stream dies. */
+const rulesFailed = () => Result.fail({ message: "Live sync is unavailable." })
+
+const editSearch = (ruleId: string) => ({ ruleId })
+
+describe("deriveRuleInitialization — editing an existing rule", () => {
+	it("is ready with the rule's own form state when the rule resolves", () => {
+		const draft = readyDraft(
+			deriveRuleInitialization({
+				search: editSearch(RULE_A),
+				chartContext: undefined,
+				rulesResult: rulesLoaded(RULE_A, RULE_B),
+				dashboardsResult: loading,
+			}),
+		)
+
+		expect(draft.editingRule?.id).toBe(RULE_A)
+		expect(draft.form.name).toBe(`Rule ${RULE_A}`)
+		expect(draft.form.serviceNames).toEqual([`svc-${RULE_A}`])
+		expect(draft.prefillNotices).toEqual([])
+		expect(draft.key).toBe(`rule:${RULE_A}`)
+	})
+
+	it("is loading — not failed — while the rules list is still resolving", () => {
+		const init = deriveRuleInitialization({
+			search: editSearch(RULE_A),
 			chartContext: undefined,
 			rulesResult: loading,
 			dashboardsResult: loading,
 		})
+
+		expect(init).toEqual({ status: "loading", editing: true })
+		// The draft is absent by construction: no blank form can leak into the
+		// pending state and read as "Create alert rule".
+		expect("draft" in init).toBe(false)
+	})
+
+	it("is ready with a blank draft and a notice when the list resolves without the rule", () => {
+		const draft = readyDraft(
+			deriveRuleInitialization({
+				search: editSearch(RULE_GONE),
+				chartContext: undefined,
+				rulesResult: rulesLoaded(RULE_A),
+				dashboardsResult: loading,
+			}),
+		)
+
+		expect(draft.editingRule).toBeNull()
+		expect(draft.form.name).toBe("")
+		expect(draft.prefillNotices).toEqual([
+			{
+				severity: "warning",
+				message: "The alert rule could not be found. Starting from a blank alert.",
+			},
+		])
+		expect(draft.key).toBe(`missing-rule:${RULE_GONE}`)
+	})
+
+	// The regression this union exists for: a terminal list failure is neither
+	// success nor pending, and used to fall through to the loading branch — the
+	// page painted a skeleton that never resolved, indistinguishable from a slow
+	// load and with no way out but a manual reload.
+	it("is failed — not loading — when the rules list terminally fails", () => {
+		const init = deriveRuleInitialization({
+			search: editSearch(RULE_A),
+			chartContext: undefined,
+			rulesResult: rulesFailed(),
+			dashboardsResult: loading,
+		})
+
+		expect(init.status).toBe("failed")
+		if (init.status !== "failed") throw new Error("unreachable")
+		expect(init.editing).toBe(true)
+		expect(init.error).toEqual({ message: "Live sync is unavailable." })
+	})
+})
+
+describe("deriveRuleInitialization — remount keys", () => {
+	const initFor = (ruleId: string) =>
+		deriveRuleInitialization({
+			search: editSearch(ruleId),
+			chartContext: undefined,
+			rulesResult: rulesLoaded(RULE_A, RULE_B),
+			dashboardsResult: loading,
+		})
+
+	it("derives a stable key for repeated derivations of the same rule", () => {
+		// A re-render must not change the key, or the surface remounts and the
+		// user's in-progress edits are discarded mid-typing.
+		expect(readyDraft(initFor(RULE_A)).key).toBe(readyDraft(initFor(RULE_A)).key)
+	})
+
+	it("derives a different key per rule so switching rules remounts the surface", () => {
+		expect(readyDraft(initFor(RULE_A)).key).not.toBe(readyDraft(initFor(RULE_B)).key)
+	})
+
+	it("does not reuse a resolved rule's key for the missing-rule fallback", () => {
+		const resolved = readyDraft(initFor(RULE_A)).key
+		const missing = readyDraft(
+			deriveRuleInitialization({
+				search: editSearch(RULE_A),
+				chartContext: undefined,
+				rulesResult: rulesLoaded(),
+				dashboardsResult: loading,
+			}),
+		).key
+
+		expect(missing).not.toBe(resolved)
+	})
+})
+
+describe("deriveRuleInitialization — template deep link", () => {
+	// `low_apdex` differs from the blank defaults on signal, comparator, and
+	// threshold, so a pass proves the template was applied (not just defaults).
+	it("pre-applies a known template and skips the first-touch overlay", () => {
+		const draft = readyDraft(
+			deriveRuleInitialization({
+				search: { template: "low_apdex" },
+				chartContext: undefined,
+				rulesResult: loading,
+				dashboardsResult: loading,
+			}),
+		)
 
 		expect(draft.form.signalType).toBe("apdex")
 		expect(draft.form.comparator).toBe("lt")
@@ -32,12 +206,14 @@ describe("deriveInitialRuleDraft — template deep link", () => {
 	})
 
 	it("falls through to a blank draft (overlay opens) for an unknown template id", () => {
-		const draft = deriveInitialRuleDraft({
-			search: { template: "not-a-real-template" },
-			chartContext: undefined,
-			rulesResult: loading,
-			dashboardsResult: loading,
-		})
+		const draft = readyDraft(
+			deriveRuleInitialization({
+				search: { template: "not-a-real-template" },
+				chartContext: undefined,
+				rulesResult: loading,
+				dashboardsResult: loading,
+			}),
+		)
 
 		expect(draft.form.signalType).toBe("error_rate")
 		expect(draft.form.name).toBe("")

--- a/apps/web/src/components/alerts/alert-create-page-content.tsx
+++ b/apps/web/src/components/alerts/alert-create-page-content.tsx
@@ -1,5 +1,6 @@
 import { useSearch } from "@tanstack/react-router"
-import { useMemo } from "react"
+import { Cause } from "effect"
+import { useMemo, type ReactNode } from "react"
 
 import type { AlertDestinationDocument, AlertRuleDocument } from "@maple/domain/http"
 import type { Dashboard } from "@/components/dashboard-builder/types"
@@ -8,6 +9,7 @@ import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { cn } from "@maple/ui/lib/utils"
 
 import { AlertCreateFormSurface } from "@/components/alerts/alert-create-form-surface"
+import { ErrorState } from "@/components/common/error-state"
 import { RULE_FORM_MAX_WIDTH } from "@/components/alerts/rule-form-layout"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { useAutocompleteValuesContext } from "@/hooks/use-autocomplete-values"
@@ -32,20 +34,34 @@ type AlertCreateSearchValue = {
 	template?: string
 }
 
-type InitialRuleDraft = {
+/**
+ * Everything the form surface needs to mount. `key` is its remount identity:
+ * equal inputs must derive an equal key (a re-render keeps in-progress edits),
+ * and a different rule/prefill source must derive a different one (the surface
+ * remounts instead of carrying the previous rule's draft over).
+ */
+export type RuleDraft = {
 	key: string
 	form: RuleFormState
 	prefillNotices: WidgetAlertPrefillNotice[]
 	editingRule: AlertRuleDocument | null
 	showTemplatesInitially: boolean
-	/**
-	 * The draft is a placeholder while the real rule (or its dashboard source) is
-	 * still loading. The form must not be shown yet — `form` is a blank default
-	 * that would read as "Create alert rule" until the fetch resolves and the
-	 * `key` change remounts it with the actual values.
-	 */
-	loading?: boolean
 }
+
+/**
+ * The page's initialization, as a closed union.
+ *
+ * The editable draft exists **only** in `ready`, which makes the old failure
+ * mode unrepresentable: a blank `defaultRuleForm` used to be built eagerly and
+ * carried alongside a `loading` flag, so a terminal list failure — which is not
+ * loading and not success — fell through to the loading branch and painted a
+ * skeleton that never resolved. `loading` and `failed` are now distinct
+ * variants with no form attached to either.
+ */
+export type RuleInitialization =
+	| { readonly status: "loading"; readonly editing: boolean }
+	| { readonly status: "failed"; readonly editing: boolean; readonly error: unknown }
+	| { readonly status: "ready"; readonly draft: RuleDraft }
 
 export function AlertCreatePageContent() {
 	const search = useSearch({ from: "/alerts/create" }) as AlertCreateSearchValue
@@ -80,9 +96,9 @@ export function AlertCreatePageContent() {
 		.onSuccess((response) => [...response.destinations] as AlertDestinationDocument[])
 		.orElse(() => [])
 
-	const initialDraft = useMemo(
+	const initialization = useMemo(
 		() =>
-			deriveInitialRuleDraft({
+			deriveRuleInitialization({
 				search,
 				chartContext,
 				rulesResult,
@@ -91,34 +107,36 @@ export function AlertCreatePageContent() {
 		[search, chartContext, rulesResult, dashboardsResult],
 	)
 
-	// Showing the blank default form here would paint a "Create alert rule" page
-	// for a second and then remount into the populated editor.
-	if (initialDraft.loading) {
-		return <AlertRuleFormSkeleton editing={search.ruleId != null} />
+	switch (initialization.status) {
+		// Showing the blank default form here would paint a "Create alert rule"
+		// page for a second and then remount into the populated editor.
+		case "loading":
+			return <AlertRuleFormSkeleton editing={initialization.editing} />
+		case "failed":
+			return <AlertRuleFormLoadError editing={initialization.editing} error={initialization.error} />
+		case "ready":
+			return (
+				<AlertCreateFormSurface
+					key={initialization.draft.key}
+					initialForm={initialization.draft.form}
+					prefillNotices={initialization.draft.prefillNotices}
+					editingRule={initialization.draft.editingRule}
+					showTemplatesInitially={initialization.draft.showTemplatesInitially}
+					destinations={destinations}
+					serviceNameOptions={serviceNameOptions}
+					environmentOptions={environmentOptions}
+					autocompleteValues={autocompleteValues}
+				/>
+			)
 	}
-
-	return (
-		<AlertCreateFormSurface
-			key={initialDraft.key}
-			initialForm={initialDraft.form}
-			prefillNotices={initialDraft.prefillNotices}
-			editingRule={initialDraft.editingRule}
-			showTemplatesInitially={initialDraft.showTemplatesInitially}
-			destinations={destinations}
-			serviceNameOptions={serviceNameOptions}
-			environmentOptions={environmentOptions}
-			autocompleteValues={autocompleteValues}
-		/>
-	)
 }
 
 /**
- * Placeholder shown while an existing rule (or a dashboard widget's prefill
- * source) loads. Mirrors the real surface's chrome — same breadcrumb, same
- * title, same two-column grid — so resolving the fetch swaps content into a
- * page that is already the right shape.
+ * The page chrome the form surface itself draws — same breadcrumb, same title,
+ * same scroll frame — so the pre-form variants resolve into a page that is
+ * already the right shape.
  */
-function AlertRuleFormSkeleton({ editing }: { editing: boolean }) {
+function AlertRuleFormShell({ editing, children }: { editing: boolean; children: ReactNode }) {
 	return (
 		<DashboardLayout.Root>
 			<DashboardLayout.Breadcrumbs
@@ -129,26 +147,59 @@ function AlertRuleFormSkeleton({ editing }: { editing: boolean }) {
 					<DashboardLayout.Sticky>
 						<DashboardLayout.Header title={editing ? "Edit alert rule" : "Create alert rule"} />
 					</DashboardLayout.Sticky>
-					<DashboardLayout.Scroll>
-						<div className={cn("mx-auto w-full space-y-4", RULE_FORM_MAX_WIDTH)}>
-							<Skeleton className="h-64 w-full" />
-							<div className="grid gap-4 lg:grid-cols-[1.6fr_1fr]">
-								<Skeleton className="h-96 w-full" />
-								<div className="space-y-4">
-									<Skeleton className="h-56 w-full" />
-									<Skeleton className="h-40 w-full" />
-									<Skeleton className="h-48 w-full" />
-								</div>
-							</div>
-						</div>
-					</DashboardLayout.Scroll>
+					<DashboardLayout.Scroll>{children}</DashboardLayout.Scroll>
 				</DashboardLayout.Content>
 			</DashboardLayout.Body>
 		</DashboardLayout.Root>
 	)
 }
 
-export function deriveInitialRuleDraft({
+/** Placeholder shown while an existing rule (or a dashboard widget's prefill source) loads. */
+function AlertRuleFormSkeleton({ editing }: { editing: boolean }) {
+	return (
+		<AlertRuleFormShell editing={editing}>
+			<div className={cn("mx-auto w-full space-y-4", RULE_FORM_MAX_WIDTH)}>
+				<Skeleton className="h-64 w-full" />
+				<div className="grid gap-4 lg:grid-cols-[1.6fr_1fr]">
+					<Skeleton className="h-96 w-full" />
+					<div className="space-y-4">
+						<Skeleton className="h-56 w-full" />
+						<Skeleton className="h-40 w-full" />
+						<Skeleton className="h-48 w-full" />
+					</div>
+				</div>
+			</div>
+		</AlertRuleFormShell>
+	)
+}
+
+/**
+ * Terminal counterpart to the skeleton: the rules stream stopped, so which rule
+ * is being edited can never be answered. Falling back to a blank form would
+ * silently turn an edit into a create, so the page stops here instead.
+ *
+ * Matches the alerts overview's own load error, down to the reload action — the
+ * list hooks' `refresh` is a no-op over a live query whose recovery budget is
+ * already spent, so a reload is the only honest retry.
+ */
+function AlertRuleFormLoadError({ editing, error }: { editing: boolean; error: unknown }) {
+	return (
+		<AlertRuleFormShell editing={editing}>
+			<div className={cn("mx-auto w-full", RULE_FORM_MAX_WIDTH)}>
+				<ErrorState
+					error={error}
+					title="Failed to load alert rules"
+					onRetry={() => window.location.reload()}
+					className="py-12"
+				/>
+			</div>
+		</AlertRuleFormShell>
+	)
+}
+
+const ready = (draft: RuleDraft): RuleInitialization => ({ status: "ready", draft })
+
+export function deriveRuleInitialization({
 	search,
 	chartContext,
 	rulesResult,
@@ -163,22 +214,31 @@ export function deriveInitialRuleDraft({
 		},
 		unknown
 	>
-}): InitialRuleDraft {
+}): RuleInitialization {
 	const base = defaultRuleForm(search.serviceName)
 
 	if (search.ruleId) {
+		// Terminal: the stream is gone, so "which rule is this?" has no answer
+		// coming. Checked before success/loading so it can never be mistaken for
+		// the pending state.
+		if (Result.isFailure(rulesResult)) {
+			return { status: "failed", editing: true, error: Cause.squash(rulesResult.cause) }
+		}
 		if (Result.isSuccess(rulesResult)) {
 			const editingRule = rulesResult.value.rules.find((rule) => rule.id === search.ruleId) ?? null
 			if (editingRule) {
-				return {
+				return ready({
 					key: `rule:${editingRule.id}`,
 					form: ruleToFormState(editingRule),
 					prefillNotices: [],
 					editingRule,
 					showTemplatesInitially: false,
-				}
+				})
 			}
-			return {
+			// Resolved, but no such rule — distinct from both "still loading" and
+			// "could not load": the list is authoritative, so a blank draft plus an
+			// explicit notice is the right recovery.
+			return ready({
 				key: `missing-rule:${search.ruleId}`,
 				form: base,
 				prefillNotices: [
@@ -189,16 +249,9 @@ export function deriveInitialRuleDraft({
 				],
 				editingRule: null,
 				showTemplatesInitially: false,
-			}
+			})
 		}
-		return {
-			key: `loading-rule:${search.ruleId}`,
-			form: base,
-			prefillNotices: [],
-			editingRule: null,
-			showTemplatesInitially: false,
-			loading: true,
-		}
+		return { status: "loading", editing: true }
 	}
 
 	// Snapshot carried through navigation — synchronous prefill, no dashboards
@@ -206,13 +259,13 @@ export function deriveInitialRuleDraft({
 	// undefined and fall through to the id-lookup path below.
 	if (chartContext) {
 		const result = createWidgetAlertPrefill(chartContext.widget, base)
-		return {
+		return ready({
 			key: `chart:${chartContext.dashboardId}:${chartContext.widget.id}`,
 			form: result.form,
 			prefillNotices: result.notices,
 			editingRule: null,
 			showTemplatesInitially: false,
-		}
+		})
 	}
 
 	if (search.dashboardId || search.widgetId) {
@@ -223,13 +276,13 @@ export function deriveInitialRuleDraft({
 				widgetId: search.widgetId,
 				base,
 			})
-			return {
+			return ready({
 				key: `missing-chart-source:${search.dashboardId ?? "dashboard"}:${search.widgetId ?? "widget"}`,
 				form: result.form,
 				prefillNotices: result.notices,
 				editingRule: null,
 				showTemplatesInitially: false,
-			}
+			})
 		}
 		if (Result.isSuccess(dashboardsResult)) {
 			const result = resolveWidgetAlertPrefill({
@@ -238,16 +291,19 @@ export function deriveInitialRuleDraft({
 				widgetId: search.widgetId,
 				base,
 			})
-			return {
+			return ready({
 				key: `dashboard:${search.dashboardId}:widget:${search.widgetId}`,
 				form: result.form,
 				prefillNotices: result.notices,
 				editingRule: null,
 				showTemplatesInitially: false,
-			}
+			})
 		}
 		if (Result.isFailure(dashboardsResult)) {
-			return {
+			// Deliberately `ready`, not `failed`: without a ruleId nothing is being
+			// edited, so a blank draft plus a notice is a usable page rather than a
+			// dead end.
+			return ready({
 				key: `dashboard-load-failed:${search.dashboardId}:${search.widgetId}`,
 				form: base,
 				prefillNotices: [
@@ -258,16 +314,9 @@ export function deriveInitialRuleDraft({
 				],
 				editingRule: null,
 				showTemplatesInitially: false,
-			}
+			})
 		}
-		return {
-			key: `loading-dashboard:${search.dashboardId}:${search.widgetId}`,
-			form: base,
-			prefillNotices: [],
-			editingRule: null,
-			showTemplatesInitially: false,
-			loading: true,
-		}
+		return { status: "loading", editing: false }
 	}
 
 	// Starter-template deep link from the overview empty state — pre-apply the
@@ -276,21 +325,21 @@ export function deriveInitialRuleDraft({
 	if (search.template) {
 		const template = ALERT_TEMPLATES.find((t) => t.id === search.template)
 		if (template) {
-			return {
+			return ready({
 				key: `new:template:${template.id}`,
 				form: applyTemplate(template, base),
 				prefillNotices: [],
 				editingRule: null,
 				showTemplatesInitially: false,
-			}
+			})
 		}
 	}
 
-	return {
+	return ready({
 		key: `new:${search.serviceName ?? "blank"}`,
 		form: base,
 		prefillNotices: [],
 		editingRule: null,
 		showTemplatesInitially: search.serviceName == null,
-	}
+	})
 }

--- a/apps/web/src/components/alerts/alert-create-remount-key.test.tsx
+++ b/apps/web/src/components/alerts/alert-create-remount-key.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import {
+	AlertRuleDocument,
+	AlertRuleId,
+	AlertRulesListResponse,
+	IsoDateTimeString,
+	UserId,
+} from "@maple/domain/http"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { useState } from "react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { Result } from "@/lib/effect-atom"
+import { deriveRuleInitialization } from "./alert-create-page-content"
+
+afterEach(cleanup)
+
+const RULE_A = "11111111-1111-4111-8111-111111111111"
+const RULE_B = "22222222-2222-4222-8222-222222222222"
+
+const iso = IsoDateTimeString.make("2026-08-16T00:00:00.000Z")
+
+const rule = (id: string) =>
+	new AlertRuleDocument({
+		id: AlertRuleId.make(id),
+		name: `Rule ${id}`,
+		notes: null,
+		notificationTemplate: null,
+		enabled: true,
+		severity: "warning",
+		serviceNames: [`svc-${id}`],
+		excludeServiceNames: [],
+		environments: [],
+		tags: [],
+		groupBy: null,
+		signalType: "error_rate",
+		comparator: "gt",
+		threshold: 0.05,
+		thresholdUpper: null,
+		windowMinutes: 15,
+		minimumSampleCount: 0,
+		consecutiveBreachesRequired: 1,
+		consecutiveHealthyRequired: 1,
+		renotifyIntervalMinutes: 60,
+		apdexThresholdMs: null,
+		queryBuilderDraft: null,
+		rawQuerySql: null,
+		rawQueryReducer: null,
+		destinationIds: [],
+		noDataBehavior: "skip",
+		lastEvaluationError: null,
+		lastEvaluatedAt: null,
+		lastScheduledAt: null,
+		createdAt: iso,
+		updatedAt: iso,
+		createdBy: UserId.make("user-1"),
+		updatedBy: UserId.make("user-1"),
+	})
+
+const rulesResult = Result.success(new AlertRulesListResponse({ rules: [rule(RULE_A), rule(RULE_B)] }))
+
+/**
+ * Stands in for `AlertCreateFormSurface`, which seeds component-local state from
+ * `initialForm` exactly like this and is far too heavy to mount here (it pulls
+ * the whole dashboard chrome, router, and org collections). Only the draft
+ * ownership matters for the keying contract.
+ */
+function DraftSurface({ initialName }: { initialName: string }) {
+	const [name, setName] = useState(() => initialName)
+	return (
+		<button type="button" onClick={() => setName("edited in progress")}>
+			{name}
+		</button>
+	)
+}
+
+/**
+ * The page's keyed mount, reduced to the part under test: the surface is keyed
+ * by `deriveRuleInitialization`'s key, so React's own remount semantics decide
+ * whether the draft survives.
+ */
+function KeyedHost({ ruleId, tick }: { ruleId: string; tick: number }) {
+	const init = deriveRuleInitialization({
+		search: { ruleId },
+		chartContext: undefined,
+		rulesResult,
+		dashboardsResult: Result.initial(),
+	})
+	if (init.status !== "ready") throw new Error(`expected ready, got ${init.status}`)
+	return (
+		<div data-tick={tick}>
+			<DraftSurface key={init.draft.key} initialName={init.draft.form.name} />
+		</div>
+	)
+}
+
+describe("alert-create remount keying", () => {
+	it("keeps in-progress edits across a re-render of the same rule", () => {
+		const { rerender } = render(<KeyedHost ruleId={RULE_A} tick={0} />)
+		fireEvent.click(screen.getByRole("button"))
+		expect(screen.getByRole("button").textContent).toBe("edited in progress")
+
+		// Same rule, new render pass — the key is unchanged, so the draft stands.
+		rerender(<KeyedHost ruleId={RULE_A} tick={1} />)
+		expect(screen.getByRole("button").textContent).toBe("edited in progress")
+	})
+
+	it("remounts with the new rule's values when the rule changes", () => {
+		const { rerender } = render(<KeyedHost ruleId={RULE_A} tick={0} />)
+		fireEvent.click(screen.getByRole("button"))
+		expect(screen.getByRole("button").textContent).toBe("edited in progress")
+
+		// Different rule → different key → fresh mount, so rule A's draft cannot
+		// be carried over onto rule B.
+		rerender(<KeyedHost ruleId={RULE_B} tick={1} />)
+		expect(screen.getByRole("button").textContent).toBe(`Rule ${RULE_B}`)
+	})
+})


### PR DESCRIPTION
Everything that was not a success fell through to the same "still loading"
return, so when the rules list reached terminal failure the edit page rendered
its skeleton and kept rendering it — identical to a slow load, with no error, no
retry and no way out but a browser reload.

Initialization is now loading | failed | ready, and the draft hangs off ready
alone, so a blank form attached to a non-ready state is unrepresentable rather
than merely fixed. Failure gets the error state the alerts overview already
uses. The create path, where nothing is being edited, still falls back to a
usable blank form.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789483829&installation_model_id=427786&pr_number=501&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F501&signature=4528dc4072b7ac2497027686a5865306bbfc571538f9ba2fb13c88f5bb974587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->