### PR TITLE
fix(web): offer only the issue transitions the matrix actually allows

### DIFF
--- a/apps/web/src/components/errors/issue-context-menu.tsx
+++ b/apps/web/src/components/errors/issue-context-menu.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react"
-import type { ErrorIssueDocument, WorkflowState } from "@maple/domain/http"
+import type { ErrorIssueDocument } from "@maple/domain/http"
+import { allowedTransitionsForAll } from "@maple/domain/http"
 import {
 	ContextMenu,
 	ContextMenuContent,
@@ -17,16 +18,6 @@ import { useCopy } from "@maple/ui/hooks/use-copy"
 import { agentPromptFromIssue } from "./agent-debug-prompt"
 import type { IssueMutations } from "./use-issue-mutations"
 
-const STATE_ORDER: ReadonlyArray<WorkflowState> = [
-	"triage",
-	"todo",
-	"in_progress",
-	"in_review",
-	"done",
-	"cancelled",
-	"wontfix",
-]
-
 export function IssueContextMenu({
 	issue,
 	mutations,
@@ -40,6 +31,10 @@ export function IssueContextMenu({
 	onOpenInNewTab: () => void
 	children: ReactNode
 }) {
+	// The offered moves come from the domain matrix the server enforces, so the
+	// menu can never present a transition the API would reject — a `cancelled`
+	// issue offers nothing at all.
+	const targets = allowedTransitionsForAll([issue.workflowState])
 	const canClaim = !issue.leaseHolder
 	const canRelease = Boolean(issue.leaseHolder)
 
@@ -64,24 +59,28 @@ export function IssueContextMenu({
 						<span>Change status</span>
 					</ContextMenuSubTrigger>
 					<ContextMenuSubContent className="w-56 p-1">
-						{STATE_ORDER.map((state) => {
-							const active = state === issue.workflowState
-							return (
+						<ContextMenuItem disabled>
+							<WorkflowRingIcon state={issue.workflowState} size={14} />
+							<span className="flex-1">{WORKFLOW_LABEL[issue.workflowState]}</span>
+							<CheckIcon size={12} className="text-muted-foreground" />
+						</ContextMenuItem>
+						{targets.length === 0 ? (
+							<ContextMenuItem disabled>
+								<span className="flex-1">
+									No moves from {WORKFLOW_LABEL[issue.workflowState]}
+								</span>
+							</ContextMenuItem>
+						) : (
+							targets.map((state) => (
 								<ContextMenuItem
 									key={state}
-									onClick={() => {
-										if (!active) void mutations.transitionTo(issue.id, state)
-									}}
-									disabled={active}
+									onClick={() => void mutations.transitionTo(issue.id, state)}
 								>
 									<WorkflowRingIcon state={state} size={14} />
 									<span className="flex-1">{WORKFLOW_LABEL[state]}</span>
-									{active ? (
-										<CheckIcon size={12} className="text-muted-foreground" />
-									) : null}
 								</ContextMenuItem>
-							)
-						})}
+							))
+						)}
 					</ContextMenuSubContent>
 				</ContextMenuSub>
 

--- a/apps/web/src/components/errors/issues-bulk-bar.test.tsx
+++ b/apps/web/src/components/errors/issues-bulk-bar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import type { ErrorIssueId } from "@maple/domain/http"
+import type { ErrorIssueId, WorkflowState } from "@maple/domain/http"
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -19,9 +19,11 @@ const mutations = (): IssueMutations => ({
 	setSeverityMany: vi.fn(),
 })
 
+const issue = (id: string, state: WorkflowState) => ({ id: id as ErrorIssueId, state })
+
 const renderBar = (overrides: Partial<React.ComponentProps<typeof IssuesBulkBar>> = {}) => {
 	const props = {
-		selectedIds: ["issue-1" as ErrorIssueId],
+		selected: [issue("issue-1", "triage")],
 		mutations: mutations(),
 		onClear: vi.fn(),
 		...overrides,
@@ -48,11 +50,11 @@ describe("IssuesBulkBar menus open without throwing", () => {
 		fireEvent.click(screen.getByRole("button", { name: "Move to" }))
 
 		expect(screen.getByText("Move to state")).toBeDefined()
-		expect(screen.getByRole("menuitem", { name: "Triage" })).toBeDefined()
+		expect(screen.getByRole("menuitem", { name: "Todo" })).toBeDefined()
 	})
 
 	it("applies a severity to every selected issue", () => {
-		const props = renderBar({ selectedIds: ["a", "b"] as ErrorIssueId[] })
+		const props = renderBar({ selected: [issue("a", "triage"), issue("b", "todo")] })
 		fireEvent.click(screen.getByRole("button", { name: "Severity" }))
 		fireEvent.click(screen.getByRole("menuitem", { name: "critical" }))
 
@@ -62,8 +64,62 @@ describe("IssuesBulkBar menus open without throwing", () => {
 
 	it("renders nothing with an empty selection", () => {
 		const { container } = render(
-			<IssuesBulkBar selectedIds={[]} mutations={mutations()} onClear={vi.fn()} />,
+			<IssuesBulkBar selected={[]} mutations={mutations()} onClear={vi.fn()} />,
 		)
 		expect(container.firstChild).toBeNull()
+	})
+})
+
+// The offered moves come from WORKFLOW_TRANSITIONS, so the bar can never
+// present a bulk transition the API would reject for part of the selection.
+describe("IssuesBulkBar move-to menu follows the transition matrix", () => {
+	const openMoveTo = () => fireEvent.click(screen.getByRole("button", { name: "Move to" }))
+	const moveItems = () => screen.getAllByRole("menuitem").map((item) => item.textContent?.trim() ?? "")
+
+	it("offers exactly the legal targets for a single triage issue", () => {
+		renderBar({ selected: [issue("a", "triage")] })
+		openMoveTo()
+
+		expect(moveItems()).toEqual(["Todo", "In progress", "Done", "Cancelled", "Won't fix"])
+	})
+
+	it("offers exactly the legal targets for a single done issue", () => {
+		renderBar({ selected: [issue("a", "done")] })
+		openMoveTo()
+
+		expect(moveItems()).toEqual(["Triage", "In progress", "Cancelled", "Won't fix"])
+	})
+
+	it("offers nothing for an issue in a state with no outgoing moves", () => {
+		renderBar({ selected: [issue("a", "cancelled")] })
+		openMoveTo()
+
+		expect(moveItems()).toEqual(["No moves from Cancelled"])
+		expect(
+			screen.getByRole("menuitem", { name: "No moves from Cancelled" }).getAttribute("data-disabled"),
+		).not.toBeNull()
+	})
+
+	it("offers the intersection for a mixed selection", () => {
+		renderBar({ selected: [issue("a", "triage"), issue("b", "in_review")] })
+		openMoveTo()
+
+		expect(moveItems()).toEqual(["In progress", "Done", "Cancelled", "Won't fix"])
+	})
+
+	it("explains a mixed selection whose intersection is empty", () => {
+		renderBar({ selected: [issue("a", "triage"), issue("b", "cancelled")] })
+		openMoveTo()
+
+		expect(moveItems()).toEqual(["No move applies to every selected issue"])
+	})
+
+	it("transitions every selected id when a legal target is chosen", () => {
+		const props = renderBar({ selected: [issue("a", "triage"), issue("b", "todo")] })
+		openMoveTo()
+		fireEvent.click(screen.getByRole("menuitem", { name: "In progress" }))
+
+		expect(props.mutations.transitionMany).toHaveBeenCalledWith(["a", "b"], "in_progress")
+		expect(props.onClear).toHaveBeenCalled()
 	})
 })

--- a/apps/web/src/components/errors/issues-bulk-bar.tsx
+++ b/apps/web/src/components/errors/issues-bulk-bar.tsx
@@ -1,4 +1,5 @@
 import type { ErrorIssueId, IssueSeverity, WorkflowState } from "@maple/domain/http"
+import { allowedTransitionsForAll } from "@maple/domain/http"
 import type { ReactNode } from "react"
 import { Button } from "@maple/ui/components/ui/button"
 import {
@@ -15,27 +16,33 @@ import { WORKFLOW_LABEL } from "@/components/icons/workflow-ring"
 import { XmarkIcon } from "@/components/icons"
 import type { IssueMutations } from "./use-issue-mutations"
 
-const STATE_ORDER: ReadonlyArray<WorkflowState> = [
-	"triage",
-	"todo",
-	"in_progress",
-	"in_review",
-	"done",
-	"cancelled",
-	"wontfix",
-]
 const SEVERITIES: ReadonlyArray<IssueSeverity> = ["critical", "high", "medium", "low"]
 
+/**
+ * A selected row carries its workflow state, not just its id: the "Move to"
+ * menu can only know which moves are legal for the whole selection if it knows
+ * where every selected issue currently sits.
+ */
+export interface SelectedIssue {
+	readonly id: ErrorIssueId
+	readonly state: WorkflowState
+}
+
 export function IssuesBulkBar({
-	selectedIds,
+	selected,
 	mutations,
 	onClear,
 }: {
-	selectedIds: ReadonlyArray<ErrorIssueId>
+	selected: ReadonlyArray<SelectedIssue>
 	mutations: IssueMutations
 	onClear: () => void
 }) {
-	if (selectedIds.length === 0) return null
+	if (selected.length === 0) return null
+
+	const selectedIds = selected.map((issue) => issue.id)
+	// The intersection of every selected issue's legal moves, so a bulk
+	// transition either applies to the whole selection or is not offered.
+	const targets = allowedTransitionsForAll(selected.map((issue) => issue.state))
 
 	return (
 		<div
@@ -83,17 +90,25 @@ export function IssuesBulkBar({
 			<BulkMenu label="Move to">
 				<DropdownMenuLabel>Move to state</DropdownMenuLabel>
 				<DropdownMenuSeparator />
-				{STATE_ORDER.map((state) => (
-					<DropdownMenuItem
-						key={state}
-						onClick={() => {
-							void mutations.transitionMany(selectedIds, state)
-							onClear()
-						}}
-					>
-						{WORKFLOW_LABEL[state]}
+				{targets.length === 0 ? (
+					<DropdownMenuItem disabled>
+						{selected.length === 1
+							? `No moves from ${WORKFLOW_LABEL[selected[0]!.state]}`
+							: "No move applies to every selected issue"}
 					</DropdownMenuItem>
-				))}
+				) : (
+					targets.map((state) => (
+						<DropdownMenuItem
+							key={state}
+							onClick={() => {
+								void mutations.transitionMany(selectedIds, state)
+								onClear()
+							}}
+						>
+							{WORKFLOW_LABEL[state]}
+						</DropdownMenuItem>
+					))
+				)}
 			</BulkMenu>
 			<Button size="icon-sm" variant="ghost" onClick={onClear} aria-label="Clear selection">
 				<XmarkIcon size={14} />

--- a/apps/web/src/components/errors/state-select.tsx
+++ b/apps/web/src/components/errors/state-select.tsx
@@ -1,5 +1,5 @@
 import type { WorkflowState } from "@maple/domain/http"
-import { WORKFLOW_TRANSITIONS as TRANSITIONS } from "@maple/domain/http"
+import { allowedTransitionsForAll, WORKFLOW_STATE_ORDER } from "@maple/domain/http"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@maple/ui/components/ui/select"
 
 const LABEL: Record<WorkflowState, string> = {
@@ -12,16 +12,6 @@ const LABEL: Record<WorkflowState, string> = {
 	wontfix: "Wontfix",
 } satisfies Record<WorkflowState, string>
 
-const ALL_STATES: ReadonlyArray<WorkflowState> = [
-	"triage",
-	"todo",
-	"in_progress",
-	"in_review",
-	"done",
-	"cancelled",
-	"wontfix",
-]
-
 export function StateSelect({
 	current,
 	disabled,
@@ -31,14 +21,18 @@ export function StateSelect({
 	disabled?: boolean
 	onChange: (next: WorkflowState) => void
 }) {
-	const allowed = new Set<WorkflowState>(TRANSITIONS[current])
+	const allowed = new Set<WorkflowState>(allowedTransitionsForAll([current]))
+	const change = (value: unknown) => {
+		const next = WORKFLOW_STATE_ORDER.find((state) => state === value)
+		if (next !== undefined && next !== current && allowed.has(next)) onChange(next)
+	}
 	return (
-		<Select value={current} onValueChange={(v) => onChange(v as WorkflowState)} disabled={disabled}>
+		<Select value={current} onValueChange={change} disabled={disabled}>
 			<SelectTrigger className="w-full">
 				<SelectValue placeholder="State" />
 			</SelectTrigger>
 			<SelectContent>
-				{ALL_STATES.map((state) => {
+				{WORKFLOW_STATE_ORDER.map((state) => {
 					const reachable = state === current || allowed.has(state)
 					return (
 						<SelectItem key={state} value={state} disabled={!reachable}>

--- a/apps/web/src/routes/errors/issues/index.tsx
+++ b/apps/web/src/routes/errors/issues/index.tsx
@@ -409,8 +409,13 @@ function IssuesPageBody({
 		return out
 	}, [grouped, visibleGroups])
 
-	const selectedArray = useMemo(
-		() => flatIssues.filter((i) => selectedIds.has(i.id)).map((i) => i.id as ErrorIssueId),
+	// The bulk bar needs each selected issue's current state, not just its id —
+	// that is what lets it offer only the moves legal for the whole selection.
+	const selectedIssues = useMemo(
+		() =>
+			flatIssues
+				.filter((issue) => selectedIds.has(issue.id))
+				.map((issue) => ({ id: issue.id, state: issue.workflowState })),
 		[flatIssues, selectedIds],
 	)
 
@@ -541,7 +546,7 @@ function IssuesPageBody({
 							)}
 						</div>
 						<IssuesBulkBar
-							selectedIds={selectedArray}
+							selected={selectedIssues}
 							mutations={mutations}
 							onClear={clearSelection}
 						/>

--- a/packages/domain/src/http/errors.ts
+++ b/packages/domain/src/http/errors.ts
@@ -62,6 +62,30 @@ export const WORKFLOW_TRANSITIONS: Record<WorkflowState, ReadonlyArray<WorkflowS
 	wontfix: ["triage", "cancelled"],
 } satisfies Record<WorkflowState, ReadonlyArray<WorkflowState>>
 
+/**
+ * Every workflow state in canonical display order. The order the issue hub
+ * shows states in — groups, selects, and status menus — so a list of states
+ * reads the same everywhere.
+ */
+export const WORKFLOW_STATE_ORDER: ReadonlyArray<WorkflowState> = WorkflowState.literals
+
+/**
+ * The states that *every* one of `from` can legally move to — the intersection
+ * of their rows in {@link WORKFLOW_TRANSITIONS}, in canonical order.
+ *
+ * This is what a menu should offer: for one issue it is that issue's row, and
+ * for a multi-issue selection it is the moves the server would accept for all
+ * of them, so a bulk action can never half-apply. A state with no outgoing
+ * moves (`cancelled`) contributes an empty row and therefore collapses the
+ * result to nothing, and an empty input yields nothing (nothing selected, no
+ * legal move).
+ */
+export const allowedTransitionsForAll = (from: Iterable<WorkflowState>): ReadonlyArray<WorkflowState> => {
+	const rows = Array.from(from, (state) => WORKFLOW_TRANSITIONS[state])
+	if (rows.length === 0) return []
+	return WORKFLOW_STATE_ORDER.filter((target) => rows.every((row) => row.includes(target)))
+}
+
 /** States from which no further transition is possible. */
 export const TERMINAL_WORKFLOW_STATES: ReadonlySet<WorkflowState> = new Set<WorkflowState>([
 	"done",

--- a/packages/domain/src/http/workflow-transitions.test.ts
+++ b/packages/domain/src/http/workflow-transitions.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest"
 import {
 	TERMINAL_WORKFLOW_STATES,
+	WORKFLOW_STATE_ORDER,
 	WORKFLOW_TRANSITIONS,
+	allowedTransitionsForAll,
 	WorkflowState,
 	describeWorkflowTransitions,
 } from "./errors"
@@ -61,5 +63,65 @@ describe("describeWorkflowTransitions", () => {
 		expect(description).toContain("wontfix→(triage|cancelled)")
 		// `cancelled` has no legal moves, so listing it would only mislead the model.
 		expect(description).not.toContain("cancelled→")
+	})
+})
+
+describe("allowedTransitionsForAll", () => {
+	it("offers exactly the matrix row for a single issue in each state", () => {
+		for (const state of ALL_STATES) {
+			expect(allowedTransitionsForAll([state]), state).toEqual(
+				WORKFLOW_STATE_ORDER.filter((target) => WORKFLOW_TRANSITIONS[state].includes(target)),
+			)
+		}
+	})
+
+	it("offers nothing for an issue in a state with no outgoing moves", () => {
+		expect(allowedTransitionsForAll(["cancelled"])).toEqual([])
+	})
+
+	it("returns the intersection for a mixed selection", () => {
+		// triage: todo, in_progress, done, cancelled, wontfix
+		// in_review: triage, in_progress, done, cancelled, wontfix
+		expect(allowedTransitionsForAll(["triage", "in_review"])).toEqual([
+			"in_progress",
+			"done",
+			"cancelled",
+			"wontfix",
+		])
+	})
+
+	it("returns nothing when a mixed selection has an empty intersection", () => {
+		// One dead-end issue kills the whole selection's options: every other
+		// row still allows `cancelled`, so `cancelled`'s empty row is the only
+		// thing that can empty an intersection.
+		expect(allowedTransitionsForAll(["triage", "todo", "cancelled"])).toEqual([])
+		expect(allowedTransitionsForAll(["cancelled", "wontfix"])).toEqual([])
+	})
+
+	it("narrows a mixed selection to the one move a dissimilar pair shares", () => {
+		// `wontfix` only reaches triage/cancelled; `triage` reaches neither
+		// triage nor itself, leaving `cancelled` as the single common move.
+		expect(allowedTransitionsForAll(["triage", "wontfix"])).toEqual(["cancelled"])
+	})
+
+	it("returns nothing for an empty selection", () => {
+		expect(allowedTransitionsForAll([])).toEqual([])
+	})
+
+	it("never offers a move the matrix rejects for any selected state", () => {
+		for (const a of ALL_STATES) {
+			for (const b of ALL_STATES) {
+				for (const target of allowedTransitionsForAll([a, b])) {
+					expect(WORKFLOW_TRANSITIONS[a], `${a}→${target}`).toContain(target)
+					expect(WORKFLOW_TRANSITIONS[b], `${b}→${target}`).toContain(target)
+				}
+			}
+		}
+	})
+
+	it("orders results canonically regardless of input order", () => {
+		expect(allowedTransitionsForAll(["in_review", "triage"])).toEqual(
+			allowedTransitionsForAll(["triage", "in_review"]),
+		)
 	})
 })


### PR DESCRIPTION
The context menu and the bulk bar each kept their own list of all seven states
and disabled only the one you were already in, so a cancelled issue — the one
state with no outgoing moves — offered all six others, and the server rejected
whichever you picked. The bulk bar could not have done better: selection carried
ids alone, so it never knew what states it was acting on.

Selection now carries {id, state}, and both menus ask the domain matrix. For
several issues that is the intersection of their rows, computed once in
packages/domain beside the matrix rather than re-derived in the app. Nothing
legal to offer now says so instead of opening an empty menu.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789483832&installation_model_id=427786&pr_number=502&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F502&signature=a1721825cfac466fd3c69e8ff6684d610fa2b53c376a7147b33529f13b513051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->