### PR TITLE
fix(api): make the closing tool and its name one value

### DIFF
--- a/apps/api/src/chat/loop/index.ts
+++ b/apps/api/src/chat/loop/index.ts
@@ -25,6 +25,7 @@ export {
 	makeTurnUsage,
 	type ChatTurnEvent,
 	type ChatTurnInput,
+	type TurnCompletion,
 	type TurnObservability,
 	type TurnUsage,
 } from "./types"

--- a/apps/api/src/chat/loop/turn.test.ts
+++ b/apps/api/src/chat/loop/turn.test.ts
@@ -8,17 +8,9 @@
 import { describe, it } from "@effect/vitest"
 import { assert } from "vitest"
 import { Effect, Layer, Schema, Stream } from "effect"
-import {
-	LLMClient,
-	LLMEvent,
-	Tool,
-	type FinishReason,
-	type LLMRequest,
-	type Model,
-	type Tools,
-} from "@maple/llm"
+import { LLMClient, LLMEvent, Tool, type FinishReason, type LLMRequest, type Model } from "@maple/llm"
 import { CloudflareWorkersAI } from "@maple/llm/providers/cloudflare"
-import { makeTurnObservability, runChatTurn, type ChatTurnEvent } from "./index"
+import { makeTurnObservability, runChatTurn, type ChatTurnEvent, type TurnCompletion } from "./index"
 import { MAX_STEP_ATTEMPTS } from "./budgets"
 import { DEFAULT_RULESET } from "../permissions"
 import type { AgentDefinition } from "../agents"
@@ -64,6 +56,41 @@ const providerError = (
  */
 const toolCall = (id: string, name: string, input: unknown = {}): LLMEvent =>
 	({ type: "tool-call", id, name, input, providerExecuted: false }) as LLMEvent
+
+const SUBMIT = "submit_candidate"
+
+/**
+ * The turn's completion, as the one value it now is.
+ *
+ * The name, the implementation and "is this call the turn's answer?" arrive together, so a fixture
+ * cannot express the shape that shipped: a submit tool the model can see and a loop that will never
+ * insist on it.
+ */
+const completionTool = (record: Array<unknown>) =>
+	Tool.make({
+		description: "Record the candidate.",
+		parameters: Schema.Struct({ claim: Schema.String }),
+		success: Schema.String,
+		execute: (value) =>
+			Effect.sync(() => {
+				record.push(value)
+				return "Recorded."
+			}),
+	})
+
+/** A completion the turn answers *through*: it is forced at the close and it ends the turn. */
+const submitCompletion = (record: Array<unknown>): TurnCompletion => ({
+	name: SUBMIT,
+	tool: completionTool(record),
+	closes: true,
+})
+
+/** The same tool, merely offered — what a human follow-up inside an investigation gets. */
+const offeredCompletion = (record: Array<unknown>): TurnCompletion => ({
+	name: SUBMIT,
+	tool: completionTool(record),
+	closes: false,
+})
 
 /**
  * Stub the model with a scripted event stream per step.
@@ -124,8 +151,7 @@ interface CollectOverrides {
 	readonly isCurrent?: () => boolean
 	readonly softStop?: () => boolean
 	readonly agent?: AgentDefinition
-	readonly extraTools?: Tools
-	readonly closingSubmit?: { readonly toolName: string }
+	readonly completion?: TurnCompletion
 }
 
 const collect = (steps: ReadonlyArray<Step>, overrides: CollectOverrides = {}) => {
@@ -142,8 +168,7 @@ const collect = (steps: ReadonlyArray<Step>, overrides: CollectOverrides = {}) =
 		...(overrides.isCurrent ? { isCurrent: overrides.isCurrent } : undefined),
 		...(overrides.softStop ? { softStop: overrides.softStop } : undefined),
 		...(overrides.agent ? { agent: overrides.agent } : undefined),
-		...(overrides.extraTools ? { extraTools: overrides.extraTools } : undefined),
-		...(overrides.closingSubmit ? { closingSubmit: overrides.closingSubmit } : undefined),
+		...(overrides.completion ? { completion: overrides.completion } : undefined),
 	}).pipe(
 		Stream.runCollect,
 		Effect.map((events) => Array.from(events) as ChatTurnEvent[]),
@@ -780,20 +805,93 @@ describe("runChatTurn max steps, defensively", () => {
  * not report any of it, and was recorded identically to one that never looked.
  */
 describe("runChatTurn closing submit", () => {
-	const SUBMIT = "submit_candidate"
+	/**
+	 * Normal completion: the model works, then answers through the tool of its own
+	 * accord, well inside its budget. Nothing is forced, and the payload still lands.
+	 */
+	it.live(
+		"records the answer and ends on stop when the model calls the completion tool itself",
+		() =>
+			Effect.gen(function* () {
+				const submitted: Array<unknown> = []
+				const result = yield* collect(
+					[
+						[toolCall("c1", "find_errors", { page: 0 }), finish()],
+						[toolCall("c2", "search_logs", { page: 1 }), finish()],
+						[
+							textDelta("Filing it."),
+							toolCall("s1", SUBMIT, { claim: "pool exhaustion" }),
+							finish("tool-calls"),
+						],
+					],
+					{ completion: submitCompletion(submitted) },
+				)
 
-	const submitTool = (record: Array<unknown>): Tools => ({
-		[SUBMIT]: Tool.make({
-			description: "Record the candidate.",
-			parameters: Schema.Struct({ claim: Schema.String }),
-			success: Schema.String,
-			execute: (value) =>
-				Effect.sync(() => {
-					record.push(value)
-					return "Recorded."
-				}),
-		}),
-	})
+				assert.deepEqual(submitted, [{ claim: "pool exhaustion" }])
+				// A completed answer, not a ceiling: nothing about this turn was cut short.
+				const end = terminal(result.events)[0]
+				assert.equal(end?.type === "turn-end" ? end.reason : undefined, "stop")
+				assert.equal(result.calls, 3)
+				// The one value registers the tool under its own name on every ordinary step, so the
+				// name the closing step would force cannot name a tool the model was never offered.
+				assert.include(
+					(result.requests[0]?.tools ?? []).map((tool) => tool.name),
+					SUBMIT,
+				)
+			}),
+		30_000,
+	)
+
+	/**
+	 * `closes: false` — the same tool, merely available. This is the human follow-up
+	 * inside an investigation: it *may* file a superseding diagnosis, but a question
+	 * about the existing one has to be answerable in prose, so the call is dispatched
+	 * and followed like any other tool result rather than ending the turn.
+	 */
+	it.live(
+		"follows an offered completion call instead of ending the turn on it",
+		() =>
+			Effect.gen(function* () {
+				const submitted: Array<unknown> = []
+				const result = yield* collect(
+					[
+						[toolCall("s1", SUBMIT, { claim: "revised" }), finish("tool-calls")],
+						[textDelta("Recorded the revised diagnosis."), finish()],
+					],
+					{ completion: offeredCompletion(submitted) },
+				)
+
+				assert.deepEqual(submitted, [{ claim: "revised" }])
+				assert.equal(result.calls, 2)
+				assert.lengthOf(terminal(result.events), 1)
+			}),
+		30_000,
+	)
+
+	/** And it closes in prose, exactly as an attended turn with no completion at all does. */
+	it.live(
+		"closes an offered completion in prose, with no tools at all",
+		() =>
+			Effect.gen(function* () {
+				const submitted: Array<unknown> = []
+				const result = yield* collect(
+					[
+						...Array.from(
+							{ length: 10 },
+							(_, i): Step => [toolCall("c1", "find_errors", { page: i }), finish()],
+						),
+						[textDelta("Here is what I found."), finish()],
+					],
+					{ completion: offeredCompletion(submitted) },
+				)
+
+				const closing = result.requests[result.requests.length - 1]
+				assert.isEmpty(closing?.tools ?? [])
+				assert.equal(closing?.toolChoice?.type, "none")
+				assert.isEmpty(submitted)
+			}),
+		30_000,
+	)
 
 	/** Ten tool-calling steps, then the model finally calls submit. */
 	const exhaustingSteps = (): ReadonlyArray<Step> => [
@@ -807,8 +905,7 @@ describe("runChatTurn closing submit", () => {
 			Effect.gen(function* () {
 				const submitted: Array<unknown> = []
 				const result = yield* collect(exhaustingSteps(), {
-					extraTools: submitTool(submitted),
-					closingSubmit: { toolName: SUBMIT },
+					completion: submitCompletion(submitted),
 				})
 
 				const closing = result.requests[result.requests.length - 1]
@@ -826,8 +923,7 @@ describe("runChatTurn closing submit", () => {
 			Effect.gen(function* () {
 				const submitted: Array<unknown> = []
 				const result = yield* collect(exhaustingSteps(), {
-					extraTools: submitTool(submitted),
-					closingSubmit: { toolName: SUBMIT },
+					completion: submitCompletion(submitted),
 				})
 
 				// The regression: the answer actually reaches the tool.
@@ -857,8 +953,7 @@ describe("runChatTurn closing submit", () => {
 						[toolCall("s1", SUBMIT, { claim: "out of clock" }), finish()],
 					],
 					{
-						extraTools: submitTool(submitted),
-						closingSubmit: { toolName: SUBMIT },
+						completion: submitCompletion(submitted),
 						// Checked after the first real tool step, which is when the forced submit closes it.
 						softStop: () => true,
 					},
@@ -891,7 +986,7 @@ describe("runChatTurn closing submit", () => {
 						[textDelta("The strongest candidate is the pool."), finish()],
 						[toolCall("s1", SUBMIT, { claim: "pool exhaustion" }), finish()],
 					],
-					{ extraTools: submitTool(submitted), closingSubmit: { toolName: SUBMIT } },
+					{ completion: submitCompletion(submitted) },
 				)
 
 				assert.deepEqual(submitted, [{ claim: "pool exhaustion" }])
@@ -911,8 +1006,7 @@ describe("runChatTurn closing submit", () => {
 				yield* collect(
 					[[finish()], [finish()], [toolCall("s1", SUBMIT, { claim: "recovered" }), finish()]],
 					{
-						extraTools: submitTool(submitted),
-						closingSubmit: { toolName: SUBMIT },
+						completion: submitCompletion(submitted),
 					},
 				)
 
@@ -933,8 +1027,7 @@ describe("runChatTurn closing submit", () => {
 						[textDelta("prose again"), finish()],
 					],
 					{
-						extraTools: submitTool(submitted),
-						closingSubmit: { toolName: SUBMIT },
+						completion: submitCompletion(submitted),
 					},
 				)
 
@@ -960,7 +1053,7 @@ describe("runChatTurn closing submit", () => {
 						[toolCall("s1", SUBMIT, { claim: "first" }), finish()],
 						[toolCall("s2", SUBMIT, { claim: "second" }), finish()],
 					],
-					{ extraTools: submitTool(submitted), closingSubmit: { toolName: SUBMIT } },
+					{ completion: submitCompletion(submitted) },
 				)
 
 				assert.deepEqual(submitted, [{ claim: "first" }])
@@ -978,8 +1071,7 @@ describe("runChatTurn closing submit", () => {
 		Effect.gen(function* () {
 			const submitted: Array<unknown> = []
 			const events = yield* collectEvents([[textDelta("hi"), finish()]], {
-				extraTools: submitTool(submitted),
-				closingSubmit: { toolName: SUBMIT },
+				completion: submitCompletion(submitted),
 				isCurrent: () => false,
 			})
 			assert.isEmpty(terminal(events))

--- a/apps/api/src/chat/loop/turn.ts
+++ b/apps/api/src/chat/loop/turn.ts
@@ -68,6 +68,7 @@ import {
 	type ChatTurnEvent,
 	type ChatTurnInput,
 	type StepState,
+	type TurnCompletion,
 } from "./types"
 
 /**
@@ -150,6 +151,16 @@ const finishTurn = (
 }
 
 /**
+ * The tool a cut-short turn has to answer *through*, if this turn has one at all.
+ *
+ * A completion with `closes: false` is offered to the model like any other tool and takes no part in
+ * how the turn ends — see `TurnCompletion`. Reading it through one helper is what keeps the closing
+ * step, the prose rescue and the end-after-submit check from ever disagreeing about that.
+ */
+const closingCompletion = (input: ChatTurnInput): TurnCompletion | undefined =>
+	input.completion !== undefined && input.completion.closes ? input.completion : undefined
+
+/**
  * Build the step that closes a turn, in whichever of its two shapes applies.
  *
  * Attended chat gets `tools: []` / `toolChoice: "none"` and answers in prose. A headless pass gets
@@ -162,14 +173,12 @@ const finishTurn = (
  */
 const closingStep = (
 	input: ChatTurnInput,
-	tools: Tools,
 	request: LLMRequest,
 	messages: ReadonlyArray<Message>,
 	notice: string,
 ): { readonly request: LLMRequest; readonly closing: "prose" | "submit" } => {
-	const forced = input.closingSubmit
-	const submitTool = forced === undefined ? undefined : tools[forced.toolName]
-	if (forced === undefined || submitTool === undefined) {
+	const forced = closingCompletion(input)
+	if (forced === undefined) {
 		return {
 			request: LLM.updateRequest(request, {
 				messages: [...messages, Message.user(notice)],
@@ -181,9 +190,9 @@ const closingStep = (
 	}
 	return {
 		request: LLM.updateRequest(request, {
-			messages: [...messages, Message.user(forcedSubmitNotice(forced.toolName))],
-			tools: toDefinitions({ [forced.toolName]: submitTool }),
-			toolChoice: forced.toolName,
+			messages: [...messages, Message.user(forcedSubmitNotice(forced.name))],
+			tools: toDefinitions({ [forced.name]: forced.tool }),
+			toolChoice: forced.name,
 		}),
 		closing: "submit",
 	}
@@ -218,7 +227,11 @@ export const runChatTurn = (input: ChatTurnInput): Stream.Stream<ChatTurnEvent> 
 				...buildChatTools(input.toolExecutor, input.tenant, agent.permission),
 				// Delegation is opt-in per agent: an agent with no `spawns` never sees `task` at all.
 				...buildTaskTool(input, spawnableFor(agent), taskBudget, runChatTurn),
-				...input.extraTools,
+				// One value, so the tool the model is offered and the name the closing step forces are
+				// the same fact rather than two that can drift apart. See `TurnCompletion`.
+				...(input.completion === undefined
+					? undefined
+					: { [input.completion.name]: input.completion.tool }),
 			}
 			const request = LLM.request({
 				id: input.messageId,
@@ -551,13 +564,11 @@ const runStep = (
 					//
 					// `state.closing === undefined` bounds it to one attempt, and the `"submit"` branch
 					// above ends the turn unconditionally whatever comes back — so this cannot loop.
-					const submitName = input.closingSubmit?.toolName
-					if (state.closing === undefined && submitName !== undefined && tools[submitName]) {
+					if (state.closing === undefined && closingCompletion(input) !== undefined) {
 						const replay =
 							emptyOutput && response.reasoning.trim() === "" ? [] : [response.message]
 						const closing = closingStep(
 							input,
-							tools,
 							request,
 							[...request.messages, ...replay],
 							MAX_STEPS_NOTICE,
@@ -602,7 +613,7 @@ const runStep = (
 				// never a mutation). Anything the provider emitted besides the forced tool is dropped
 				// rather than run, because this step offered exactly one tool.
 				if (state.closing === "submit") {
-					const submitName = input.closingSubmit?.toolName
+					const submitName = closingCompletion(input)?.name
 					const forced = calls.filter((call) => call.name === submitName)
 					if (forced.length === 0) {
 						return finishTurn(input, state, "error", {
@@ -718,10 +729,8 @@ const runStep = (
 						// Recursing would spend another model call on a turn that is already over — and
 						// under a one-step budget (the validator's) that next step is the *forced* closing
 						// one, which asks for a second verdict and overwrites the first with it.
-						if (
-							input.closingSubmit !== undefined &&
-							calls.some((call) => call.name === input.closingSubmit?.toolName)
-						) {
+						const closesHere = closingCompletion(input)?.name
+						if (closesHere !== undefined && calls.some((call) => call.name === closesHere)) {
 							return Stream.concat(
 								Stream.fromIterable(results),
 								finishTurn(input, state, "stop", { finishReason }),
@@ -796,7 +805,6 @@ const runStep = (
 						) {
 							const closing = closingStep(
 								input,
-								tools,
 								request,
 								transcript,
 								observed.stop ? DOOM_LOOP_NOTICE : MAX_STEPS_NOTICE,

--- a/apps/api/src/chat/loop/types.ts
+++ b/apps/api/src/chat/loop/types.ts
@@ -5,7 +5,7 @@
  * plus two small stamping helpers; nothing here decides anything.
  */
 import type { ChatEvent, ChatTaskRef } from "@maple/domain/chat-session"
-import type { FinishReason, Message, Model, Tools, Usage } from "@maple/llm"
+import type { AnyTool, FinishReason, Message, Model, Usage } from "@maple/llm"
 import type { TenantContext } from "@/services/auth/tenant-context"
 import type { McpToolExecutorApi } from "@/mcp/dispatcher"
 import type { AgentDefinition } from "../agents"
@@ -22,6 +22,42 @@ type WithoutSeq<T> = T extends unknown ? Omit<T, "seq"> : never
  */
 export type ChatTurnEvent = WithoutSeq<Exclude<ChatEvent, { type: "user-message" }>>
 
+/**
+ * The one tool a turn can *answer through*, supplied as a single value.
+ *
+ * The name and the implementation used to arrive separately — a `Tools` record merged into the
+ * turn's tool map, plus a `closingSubmit: { toolName }` naming which key of it closes the turn — and
+ * nothing tied the two together. Every disagreement between them was silent and shipped: the
+ * investigation chat session supplied `submit_diagnosis` and no closing name, so an investigation
+ * that spent its whole step budget reached the tool-less closing step, answered in prose, and left
+ * `investigations.diagnosis` null. A name with no matching tool was equally representable and simply
+ * fell back to the prose closing step.
+ *
+ * Absent means the turn has no structured answer at all — plain attended chat. Present means exactly
+ * this tool, under exactly this name, is offered to the model.
+ *
+ * `closes` is the remaining choice, and it is required rather than defaulted so no caller can make
+ * it by omission:
+ *
+ *   - `true` — the turn's answer *is* this call. The step that closes a cut-short turn carries this
+ *     one tool with `toolChoice` forcing it, a step that produced prose instead of calling it is
+ *     asked once more through it, and the call itself ends the turn. Headless passes.
+ *   - `false` — the tool is merely available. The turn closes in prose like any attended one, and a
+ *     call to it is dispatched and then followed like any other tool result. This is what a human
+ *     follow-up inside an investigation gets: it *may* file a superseding diagnosis, but a question
+ *     about the existing one must not be answered by rewriting it.
+ *
+ * It is supplied by the caller rather than built inside the loop because its handler needs
+ * `InvestigationService`, which would otherwise drag the service graph into the loop's imports.
+ */
+export interface TurnCompletion {
+	/** The name the model sees, and the key it is registered under in the turn's tool map. */
+	readonly name: string
+	readonly tool: AnyTool
+	/** Whether this call is the turn's answer, rather than one tool among many. */
+	readonly closes: boolean
+}
+
 export interface ChatTurnInput {
 	readonly sessionId: string
 	readonly tenant: TenantContext
@@ -32,11 +68,9 @@ export interface ChatTurnInput {
 	readonly messages: ReadonlyArray<Message>
 	readonly messageId: string
 	/**
-	 * Investigate-mode sessions get a `submit_diagnosis` tool. It is supplied rather than built
-	 * inside the loop because it needs `InvestigationService`, which would otherwise drag the
-	 * service graph into the loop's imports.
+	 * The tool this turn answers *through*, if it has one. See {@link TurnCompletion}.
 	 */
-	readonly extraTools?: Tools
+	readonly completion?: TurnCompletion
 	/**
 	 * Whether this turn still holds the session's turn slot.
 	 *
@@ -57,18 +91,6 @@ export interface ChatTurnInput {
 	 * and the lane was recorded as a no-finding.
 	 */
 	readonly softStop?: () => boolean
-	/**
-	 * The tool a headless turn answers *through*.
-	 *
-	 * The closing step that serves attended chat sends `tools: []` and `toolChoice: "none"`, because
-	 * there the answer is prose. An investigation's answer is a `submit_diagnosis` / `submit_candidate`
-	 * call, so that same closing step silences it — an agent that spent its whole budget investigating
-	 * could not report what it found. When this is set, the closing step instead carries exactly this
-	 * one tool with `toolChoice` forcing it. The name must be a key of {@link extraTools}.
-	 *
-	 * Unset — every attended surface — keeps the tool-less closing step byte-for-byte.
-	 */
-	readonly closingSubmit?: { readonly toolName: string }
 	/** Accumulates this turn's token usage; see {@link TurnUsage}. */
 	readonly usage?: TurnUsage
 	/** Mutable outcome facts annotated on the enclosing `chat.turn` span by the session runner. */

--- a/apps/api/src/chat/tools.test.ts
+++ b/apps/api/src/chat/tools.test.ts
@@ -1,0 +1,69 @@
+/**
+ * `buildDiagnosisCompletion` — the one value an investigation turn answers through.
+ *
+ * The tool and the fact that calling it *ends the turn* used to be two independent inputs to the
+ * loop: a `Tools` record and a `closingSubmit: { toolName }`. The chat session supplied the first
+ * and never the second, so an autonomous investigation that spent its whole step budget reached the
+ * tool-less closing step and filed no diagnosis at all. These pin both halves to the same value.
+ */
+import { OrgId, UserId } from "@maple/domain/primitives"
+import { CloudflareWorkersAI } from "@maple/llm/providers/cloudflare"
+import { Effect, Schema } from "effect"
+import { assert, describe, it } from "vitest"
+import { buildDiagnosisCompletion, type SubmitDiagnosis } from "./tools"
+import { makeTurnUsage } from "./loop"
+import type { TenantContext } from "@/services/auth/tenant-context"
+
+const orgId = Schema.decodeSync(OrgId)("org_test")
+const human = Schema.decodeSync(UserId)("user_test")
+const internal = Schema.decodeSync(UserId)("internal-service")
+
+const tenantFor = (userId: UserId): TenantContext => ({
+	orgId,
+	userId,
+	roles: [],
+	authMode: "self_hosted",
+})
+
+const MODEL = CloudflareWorkersAI.configure({ accountId: "test", apiKey: "test" }).model(
+	"@cf/test/model",
+)
+
+const INVESTIGATION_SESSION = `${orgId}:inv-00000000-0000-0000-0000-000000000000`
+
+const submitDiagnosis: SubmitDiagnosis = () => Effect.succeed(undefined)
+
+const build = (sessionId: string, userId: UserId) =>
+	buildDiagnosisCompletion(sessionId, tenantFor(userId), submitDiagnosis, makeTurnUsage(), MODEL)
+
+describe("buildDiagnosisCompletion", () => {
+	it("gives an ordinary conversation no completion at all", () => {
+		assert.isUndefined(build(`${orgId}:tab`, human))
+	})
+
+	it("gives a session whose inv- suffix is not an id no completion", () => {
+		assert.isUndefined(build(`${orgId}:inv-not-a-uuid`, human))
+	})
+
+	/**
+	 * The production bug. The autonomous pass answers *through* `submit_diagnosis` — it is the only
+	 * thing that writes `investigations.diagnosis` — so the turn has to close on it.
+	 */
+	it("closes the autonomous investigation turn on submit_diagnosis", () => {
+		const completion = build(INVESTIGATION_SESSION, internal)
+
+		assert.equal(completion?.name, "submit_diagnosis")
+		assert.isTrue(completion?.closes)
+	})
+
+	/**
+	 * A human follow-up in the same session gets the same tool and does not close on it: it may file
+	 * a superseding diagnosis, but "what did you mean by the pool?" must be answerable in prose.
+	 */
+	it("offers, without forcing, the same tool to a human follow-up", () => {
+		const completion = build(INVESTIGATION_SESSION, human)
+
+		assert.equal(completion?.name, "submit_diagnosis")
+		assert.isFalse(completion?.closes)
+	})
+})

--- a/apps/api/src/chat/tools.ts
+++ b/apps/api/src/chat/tools.ts
@@ -14,13 +14,13 @@ import {
 	InvestigationPersistenceError,
 	SubmitDiagnosisRequest,
 } from "@maple/domain/http"
-import { InvestigationId } from "@maple/domain/primitives"
+import { InvestigationId, UserId } from "@maple/domain/primitives"
 import { Tool, ToolFailure, type Model, type Tools } from "@maple/llm"
 import { Effect, Option, Schema } from "effect"
 import type { McpToolExecutorApi } from "@/mcp/dispatcher"
 import { buildMapleTools, summarizeToolFailure } from "@/mcp/tools/llm-tools"
 import type { TenantContext } from "@/services/auth/tenant-context"
-import type { TurnUsage } from "./loop/types"
+import type { TurnCompletion, TurnUsage } from "./loop/types"
 
 const decodeInvestigationIdOption = Schema.decodeUnknownOption(InvestigationId)
 
@@ -48,23 +48,31 @@ export type SubmitDiagnosis = (
 	InvestigationPersistenceError | InvestigationNotFoundError | InvestigationDataCorruptionError
 >
 
-export const buildSubmitDiagnosisTool = (
+/**
+ * The user id every machine-started turn runs as.
+ *
+ * An investigation's own autonomous pass is claimed by `InvestigationService` under this actor; a
+ * human opening the same session and asking a follow-up is not. That difference is what decides
+ * whether the diagnosis tool merely exists or is the turn's *answer* — see below.
+ */
+const INTERNAL_SERVICE_USER_ID = Schema.decodeSync(UserId)("internal-service")
+
+export const buildDiagnosisCompletion = (
 	sessionId: string,
 	tenant: TenantContext,
 	submitDiagnosis: SubmitDiagnosis,
 	usage: TurnUsage,
 	model: Model,
-): Tools => {
-	const tools: Tools = {}
+): TurnCompletion | undefined => {
 	const rawId = investigationIdFromChatSessionId(sessionId)
-	if (!rawId) return tools
+	if (!rawId) return undefined
 	// `decodeUnknownSync` here turned a session id whose `inv-` suffix was not a UUID into a thrown
 	// defect on a user-supplied string. An unparseable id simply means this conversation is not an
 	// investigation, so it gets no `submit_diagnosis` tool.
 	const decoded = decodeInvestigationIdOption(rawId)
-	if (Option.isNone(decoded)) return tools
+	if (Option.isNone(decoded)) return undefined
 	const investigationId = decoded.value
-	tools.submit_diagnosis = Tool.make({
+	const tool = Tool.make({
 		description:
 			"Record your structured diagnosis for THIS investigation. Call it exactly once, " +
 			"after you have gathered evidence, with your final assessment. It persists the report " +
@@ -94,7 +102,24 @@ export const buildSubmitDiagnosisTool = (
 				),
 			),
 	})
-	return tools
+	return {
+		name: "submit_diagnosis",
+		tool,
+		/**
+		 * The autonomous pass answers *through* this tool, so its turn has to close on it: it is the
+		 * only thing that writes `investigations.diagnosis`, and a pass that spends its 14 steps
+		 * gathering evidence and then hits the tool-less closing step files nothing at all. Supplying
+		 * the tool without saying so is exactly what this session did before the two facts became one
+		 * value — the report existed as a tool the model could call and as nothing the loop would ever
+		 * insist on.
+		 *
+		 * A human follow-up in the same session gets the same tool and `closes: false`. It *may* file
+		 * a superseding diagnosis (the `superseded` status exists for that), but "what did you mean by
+		 * the pool?" must be answerable in prose — forcing the close there would rewrite the report
+		 * every time someone asked a question about it.
+		 */
+		closes: tenant.userId === INTERNAL_SERVICE_USER_ID,
+	}
 }
 
 /**

--- a/apps/api/src/chat/turn-runner.ts
+++ b/apps/api/src/chat/turn-runner.ts
@@ -216,7 +216,7 @@ export const runChatSessionTurn = async (input: RunChatSessionTurnInput): Promis
 		{ layerPg },
 		{ layerLlm, resolveTriageModel },
 		loop,
-		{ buildSubmitDiagnosisTool },
+		{ buildDiagnosisCompletion },
 		{ McpToolExecutor },
 	] = await Promise.all([
 		import("../runtime/mcp-service-graph"),
@@ -270,7 +270,10 @@ export const runChatSessionTurn = async (input: RunChatSessionTurnInput): Promis
 		// Shared with the turn so `submit_diagnosis` can report what the investigation cost. See
 		// `TurnUsage` — the tool is invoked mid-turn, so there is no later moment to hand it a total.
 		const usage = loop.makeTurnUsage()
-		const extraTools = buildSubmitDiagnosisTool(
+		// One value: the tool *and* whether this turn's answer is a call to it. Passing the tool alone
+		// is what left an autonomous investigation with no way to file its report once it ran out of
+		// steps — see `buildDiagnosisCompletion`.
+		const completion = buildDiagnosisCompletion(
 			input.sessionId,
 			tenant,
 			investigations.submitDiagnosis,
@@ -286,7 +289,7 @@ export const runChatSessionTurn = async (input: RunChatSessionTurnInput): Promis
 				model,
 				messages: toLlmMessages(history, input.session.compaction()),
 				messageId: input.messageId,
-				extraTools,
+				...(completion === undefined ? undefined : { completion }),
 				usage,
 				observability,
 				// An abort clears the claim; the turn notices here and stops at the next event

--- a/apps/api/src/workflows/agent-pass.ts
+++ b/apps/api/src/workflows/agent-pass.ts
@@ -9,9 +9,9 @@
  * Two things a workflow needs that a chat session gets for free:
  *
  * - **A structured answer.** The turn emits events, not objects, so the schema
- *   arrives the way `submit_diagnosis` already does: a tool supplied through
- *   `extraTools` whose `parameters` *is* the schema. The model filling it in is
- *   the model answering.
+ *   arrives the way `submit_diagnosis` already does: the turn's `completion`
+ *   tool, whose `parameters` *is* the schema. The model filling it in is the
+ *   model answering.
  * - **A deadline.** `softStop`, checked between steps. This used to ride on
  *   `isCurrent`, which looked like the same thing and is not: `isCurrent` is the
  *   *abort* hook, so a pass that ran out of clock returned an empty stream, never
@@ -20,13 +20,14 @@
  *   never looked. `softStop` means "finish by answering", and the loop responds by
  *   spending one last step on the forced submit call.
  *
- * Both of those depend on `closingSubmit`: the tool-less closing step that serves
- * attended chat has nothing to say for an agent whose answer *is* a tool call.
+ * Both of those depend on `completion.closes`: the tool-less closing step that
+ * serves attended chat has nothing to say for an agent whose answer *is* a tool
+ * call.
  */
 import { Cause, Schema, Stream, Effect, Option } from "effect"
-import { Tool, type Model, type Tools } from "@maple/llm"
+import { Tool, type Model } from "@maple/llm"
 import { Message } from "@maple/llm"
-import { runChatTurn, makeTurnUsage, type TurnUsage } from "@/chat/loop"
+import { runChatTurn, makeTurnUsage, type TurnCompletion, type TurnUsage } from "@/chat/loop"
 import type { AgentDefinition } from "@/chat/agents"
 import { McpToolExecutor } from "@/mcp/dispatcher"
 import type { TenantContext } from "@/services/auth/tenant-context"
@@ -80,8 +81,11 @@ export const runAgentPass = <S extends Schema.Top>(
 		let toolCalls = 0
 		let deadlineHit = false
 
-		const submit: Tools = {
-			[input.submitToolName]: Tool.make({
+		// The name and the tool are one value, so a pass can never offer its submit tool without the
+		// loop knowing that calling it is how this turn ends. See `TurnCompletion`.
+		const completion: TurnCompletion = {
+			name: input.submitToolName,
+			tool: Tool.make({
 				description: input.submitToolDescription,
 				parameters: input.schema as never,
 				success: Schema.String,
@@ -91,6 +95,8 @@ export const runAgentPass = <S extends Schema.Top>(
 						return "Recorded."
 					}),
 			}),
+			// The turn's answer *is* this tool call, so the closing step has to keep offering it.
+			closes: true,
 		}
 
 		yield* runChatTurn({
@@ -101,10 +107,8 @@ export const runAgentPass = <S extends Schema.Top>(
 			messages: [Message.user(input.prompt)],
 			messageId: input.id,
 			agent: input.agent,
-			extraTools: submit,
+			completion,
 			usage,
-			// The turn's answer is this tool call, so the closing step has to keep offering it.
-			closingSubmit: { toolName: input.submitToolName },
 			softStop: () => {
 				if (input.deadlineAtMs === undefined) return false
 				if (Date.now() < input.deadlineAtMs) return false


### PR DESCRIPTION
The turn took the completion tool and the name that closes on it as two
independent inputs, and the ChatSession path supplied only the first. So an
autonomous investigation dispatched submit_diagnosis but kept going, and when it
ran out of steps the closing step offered no tools at all — the model answered
in prose, `investigations.diagnosis` stayed null, and a run that had gathered
its evidence was indistinguishable from one that found nothing. The workflow
path had already fixed this for lanes; the chat path never got it.

One optional {name, tool, closes} now carries the whole fact, so a name without
its tool cannot be built. The autonomous turn closes on submit_diagnosis; a
human follow-up in the same session is still offered the tool but not forced
into it, since forcing would rewrite the diagnosis on every question asked.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789483835&installation_model_id=427786&pr_number=503&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F503&signature=b21881eaca65fc2aef0594e76daa0a1d7d28d62a1c563a37cce8d8bae42a3f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->