### PR TITLE
fix(auth): decode self-hosted session claims once, strictly, after verification

### DIFF
--- a/packages/auth/src/auth.test.ts
+++ b/packages/auth/src/auth.test.ts
@@ -1,5 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
+import { createHmac } from "node:crypto"
 import { Effect, Exit, Option, Redacted, Schema } from "effect"
+import { TestClock } from "effect/testing"
 import { OrgId, RoleName, UserId } from "@maple/domain/http"
 import { makeGetCustomerData, makeLoginSelfHosted, makeResolveMcpTenant, makeResolveTenant } from "./index"
 
@@ -19,6 +21,49 @@ const baseEnv = {
 
 const getFailure = <A, E>(exit: Exit.Exit<A, E>): E | undefined =>
 	Option.getOrUndefined(Exit.findErrorOption(exit))
+
+// A signing oracle for the self-hosted HS256 scheme: these tokens carry a VALID
+// signature made with the real root password, so they get past signature
+// verification. Everything they exercise is claim validation.
+const rootPassword = "root-password"
+const base64UrlJson = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url")
+
+// Takes the payload as raw JSON text so a test can express shapes `JSON.stringify`
+// cannot round-trip — notably an overflowing number literal, which `JSON.parse`
+// turns into `Infinity` while `JSON.stringify(Infinity)` would emit `null`.
+const signClaimsJson = (claimsJson: string, header: unknown = { alg: "HS256", typ: "JWT" }): string => {
+	const data = `${base64UrlJson(header)}.${Buffer.from(claimsJson).toString("base64url")}`
+	return `${data}.${createHmac("sha256", rootPassword).update(data).digest("base64url")}`
+}
+
+const signClaims = (claims: unknown, header?: unknown): string =>
+	signClaimsJson(JSON.stringify(claims), header)
+
+const validClaims = { sub: "root", org_id: "default", roles: ["root"], authMode: "self_hosted" }
+
+// TestClock starts at epoch 0; park it at a round wall-clock so `exp`/`nbf`
+// boundaries are exact rather than racing the real clock.
+const clockSeconds = 1_700_000_000
+const atFixedTime = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+	Effect.gen(function* () {
+		yield* TestClock.adjust(`${clockSeconds} seconds`)
+		return yield* effect
+	})
+
+const resolveSignedToken = (token: string) =>
+	atFixedTime(Effect.exit(makeResolveTenant(baseEnv)({ authorization: `Bearer ${token}` })))
+
+const resolveSignedClaims = (claims: unknown, header?: unknown) =>
+	resolveSignedToken(signClaims(claims, header))
+
+const resolveSignedClaimsJson = (claimsJson: string) => resolveSignedToken(signClaimsJson(claimsJson))
+
+const assertRejected = <A>(exit: Exit.Exit<A, unknown>, message: string) => {
+	const failure = getFailure(exit) as { _tag?: string; message?: string } | undefined
+	assert.isTrue(Exit.isFailure(exit))
+	assert.strictEqual(failure?._tag, "@maple/http/errors/UnauthorizedError")
+	assert.strictEqual(failure?.message, message)
+}
 
 describe("makeResolveTenant", () => {
 	it.effect("resolves a Clerk tenant from verified session claims", () =>
@@ -395,6 +440,262 @@ describe("makeResolveMcpTenant", () => {
 				roles: [asRoleName("org:admin")],
 				authMode: "clerk",
 			})
+		}),
+	)
+})
+
+// A correctly signed token is NOT a valid session. Anyone holding the root
+// password can mint arbitrary claims, and a self-hosted deployment may still be
+// carrying tokens minted by an older build, so every claim shape below has to be
+// judged on its own merits by `SelfHostedSessionClaims`.
+describe("self-hosted session claims (correctly signed, malformed)", () => {
+	it.effect("rejects a token whose authMode is not the self_hosted literal", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ ...validClaims, authMode: "clerk" }),
+				"Invalid self-hosted session token",
+			)
+		}),
+	)
+
+	it.effect("rejects a token with no authMode claim", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ sub: "root", org_id: "default", roles: ["root"] }),
+				"Invalid self-hosted session token",
+			)
+		}),
+	)
+
+	it.effect("rejects a token with no sub claim", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ org_id: "default", roles: ["root"], authMode: "self_hosted" }),
+				"Invalid self-hosted session token",
+			)
+		}),
+	)
+
+	it.effect("rejects a token with no org_id claim", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ sub: "root", roles: ["root"], authMode: "self_hosted" }),
+				"Invalid self-hosted session token",
+			)
+		}),
+	)
+
+	it.effect("rejects an untrimmed sub (UserId is a trimmed brand)", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ ...validClaims, sub: "root " }),
+				"Invalid self-hosted session token",
+			)
+		}),
+	)
+
+	it.effect("rejects an empty org_id", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ ...validClaims, org_id: "" }),
+				"Invalid self-hosted session token",
+			)
+		}),
+	)
+
+	it.effect("rejects a non-string role entry", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ ...validClaims, roles: [1, 2] }),
+				"Invalid self-hosted session token",
+			)
+		}),
+	)
+
+	it.effect("rejects a blank role entry inside a roles array", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ ...validClaims, roles: ["root", "  "] }),
+				"Invalid self-hosted session token",
+			)
+		}),
+	)
+
+	it.effect("rejects a non-numeric exp", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ ...validClaims, exp: "4102444800" }),
+				"Invalid self-hosted session token",
+			)
+		}),
+	)
+
+	it.effect("rejects a non-finite exp (an overflowing literal parses to Infinity)", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaimsJson(
+					'{"sub":"root","org_id":"default","roles":["root"],"authMode":"self_hosted","exp":1e999}',
+				),
+				"Invalid self-hosted session token",
+			)
+		}),
+	)
+
+	it.effect("normalizes a comma-separated roles claim", () =>
+		Effect.gen(function* () {
+			const exit = yield* resolveSignedClaims({ ...validClaims, roles: " root , viewer " })
+
+			assert.isTrue(Exit.isSuccess(exit))
+			assert.deepStrictEqual(Exit.isSuccess(exit) ? exit.value.roles : undefined, [
+				asRoleName("root"),
+				asRoleName("viewer"),
+			])
+		}),
+	)
+
+	it.effect("defaults an absent roles claim to root", () =>
+		Effect.gen(function* () {
+			const exit = yield* resolveSignedClaims({
+				sub: "root",
+				org_id: "default",
+				authMode: "self_hosted",
+			})
+
+			assert.isTrue(Exit.isSuccess(exit))
+			assert.deepStrictEqual(Exit.isSuccess(exit) ? exit.value.roles : undefined, [asRoleName("root")])
+		}),
+	)
+
+	it.effect("defaults an empty roles claim to root", () =>
+		Effect.gen(function* () {
+			const exit = yield* resolveSignedClaims({ ...validClaims, roles: [] })
+
+			assert.isTrue(Exit.isSuccess(exit))
+			assert.deepStrictEqual(Exit.isSuccess(exit) ? exit.value.roles : undefined, [asRoleName("root")])
+		}),
+	)
+
+	it.effect("ignores unknown claims rather than trusting them", () =>
+		Effect.gen(function* () {
+			const exit = yield* resolveSignedClaims({ ...validClaims, admin: true, org_id_override: "other" })
+
+			assert.isTrue(Exit.isSuccess(exit))
+			assert.deepStrictEqual(Exit.isSuccess(exit) ? exit.value : undefined, {
+				orgId: asOrgId("default"),
+				userId: asUserId("root"),
+				roles: [asRoleName("root")],
+				authMode: "self_hosted",
+			})
+		}),
+	)
+})
+
+describe("self-hosted session temporal boundaries", () => {
+	it.effect("rejects an expired token", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ ...validClaims, exp: clockSeconds - 1 }),
+				"JWT has expired",
+			)
+		}),
+	)
+
+	// RFC 7519 §4.1.4: the current time must be BEFORE `exp`, so `now === exp` is expired.
+	it.effect("rejects a token exactly at its exp boundary", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ ...validClaims, exp: clockSeconds }),
+				"JWT has expired",
+			)
+		}),
+	)
+
+	it.effect("accepts a token one second before its exp boundary", () =>
+		Effect.gen(function* () {
+			const exit = yield* resolveSignedClaims({ ...validClaims, exp: clockSeconds + 1 })
+
+			assert.isTrue(Exit.isSuccess(exit))
+		}),
+	)
+
+	// Regression: `exp: 0` is a token that expired at the epoch. A truthiness guard
+	// (`if (payload.exp && ...)`) skipped the check entirely and accepted it forever.
+	it.effect("rejects exp = 0 instead of reading it as no expiry", () =>
+		Effect.gen(function* () {
+			assertRejected(yield* resolveSignedClaims({ ...validClaims, exp: 0 }), "JWT has expired")
+		}),
+	)
+
+	it.effect("rejects a not-yet-valid token", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ ...validClaims, nbf: clockSeconds + 60 }),
+				"JWT is not active yet",
+			)
+		}),
+	)
+
+	// RFC 7519 §4.1.5: the current time must be AT or after `nbf`, so `now === nbf` is active.
+	it.effect("accepts a token exactly at its nbf boundary", () =>
+		Effect.gen(function* () {
+			const exit = yield* resolveSignedClaims({ ...validClaims, nbf: clockSeconds })
+
+			assert.isTrue(Exit.isSuccess(exit))
+		}),
+	)
+
+	it.effect("rejects a token one second before its nbf boundary", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims({ ...validClaims, nbf: clockSeconds + 1 }),
+				"JWT is not active yet",
+			)
+		}),
+	)
+
+	it.effect("accepts nbf = 0 (already active) and a token with no exp", () =>
+		Effect.gen(function* () {
+			const exit = yield* resolveSignedClaims({ ...validClaims, nbf: 0 })
+
+			assert.isTrue(Exit.isSuccess(exit))
+		}),
+	)
+})
+
+describe("self-hosted JWT algorithm pinning", () => {
+	it.effect("rejects alg: none", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims(validClaims, { alg: "none", typ: "JWT" }),
+				"Unsupported JWT algorithm",
+			)
+		}),
+	)
+
+	it.effect("rejects an asymmetric alg", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims(validClaims, { alg: "RS256", typ: "JWT" }),
+				"Unsupported JWT algorithm",
+			)
+		}),
+	)
+
+	it.effect("rejects a header with no alg", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims(validClaims, { typ: "JWT" }),
+				"Unsupported JWT algorithm",
+			)
+		}),
+	)
+
+	it.effect("rejects a case-folded hs256", () =>
+		Effect.gen(function* () {
+			assertRejected(
+				yield* resolveSignedClaims(validClaims, { alg: "hs256", typ: "JWT" }),
+				"Unsupported JWT algorithm",
+			)
 		}),
 	)
 })

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -18,7 +18,7 @@ import {
 	UnauthorizedError,
 	UserId,
 } from "@maple/domain/http"
-import { Clock, Data, Effect, Option, Redacted, Schema } from "effect"
+import { Clock, Data, Effect, Option, Redacted, Schema, SchemaGetter } from "effect"
 
 export interface TenantContext {
 	readonly orgId: OrgId
@@ -29,28 +29,65 @@ export interface TenantContext {
 
 type HeaderRecord = Record<string, string | undefined>
 
-type JwtPayload = {
-	sub?: string
-	exp?: number
-	nbf?: number
-	iat?: number
-	org_id?: string
-	authMode?: AuthMode
-	roles?: readonly string[] | string
-}
-
 const JwtHeaderSchema = Schema.Struct({
 	alg: Schema.optionalKey(Schema.String),
 })
-const JwtPayloadSchema = Schema.Struct({
-	sub: Schema.optionalKey(Schema.String),
-	exp: Schema.optionalKey(Schema.Number),
-	nbf: Schema.optionalKey(Schema.Number),
-	iat: Schema.optionalKey(Schema.Number),
-	org_id: Schema.optionalKey(Schema.String),
-	authMode: Schema.optionalKey(AuthMode),
-	roles: Schema.optionalKey(Schema.Union([Schema.Array(Schema.String), Schema.String])),
+
+// RFC 7519 temporal claims are "seconds since epoch" numbers. `isFinite` rejects
+// the one JSON-reachable non-number: an overflowing literal such as `1e999`,
+// which parses to `Infinity` and would otherwise mean "never expires".
+const JwtSeconds = Schema.Number.check(Schema.isFinite())
+
+// A `roles` claim arrives either as an array or as a comma-separated string.
+// Normalization is deliberately ASYMMETRIC and must stay that way: the string
+// form splits/trims/drops blanks, the array form is passed through untouched so
+// that `["root", "  "]` keeps failing `RoleName` (trimmed, min length 1). Trimming
+// array entries here would ACCEPT tokens that are rejected today.
+const normalizeRoles = (value: readonly string[] | string): readonly string[] => {
+	const roles =
+		typeof value === "string"
+			? value
+					.split(",")
+					.map((part) => part.trim())
+					.filter(Boolean)
+			: value
+	// A self-hosted token that names no role is the root operator: the HMAC key IS
+	// the root password, so signing capability already implies root. Preserved from
+	// the pre-schema code path rather than introduced here.
+	return roles.length > 0 ? roles : ["root"]
+}
+
+const SelfHostedRoles = Schema.Union([Schema.Array(Schema.String), Schema.String]).pipe(
+	Schema.decodeTo(Schema.Array(RoleName), {
+		decode: SchemaGetter.transform(normalizeRoles),
+		encode: SchemaGetter.passthrough({ strict: false }),
+	}),
+	Schema.withDecodingDefaultKey(Effect.succeed<readonly string[]>([])),
+)
+
+/**
+ * The self-hosted session contract, decoded IMMEDIATELY after the HMAC signature
+ * is verified — there is no permissive intermediate payload and no second
+ * validation pipeline downstream.
+ *
+ * Every field a caller is trusted with is required and branded here: `sub` is a
+ * `UserId`, `org_id` an `OrgId`, `roles` a normalized `RoleName[]`, and `authMode`
+ * the literal `"self_hosted"` (a Clerk-mode token presented on the self-hosted
+ * path is not a self-hosted session). `exp`/`nbf`/`iat` stay optional because
+ * `signHs256Jwt` mints session tokens with `iat` only — requiring `exp` would
+ * invalidate every token already issued by a running self-hosted deployment.
+ */
+const SelfHostedSessionClaims = Schema.Struct({
+	sub: UserId,
+	org_id: OrgId,
+	authMode: Schema.Literal("self_hosted"),
+	roles: SelfHostedRoles,
+	exp: Schema.optionalKey(JwtSeconds),
+	nbf: Schema.optionalKey(JwtSeconds),
+	iat: Schema.optionalKey(JwtSeconds),
 })
+type SelfHostedSessionClaims = Schema.Schema.Type<typeof SelfHostedSessionClaims>
+
 const decodeOrgIdSync = Schema.decodeUnknownSync(OrgId)
 const decodeUserIdSync = Schema.decodeUnknownSync(UserId)
 const decodeRoleNameSync = Schema.decodeUnknownSync(RoleName)
@@ -118,10 +155,10 @@ const decodeBase64Url = (input: string): string => {
 
 const encodeBase64Url = (value: unknown): string => Buffer.from(JSON.stringify(value)).toString("base64url")
 
-const verifyHs256Jwt = Effect.fn("AuthService.verifyHs256Jwt")(function* (
+const verifySelfHostedSessionToken = Effect.fn("AuthService.verifySelfHostedSessionToken")(function* (
 	token: string,
 	secret: string,
-): Effect.fn.Return<JwtPayload, UnauthorizedError> {
+): Effect.fn.Return<SelfHostedSessionClaims, UnauthorizedError> {
 	const parts = token.split(".")
 	if (parts.length !== 3) {
 		return yield* unauthorized("Invalid JWT format")
@@ -131,6 +168,9 @@ const verifyHs256Jwt = Effect.fn("AuthService.verifyHs256Jwt")(function* (
 	const header = yield* Schema.decodeEffect(Schema.fromJsonString(JwtHeaderSchema))(
 		decodeBase64Url(encodedHeader),
 	).pipe(Effect.mapError(() => unauthorized("Invalid JWT header")))
+	// HS256 is pinned, not negotiated: the header cannot select `none`, another MAC,
+	// or an asymmetric algorithm. The only verification below is an HMAC with the
+	// root password, so there is no key-confusion surface either.
 	if (header.alg !== "HS256") {
 		return yield* unauthorized("Unsupported JWT algorithm")
 	}
@@ -144,24 +184,36 @@ const verifyHs256Jwt = Effect.fn("AuthService.verifyHs256Jwt")(function* (
 		return yield* unauthorized("Invalid JWT signature")
 	}
 
-	const payload = yield* Schema.decodeEffect(Schema.fromJsonString(JwtPayloadSchema))(
+	const claims = yield* Schema.decodeEffect(Schema.fromJsonString(SelfHostedSessionClaims))(
 		decodeBase64Url(encodedPayload),
-	).pipe(Effect.mapError(() => unauthorized("Invalid JWT payload")))
+	).pipe(Effect.mapError(() => unauthorized("Invalid self-hosted session token")))
 	// JWT exp/nbf are in seconds since epoch (RFC 7519); divide Clock millis.
 	const now = Math.floor((yield* Clock.currentTimeMillis) / 1000)
 
-	if (payload.nbf && now < payload.nbf) {
+	// Presence, not truthiness: `exp: 0` is a token that expired at the epoch, and
+	// a truthiness guard silently turned it into a token that never expires.
+	// Boundaries follow RFC 7519 §4.1.4/§4.1.5 — `now >= exp` is expired, `now == nbf`
+	// is already active.
+	if (claims.nbf !== undefined && now < claims.nbf) {
 		return yield* unauthorized("JWT is not active yet")
 	}
 
-	if (payload.exp && now >= payload.exp) {
+	if (claims.exp !== undefined && now >= claims.exp) {
 		return yield* unauthorized("JWT has expired")
 	}
 
-	return payload
+	return claims
 })
 
-const signHs256Jwt = (payload: JwtPayload, secret: string): string => {
+type SelfHostedTokenClaims = {
+	readonly sub: UserId
+	readonly org_id: OrgId
+	readonly roles: readonly RoleName[]
+	readonly authMode: "self_hosted"
+	readonly iat: number
+}
+
+const signHs256Jwt = (payload: SelfHostedTokenClaims, secret: string): string => {
 	const header = { alg: "HS256", typ: "JWT" }
 	const encodedHeader = encodeBase64Url(header)
 	const encodedPayload = encodeBase64Url(payload)
@@ -182,20 +234,6 @@ const constantTimeEquals = (left: string, right: string): boolean => {
 
 	return leftBuffer.length === rightBuffer.length && timingSafeEqual(normalizedLeft, normalizedRight)
 }
-
-const parseRawRoles = (value: JwtPayload["roles"]): string[] => {
-	if (Array.isArray(value)) return value
-	if (typeof value === "string") {
-		return value
-			.split(",")
-			.map((part) => part.trim())
-			.filter(Boolean)
-	}
-	return []
-}
-
-const parseRoles = (value: JwtPayload["roles"]): Effect.Effect<Array<RoleName>, UnauthorizedError> =>
-	Effect.forEach(parseRawRoles(value), (role) => decodeRoleName(role, "Invalid role in session token"))
 
 const getAuthMode = (mode: string): AuthMode => (mode.toLowerCase() === "clerk" ? "clerk" : "self_hosted")
 
@@ -391,23 +429,15 @@ export const makeResolveTenant = (
 		}
 
 		const rootPassword = yield* requireSecret(env.MAPLE_ROOT_PASSWORD, "MAPLE_ROOT_PASSWORD")
-		const payload = yield* verifyHs256Jwt(token, rootPassword)
-
-		if (
-			payload.authMode !== "self_hosted" ||
-			typeof payload.sub !== "string" ||
-			typeof payload.org_id !== "string"
-		) {
-			return yield* unauthorized("Invalid self-hosted session token")
-		}
-
-		const roles = yield* parseRoles(payload.roles)
+		// `claims` is already the validated tenant: branded ids, a normalized role
+		// list and a literal `authMode`. Nothing below re-checks it.
+		const claims = yield* verifySelfHostedSessionToken(token, rootPassword)
 
 		const tenant: TenantContext = {
-			orgId: yield* decodeOrgId(payload.org_id, "Invalid organization in self-hosted session token"),
-			userId: yield* decodeUserId(payload.sub, "Invalid user in self-hosted session token"),
-			roles: roles.length > 0 ? roles : [decodeRoleNameSync("root")],
-			authMode: "self_hosted",
+			orgId: claims.org_id,
+			userId: claims.sub,
+			roles: claims.roles,
+			authMode: claims.authMode,
 		}
 
 		const orgIdOverride = getOptionalString(env.MAPLE_ORG_ID_OVERRIDE)


### PR DESCRIPTION
The verified payload came back permissive — unbranded ids, optional mode, roles
in two shapes — and a second pass downstream re-checked all of it. The expiry
check lived in that second pass as `payload.exp && now >= payload.exp`, so a
correctly signed token carrying `exp: 0` skipped the check on falsiness and was
accepted forever; `1e999` parses to Infinity and read as "never expires" the
same way.

Claims are now decoded straight after signature verification into branded ids, a
literal mode, normalized roles and finite temporal claims, and the temporal
guards test presence rather than truthiness. The second pipeline is gone, so
there is no longer a gap between what was verified and what is trusted.

HS256 was already pinned against `none` and asymmetric algorithms; that is now
covered by tests. Acceptance narrows in exactly two places — `exp: 0` and
non-finite temporal claims — and is unchanged for all thirty other shapes
probed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789483839&installation_model_id=427786&pr_number=504&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F504&signature=3b96b1d577b36d2196bdb0a44c78d18d87dc9b5a42fb2a57a5824292679a3041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->